### PR TITLE
localize config templates to English

### DIFF
--- a/apps/mcp-server/src/cli/init/templates/frameworks/default.template.ts
+++ b/apps/mcp-server/src/cli/init/templates/frameworks/default.template.ts
@@ -30,18 +30,18 @@ export const defaultTemplate: ConfigTemplate = {
   comments: {
     header: `// ============================================================
 // CodingBuddy Configuration
-// 프로젝트 설정 파일
+// Project Configuration File
 //
-// 이 파일은 AI 코딩 어시스턴트가 프로젝트 컨텍스트를 이해하는 데 사용됩니다.
-// 프로젝트에 맞게 값을 수정하세요.
+// This file is used by AI coding assistants to understand project context.
+// Modify the values to match your project.
 // ============================================================`,
-    language: `// 🌍 언어 설정
-  // AI 응답 언어를 지정합니다. ('ko', 'en', 'ja' 등)`,
-    projectInfo: `// 📦 프로젝트 정보
-  // projectName: 프로젝트 이름
-  // description: 프로젝트 설명`,
-    techStack: `// 🛠️ 기술 스택
-  // 프로젝트에서 사용하는 기술을 정의하세요.
+    language: `// 🌍 Language Setting
+  // Specify the language for AI responses. ('ko', 'en', 'ja', etc.)`,
+    projectInfo: `// 📦 Project Information
+  // projectName: Project name
+  // description: Project description`,
+    techStack: `// 🛠️ Tech Stack
+  // Define the technologies used in your project.
   //
   // techStack: {
   //   languages: ['TypeScript', 'Python'],
@@ -51,27 +51,27 @@ export const defaultTemplate: ConfigTemplate = {
   //   infrastructure: ['Docker', 'AWS'],
   //   tools: ['GitHub Actions', 'Sentry'],
   // }`,
-    architecture: `// 🏗️ 아키텍처
-  // 프로젝트 구조와 패턴을 정의합니다.
+    architecture: `// 🏗️ Architecture
+  // Define your project structure and patterns.
   //
   // architecture: {
   //   pattern: 'feature-based',  // 'layered', 'clean', 'modular'
   //   componentStyle: 'grouped', // 'flat', 'feature-based'
   //   structure: ['src', 'lib', 'tests'],
   // }`,
-    conventions: `// 📝 코딩 컨벤션
-  // 네이밍 규칙 및 코드 스타일을 정의합니다.`,
-    testStrategy: `// 🧪 테스트 전략
-  // approach: 'tdd' (테스트 먼저) | 'test-after' (구현 후 테스트) | 'mixed'
-  // coverage: 목표 테스트 커버리지 (%)
-  // mockingStrategy: 'minimal' (최소 모킹) | 'no-mocks' | 'extensive'`,
+    conventions: `// 📝 Coding Conventions
+  // Define naming rules and code style.`,
+    testStrategy: `// 🧪 Test Strategy
+  // approach: 'tdd' (test first) | 'test-after' (implement then test) | 'mixed'
+  // coverage: Target test coverage (%)
+  // mockingStrategy: 'minimal' | 'no-mocks' | 'extensive'`,
     footer: `// ============================================================
-  // 💡 TIP: MCP 사용 시 동기화
+  // 💡 TIP: Sync with MCP
   //
-  // codingbuddy MCP가 프로젝트를 분석하여 설정 업데이트를 제안합니다.
-  // 프로젝트가 변경되면 'suggest_config_updates' 도구로 확인하세요.
+  // codingbuddy MCP analyzes your project and suggests config updates.
+  // When your project changes, use 'suggest_config_updates' tool to check.
   //
-  // 📚 문서: https://github.com/anthropics/codingbuddy
+  // 📚 Docs: https://github.com/JeremyDev87/codingbuddy
   // ============================================================`,
   },
 };

--- a/apps/mcp-server/src/cli/init/templates/frameworks/express.template.ts
+++ b/apps/mcp-server/src/cli/init/templates/frameworks/express.template.ts
@@ -36,25 +36,25 @@ export const expressTemplate: ConfigTemplate = {
   comments: {
     header: `// ============================================================
 // CodingBuddy Configuration
-// Express 프로젝트용 설정 파일
+// Express Project Configuration File
 //
-// 이 파일은 AI 코딩 어시스턴트가 프로젝트 컨텍스트를 이해하는 데 사용됩니다.
-// 프로젝트에 맞게 값을 수정하세요.
+// This file is used by AI coding assistants to understand project context.
+// Modify the values to match your project.
 // ============================================================`,
-    language: `// 🌍 언어 설정`,
-    projectInfo: `// 📦 프로젝트 정보`,
-    techStack: `// 🛠️ 기술 스택
-  // 미들웨어 및 데이터베이스를 추가하세요.
-  // 예: backend: ['Express', 'Passport'], database: ['MongoDB']`,
-    architecture: `// 🏗️ 아키텍처
-  // Express는 routes → controllers → services → models 패턴을 권장합니다.`,
-    conventions: `// 📝 코딩 컨벤션`,
-    testStrategy: `// 🧪 테스트 전략
-  // supertest를 사용한 API 테스트를 권장합니다.`,
+    language: `// 🌍 Language Setting`,
+    projectInfo: `// 📦 Project Information`,
+    techStack: `// 🛠️ Tech Stack
+  // Add middleware and databases.
+  // Example: backend: ['Express', 'Passport'], database: ['MongoDB']`,
+    architecture: `// 🏗️ Architecture
+  // Express recommends routes → controllers → services → models pattern.`,
+    conventions: `// 📝 Coding Conventions`,
+    testStrategy: `// 🧪 Test Strategy
+  // Recommended to use supertest for API testing.`,
     footer: `// ============================================================
-  // 💡 TIP: MCP 사용 시 동기화
+  // 💡 TIP: Sync with MCP
   //
-  // codingbuddy MCP가 프로젝트를 분석하여 설정 업데이트를 제안합니다.
+  // codingbuddy MCP analyzes your project and suggests config updates.
   // ============================================================`,
   },
 };

--- a/apps/mcp-server/src/cli/init/templates/frameworks/nestjs.template.ts
+++ b/apps/mcp-server/src/cli/init/templates/frameworks/nestjs.template.ts
@@ -37,28 +37,28 @@ export const nestjsTemplate: ConfigTemplate = {
   comments: {
     header: `// ============================================================
 // CodingBuddy Configuration
-// NestJS 프로젝트용 설정 파일
+// NestJS Project Configuration File
 //
-// 이 파일은 AI 코딩 어시스턴트가 프로젝트 컨텍스트를 이해하는 데 사용됩니다.
-// 프로젝트에 맞게 값을 수정하세요.
+// This file is used by AI coding assistants to understand project context.
+// Modify the values to match your project.
 // ============================================================`,
-    language: `// 🌍 언어 설정`,
-    projectInfo: `// 📦 프로젝트 정보`,
-    techStack: `// 🛠️ 기술 스택
-  // NestJS 모듈 및 데이터베이스를 추가하세요.
-  // 예: backend: ['NestJS', 'TypeORM'], database: ['PostgreSQL']`,
-    architecture: `// 🏗️ 아키텍처
-  // NestJS는 모듈 기반 레이어드 아키텍처를 사용합니다.
-  // structure: 프로젝트 레이어 구조`,
-    conventions: `// 📝 코딩 컨벤션
-  // NestJS 공식 스타일 가이드를 따릅니다.`,
-    testStrategy: `// 🧪 테스트 전략
-  // NestJS의 @nestjs/testing 모듈을 활용합니다.
-  // e2e 테스트는 test/ 디렉토리에 위치합니다.`,
+    language: `// 🌍 Language Setting`,
+    projectInfo: `// 📦 Project Information`,
+    techStack: `// 🛠️ Tech Stack
+  // Add NestJS modules and databases.
+  // Example: backend: ['NestJS', 'TypeORM'], database: ['PostgreSQL']`,
+    architecture: `// 🏗️ Architecture
+  // NestJS uses module-based layered architecture.
+  // structure: Project layer structure`,
+    conventions: `// 📝 Coding Conventions
+  // Follows NestJS official style guide.`,
+    testStrategy: `// 🧪 Test Strategy
+  // Uses NestJS @nestjs/testing module.
+  // e2e tests are located in the test/ directory.`,
     footer: `// ============================================================
-  // 💡 TIP: MCP 사용 시 동기화
+  // 💡 TIP: Sync with MCP
   //
-  // codingbuddy MCP가 프로젝트를 분석하여 설정 업데이트를 제안합니다.
+  // codingbuddy MCP analyzes your project and suggests config updates.
   // ============================================================`,
   },
 };

--- a/apps/mcp-server/src/cli/init/templates/frameworks/nextjs.template.ts
+++ b/apps/mcp-server/src/cli/init/templates/frameworks/nextjs.template.ts
@@ -37,34 +37,34 @@ export const nextjsTemplate: ConfigTemplate = {
   comments: {
     header: `// ============================================================
 // CodingBuddy Configuration
-// Next.js 프로젝트용 설정 파일
+// Next.js Project Configuration File
 //
-// 이 파일은 AI 코딩 어시스턴트가 프로젝트 컨텍스트를 이해하는 데 사용됩니다.
-// 프로젝트에 맞게 값을 수정하세요.
+// This file is used by AI coding assistants to understand project context.
+// Modify the values to match your project.
 // ============================================================`,
-    language: `// 🌍 언어 설정
-  // AI 응답 언어를 지정합니다. ('ko', 'en', 'ja' 등)`,
-    projectInfo: `// 📦 프로젝트 정보
-  // projectName, description은 자동 감지되며 필요시 수정하세요.`,
-    techStack: `// 🛠️ 기술 스택
-  // 자동 감지된 값입니다. 추가 기술이 있으면 배열에 추가하세요.
-  // 예: backend: ['Prisma', 'tRPC'], database: ['PostgreSQL']`,
-    architecture: `// 🏗️ 아키텍처
+    language: `// 🌍 Language Setting
+  // Specify the language for AI responses. ('ko', 'en', 'ja', etc.)`,
+    projectInfo: `// 📦 Project Information
+  // projectName and description are auto-detected. Modify if needed.`,
+    techStack: `// 🛠️ Tech Stack
+  // Auto-detected values. Add additional technologies to the arrays.
+  // Example: backend: ['Prisma', 'tRPC'], database: ['PostgreSQL']`,
+    architecture: `// 🏗️ Architecture
   // pattern: 'feature-based' | 'layered' | 'clean' | 'modular'
   // componentStyle: 'flat' | 'grouped' | 'feature-based'`,
-    conventions: `// 📝 코딩 컨벤션
-  // 프로젝트의 네이밍 규칙을 정의합니다.`,
-    testStrategy: `// 🧪 테스트 전략
-  // approach: 'tdd' (테스트 먼저) | 'test-after' | 'mixed'
-  // coverage: 목표 테스트 커버리지 (%)
+    conventions: `// 📝 Coding Conventions
+  // Define naming rules for your project.`,
+    testStrategy: `// 🧪 Test Strategy
+  // approach: 'tdd' (test first) | 'test-after' | 'mixed'
+  // coverage: Target test coverage (%)
   // mockingStrategy: 'minimal' | 'no-mocks' | 'extensive'`,
     footer: `// ============================================================
-  // 💡 TIP: MCP 사용 시 동기화
+  // 💡 TIP: Sync with MCP
   //
-  // codingbuddy MCP가 프로젝트를 분석하여 설정 업데이트를 제안합니다.
-  // 새로운 의존성 추가 시 'suggest_config_updates' 도구로 확인하세요.
+  // codingbuddy MCP analyzes your project and suggests config updates.
+  // When adding new dependencies, use 'suggest_config_updates' tool to check.
   //
-  // 📚 문서: https://github.com/anthropics/codingbuddy
+  // 📚 Docs: https://github.com/JeremyDev87/codingbuddy
   // ============================================================`,
   },
 };

--- a/apps/mcp-server/src/cli/init/templates/frameworks/node.template.ts
+++ b/apps/mcp-server/src/cli/init/templates/frameworks/node.template.ts
@@ -34,24 +34,24 @@ export const nodeTemplate: ConfigTemplate = {
   comments: {
     header: `// ============================================================
 // CodingBuddy Configuration
-// Node.js 프로젝트용 설정 파일
+// Node.js Project Configuration File
 //
-// 이 파일은 AI 코딩 어시스턴트가 프로젝트 컨텍스트를 이해하는 데 사용됩니다.
-// 프로젝트에 맞게 값을 수정하세요.
+// This file is used by AI coding assistants to understand project context.
+// Modify the values to match your project.
 // ============================================================`,
-    language: `// 🌍 언어 설정`,
-    projectInfo: `// 📦 프로젝트 정보`,
-    techStack: `// 🛠️ 기술 스택
-  // 사용하는 라이브러리를 추가하세요.
-  // 예: tools: ['Commander', 'Chalk']`,
-    architecture: `// 🏗️ 아키텍처
+    language: `// 🌍 Language Setting`,
+    projectInfo: `// 📦 Project Information`,
+    techStack: `// 🛠️ Tech Stack
+  // Add libraries you use.
+  // Example: tools: ['Commander', 'Chalk']`,
+    architecture: `// 🏗️ Architecture
   // pattern: 'modular' | 'layered' | 'plugin-based'`,
-    conventions: `// 📝 코딩 컨벤션`,
-    testStrategy: `// 🧪 테스트 전략`,
+    conventions: `// 📝 Coding Conventions`,
+    testStrategy: `// 🧪 Test Strategy`,
     footer: `// ============================================================
-  // 💡 TIP: MCP 사용 시 동기화
+  // 💡 TIP: Sync with MCP
   //
-  // codingbuddy MCP가 프로젝트를 분석하여 설정 업데이트를 제안합니다.
+  // codingbuddy MCP analyzes your project and suggests config updates.
   // ============================================================`,
   },
 };

--- a/apps/mcp-server/src/cli/init/templates/frameworks/react.template.ts
+++ b/apps/mcp-server/src/cli/init/templates/frameworks/react.template.ts
@@ -37,27 +37,27 @@ export const reactTemplate: ConfigTemplate = {
   comments: {
     header: `// ============================================================
 // CodingBuddy Configuration
-// React 프로젝트용 설정 파일
+// React Project Configuration File
 //
-// 이 파일은 AI 코딩 어시스턴트가 프로젝트 컨텍스트를 이해하는 데 사용됩니다.
-// 프로젝트에 맞게 값을 수정하세요.
+// This file is used by AI coding assistants to understand project context.
+// Modify the values to match your project.
 // ============================================================`,
-    language: `// 🌍 언어 설정
-  // AI 응답 언어를 지정합니다. ('ko', 'en', 'ja' 등)`,
-    projectInfo: `// 📦 프로젝트 정보`,
-    techStack: `// 🛠️ 기술 스택
-  // 자동 감지된 값입니다. 상태관리, 스타일링 라이브러리 등을 추가하세요.
-  // 예: frontend: ['React', 'Redux', 'Tailwind CSS']`,
-    architecture: `// 🏗️ 아키텍처
+    language: `// 🌍 Language Setting
+  // Specify the language for AI responses. ('ko', 'en', 'ja', etc.)`,
+    projectInfo: `// 📦 Project Information`,
+    techStack: `// 🛠️ Tech Stack
+  // Auto-detected values. Add state management, styling libraries, etc.
+  // Example: frontend: ['React', 'Redux', 'Tailwind CSS']`,
+    architecture: `// 🏗️ Architecture
   // pattern: 'feature-based' | 'atomic' | 'layered'
   // componentStyle: 'flat' | 'grouped' | 'feature-based'`,
-    conventions: `// 📝 코딩 컨벤션`,
-    testStrategy: `// 🧪 테스트 전략
-  // React Testing Library와 함께 사용을 권장합니다.`,
+    conventions: `// 📝 Coding Conventions`,
+    testStrategy: `// 🧪 Test Strategy
+  // Recommended to use with React Testing Library.`,
     footer: `// ============================================================
-  // 💡 TIP: MCP 사용 시 동기화
+  // 💡 TIP: Sync with MCP
   //
-  // codingbuddy MCP가 프로젝트를 분석하여 설정 업데이트를 제안합니다.
+  // codingbuddy MCP analyzes your project and suggests config updates.
   // ============================================================`,
   },
 };


### PR DESCRIPTION
# fix(templates): Localize config templates to English

## 📋 Summary

This PR localizes all config template comments from Korean to English, making the generated configuration files more accessible to international users. It also updates the GitHub repository URL in template footers to reflect the correct repository location.

## 🔄 Changes

### Template Localization

All framework template comments have been translated from Korean to English:

**Affected Templates:**
- `default.template.ts`
- `nextjs.template.ts`
- `react.template.ts`
- `nestjs.template.ts`
- `express.template.ts`
- `node.template.ts`

### Comment Sections Translated

Each template includes the following comment sections, all now in English:

1. **Header**: File purpose and usage instructions
2. **Language Setting**: How to specify AI response language
3. **Project Information**: Project name and description fields
4. **Tech Stack**: How to define technologies used
5. **Architecture**: Project structure and patterns
6. **Coding Conventions**: Naming rules and code style
7. **Test Strategy**: Testing approach and coverage
8. **Footer**: MCP sync tips and documentation link

### Example Changes

#### Before (Korean):
```javascript
header: `// ============================================================
// CodingBuddy Configuration
// 프로젝트 설정 파일
//
// 이 파일은 AI 코딩 어시스턴트가 프로젝트 컨텍스트를 이해하는 데 사용됩니다.
// 프로젝트에 맞게 값을 수정하세요.
// ============================================================`,
language: `// 🌍 언어 설정
  // AI 응답 언어를 지정합니다. ('ko', 'en', 'ja' 등)`,
```

#### After (English):
```javascript
header: `// ============================================================
// CodingBuddy Configuration
// Project Configuration File
//
// This file is used by AI coding assistants to understand project context.
// Modify the values to match your project.
// ============================================================`,
language: `// 🌍 Language Setting
  // Specify the language for AI responses. ('ko', 'en', 'ja', etc.)`,
```

### Repository URL Update

**Before:**
```javascript
// 📚 문서: https://github.com/anthropics/codingbuddy
```

**After:**
```javascript
// 📚 Docs: https://github.com/JeremyDev87/codingbuddy
```

## 🎯 Motivation

### Problem

The template comments were hardcoded in Korean, which:
- Created a barrier for non-Korean speaking users
- Made the generated config files less accessible internationally
- Didn't align with the project's international audience
- Used incorrect repository URL

### Solution

By localizing templates to English:
- ✅ **Broader Accessibility**: English is the most widely understood language in tech
- ✅ **Better UX**: Users can understand comments without translation
- ✅ **Consistency**: Aligns with international open-source standards
- ✅ **Correct URLs**: Points to the actual repository

### Note on Language Support

While templates are now in English, the actual config `language` field still supports multiple languages (`'ko'`, `'en'`, `'ja'`, etc.). This change only affects the template comments, not the config language setting itself.

## 📊 Impact

### Files Changed
- **6 files changed**
- **103 insertions(+), 103 deletions(-)**

### User Impact

✅ **Improved**: Generated config files are now readable for English speakers
✅ **Fixed**: Repository URL now points to correct location
✅ **Better UX**: Clearer instructions in generated files

### Behavior Changes

**Before:**
- Template comments in Korean
- Repository URL: `anthropics/codingbuddy`

**After:**
- Template comments in English
- Repository URL: `JeremyDev87/codingbuddy`

## ✅ Testing

### Manual Testing

- [x] Verified all templates generate with English comments
- [x] Confirmed repository URL is correct
- [x] Tested template rendering for all frameworks
- [x] Verified config language field still works correctly

### Test Scenarios

1. **Template Rendering**:
   ```bash
   npx codingbuddy init
   # Check generated codingbuddy.config.js has English comments
   ```

2. **All Frameworks**:
   - Default template
   - Next.js template
   - React template
   - NestJS template
   - Express template
   - Node template

## 🔍 Technical Details

### Template Structure

Templates use a `comments` object with sections:
- `header`: File header with purpose
- `language`: Language setting explanation
- `projectInfo`: Project information fields
- `techStack`: Tech stack definition
- `architecture`: Architecture patterns
- `conventions`: Coding conventions
- `testStrategy`: Test strategy options
- `footer`: Tips and documentation links

### Language Field

The config `language` field is separate from template comments:
- Template comments: Always English (for readability)
- Config `language`: User-configurable (`'ko'`, `'en'`, `'ja'`, etc.)
- Template renderer can override comments based on `language` option (future enhancement)

### Future Enhancements

- [ ] Add multi-language template support (comments in user's preferred language)
- [ ] Template renderer could use `language` option to select comment language
- [ ] Add template comment translations for other languages

## 🔗 Related

- Follows up on PR #a8cd315 (Template-based init)
- Improves international accessibility
- Aligns with open-source best practices

## 📝 Notes

### Why English?

English was chosen as the default because:
- Most widely understood language in software development
- Standard practice for open-source projects
- Easier to maintain than multiple language versions
- Can be extended later with language-specific templates

### Config Language vs Template Language

**Important Distinction:**
- **Template Comments**: Now in English (for file readability)
- **Config Language Field**: Still supports multiple languages (`'ko'`, `'en'`, `'ja'`, etc.)
- **AI Responses**: Controlled by `config.language` field, not template comments

Users can still set their preferred language in the config:
```javascript
module.exports = {
  language: 'ko',  // AI will respond in Korean
  // ... rest of config
};
```

