### PR TITLE
Reload config in suggest_config_updates and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ coverage/
 
 # AI
 .mcp.json
+
+# codingbuddy.config.js
+codingbuddy.config.js

--- a/apps/mcp-server/src/mcp/mcp.service.spec.ts
+++ b/apps/mcp-server/src/mcp/mcp.service.spec.ts
@@ -116,6 +116,16 @@ const createMockConfigService = (
   getSettings: vi.fn().mockResolvedValue(config),
   getLanguage: vi.fn().mockResolvedValue(config.language),
   getFormattedContext: vi.fn().mockResolvedValue(''),
+  reload: vi.fn().mockResolvedValue({
+    settings: config,
+    ignorePatterns: ['node_modules', '.git'],
+    contextFiles: [],
+    sources: {
+      config: '/test/codingbuddy.config.js',
+      ignore: null,
+      context: null,
+    },
+  } as ProjectConfig),
 });
 
 const createMockConfigDiffService = (): Partial<ConfigDiffService> => ({
@@ -302,6 +312,9 @@ describe('McpService', () => {
       const parsedContent = JSON.parse(result.content[0].text);
       expect(parsedContent).toHaveProperty('isUpToDate');
       expect(parsedContent).toHaveProperty('suggestions');
+
+      // Verify reload is called to get fresh config
+      expect(mockConfigService.reload).toHaveBeenCalledTimes(1);
     });
 
     it('should include language setting in parse_mode response', async () => {

--- a/apps/mcp-server/src/mcp/mcp.service.ts
+++ b/apps/mcp-server/src/mcp/mcp.service.ts
@@ -351,6 +351,9 @@ export class McpService implements OnModuleInit {
       // Analyze project
       const analysis = await this.analyzerService.analyzeProject(projectRoot);
 
+      // Reload config from disk to get latest changes
+      await this.configService.reload();
+
       // Get current config
       const currentConfig = await this.configService.getSettings();
 


### PR DESCRIPTION
# Reload config in suggest_config_updates and update gitignore

## 📋 Summary

This PR fixes a bug where `suggest_config_updates` MCP tool was comparing against stale config data, and adds `codingbuddy.config.js` to `.gitignore` to prevent generated config files from being committed to the repository.

## 🐛 Problem

### Issue 1: Stale Config Data

The `suggest_config_updates` tool was comparing project analysis against cached config data, which could be outdated if the user had modified `codingbuddy.config.js` after the MCP server started.

**Scenario:**
1. User runs `npx codingbuddy init` → creates `codingbuddy.config.js`
2. User modifies `codingbuddy.config.js` manually
3. User calls `suggest_config_updates` MCP tool
4. Tool compares against old cached config, not the latest file contents

### Issue 2: Generated Config in Git

The `codingbuddy.config.js` file generated by `npx codingbuddy init` was not ignored by git, potentially causing:
- Unnecessary commits of generated files
- Merge conflicts on project-specific config
- Repository pollution with user-specific settings

## 🔄 Changes

### 1. Config Reload Before Comparison (`apps/mcp-server/src/mcp/mcp.service.ts`)

**Before:**
```typescript
private async handleSuggestConfigUpdates(args) {
  const analysis = await this.analyzerService.analyzeProject(projectRoot);
  
  // Get current config (might be stale)
  const currentConfig = await this.configService.getSettings();
  
  const result = this.configDiffService.compareConfig(analysis, currentConfig);
  return this.jsonResponse(result);
}
```

**After:**
```typescript
private async handleSuggestConfigUpdates(args) {
  const analysis = await this.analyzerService.analyzeProject(projectRoot);
  
  // Reload config from disk to get latest changes
  await this.configService.reload();
  
  // Get current config (now fresh)
  const currentConfig = await this.configService.getSettings();
  
  const result = this.configDiffService.compareConfig(analysis, currentConfig);
  return this.jsonResponse(result);
}
```

**Impact:**
- Ensures `suggest_config_updates` always compares against the latest config file
- Prevents false positives from stale cached data
- Provides accurate suggestions based on current project state

### 2. Gitignore Update (`.gitignore`)

**Added:**
```gitignore
# codingbuddy.config.js
codingbuddy.config.js
```

**Rationale:**
- `codingbuddy.config.js` is a generated file created by `npx codingbuddy init`
- Contains project-specific configuration that varies per developer/project
- Should not be committed to version control
- Similar to `.env` files or other generated config files

### 3. Test Updates (`apps/mcp-server/src/mcp/mcp.service.spec.ts`)

**Added `reload` mock:**
```typescript
const createMockConfigService = (config) => ({
  // ... existing mocks
  reload: vi.fn().mockResolvedValue({
    settings: config,
    ignorePatterns: ['node_modules', '.git'],
    contextFiles: [],
    sources: {
      config: '/test/codingbuddy.config.js',
      ignore: null,
      context: null,
    },
  } as ProjectConfig),
});
```

**Added test verification:**
```typescript
it('should call suggest_config_updates tool', async () => {
  // ... test code
  
  // Verify reload is called to get fresh config
  expect(mockConfigService.reload).toHaveBeenCalledTimes(1);
});
```

**Impact:**
- Ensures reload is properly called
- Verifies the fix works as expected
- Maintains test coverage

## 📊 Impact

### Files Changed
- **3 files changed**
- **19 insertions(+)**

### User Impact

✅ **Fixed**: `suggest_config_updates` now uses latest config file
✅ **Improved**: Generated config files won't be accidentally committed
✅ **Better UX**: More accurate config update suggestions

### Behavior Changes

**Before:**
- Config comparison used cached data (potentially stale)
- `codingbuddy.config.js` could be committed to git

**After:**
- Config is reloaded from disk before comparison (always fresh)
- `codingbuddy.config.js` is ignored by git

## ✅ Testing

### Manual Testing

- [x] Verified `suggest_config_updates` reloads config before comparison
- [x] Confirmed `codingbuddy.config.js` is ignored by git
- [x] Tested with modified config file after server start
- [x] Verified reload mock works correctly in tests

### Test Scenarios

1. **Config Reload Test**:
   ```typescript
   // Verify reload is called
   expect(mockConfigService.reload).toHaveBeenCalledTimes(1);
   ```

2. **Gitignore Test**:
   ```bash
   git status  # codingbuddy.config.js should not appear
   ```

3. **Fresh Config Test**:
   - Start MCP server
   - Modify `codingbuddy.config.js`
   - Call `suggest_config_updates`
   - Verify suggestions reflect latest changes

## 🔍 Technical Details

### Config Service Reload

The `configService.reload()` method:
- Reads `codingbuddy.config.js` from disk
- Parses and validates the config
- Updates internal cache
- Returns `ProjectConfig` with latest data

### Why Reload is Necessary

MCP servers typically run as long-lived processes:
- Config is loaded once at startup
- File changes on disk don't automatically update cache
- Manual reload ensures fresh data for comparisons

### Gitignore Best Practice

Generated config files should be ignored because:
- They're created by tooling, not manually written
- Content varies per project/developer
- Can cause merge conflicts
- Should be regenerated, not versioned

## 🔗 Related

- Follows up on PR #a8cd315 (Template-based init)
- Fixes issue with `suggest_config_updates` tool
- Improves developer experience

## 📝 Notes

### Future Considerations

- Consider auto-reload on file change (file watcher)
- Add config validation on reload
- Consider config template in git (not generated file)

### Migration

For existing repositories with `codingbuddy.config.js` committed:
```bash
# Remove from git but keep local file
git rm --cached codingbuddy.config.js
git commit -m "Remove codingbuddy.config.js from version control"
```

