### PR TITLE
update Node.js version to 24 in CI workflows

### DIFF
--- a/.github/workflows/codebuddy-canary.yml
+++ b/.github/workflows/codebuddy-canary.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/codebuddy-dev.yml
+++ b/.github/workflows/codebuddy-dev.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/codebuddy-release.yml
+++ b/.github/workflows/codebuddy-release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## 📋 Summary

Updates Node.js version from 20 to 24 in all CI/CD workflows.

## 🔄 Changes

- Updated `node-version` from `'20'` to `'24'` in all GitHub Actions workflow files
- Affected workflows:
  - `codebuddy-canary.yml` - Canary deployment workflow
  - `codebuddy-dev.yml` - Development environment deployment workflow
  - `codebuddy-release.yml` - Production release workflow

## 🎯 Motivation

- Utilize latest features and performance improvements with Node.js 24 LTS
- Synchronize CI/CD environment with the latest Node.js version

## ✅ Testing

- [ ] Verify that each workflow runs successfully
- [ ] Validate that build and deployment processes work correctly

## 📝 Notes

This change only affects CI/CD environments and is independent of local development Node.js versions.