### PR TITLE
Fix release-drafter config keys and add workflow permissions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,7 +32,7 @@ categories:
       - 'documentation'
       - 'Documentation' 
   - title: '🧰 Maintenance'
-    label:
+    labels:
       - 'chore'
       - 'Chore'
       - 'ci'
@@ -40,7 +40,7 @@ categories:
       - 'build'
       - 'Build'
   - title: '🛠 Dependencies'
-    label:
+    labels:
       - 'dependencies'    
       - 'Dependencies'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Fix Release Drafter Configuration and Workflow Permissions

## Summary

This PR fixes a configuration bug in the release-drafter setup and adds required permissions to the GitHub Actions workflow. The changes ensure that release-drafter can properly categorize PRs and create release drafts.

## Problem

1. **Configuration Bug**: The release-drafter.yml file was using incorrect key name `label:` instead of `labels:` in two category definitions, which would cause those categories to be ignored.

2. **Missing Permissions**: The GitHub Actions workflow lacked explicit permissions, which could cause failures when trying to create releases or update release drafts in repositories with restricted permissions.

## Changes

### 1. Fixed Configuration Keys

**File**: `.github/release-drafter.yml`

Changed incorrect `label:` to `labels:` in two categories:

- **🧰 Maintenance** category (line 35)
  - Fixed: `label:` → `labels:`
  - Affects labels: `chore`, `Chore`, `ci`, `CI`, `build`, `Build`

- **🛠 Dependencies** category (line 43)
  - Fixed: `label:` → `labels:`
  - Affects labels: `dependencies`, `Dependencies`

### 2. Added Workflow Permissions

**File**: `.github/workflows/release-drafter.yml`

Added explicit permissions section:

```yaml
permissions:
  contents: write
  pull-requests: write
```

**Why these permissions are needed:**
- `contents: write` - Required to create and update GitHub releases
- `pull-requests: write` - Required to update release draft PRs

## Impact

### Before
- Maintenance and Dependencies PRs were not being categorized correctly
- Workflow might fail in repositories with restricted permissions
- Release drafts might not be created or updated properly

### After
- All PR categories are properly recognized and categorized
- Workflow has explicit permissions to perform required actions
- Release drafts will be created and updated correctly

## Testing

- [x] Verified YAML syntax is correct
- [x] Confirmed `labels:` is the correct key name per release-drafter documentation
- [x] Verified permissions match GitHub Actions requirements
- [x] Checked that other categories use correct `labels:` key

## Related Documentation

- [Release Drafter Configuration](https://github.com/release-drafter/release-drafter#configuration)
- [GitHub Actions Permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

## Files Changed

- `.github/release-drafter.yml` - Fixed 2 configuration keys
- `.github/workflows/release-drafter.yml` - Added permissions section

## Statistics

- **2 files changed**
- **6 insertions**, 2 deletions
- **2 bug fixes** (incorrect key names)
- **1 improvement** (explicit permissions)

## Notes

This is a critical fix for the release automation workflow. Without these changes:
- PRs labeled with `chore`, `ci`, `build`, or `dependencies` would not appear in release notes
- The workflow might fail silently or with permission errors in restricted repositories

The fix ensures that the release-drafter tool works as intended and all PR categories are properly handled.

