### PR TITLE
Use jq instead of npm version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           TAG_NAME="${GITHUB_REF#refs/tags/}"
           TAG_NAME="${TAG_NAME#v}"
           echo "Publishing codingbuddy-rules version: $TAG_NAME"
-          npm version "$TAG_NAME" --no-git-tag-version
+          cat <<< "$( jq --arg v "$TAG_NAME" '.version = $v' package.json )" > package.json
           yarn npm publish
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -43,9 +43,8 @@ jobs:
           TAG_NAME="${GITHUB_REF#refs/tags/}"
           TAG_NAME="${TAG_NAME#v}"
           echo "Publishing codingbuddy version: $TAG_NAME"
-          npm version "$TAG_NAME" --no-git-tag-version
-          # Replace workspace dependency with actual version
-          cat <<< "$( jq --arg v "$TAG_NAME" '.dependencies["codingbuddy-rules"] = $v' package.json )" > package.json
+          # Update version and replace workspace dependency with actual version
+          cat <<< "$( jq --arg v "$TAG_NAME" '.version = $v | .dependencies["codingbuddy-rules"] = $v' package.json )" > package.json
           yarn npm publish
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# fix: Use jq instead of npm version in release workflow

## 📋 Summary

This PR replaces the `npm version` command with `jq` for updating package versions in the release workflow. This change provides more reliable and explicit control over version updates during the publishing process.

## 🔄 Changes

### Release Workflow Updates (`.github/workflows/release.yml`)

#### 1. `codingbuddy-rules` Package Publishing

**Before:**
```bash
npm version "$TAG_NAME" --no-git-tag-version
```

**After:**
```bash
cat <<< "$( jq --arg v "$TAG_NAME" '.version = $v' package.json )" > package.json
```

- Replaced `npm version` command with `jq` for direct JSON manipulation
- More explicit and predictable version update process

#### 2. `codingbuddy` Package Publishing

**Before:**
```bash
npm version "$TAG_NAME" --no-git-tag-version
# Replace workspace dependency with actual version
cat <<< "$( jq --arg v "$TAG_NAME" '.dependencies["codingbuddy-rules"] = $v' package.json )" > package.json
```

**After:**
```bash
# Update version and replace workspace dependency with actual version
cat <<< "$( jq --arg v "$TAG_NAME" '.version = $v | .dependencies["codingbuddy-rules"] = $v' package.json )" > package.json
```

- Consolidated version and dependency updates into a single `jq` command
- Removed redundant `npm version` call
- More efficient and atomic update operation

## 🎯 Motivation

### Why Replace `npm version`?

1. **Reliability**: `npm version` may have issues in CI/CD environments or with workspace setups
2. **Explicitness**: Using `jq` makes the version update process more transparent and debuggable
3. **Consistency**: Both packages now use the same approach for version updates
4. **Efficiency**: Single `jq` command handles multiple updates in the `codingbuddy` package

### Benefits

- ✅ More reliable version updates in CI/CD
- ✅ Better error handling and debugging
- ✅ Consistent approach across both packages
- ✅ Atomic updates (version + dependency in one operation)

## 📊 Impact

### Files Changed
- **1 file changed**: `.github/workflows/release.yml`
- **3 insertions(+), 4 deletions(-)**

### Testing

- [x] Verified `jq` is available in GitHub Actions runners
- [x] Confirmed version update syntax is correct
- [x] Validated that both version and dependency updates work correctly

## 🔍 Technical Details

### `jq` Command Breakdown

For `codingbuddy-rules`:
```bash
jq --arg v "$TAG_NAME" '.version = $v' package.json
```
- Sets the `version` field to the tag name value

For `codingbuddy`:
```bash
jq --arg v "$TAG_NAME" '.version = $v | .dependencies["codingbuddy-rules"] = $v' package.json
```
- Sets both `version` and `dependencies["codingbuddy-rules"]` to the tag name value
- Uses pipe (`|`) to chain multiple updates in a single command

## ✅ Verification

The workflow will:
1. Extract version from GitHub release tag (removing `v` prefix)
2. Update `package.json` version using `jq`
3. For `codingbuddy`, also update the `codingbuddy-rules` dependency version
4. Publish packages to npm using `yarn npm publish`

