### PR TITLE
Fix package root path calculation in rules service

### DIFF
--- a/mcp-server/src/rules/rules.service.ts
+++ b/mcp-server/src/rules/rules.service.ts
@@ -15,8 +15,8 @@ export class RulesService {
     // 2. NPM 패키지로 설치된 경우: node_modules/codingbuddy/.ai-rules
     // 3. 개발 환경: mcp-server/../.ai-rules
     //
-    // 빌드 후 구조: dist/rules/rules.service.js
-    // __dirname = dist/rules, 패키지 루트 = dist/rules/../.. = 패키지 루트
+    // 빌드 후 구조: dist/src/rules/rules.service.js
+    // 개발 환경: src/rules/rules.service.ts
 
     if (process.env.CODINGBUDDY_RULES_DIR) {
       this.rulesDir = process.env.CODINGBUDDY_RULES_DIR;
@@ -24,8 +24,12 @@ export class RulesService {
       return;
     }
 
-    // 패키지 루트 (dist/rules -> 2단계 상위)
-    const packageRoot = path.resolve(__dirname, '../..');
+    // 빌드 후: dist/src/rules → 패키지 루트로 3단계 상위
+    // 개발 환경: src/rules → 패키지 루트로 2단계 상위
+    const isBuilt =
+      __dirname.includes('/dist/') || __dirname.includes('\\dist\\');
+    const stepsUp = isBuilt ? '../../..' : '../..';
+    const packageRoot = path.resolve(__dirname, stepsUp);
 
     // 1. 패키지 루트의 .ai-rules (NPM 설치 시)
     let candidate = path.join(packageRoot, '.ai-rules');


### PR DESCRIPTION
# Fix Package Root Path Calculation in Rules Service

## Summary

This PR fixes a critical bug in the `RulesService` where the package root path calculation was incorrect for built environments. The service was using a hardcoded 2-step path resolution (`../..`) which worked for development but failed in production builds where the structure is `dist/src/rules/` instead of `dist/rules/`.

## Problem

### Bug Description

The `RulesService` was incorrectly calculating the package root path in built environments:

**Before:**
- Always used `../..` (2 steps up) regardless of environment
- Assumed build structure: `dist/rules/rules.service.js`
- Actual build structure: `dist/src/rules/rules.service.js`

**Impact:**
- In production builds, the service couldn't locate `.ai-rules` directory
- MCP server failed to load rules when running from built code
- Only worked correctly in development environment

### Root Cause

The code assumed the build output structure matched the source structure, but TypeScript compilation preserves the `src/` directory structure in the `dist/` output:

```
Source:  src/rules/rules.service.ts
Built:   dist/src/rules/rules.service.js  ← 3 steps up needed
```

## Solution

### Changes Made

1. **Environment Detection**
   - Added detection logic to distinguish between built and development environments
   - Checks if `__dirname` contains `/dist/` or `\dist\` (cross-platform)

2. **Dynamic Path Resolution**
   - Built environment: `../../..` (3 steps up from `dist/src/rules/`)
   - Development environment: `../..` (2 steps up from `src/rules/`)

3. **Updated Comments**
   - Corrected comments to reflect actual build structure
   - Added clear explanation of path resolution logic

### Code Changes

**File**: `mcp-server/src/rules/rules.service.ts`

```typescript
// Before
const packageRoot = path.resolve(__dirname, '../..');

// After
const isBuilt =
  __dirname.includes('/dist/') || __dirname.includes('\\dist\\');
const stepsUp = isBuilt ? '../../..' : '../..';
const packageRoot = path.resolve(__dirname, stepsUp);
```

## Impact

### Before Fix
- ❌ Production builds failed to locate `.ai-rules` directory
- ❌ MCP server couldn't load rules in built environment
- ❌ Only worked in development mode

### After Fix
- ✅ Correctly resolves package root in both environments
- ✅ MCP server works in production builds
- ✅ Maintains backward compatibility with development environment
- ✅ Cross-platform path detection (Windows/Unix)

## Testing

### Test Scenarios

1. **Development Environment**
   - ✅ Service correctly resolves path from `src/rules/`
   - ✅ Finds `.ai-rules` directory at package root

2. **Production Build**
   - ✅ Service correctly resolves path from `dist/src/rules/`
   - ✅ Finds `.ai-rules` directory at package root

3. **Cross-Platform**
   - ✅ Works on Windows (`\dist\` detection)
   - ✅ Works on Unix/Linux/macOS (`/dist/` detection)

### Verification Steps

1. Build the project: `npm run build`
2. Run MCP server from built code
3. Verify `.ai-rules` directory is found correctly
4. Confirm rules are loaded successfully

## Related Issue

Closes #77

## Files Changed

- `mcp-server/src/rules/rules.service.ts` - Fixed path calculation logic

## Statistics

- **1 file changed**
- **8 insertions**, 4 deletions
- **1 bug fix** (path resolution)

## Technical Details

### Path Resolution Logic

```
Development:
src/rules/rules.service.ts
  → ../.. (2 steps)
  → package root ✓

Production:
dist/src/rules/rules.service.js
  → ../../.. (3 steps)
  → package root ✓
```

### Environment Detection

The fix uses a simple string check on `__dirname`:
- Checks for `/dist/` (Unix-style paths)
- Checks for `\dist\` (Windows-style paths)
- Works cross-platform without requiring `path` module operations

## Notes

This is a critical fix for production deployments. Without this fix, the MCP server would fail to locate rules files when running from built code, making it unusable in production environments.

The fix maintains backward compatibility with development environments while correctly handling the production build structure.

