### PR TITLE
Add npm package metadata to mcp-server package.json

### DIFF
--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,7 +1,35 @@
 {
   "name": "codingbuddy",
   "version": "1.0.0",
-  "description": "Multi-AI Rules MCP Server",
+  "description": "Multi-AI Rules MCP Server - One source of truth for AI coding rules across all AI assistants",
+  "author": "JeremyDev87",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JeremyDev87/codingbuddy.git",
+    "directory": "apps/mcp-server"
+  },
+  "bugs": {
+    "url": "https://github.com/JeremyDev87/codingbuddy/issues"
+  },
+  "homepage": "https://github.com/JeremyDev87/codingbuddy#readme",
+  "keywords": [
+    "ai",
+    "mcp",
+    "model-context-protocol",
+    "coding-assistant",
+    "cursor",
+    "claude",
+    "claude-code",
+    "copilot",
+    "antigravity",
+    "amazon-q",
+    "kiro",
+    "coding-rules",
+    "ai-rules",
+    "developer-tools",
+    "nestjs"
+  ],
   "main": "dist/src/main.js",
   "bin": "./dist/src/cli/cli.js",
   "files": [


### PR DESCRIPTION
# Add npm Package Metadata to MCP Server package.json

## Summary

This PR adds essential npm package metadata fields to `apps/mcp-server/package.json` to ensure proper npm package distribution, discoverability, and compliance.

Closes #99

## Changes

### Modified
- **`apps/mcp-server/package.json`**: Added npm package metadata fields
  - **author**: "JeremyDev87"
  - **license**: "MIT"
  - **repository**: GitHub repository object with `directory` field for monorepo structure
  - **bugs**: GitHub Issues URL
  - **homepage**: GitHub README URL
  - **keywords**: Array of 15 relevant npm search terms
  - **description**: Enhanced with more detailed text

## Motivation

- The publishable package lacked essential npm metadata
- Missing `repository` field prevented npm from linking to source code
- Missing `bugs` field made it harder for users to report issues
- Missing `homepage` field reduced package visibility on npm
- Missing `license` field could cause npm publish warnings
- Missing `author` field affected package credibility
- Missing `keywords` field reduced searchability on npm

## Benefits

- ✅ Enables proper npm package distribution without warnings
- ✅ Improves package discoverability through keywords
- ✅ Provides clear links to repository, issues, and homepage
- ✅ Enhances package credibility with author and license information
- ✅ Supports monorepo structure with `repository.directory` field
- ✅ Follows npm best practices for package metadata

## Implementation Details

### Added Fields

| Field | Value |
|-------|-------|
| `author` | "JeremyDev87" |
| `license` | "MIT" |
| `repository` | GitHub repository with `directory: "apps/mcp-server"` |
| `bugs` | GitHub Issues URL |
| `homepage` | GitHub README URL |
| `keywords` | 15 relevant search terms (ai, mcp, coding-assistant, etc.) |
| `description` | Enhanced description text |

### Repository Field Configuration

The `repository.directory` field is crucial for monorepo packages to correctly point to the package subdirectory:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/JeremyDev87/codingbuddy.git",
  "directory": "apps/mcp-server"
}
```

### Keywords

Added 15 relevant keywords for npm searchability:
- ai, mcp, model-context-protocol
- coding-assistant, coding-rules, ai-rules
- cursor, claude, claude-code, copilot, antigravity, amazon-q, kiro
- developer-tools, nestjs

## Testing

- [x] Verified all metadata fields are correctly added
- [x] Confirmed JSON syntax is valid
- [x] Checked repository.directory points to correct subdirectory
- [x] Validated all URLs are correct and accessible
- [x] Verified keywords array contains relevant search terms
- [ ] `npm publish --dry-run` shows no metadata warnings (to be verified after merge)

## Acceptance Criteria

- [x] `author` field is added
- [x] `license` field is set to "MIT"
- [x] `repository` object includes `directory` field pointing to "apps/mcp-server"
- [x] `bugs` URL points to GitHub issues
- [x] `homepage` URL points to repository
- [x] `keywords` array contains relevant npm search terms
- [ ] `npm publish --dry-run` shows no metadata warnings (to be verified)
- [x] JSON is valid and properly formatted

## Related

- Issue: #99
- npm Documentation: [package.json metadata](https://docs.npmjs.com/cli/v10/configuring-npm/package-json)
- npm Documentation: [repository field](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository)

