### PR TITLE
migrate repository references to new owner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Be respectful and inclusive. We welcome contributors of all backgrounds and expe
 
 ```bash
 # Clone the repository
-git clone https://github.com/Codingbuddydev/codingbuddy.git
+git clone https://github.com/JeremyDev87/codingbuddy.git
 cd codingbuddy
 
 # Install dependencies
@@ -64,7 +64,7 @@ codingbuddy/
 
 ### 1. Find or Create an Issue
 
-- Check [existing issues](https://github.com/Codingbuddydev/codingbuddy/issues)
+- Check [existing issues](https://github.com/JeremyDev87/codingbuddy/issues)
 - For new features, create an issue first to discuss the approach
 - For bug fixes, you can proceed directly with a PR
 
@@ -260,7 +260,7 @@ Include:
 
 ## Questions?
 
-- Open a [GitHub Discussion](https://github.com/Codingbuddydev/codingbuddy/discussions)
+- Open a [GitHub Discussion](https://github.com/JeremyDev87/codingbuddy/discussions)
 - Check existing issues and documentation
 
 ---

--- a/README.es.md
+++ b/README.es.md
@@ -8,7 +8,7 @@
 
 # Codingbuddy
 
-[![CI](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml)
+[![CI](https://github.com/JeremyDev87/codingbuddy/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/JeremyDev87/codingbuddy/codingbuddy/actions/workflows/dev.yml)
 [![npm version](https://img.shields.io/npm/v/codingbuddy.svg)](https://www.npmjs.com/package/codingbuddy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -94,4 +94,4 @@ Todas las configuraciones de herramientas de IA referencian el mismo directorio 
 
 ## Licencia
 
-MIT © [Codingbuddy](https://github.com/Codingbuddydev)
+MIT © [Codingbuddy](https://github.com/JeremyDev87/codingbuddy)

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 
 # Codingbuddy
 
-[![CI](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml)
+[![CI](https://github.com/JeremyDev87/codingbuddy/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/JeremyDev87/codingbuddy/codingbuddy/actions/workflows/dev.yml)
 [![npm version](https://img.shields.io/npm/v/codingbuddy.svg)](https://www.npmjs.com/package/codingbuddy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -94,4 +94,4 @@ packages/rules/.ai-rules/  ← 共有ルール（単一ソース）
 
 ## ライセンス
 
-MIT © [Codingbuddy](https://github.com/Codingbuddydev)
+MIT © [Codingbuddy](https://github.com/JeremyDev87/codingbuddy)

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,7 +8,7 @@
 
 # Codingbuddy
 
-[![CI](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml)
+[![CI](https://github.com/JeremyDev87/codingbuddy/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/JeremyDev87/codingbuddy/codingbuddy/actions/workflows/dev.yml)
 [![npm version](https://img.shields.io/npm/v/codingbuddy.svg)](https://www.npmjs.com/package/codingbuddy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -94,4 +94,4 @@ packages/rules/.ai-rules/  ← 공유 규칙 (단일 소스)
 
 ## 라이선스
 
-MIT © [Codingbuddy](https://github.com/Codingbuddydev)
+MIT © [Codingbuddy](https://github.com/JeremyDev87/codingbuddy)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Codingbuddy
 
-[![CI](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml)
+[![CI](https://github.com/JeremyDev87/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/JeremyDev87/codingbuddy/actions/workflows/dev.yml)
 [![npm version](https://img.shields.io/npm/v/codingbuddy.svg)](https://www.npmjs.com/package/codingbuddy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -97,4 +97,4 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-MIT © [Codingbuddy](https://github.com/Codingbuddydev)
+MIT © [Codingbuddy](https://github.com/JeremyDev87/codingbuddy)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 # Codingbuddy
 
-[![CI](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml)
+[![CI](https://github.com/JeremyDev87/codingbuddy/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/JeremyDev87/codingbuddy/codingbuddy/actions/workflows/dev.yml)
 [![npm version](https://img.shields.io/npm/v/codingbuddy.svg)](https://www.npmjs.com/package/codingbuddy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -94,4 +94,4 @@ packages/rules/.ai-rules/  ← 共享规则（单一数据源）
 
 ## 许可证
 
-MIT © [Codingbuddy](https://github.com/Codingbuddydev)
+MIT © [Codingbuddy](https://github.com/JeremyDev87/codingbuddy)

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -1,6 +1,6 @@
 # Codingbuddy MCP Server
 
-[![CI](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/Codingbuddydev/codingbuddy/actions/workflows/dev.yml)
+[![CI](https://github.com/JeremyDev87/codingbuddy/actions/workflows/dev.yml/badge.svg)](https://github.com/JeremyDev87/codingbuddy/actions/workflows/dev.yml)
 
 A NestJS-based Model Context Protocol (MCP) server that provides AI coding assistants with project-specific context and rules.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,7 +35,7 @@ corepack enable
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/Codingbuddydev/codingbuddy.git
+git clone https://github.com/JeremyDev87/codingbuddy.git
 cd codingbuddy
 ```
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -355,7 +355,7 @@ yarn workspace codingbuddy build
 
 If you encounter an error not listed here:
 
-1. Check [GitHub Issues](https://github.com/Codingbuddydev/codingbuddy/issues)
+1. Check [GitHub Issues](https://github.com/JeremyDev87/codingbuddy/issues)
 2. Open a new issue with:
    - Error message
    - Steps to reproduce


### PR DESCRIPTION
# Migrate Repository References to New Owner

## Summary

This PR updates all GitHub repository URLs across documentation files to reflect the repository ownership change from `Codingbuddydev/codingbuddy` to `JeremyDev87/codingbuddy`.

## Changes

Updated repository references in the following files:

- **README files** (all language versions):
  - `README.md` (English)
  - `README.ko.md` (Korean)
  - `README.ja.md` (Japanese)
  - `README.zh-CN.md` (Chinese Simplified)
  - `README.es.md` (Spanish)
  
- **Documentation files**:
  - `CONTRIBUTING.md`
  - `apps/mcp-server/README.md`
  - `docs/development.md`
  - `docs/errors.md`

## Details

### Updated References

1. **CI Badge URLs**: Updated GitHub Actions workflow badge URLs
2. **Clone URLs**: Updated git clone commands in setup instructions
3. **Issue Links**: Updated links to GitHub Issues
4. **Discussion Links**: Updated links to GitHub Discussions
5. **License Links**: Updated repository links in license sections

### Files Changed

- 9 files changed
- 16 insertions(+), 16 deletions(-)

## Related Issue

Resolves #94

## Testing

- [x] Verified all URLs point to the correct repository
- [x] Checked that CI badge URLs are correctly formatted
- [x] Confirmed all documentation links are updated consistently

## Notes

This is a documentation-only change that ensures all references point to the new repository owner. No code functionality is affected.

