### PR TITLE
fix: Add mcp CLI command and fix documentation

### DIFF
--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -20,6 +20,7 @@ npx codingbuddy init
 | Command | Description |
 |---------|-------------|
 | `codingbuddy init` | Analyze project and generate configuration |
+| `codingbuddy mcp` | Start MCP server (stdio mode by default) |
 | `codingbuddy --help` | Show help |
 | `codingbuddy --version` | Show version |
 
@@ -63,15 +64,13 @@ Add the following configuration to your Claude Desktop config:
 ```json
 {
   "mcpServers": {
-    "codingbuddy-rules": {
+    "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["-y", "codingbuddy", "mcp"]
     }
   }
 }
 ```
-
-> **Note**: Use `codingbuddy-mcp` for the MCP server. The `codingbuddy` command is for CLI operations like `init`.
 
 ### Option 2: Global Installation
 
@@ -84,8 +83,9 @@ Then configure Claude Desktop:
 ```json
 {
   "mcpServers": {
-    "codingbuddy-rules": {
-      "command": "codingbuddy-mcp"
+    "codingbuddy": {
+      "command": "codingbuddy",
+      "args": ["mcp"]
     }
   }
 }
@@ -94,7 +94,7 @@ Then configure Claude Desktop:
 ### Option 3: Local Development (Stdio Mode)
 
 ```bash
-cd mcp-server
+cd apps/mcp-server
 yarn install
 yarn build
 ```
@@ -102,9 +102,9 @@ yarn build
 ```json
 {
   "mcpServers": {
-    "codingbuddy-rules": {
+    "codingbuddy": {
       "command": "node",
-      "args": ["/ABSOLUTE/PATH/TO/codingbuddy/mcp-server/dist/src/main.js"]
+      "args": ["/ABSOLUTE/PATH/TO/codingbuddy/apps/mcp-server/dist/src/cli/cli.js", "mcp"]
     }
   }
 }
@@ -118,7 +118,7 @@ Build the Docker image from the **repository root**:
 
 ```bash
 # Run from codingbuddy root
-docker build -f mcp-server/Dockerfile -t codingbuddy-rules-mcp .
+docker build -f apps/mcp-server/Dockerfile -t codingbuddy-mcp .
 ```
 
 Run the container:
@@ -127,7 +127,7 @@ Run the container:
 docker run -p 3000:3000 \
   -e MCP_TRANSPORT=sse \
   -e PORT=3000 \
-  codingbuddy-rules-mcp
+  codingbuddy-mcp
 ```
 
 The server will start in SSE mode, exposing:

--- a/apps/mcp-server/src/cli/cli.ts
+++ b/apps/mcp-server/src/cli/cli.ts
@@ -6,6 +6,7 @@
  */
 
 import { runInit } from './init';
+import { bootstrap } from '../main';
 import type { InitOptions } from './cli.types';
 
 // Package version (injected at build time or read from package.json)
@@ -15,7 +16,7 @@ const VERSION = '1.0.0';
  * Parsed command line arguments
  */
 export interface ParsedArgs {
-  command: 'init' | 'help' | 'version';
+  command: 'init' | 'mcp' | 'help' | 'version';
   options: Partial<InitOptions>;
 }
 
@@ -40,6 +41,10 @@ export function parseArgs(args: string[]): ParsedArgs {
 
   // Get command
   const command = args[0];
+
+  if (command === 'mcp') {
+    return { command: 'mcp', options };
+  }
 
   if (command !== 'init') {
     return { command: 'help', options };
@@ -76,6 +81,7 @@ CodingBuddy CLI - AI-powered project configuration generator
 
 Usage:
   codingbuddy init [path] [options]    Initialize configuration
+  codingbuddy mcp                      Start MCP server (stdio mode)
   codingbuddy --help                   Show this help
   codingbuddy --version                Show version
 
@@ -89,9 +95,12 @@ Examples:
   codingbuddy init ./my-project        Initialize in specific directory
   codingbuddy init --format json       Generate JSON config
   codingbuddy init --force             Overwrite existing config
+  codingbuddy mcp                      Start MCP server for AI assistants
 
 Environment:
   ANTHROPIC_API_KEY    API key for AI generation
+  MCP_TRANSPORT        MCP transport mode: stdio (default) or sse
+  PORT                 HTTP port for SSE mode (default: 3000)
 `;
 
   process.stdout.write(usage + '\n');
@@ -119,6 +128,10 @@ export async function main(
 
     case 'version':
       printVersion();
+      break;
+
+    case 'mcp':
+      await bootstrap();
       break;
 
     case 'init': {

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -4,7 +4,7 @@ import { AppModule } from './app.module';
 import { McpService } from './mcp/mcp.service';
 import { Logger } from '@nestjs/common';
 
-async function bootstrap() {
+export async function bootstrap(): Promise<void> {
   const logger = new Logger('Bootstrap');
   const transportMode = process.env.MCP_TRANSPORT || 'stdio';
 
@@ -22,4 +22,8 @@ async function bootstrap() {
     logger.log('MCP Server running in Stdio mode');
   }
 }
-bootstrap();
+
+// Run if executed directly
+if (require.main === module) {
+  bootstrap();
+}


### PR DESCRIPTION
# Add mcp CLI command and fix documentation

## 📋 Summary

This PR adds a new `mcp` CLI command to start the MCP server directly from the command line, and fixes documentation inconsistencies related to server names, paths, and command usage after the monorepo restructure.

## 🔄 Changes

### 1. New CLI Command: `codingbuddy mcp`

Added a new `mcp` command to the CLI that allows users to start the MCP server directly:

```bash
codingbuddy mcp
```

**Benefits:**
- Unified CLI interface for all CodingBuddy operations
- No need for separate `codingbuddy-mcp` binary
- Consistent command structure across all features

### 2. Code Changes

#### `apps/mcp-server/src/cli/cli.ts`

- **Added `mcp` command support**:
  - Updated `ParsedArgs` interface to include `'mcp'` command type
  - Added command parsing logic for `mcp` command
  - Imported `bootstrap` function from `main.ts`
  - Added `mcp` case handler in `main()` function

- **Updated help text**:
  - Added `codingbuddy mcp` usage example
  - Added environment variable documentation (`MCP_TRANSPORT`, `PORT`)

#### `apps/mcp-server/src/main.ts`

- **Exported `bootstrap` function**:
  ```typescript
  export async function bootstrap(): Promise<void>
  ```
  - Allows CLI to import and use the bootstrap function
  - Maintains backward compatibility for direct execution

- **Conditional execution**:
  ```typescript
  if (require.main === module) {
    bootstrap();
  }
  ```
  - Only runs bootstrap automatically when executed directly
  - Prevents auto-execution when imported as a module

### 3. Documentation Updates (`apps/mcp-server/README.md`)

#### Fixed Server Name References

**Before:**
```json
{
  "mcpServers": {
    "codingbuddy-rules": {
      "command": "npx",
      "args": ["codingbuddy-mcp"]
    }
  }
}
```

**After:**
```json
{
  "mcpServers": {
    "codingbuddy": {
      "command": "npx",
      "args": ["-y", "codingbuddy", "mcp"]
    }
  }
}
```

- Changed server name from `codingbuddy-rules` to `codingbuddy`
- Updated command from `codingbuddy-mcp` to `codingbuddy mcp`
- Removed confusing note about separate commands

#### Updated Paths for Monorepo Structure

- **Local Development**: `mcp-server` → `apps/mcp-server`
- **Docker Build**: `mcp-server/Dockerfile` → `apps/mcp-server/Dockerfile`
- **Docker Image**: `codingbuddy-rules-mcp` → `codingbuddy-mcp`
- **CLI Path**: `dist/src/main.js` → `dist/src/cli/cli.js` (with `mcp` argument)

#### Updated Command Table

Added new command to the commands table:
```markdown
| `codingbuddy mcp` | Start MCP server (stdio mode by default) |
```

## 🎯 Motivation

### Problems Solved

1. **Inconsistent Command Structure**: Previously, users needed to use `codingbuddy-mcp` for the MCP server, which was confusing and inconsistent with the main `codingbuddy` CLI.

2. **Documentation Outdated**: After the monorepo restructure, documentation still referenced old paths (`mcp-server` instead of `apps/mcp-server`) and old server names (`codingbuddy-rules`).

3. **Separate Binary Required**: Users had to install or reference a separate binary (`codingbuddy-mcp`) instead of using the unified CLI.

### Benefits

- ✅ **Unified CLI**: All CodingBuddy functionality accessible through single `codingbuddy` command
- ✅ **Better UX**: Consistent command structure (`codingbuddy <command>`)
- ✅ **Accurate Documentation**: All paths and commands reflect current monorepo structure
- ✅ **Simplified Installation**: No need for separate MCP server binary

## 📊 Impact

### Files Changed
- **3 files changed**
- **31 insertions(+), 14 deletions(-)**

### Breaking Changes
⚠️ **Claude Desktop Configuration**: Users need to update their Claude Desktop config:
- Server name: `codingbuddy-rules` → `codingbuddy`
- Command: `codingbuddy-mcp` → `codingbuddy mcp` (or `codingbuddy` with `args: ["mcp"]`)

### Migration Guide

For users with existing Claude Desktop configurations:

**Option 1: Using npx (Recommended)**
```json
{
  "mcpServers": {
    "codingbuddy": {
      "command": "npx",
      "args": ["-y", "codingbuddy", "mcp"]
    }
  }
}
```

**Option 2: Global Installation**
```json
{
  "mcpServers": {
    "codingbuddy": {
      "command": "codingbuddy",
      "args": ["mcp"]
    }
  }
}
```

**Option 3: Local Development**
```json
{
  "mcpServers": {
    "codingbuddy": {
      "command": "node",
      "args": ["/ABSOLUTE/PATH/TO/codingbuddy/apps/mcp-server/dist/src/cli/cli.js", "mcp"]
    }
  }
}
```

## ✅ Testing

- [x] Verified `codingbuddy mcp` command starts server in stdio mode
- [x] Verified `codingbuddy mcp` works with `MCP_TRANSPORT=sse` environment variable
- [x] Confirmed bootstrap function can be imported without auto-execution
- [x] Verified direct execution of `main.ts` still works
- [x] Tested all Claude Desktop configuration examples

## 🔍 Technical Details

### Command Flow

1. User runs `codingbuddy mcp`
2. CLI parses arguments and identifies `mcp` command
3. CLI imports `bootstrap` from `main.ts`
4. `bootstrap()` function checks `MCP_TRANSPORT` environment variable
5. Server starts in appropriate mode (stdio or SSE)

### Environment Variables

- `MCP_TRANSPORT`: Transport mode (`stdio` default, or `sse`)
- `PORT`: HTTP port for SSE mode (default: `3000`)

### Backward Compatibility

- Direct execution of `main.ts` still works (`node dist/src/main.js`)
- Existing scripts using `codingbuddy-mcp` binary will need to migrate
- All functionality remains the same, only the entry point changed

