### PR TITLE
Update docs to use codingbuddy mcp instead of codingbuddy-mcp

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -40,7 +40,7 @@ Añade a la configuración de Claude Desktop (`~/Library/Application Support/Cla
   "mcpServers": {
     "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["codingbuddy", "mcp"]
     }
   }
 }

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,7 +40,7 @@ Claude Desktop設定に追加（`~/Library/Application Support/Claude/claude_des
   "mcpServers": {
     "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["codingbuddy", "mcp"]
     }
   }
 }

--- a/README.ko.md
+++ b/README.ko.md
@@ -40,7 +40,7 @@ Claude Desktop 설정 파일에 추가 (`~/Library/Application Support/Claude/cl
   "mcpServers": {
     "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["codingbuddy", "mcp"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add to Claude Desktop config (`~/Library/Application Support/Claude/claude_deskt
   "mcpServers": {
     "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["codingbuddy", "mcp"]
     }
   }
 }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,7 +40,7 @@ npx codingbuddy init
   "mcpServers": {
     "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["codingbuddy", "mcp"]
     }
   }
 }

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -469,7 +469,7 @@ For specialist agents, use the `modes` structure:
 4. **Test**:
    ```bash
    # Verify MCP server works
-   npx @modelcontextprotocol/inspector npx codingbuddy-mcp
+   npx @modelcontextprotocol/inspector npx codingbuddy mcp
    ```
 
 ### Upgrade Checklist

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -294,7 +294,7 @@ ls -la packages/rules/.ai-rules/agents/
      "mcpServers": {
        "codingbuddy-rules": {
          "command": "npx",
-         "args": ["codingbuddy-mcp"]
+         "args": ["codingbuddy", "mcp"]
        }
      }
    }

--- a/docs/es/getting-started.md
+++ b/docs/es/getting-started.md
@@ -45,7 +45,7 @@ Añade Codingbuddy a tu asistente de IA. Aquí tienes un ejemplo para Claude Des
   "mcpServers": {
     "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["codingbuddy", "mcp"]
     }
   }
 }

--- a/docs/es/supported-tools.md
+++ b/docs/es/supported-tools.md
@@ -40,7 +40,7 @@ Claude Code se conecta a través de MCP, proporcionando acceso completo a la con
      "mcpServers": {
        "codingbuddy": {
          "command": "npx",
-         "args": ["codingbuddy-mcp"]
+         "args": ["codingbuddy", "mcp"]
        }
      }
    }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,7 +45,7 @@ Add Codingbuddy to your AI assistant. Here's an example for Claude Desktop:
   "mcpServers": {
     "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["codingbuddy", "mcp"]
     }
   }
 }

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -45,7 +45,7 @@ CodingbuddyをAIアシスタントに追加します。以下はClaude Desktop�
   "mcpServers": {
     "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["codingbuddy", "mcp"]
     }
   }
 }

--- a/docs/ja/supported-tools.md
+++ b/docs/ja/supported-tools.md
@@ -40,7 +40,7 @@ Claude CodeはMCPを通じて接続し、プロジェクト設定、ルール、
      "mcpServers": {
        "codingbuddy": {
          "command": "npx",
-         "args": ["codingbuddy-mcp"]
+         "args": ["codingbuddy", "mcp"]
        }
      }
    }

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -45,7 +45,7 @@ AI 어시스턴트에 Codingbuddy를 추가합니다. Claude Desktop 예시:
   "mcpServers": {
     "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["codingbuddy", "mcp"]
     }
   }
 }

--- a/docs/ko/supported-tools.md
+++ b/docs/ko/supported-tools.md
@@ -40,7 +40,7 @@ Claude Code는 MCP를 통해 연결되어 프로젝트 설정, 규칙, 전문가
      "mcpServers": {
        "codingbuddy": {
          "command": "npx",
-         "args": ["codingbuddy-mcp"]
+         "args": ["codingbuddy", "mcp"]
        }
      }
    }

--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -40,7 +40,7 @@ Claude Code connects via MCP, providing full access to project configuration, ru
      "mcpServers": {
        "codingbuddy": {
          "command": "npx",
-         "args": ["codingbuddy-mcp"]
+         "args": ["codingbuddy", "mcp"]
        }
      }
    }

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -45,7 +45,7 @@ npx codingbuddy init
   "mcpServers": {
     "codingbuddy": {
       "command": "npx",
-      "args": ["codingbuddy-mcp"]
+      "args": ["codingbuddy", "mcp"]
     }
   }
 }

--- a/docs/zh-CN/supported-tools.md
+++ b/docs/zh-CN/supported-tools.md
@@ -40,7 +40,7 @@ Claude Code 通过 MCP 连接，提供对项目配置、规则和专家代理的
      "mcpServers": {
        "codingbuddy": {
          "command": "npx",
-         "args": ["codingbuddy-mcp"]
+         "args": ["codingbuddy", "mcp"]
        }
      }
    }


### PR DESCRIPTION
# Update docs to use codingbuddy mcp instead of codingbuddy-mcp

## 📋 Summary

This PR updates all documentation files to reflect the new unified CLI command structure. All references to the deprecated `codingbuddy-mcp` binary are replaced with the new `codingbuddy mcp` command syntax across all languages and documentation files.

## 🔄 Changes

### Documentation Updates

All documentation files have been updated to use the new command syntax:

**Before:**
```json
{
  "mcpServers": {
    "codingbuddy": {
      "command": "npx",
      "args": ["codingbuddy-mcp"]
    }
  }
}
```

**After:**
```json
{
  "mcpServers": {
    "codingbuddy": {
      "command": "npx",
      "args": ["codingbuddy", "mcp"]
    }
  }
}
```

### Files Updated

#### README Files (5 files)
- `README.md` (English)
- `README.es.md` (Spanish)
- `README.ja.md` (Japanese)
- `README.ko.md` (Korean)
- `README.zh-CN.md` (Chinese)

#### Documentation Files (12 files)

**English:**
- `docs/getting-started.md`
- `docs/supported-tools.md`
- `docs/customization.md`
- `docs/errors.md`

**Spanish:**
- `docs/es/getting-started.md`
- `docs/es/supported-tools.md`

**Japanese:**
- `docs/ja/getting-started.md`
- `docs/ja/supported-tools.md`

**Korean:**
- `docs/ko/getting-started.md`
- `docs/ko/supported-tools.md`

**Chinese:**
- `docs/zh-CN/getting-started.md`
- `docs/zh-CN/supported-tools.md`

### Specific Changes

1. **Claude Desktop Configuration Examples**
   - Updated all configuration examples to use `["codingbuddy", "mcp"]` instead of `["codingbuddy-mcp"]`
   - Applied consistently across all language versions

2. **MCP Inspector Command** (`docs/customization.md`)
   ```bash
   # Before
   npx @modelcontextprotocol/inspector npx codingbuddy-mcp
   
   # After
   npx @modelcontextprotocol/inspector npx codingbuddy mcp
   ```

3. **Error Resolution Examples** (`docs/errors.md`)
   - Updated troubleshooting examples with correct command syntax

## 🎯 Motivation

### Context

This PR follows the migration from the separate `codingbuddy-mcp` binary to the unified `codingbuddy mcp` command structure (introduced in PRs 78779f1 and 77e30e7). The documentation needed to be updated to reflect this change and prevent user confusion.

### Problems Solved

1. **Outdated Documentation**: Documentation still referenced the deprecated `codingbuddy-mcp` binary, which could mislead users.

2. **Inconsistent Examples**: Different documentation files showed different command syntaxes, causing confusion.

3. **Multi-language Consistency**: All language versions needed to be updated to maintain consistency.

### Benefits

- ✅ **Accurate Documentation**: All examples now reflect the current command structure
- ✅ **User Clarity**: Users won't encounter errors from following outdated examples
- ✅ **Consistency**: All documentation files use the same command syntax
- ✅ **Multi-language Support**: All language versions are synchronized

## 📊 Impact

### Files Changed
- **17 files changed**
- **17 insertions(+), 17 deletions(-)**

### User Impact

⚠️ **Breaking Change for Existing Users**: Users who have existing Claude Desktop configurations using `codingbuddy-mcp` will need to update their configuration files.

### Migration Required

Users with existing configurations need to update:

**Before:**
```json
"args": ["codingbuddy-mcp"]
```

**After:**
```json
"args": ["codingbuddy", "mcp"]
```

## ✅ Verification

- [x] All README files updated consistently
- [x] All documentation files updated
- [x] All language versions synchronized
- [x] Configuration examples verified
- [x] Command syntax validated

## 🔍 Technical Details

### Command Syntax Change

The change from `codingbuddy-mcp` to `codingbuddy mcp` reflects:

1. **Unified CLI**: Single `codingbuddy` command with subcommands
2. **Better UX**: Consistent command structure (`codingbuddy <command>`)
3. **Simplified Installation**: No need for separate binary

### Documentation Coverage

This PR ensures:
- All getting started guides are updated
- All configuration examples are correct
- All troubleshooting guides reflect new syntax
- All language versions are synchronized
- All tool-specific documentation is updated

## 🔗 Related

- Follows up on PR #78779f1 (Add mcp CLI command)
- Follows up on PR #77e30e7 (Remove deprecated binary)
- Completes documentation migration to unified CLI structure

