### PR TITLE
Fix Timestamp Mismatch Bug in Canary Deployment

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -38,30 +38,38 @@ jobs:
       - name: Build mcp-server
         run: yarn workspace codingbuddy build
 
-      - name: Publish rules canary
-        working-directory: packages/rules
+      # Generate a single canary version to ensure both packages use the same version
+      # This fixes the timestamp mismatch bug where rules and mcp-server had different versions
+      - name: Generate canary version
         run: |
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
           COMMIT_SHA=${GITHUB_SHA::7}
           VERSION="0.0.0-canary.${TIMESTAMP}.${COMMIT_SHA}"
+          if [ -z "$VERSION" ]; then
+            echo "::error::Failed to generate canary version"
+            exit 1
+          fi
+          echo "CANARY_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Generated canary version: $VERSION"
+
+      - name: Publish rules canary
+        working-directory: packages/rules
+        run: |
+          VERSION="${{ env.CANARY_VERSION }}"
           cat <<< "$( jq --arg v "$VERSION" '.version = $v' package.json )" > package.json
           yarn npm publish --tag canary
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_SHA: ${{ github.sha }}
 
       - name: Publish mcp-server canary
         working-directory: apps/mcp-server
         run: |
-          TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          COMMIT_SHA=${GITHUB_SHA::7}
-          VERSION="0.0.0-canary.${TIMESTAMP}.${COMMIT_SHA}"
+          VERSION="${{ env.CANARY_VERSION }}"
           # Update version and replace workspace dependency with canary version
           cat <<< "$( jq --arg v "$VERSION" '.version = $v | .dependencies["codingbuddy-rules"] = $v' package.json )" > package.json
           yarn npm publish --tag canary
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_SHA: ${{ github.sha }}
 
       - name: Output canary version number
         working-directory: apps/mcp-server


### PR DESCRIPTION
# Fix Timestamp Mismatch Bug in Canary Deployment

## 📋 Summary

Fixed a bug where `codingbuddy-rules` and `codingbuddy-mcp-server` packages were published with different canary versions during CI/CD deployment, causing dependency resolution issues. The fix ensures both packages use the same timestamp-based version by generating it once and sharing via environment variable.

## 🐛 Problem

Previously, each package generated its own canary version independently:
- `rules` package: Generated version `0.0.0-canary.{TIMESTAMP1}.{SHA}`
- `mcp-server` package: Generated version `0.0.0-canary.{TIMESTAMP2}.{SHA}`

Since these steps ran sequentially with a small time gap, `TIMESTAMP1` and `TIMESTAMP2` could differ by 1-2 seconds, resulting in:
- Version mismatch between dependent packages
- Dependency resolution failures
- Inconsistent canary releases

## 🔧 Solution

### Single Version Generation
- Added a dedicated "Generate canary version" step that runs before package publishing
- Version is generated once and stored in `CANARY_VERSION` environment variable
- Both `rules` and `mcp-server` publish steps use the same `CANARY_VERSION`

### Error Handling
- Added validation to ensure version generation succeeds
- Fails fast with clear error message if version generation fails

## 🧪 Testing

### Manual Verification
1. Trigger canary deployment workflow
2. Verify both packages are published with identical version numbers
3. Confirm `mcp-server` package.json has correct `codingbuddy-rules` dependency version

### Expected Behavior
- Single version generated at start
- Both packages published with same version
- No dependency resolution errors
- Clear error message if version generation fails

## 🔗 Related Issues

Resolves #142

