### PR TITLE
change default language from Korean to English

### DIFF
--- a/.claude/rules/custom-instructions.md
+++ b/.claude/rules/custom-instructions.md
@@ -21,7 +21,7 @@ Follow the common rules defined in `packages/rules/.ai-rules/` for consistency a
 
 **Source**: `packages/rules/.ai-rules/rules/project.md`
 
-**Tech Stack**: 프로젝트의 `package.json` 참조
+**Tech Stack**: See project's `package.json`
 
 **Architecture**:
 - Layered structure: app → widgets → features → entities → shared
@@ -81,7 +81,7 @@ Failure to call `parse_mode` when these keywords are present will result in:
 
 </CODINGBUDDY_CRITICAL_RULE>
 
-예시: `PLAN 인증 기능 설계` → **즉시** parse_mode 호출 → PLAN 모드로 작업
+Example: `PLAN design auth feature` → **immediately** call parse_mode → work in PLAN mode
 
 ## 🔴 MANDATORY: Parallel Specialist Agent Execution
 
@@ -110,7 +110,7 @@ Failure to call `parse_mode` when these keywords are present will result in:
 
 ## Claude Code Specific
 
-- Always respond in **Korean (한국어)**
+- Follow project's configured language setting
 - Use structured markdown formatting
 - Provide clear, actionable feedback
 - Reference project context from `packages/rules/.ai-rules/rules/project.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,4 +90,4 @@ When working in this codebase, use these modes:
 
 ## Communication
 
-Follow the `language` setting in `codingbuddy.config.js` - use `get_project_config` MCP tool to retrieve current language setting. Default to Korean (한국어) if not specified.
+Follow the `language` setting in `codingbuddy.config.js` - use `get_project_config` MCP tool to retrieve current language setting.

--- a/apps/mcp-server/src/cli/init/init.wizard.spec.ts
+++ b/apps/mcp-server/src/cli/init/init.wizard.spec.ts
@@ -44,7 +44,7 @@ vi.mock('./prompts', () => ({
   promptArchitectureSettings: mockPromptArchitectureSettings,
   promptConventionsSettings: mockPromptConventionsSettings,
   promptTestStrategySettings: mockPromptTestStrategySettings,
-  DEFAULT_LANGUAGE: 'ko',
+  DEFAULT_LANGUAGE: 'en',
   DEFAULT_MODEL_CHOICE: 'sonnet',
   DEFAULT_PRIMARY_AGENT: 'frontend-developer',
   DEFAULT_PROJECT_NAME: 'my-project',
@@ -142,8 +142,8 @@ describe('init.wizard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Setup default mock behaviors
-    mockPromptLanguageSelection.mockResolvedValue('ko');
+    // Setup default mock behaviors - use 'en' to match DEFAULT_LANGUAGE_CODE
+    mockPromptLanguageSelection.mockResolvedValue('en');
     mockPromptModelSelection.mockResolvedValue('sonnet');
     mockPromptPrimaryAgentSelection.mockResolvedValue('frontend-developer');
     mockPromptBasicSettings.mockResolvedValue(mockBasicSettings);
@@ -160,7 +160,7 @@ describe('init.wizard', () => {
       const result = await runInitWizard({ analysis: mockAnalysis });
 
       expect(result).not.toBeNull();
-      expect(result?.basic.language).toBe('ko');
+      expect(result?.basic.language).toBe('en');
       expect(result?.basic.projectName).toBe('test-project');
     });
 

--- a/apps/mcp-server/src/cli/init/prompts/language-prompt.spec.ts
+++ b/apps/mcp-server/src/cli/init/prompts/language-prompt.spec.ts
@@ -3,8 +3,8 @@ import { getLanguageChoices, DEFAULT_LANGUAGE } from './language-prompt';
 
 describe('language-prompt', () => {
   describe('DEFAULT_LANGUAGE', () => {
-    it('should be Korean (ko)', () => {
-      expect(DEFAULT_LANGUAGE).toBe('ko');
+    it('should be English (en)', () => {
+      expect(DEFAULT_LANGUAGE).toBe('en');
     });
   });
 
@@ -15,10 +15,10 @@ describe('language-prompt', () => {
       expect(choices.length).toBeGreaterThan(0);
     });
 
-    it('should include Korean as first option', () => {
+    it('should include English as first option', () => {
       const choices = getLanguageChoices();
-      expect(choices[0].value).toBe('ko');
-      expect(choices[0].name).toContain('Korean');
+      expect(choices[0].value).toBe('en');
+      expect(choices[0].name).toBe('English');
     });
 
     it('should include English option', () => {

--- a/apps/mcp-server/src/config/config.schema.ts
+++ b/apps/mcp-server/src/config/config.schema.ts
@@ -98,7 +98,7 @@ export const CodingBuddyConfigSchema = z.object({
   // AI Configuration
   ai: AIConfigSchema.optional(),
 
-  // AUTO 모드 설정
+  // AUTO mode settings
   auto: AutoConfigSchema.optional(),
 
   // Additional Context

--- a/apps/mcp-server/src/keyword/auto-executor.types.ts
+++ b/apps/mcp-server/src/keyword/auto-executor.types.ts
@@ -3,24 +3,24 @@ import type { ParseModeResult, AutoConfig } from './keyword.types';
 // Re-export AutoConfig for convenience
 export type { AutoConfig };
 
-/** AUTO 모드 실행 옵션 */
+/** AUTO mode execution options */
 export interface AutoExecutorOptions {
-  /** 최대 반복 횟수 */
+  /** Maximum iteration count */
   maxIterations: number;
-  /** 사용자 프롬프트 */
+  /** User prompt */
   prompt: string;
 }
 
-/** 이슈 심각도 */
+/** Issue severity */
 export type IssueSeverity = 'critical' | 'high' | 'medium' | 'low';
 
-/** EVAL 결과에서 추출한 이슈 정보 */
+/** Issue info extracted from EVAL result */
 export interface EvalIssue {
   severity: IssueSeverity;
   description: string;
 }
 
-/** EVAL 결과 요약 */
+/** EVAL result summary */
 export interface EvalSummary {
   criticalCount: number;
   highCount: number;
@@ -29,7 +29,7 @@ export interface EvalSummary {
   issues: EvalIssue[];
 }
 
-/** 단일 이터레이션 결과 */
+/** Single iteration result */
 export interface IterationResult {
   iteration: number;
   planResult: ParseModeResult;
@@ -39,7 +39,7 @@ export interface IterationResult {
   approach: string;
 }
 
-/** AUTO 모드 최종 결과 */
+/** AUTO mode final result */
 export interface AutoResult {
   success: boolean;
   iterations: number;
@@ -51,7 +51,7 @@ export interface AutoResult {
   fallbackPlanResult?: ParseModeResult;
 }
 
-/** AUTO 모드 상태 */
+/** AUTO mode phase */
 export type AutoPhase =
   | 'starting'
   | 'plan'
@@ -60,7 +60,7 @@ export type AutoPhase =
   | 'completed'
   | 'failed';
 
-/** AUTO 모드 진행 상황 콜백 */
+/** AUTO mode progress callback */
 export interface AutoProgressCallback {
   onPhaseStart: (
     phase: AutoPhase,
@@ -72,7 +72,7 @@ export interface AutoProgressCallback {
   onComplete: (result: AutoResult) => void;
 }
 
-/** 기본 AUTO 설정 */
+/** Default AUTO configuration */
 export const DEFAULT_AUTO_CONFIG: AutoConfig = {
   maxIterations: 3,
 };

--- a/apps/mcp-server/src/keyword/auto-formatter.spec.ts
+++ b/apps/mcp-server/src/keyword/auto-formatter.spec.ts
@@ -169,7 +169,7 @@ describe('AutoFormatter', () => {
 
       const output = AutoFormatter.formatEvalSummary(summary);
 
-      expect(output).toContain('반복 필요');
+      expect(output).toContain('iteration needed');
     });
   });
 });

--- a/apps/mcp-server/src/keyword/auto-formatter.ts
+++ b/apps/mcp-server/src/keyword/auto-formatter.ts
@@ -34,7 +34,7 @@ Max Iterations: ${maxIterations}
     return `
 Issues Found:
 - Critical: ${summary.criticalCount}
-- High: ${summary.highCount}${needsIteration ? ' <- 반복 필요' : ''}
+- High: ${summary.highCount}${needsIteration ? ' <- iteration needed' : ''}
 - Medium: ${summary.mediumCount}
 - Low: ${summary.lowCount}`;
   }
@@ -77,12 +77,12 @@ ${files}`;
 ---
 # Mode: AUTO - MAX ITERATIONS REACHED
 
-${result.maxIterations}회 시도했지만 일부 이슈가 남아있습니다.
+Tried ${result.maxIterations} iterations but some issues remain.
 
 Remaining Issues:
 ${remainingIssues}
 
-시도한 접근:
+Attempted approaches:
 ${attempts}
 
 ---

--- a/apps/mcp-server/src/keyword/keyword.types.spec.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidLanguageCode,
+  SUPPORTED_LANGUAGE_CODES,
+  SUPPORTED_LANGUAGES,
+  DEFAULT_LANGUAGE_CODE,
+  type SupportedLanguageCode,
+} from './keyword.types';
+
+describe('keyword.types', () => {
+  describe('isValidLanguageCode', () => {
+    describe('valid language codes', () => {
+      it.each(['en', 'ko', 'ja', 'zh', 'es'] as const)(
+        'returns true for valid code: %s',
+        code => {
+          expect(isValidLanguageCode(code)).toBe(true);
+        },
+      );
+
+      it('returns true for all SUPPORTED_LANGUAGE_CODES', () => {
+        for (const code of SUPPORTED_LANGUAGE_CODES) {
+          expect(isValidLanguageCode(code)).toBe(true);
+        }
+      });
+
+      it('narrows type to SupportedLanguageCode when true', () => {
+        const input: string = 'en';
+        if (isValidLanguageCode(input)) {
+          // TypeScript should narrow input to SupportedLanguageCode
+          const code: SupportedLanguageCode = input;
+          expect(code).toBe('en');
+        }
+      });
+    });
+
+    describe('invalid language codes', () => {
+      it.each(['fr', 'de', 'pt', 'ru', 'it'])(
+        'returns false for unsupported code: %s',
+        code => {
+          expect(isValidLanguageCode(code)).toBe(false);
+        },
+      );
+
+      it('returns false for empty string', () => {
+        expect(isValidLanguageCode('')).toBe(false);
+      });
+
+      it('returns false for random string', () => {
+        expect(isValidLanguageCode('invalid')).toBe(false);
+      });
+
+      it('returns false for uppercase valid code', () => {
+        expect(isValidLanguageCode('EN')).toBe(false);
+      });
+
+      it('returns false for code with whitespace', () => {
+        expect(isValidLanguageCode(' en')).toBe(false);
+        expect(isValidLanguageCode('en ')).toBe(false);
+      });
+    });
+  });
+
+  describe('SUPPORTED_LANGUAGE_CODES', () => {
+    it('contains exactly 5 language codes', () => {
+      expect(SUPPORTED_LANGUAGE_CODES).toHaveLength(5);
+    });
+
+    it('has English as first entry', () => {
+      expect(SUPPORTED_LANGUAGE_CODES[0]).toBe('en');
+    });
+
+    it('matches keys of SUPPORTED_LANGUAGES', () => {
+      const expectedCodes = Object.keys(SUPPORTED_LANGUAGES);
+      expect(SUPPORTED_LANGUAGE_CODES).toEqual(expectedCodes);
+    });
+  });
+
+  describe('DEFAULT_LANGUAGE_CODE', () => {
+    it('is English (en)', () => {
+      expect(DEFAULT_LANGUAGE_CODE).toBe('en');
+    });
+
+    it('is a valid supported language code', () => {
+      expect(isValidLanguageCode(DEFAULT_LANGUAGE_CODE)).toBe(true);
+    });
+
+    it('matches first entry in SUPPORTED_LANGUAGE_CODES', () => {
+      expect(DEFAULT_LANGUAGE_CODE).toBe(SUPPORTED_LANGUAGE_CODES[0]);
+    });
+  });
+});

--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -158,15 +158,15 @@ export interface LanguageDisplayInfo {
  * Language codes follow ISO 639-1 standard.
  */
 export const SUPPORTED_LANGUAGES: Record<string, LanguageDisplayInfo> = {
-  ko: {
-    name: 'Korean',
-    nativeName: '한국어',
-    description: 'AI responses will be in Korean',
-  },
   en: {
     name: 'English',
     nativeName: 'English',
     description: 'AI responses will be in English',
+  },
+  ko: {
+    name: 'Korean',
+    nativeName: '한국어',
+    description: 'AI responses will be in Korean',
   },
   ja: {
     name: 'Japanese',
@@ -186,12 +186,49 @@ export const SUPPORTED_LANGUAGES: Record<string, LanguageDisplayInfo> = {
 } as const;
 
 /** Default language code */
-export const DEFAULT_LANGUAGE_CODE = 'ko' as const;
+export const DEFAULT_LANGUAGE_CODE = 'en' as const;
 
-/** List of supported language codes */
-export const SUPPORTED_LANGUAGE_CODES = Object.keys(
+/**
+ * Type-safe language code type derived from SUPPORTED_LANGUAGES keys.
+ * Use this type for function parameters and return types.
+ */
+export type SupportedLanguageCode = keyof typeof SUPPORTED_LANGUAGES;
+
+/**
+ * List of supported language codes.
+ *
+ * Note: Object.keys() returns string[] at runtime, but we use a type assertion
+ * here because SUPPORTED_LANGUAGES is defined with `as const` and its shape
+ * is guaranteed at compile time. The order matches SUPPORTED_LANGUAGES definition.
+ */
+export const SUPPORTED_LANGUAGE_CODES: SupportedLanguageCode[] = Object.keys(
   SUPPORTED_LANGUAGES,
-) as (keyof typeof SUPPORTED_LANGUAGES)[];
+) as SupportedLanguageCode[];
+
+/**
+ * Type guard to check if a string is a valid supported language code.
+ *
+ * @param code - The string to check
+ * @returns True if the code is a valid SupportedLanguageCode
+ *
+ * @example
+ * ```typescript
+ * const userInput = getUserLanguagePreference(); // string
+ *
+ * if (isValidLanguageCode(userInput)) {
+ *   // TypeScript narrows userInput to SupportedLanguageCode
+ *   const langInfo = SUPPORTED_LANGUAGES[userInput];
+ *   console.log(`Selected: ${langInfo.nativeName}`);
+ * } else {
+ *   console.log(`Invalid language code: ${userInput}`);
+ * }
+ * ```
+ */
+export const isValidLanguageCode = (
+  code: string,
+): code is SupportedLanguageCode => {
+  return code in SUPPORTED_LANGUAGES;
+};
 
 /** @deprecated Use LOCALIZED_KEYWORD_MAP instead */
 export const KOREAN_KEYWORD_MAP = LOCALIZED_KEYWORD_MAP;
@@ -262,6 +299,18 @@ export interface AutoConfig {
   maxIterations: number;
 }
 
+/**
+ * Result of parsing a workflow mode from user prompt.
+ *
+ * **Naming Convention Note:**
+ * This interface uses mixed naming conventions intentionally:
+ * - snake_case properties (delegates_to, primary_agent_source, etc.) are used for
+ *   MCP protocol compatibility and external API responses consumed by AI tools.
+ * - camelCase properties (originalPrompt, parallelAgentsRecommendation, etc.) are
+ *   used for internal TypeScript usage and newer additions.
+ *
+ * Do not rename snake_case properties as they are part of the external API contract.
+ */
 export interface ParseModeResult {
   mode: Mode;
   originalPrompt: string;
@@ -269,16 +318,18 @@ export interface ParseModeResult {
   rules: RuleContent[];
   warnings?: string[];
   agent?: string;
+  /** @apiProperty External API - do not rename */
   delegates_to?: string;
+  /** @apiProperty External API - do not rename */
   delegate_agent_info?: AgentInfo;
-  /** Source of Primary Agent selection */
+  /** @apiProperty External API - do not rename. Source of Primary Agent selection */
   primary_agent_source?: PrimaryAgentSource;
   parallelAgentsRecommendation?: ParallelAgentRecommendation;
-  /** ACT mode agent recommendation (only in PLAN mode response) */
+  /** @apiProperty External API - do not rename. ACT mode agent recommendation (only in PLAN mode response) */
   recommended_act_agent?: ActAgentRecommendation;
-  /** Available ACT agents for selection (only in PLAN mode response) */
+  /** @apiProperty External API - do not rename. Available ACT agents for selection (only in PLAN mode response) */
   available_act_agents?: string[];
-  /** Activation message for user visibility */
+  /** @apiProperty External API - do not rename. Activation message for user visibility */
   activation_message?: ActivationMessage;
   /** AUTO mode configuration (only in AUTO mode response) */
   autoConfig?: AutoConfig;

--- a/packages/rules/.ai-rules/adapters/antigravity.md
+++ b/packages/rules/.ai-rules/adapters/antigravity.md
@@ -50,7 +50,7 @@ See full workflow details in `.ai-rules/rules/core.md`
 
 #### Tech Stack
 
-프로젝트의 `package.json`을 참조하세요.
+See project `package.json`.
 
 #### Project Structure
 ```
@@ -126,7 +126,7 @@ Antigravity uses artifact files for:
 
 ### Communication
 
-- **Always respond in Korean (한국어)** as specified in common rules
+- **Follow project's configured language setting**
 - Use structured markdown formatting
 - Provide clear, actionable feedback
 
@@ -161,7 +161,7 @@ When working with Antigravity, it automatically has access to:
 ### Workflow Example
 
 ```
-User: 새로운 뉴스레터 기능 만들어줘
+User: Build a new newsletter feature
 
 AI: # Mode: PLAN
     ## 📋 Plan Overview
@@ -206,7 +206,7 @@ Use the `AUTO` keyword (or localized versions) at the start of your message:
 ### Example Usage
 
 ```
-User: AUTO 새로운 결제 시스템 기능 만들어줘
+User: AUTO Build a new payment system feature
 
 AI: # Mode: AUTO (Iteration 1/3)
     ## Phase: PLAN

--- a/packages/rules/.ai-rules/adapters/claude-code.md
+++ b/packages/rules/.ai-rules/adapters/claude-code.md
@@ -27,7 +27,7 @@ See `.ai-rules/rules/core.md` for:
 
 ### Project Context
 See `.ai-rules/rules/project.md` for:
-- Tech stack (프로젝트의 package.json 참조)
+- Tech stack (see project package.json)
 - Project structure (app → widgets → features → entities → shared)
 - Development rules and file naming conventions
 - Domain knowledge
@@ -44,7 +44,7 @@ See `.ai-rules/agents/README.md` for available specialist agents and their exper
 
 ## Claude Code Specific
 
-- Always respond in Korean (한국어)
+- Follow project's configured language setting
 - Use structured markdown formatting
 - Provide clear, actionable feedback
 - Reference project context from `.ai-rules/rules/project.md`
@@ -85,7 +85,7 @@ See `.ai-rules/agents/README.md` for available specialist agents and their exper
 ### In Claude Chat
 
 ```
-User: 새로운 기능 만들어줘
+User: Build a new feature
 
 Claude: # Mode: PLAN
         [Following .ai-rules/rules/core.md workflow]
@@ -198,7 +198,7 @@ Specialist agents can be invoked by any Primary Agent as needed:
 
 1. **PLAN mode**: Always uses `solution-architect` or `technical-planner` based on prompt analysis
 2. **ACT mode**: Resolution priority:
-   1. Explicit agent request in prompt (e.g., "backend-developer로 작업해")
+   1. Explicit agent request in prompt (e.g., "work with backend-developer")
    2. `recommended_agent` parameter (from PLAN mode recommendation)
    3. Tooling pattern matching (config files, build tools → `tooling-engineer`)
    4. Project configuration (`primaryAgent` setting)
@@ -321,22 +321,22 @@ The `parse_mode` MCP tool returns this field to recommend parallel specialist ex
 ### Parallel Execution Workflow
 
 ```
-parse_mode 호출
+Call parse_mode
      ↓
-parallelAgentsRecommendation 확인
-     ↓ (있으면)
-사용자에게 시작 메시지 표시
+Check parallelAgentsRecommendation
+     ↓ (if exists)
+Display start message to user
      ↓
-prepare_parallel_agents MCP 호출
+Call prepare_parallel_agents MCP
      ↓
-반환된 각 agent.taskPrompt를 Task tool로 병렬 호출:
+Call each agent.taskPrompt via Task tool in parallel:
   - subagent_type: "general-purpose"
   - run_in_background: true
   - prompt: agent.taskPrompt
      ↓
-TaskOutput으로 결과 수집
+Collect results with TaskOutput
      ↓
-사용자에게 결과 종합하여 표시
+Display consolidated results to user
 ```
 
 ### Code Example

--- a/packages/rules/.ai-rules/adapters/kiro.md
+++ b/packages/rules/.ai-rules/adapters/kiro.md
@@ -29,7 +29,7 @@ See `.ai-rules/rules/core.md` for:
 ### Project Context
 
 See `.ai-rules/rules/project.md` for:
-- **Tech Stack**: 프로젝트의 package.json 참조
+- **Tech Stack**: See project package.json
 - **Architecture**: Layered structure (app → widgets → features → entities → shared)
 - **Conventions**: File naming, import/export rules, pure/impure function separation
 
@@ -56,7 +56,7 @@ See `.ai-rules/agents/` for domain expertise:
 [Add Kiro-specific customizations here]
 
 ### Communication
-- Always respond in Korean (한국어)
+- Follow project's configured language setting
 - Use clear, structured markdown formatting
 - Provide actionable, specific feedback
 ```
@@ -85,7 +85,7 @@ See `.ai-rules/agents/` for domain expertise:
 ### In Kiro Session
 
 ```
-User: 새로운 컴포넌트 구현해줘
+User: Build a new component
 
 Kiro: # Mode: PLAN
       [Follows .ai-rules/rules/core.md workflow]

--- a/packages/rules/.ai-rules/adapters/opencode-skills.md
+++ b/packages/rules/.ai-rules/adapters/opencode-skills.md
@@ -50,24 +50,24 @@ OpenCode/Crush supports Agent Skills standard for structured AI capabilities. Th
 ### 1. Direct Skill Invocation
 ```bash
 # In OpenCode CLI
-/skill brainstorming "새로운 기능 아이디어"
-/skill tdd "사용자 인증 구현"
-/skill debug "로그인 버그 해결"
+/skill brainstorming "new feature ideas"
+/skill tdd "user authentication implementation"
+/skill debug "fix login bug"
 ```
 
 ### 2. Agent + Skill Combination
 ```bash
 # Planning with brainstorming skill
 /agent plan
-/skill brainstorming "대시보드 UI 개선"
+/skill brainstorming "improve dashboard UI"
 
-# Implementation with TDD skill  
+# Implementation with TDD skill
 /agent build
-/skill tdd "API 연동 구현"
+/skill tdd "implement API integration"
 
 # Review with debugging skill
 /agent reviewer
-/skill debug "성능 이슈 분석"
+/skill debug "analyze performance issues"
 ```
 
 ### 3. Automatic Skill Recommendation
@@ -76,9 +76,9 @@ OpenCode can automatically recommend skills based on prompts using the `recommen
 
 ```typescript
 // Auto-triggered when user enters certain keywords
-"버그가 있어" → recommends: systematic-debugging
-"계획을 세워줘" → recommends: writing-plans  
-"UI를 만들어줘" → recommends: frontend-design
+"there's a bug" → recommends: systematic-debugging
+"create a plan" → recommends: writing-plans
+"build the UI" → recommends: frontend-design
 ```
 
 ## Skill Conversion Process
@@ -201,20 +201,20 @@ The MCP server handles Korean→English skill name mapping automatically.
 /agent plan
 
 # Use brainstorming skill
-/skill brainstorming "사용자 대시보드 개선"
+/skill brainstorming "improve user dashboard"
 
 # Generate implementation plan
-계획을 세워줘
+Create a plan for me
 ```
 
 ### Implementing with TDD
 
-```bash  
+```bash
 # Switch to build agent
 /agent build
 
 # Load TDD skill
-/skill test-driven-development "로그인 API 구현"
+/skill test-driven-development "implement login API"
 
 # Start TDD cycle
 ACT
@@ -224,10 +224,10 @@ ACT
 
 ```bash
 # Use systematic debugging
-/skill systematic-debugging "로그인 후 화면이 안 나와"
+/skill systematic-debugging "screen not showing after login"
 
 # Apply debugging methodology
-디버깅해줘
+Debug this for me
 ```
 
 ## Benefits

--- a/packages/rules/.ai-rules/adapters/opencode.md
+++ b/packages/rules/.ai-rules/adapters/opencode.md
@@ -220,16 +220,16 @@ The `parse_mode` tool now returns additional Mode Agent information and dynamic 
 ```json
 {
   "mode": "PLAN",
-  "originalPrompt": "새로운 사용자 등록 기능을 만들어줘",
-  "instructions": "설계 우선 접근. TDD 관점에서...",
+  "originalPrompt": "Build a new user registration feature",
+  "instructions": "Design-first approach. From TDD perspective...",
   "rules": [...],
-  "language": "ko",
-  "languageInstruction": "Always respond in Korean (한국어).",
+  "language": "en",
+  "languageInstruction": "Always respond in English.",
   "agent": "plan-mode",
-  "delegates_to": "frontend-developer", 
+  "delegates_to": "frontend-developer",
   "delegate_agent_info": {
     "name": "Frontend Developer",
-    "description": "React/Next.js 전문가, TDD 및 디자인 시스템 경험",
+    "description": "React/Next.js expert, TDD and design system experience",
     "expertise": ["React", "Next.js", "TDD", "TypeScript"]
   }
 }
@@ -255,11 +255,11 @@ The `parse_mode` tool now returns additional Mode Agent information and dynamic 
 /agent plan-mode
 
 # Then in chat
-새로운 사용자 등록 기능을 만들어줘
+Build a new user registration feature
 ```
 
 **Plan-mode agent will:**
-- Analyze requirements (Korean response)
+- Analyze requirements
 - Create structured implementation plan
 - Generate todo list using todo_write tool
 - Reference .ai-rules for consistent standards
@@ -477,7 +477,7 @@ npx codingbuddy@latest mcp
 ```bash
 # Terminal 1: Planning
 opencode --agent plan-mode
-계획을 세워줘
+Create a plan for me
 
 # Terminal 2: Implementation  
 opencode --agent act-mode
@@ -514,10 +514,10 @@ EVAL
 ```bash
 # 1. Start planning
 /agent plan-mode
-React 컴포넌트 라이브러리를 만들어줘
+Build a React component library
 
 # 2. Implement
-/agent act-mode  
+/agent act-mode
 ACT
 
 # 3. Review
@@ -526,7 +526,7 @@ EVAL
 
 # 4. Optimize
 /agent performance
-성능 최적화 제안해줘
+Suggest performance optimizations
 ```
 
 ### Full-Stack Development
@@ -534,15 +534,15 @@ EVAL
 ```bash
 # Frontend work
 /agent plan-mode
-사용자 대시보드 UI 계획
+Plan user dashboard UI
 
-# Backend work  
+# Backend work
 /agent backend
-API 엔드포인트 구현
+Implement API endpoint
 
 # Security review
 /agent security
-보안 취약점 검사
+Check security vulnerabilities
 ```
 
 ## AUTO Mode
@@ -566,7 +566,7 @@ Use the `AUTO` keyword (or localized versions) at the start of your message:
 ```bash
 # Start AUTO mode
 /agent plan-mode
-AUTO 새로운 사용자 인증 기능을 만들어줘
+AUTO Build a new user authentication feature
 ```
 
 ### Workflow

--- a/packages/rules/.ai-rules/adapters/q.md
+++ b/packages/rules/.ai-rules/adapters/q.md
@@ -29,7 +29,7 @@ Refer to `.ai-rules/rules/core.md` for:
 ### Project Setup
 
 Refer to `.ai-rules/rules/project.md` for:
-- **Tech Stack**: 프로젝트의 package.json 참조
+- **Tech Stack**: See project package.json
 - **Architecture**: Layered structure (app → widgets → features → entities → shared)
 - **Development Rules**: File naming, import/export conventions
 
@@ -56,8 +56,8 @@ Refer to `.ai-rules/agents/*.json` for domain-specific knowledge:
 - Apply Q's cost optimization suggestions
 
 ### Language Support
-- Respond in Korean (한국어) as per project standard
-- Use technical Korean terminology
+- Follow project's configured language setting
+- Use appropriate technical terminology
 ```
 
 ## Directory Structure
@@ -84,7 +84,7 @@ Refer to `.ai-rules/agents/*.json` for domain-specific knowledge:
 ### In Amazon Q Chat
 
 ```
-You: 새로운 API 엔드포인트 만들어줘
+You: Build a new API endpoint
 
 Q: [Follows .ai-rules/rules/core.md workflow]
    [Applies .ai-rules/rules/augmented-coding.md TDD]

--- a/packages/rules/.ai-rules/agents/accessibility-specialist.json
+++ b/packages/rules/.ai-rules/agents/accessibility-specialist.json
@@ -494,7 +494,7 @@
     }
   },
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding accessibility context (planning/implementation/evaluation)",
       "Plan/verify WCAG 2.1 AA compliance",

--- a/packages/rules/.ai-rules/agents/act-mode.json
+++ b/packages/rules/.ai-rules/agents/act-mode.json
@@ -1,6 +1,6 @@
 {
   "name": "Act Mode Agent",
-  "description": "ACT 모드 전용 에이전트 - 실제 구현 실행에 특화",
+  "description": "ACT mode agent - specialized for actual implementation execution",
 
   "model": {
     "preferred": "claude-sonnet-4-20250514",
@@ -12,23 +12,23 @@
     "mode": "ACT",
     "purpose": "Mode Agent - delegates to Primary Developer Agent",
     "expertise": [
-      "TDD 사이클 실행 (Red → Green → Refactor)",
-      "코드 품질 기준 준수",
-      "타입 안전성 보장",
-      "테스트 커버리지 90%+ 달성",
-      "실시간 품질 검증"
+      "TDD cycle execution (Red → Green → Refactor)",
+      "Code quality standards compliance",
+      "Type safety assurance",
+      "Achieve 90%+ test coverage",
+      "Real-time quality verification"
     ],
     "delegates_to": "frontend-developer",
     "responsibilities": [
-      "PLAN 모드에서 정의된 계획 실행",
-      "TDD 사이클 엄격히 준수 (Red → Green → Refactor)",
-      "코어 로직: Test-First, UI 컴포넌트: Test-After 접근",
-      "타입 안전성 유지 (TypeScript strict mode, no any)",
-      "테스트 커버리지 90%+ 목표 달성",
-      "SOLID 원칙 및 코드 품질 기준 유지",
-      "프레임워크별 컴포넌트 패턴 준수",
-      "디자인 시스템 우선 사용",
-      "접근성 및 성능 최적화 적용"
+      "Execute plans defined in PLAN mode",
+      "Strictly follow TDD cycle (Red → Green → Refactor)",
+      "Core logic: Test-First, UI components: Test-After approach",
+      "Maintain type safety (TypeScript strict mode, no any)",
+      "Achieve 90%+ test coverage goal",
+      "Maintain SOLID principles and code quality standards",
+      "Follow framework-specific component patterns",
+      "Prioritize design system usage",
+      "Apply accessibility and performance optimizations"
     ]
   },
 
@@ -94,8 +94,8 @@
 
   "delegate_agent": {
     "primary": "frontend-developer",
-    "description": "이 Mode Agent는 Frontend Developer Agent의 implementation 워크플로우를 활용합니다",
-    "integration": "Frontend Developer Agent의 TDD cycle과 code quality checklist를 적용"
+    "description": "This Mode Agent utilizes the Frontend Developer Agent's implementation workflow",
+    "integration": "Applies Frontend Developer Agent's TDD cycle and code quality checklist"
   },
 
   "tdd_cycle": {
@@ -135,29 +135,29 @@
   },
 
   "communication": {
-    "language": "ko",
-    "style": "실행 중심의 단계별 진행 보고",
-    "format": "구현 진행상황과 품질 검증 결과를 명확히 표시"
+    "language": "en",
+    "style": "Execution-focused step-by-step progress reporting",
+    "format": "Clearly display implementation progress and quality verification results"
   },
 
   "verification_guide": {
     "mode_compliance": [
-      "✅ '# Mode: ACT' 표시 확인",
-      "✅ '## Agent : Frontend Developer' (또는 적절한 delegate) 표시 확인",
-      "✅ Korean 응답 확인",
-      "✅ TDD 사이클 준수 (Red → Green → Refactor) 확인",
-      "✅ 타입 안전성 (no any) 확인",
-      "✅ 테스트 커버리지 90%+ 확인",
-      "✅ Todo 항목 completed로 업데이트 확인",
-      "✅ ACT 완료 후 PLAN 모드로 자동 복귀 확인",
-      "✅ Delegate Agent의 implementation 워크플로우 적용 확인"
+      "✅ Verify '# Mode: ACT' is displayed",
+      "✅ Verify '## Agent : Frontend Developer' (or appropriate delegate) is displayed",
+      "✅ Verify response in configured language",
+      "✅ Verify TDD cycle compliance (Red → Green → Refactor)",
+      "✅ Verify type safety (no any)",
+      "✅ Verify 90%+ test coverage",
+      "✅ Verify todo items updated to completed",
+      "✅ Verify automatic return to PLAN mode after ACT completes",
+      "✅ Verify Delegate Agent's implementation workflow is applied"
     ],
     "implementation_verification": [
-      "✅ 실제 구현 완료 (파일 생성/수정)",
-      "✅ 테스트 작성 및 통과",
-      "✅ 타입 정의 완료",
-      "✅ 린팅 에러 해결",
-      "✅ 디자인 시스템 컴포넌트 활용"
+      "✅ Actual implementation completed (files created/modified)",
+      "✅ Tests written and passing",
+      "✅ Type definitions completed",
+      "✅ Linting errors resolved",
+      "✅ Design system components utilized"
     ]
   }
 }

--- a/packages/rules/.ai-rules/agents/agent-architect.json
+++ b/packages/rules/.ai-rules/agents/agent-architect.json
@@ -182,8 +182,8 @@
   ],
 
   "communication": {
-    "language": "ko",
-    "style": "체계적이고 명확한 접근, 스키마 중심 설계",
+    "language": "en",
+    "style": "Systematic and clear approach, schema-driven design",
     "approach": [
       "Start by understanding agent requirements",
       "Reference existing agents for patterns",

--- a/packages/rules/.ai-rules/agents/architecture-specialist.json
+++ b/packages/rules/.ai-rules/agents/architecture-specialist.json
@@ -481,7 +481,7 @@
     }
   },
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding architecture context (planning/implementation/evaluation)",
       "Plan/verify layer placement for all files",

--- a/packages/rules/.ai-rules/agents/backend-developer.json
+++ b/packages/rules/.ai-rules/agents/backend-developer.json
@@ -388,7 +388,7 @@
   },
 
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding current code state",
       "Read code files before making changes",

--- a/packages/rules/.ai-rules/agents/code-quality-specialist.json
+++ b/packages/rules/.ai-rules/agents/code-quality-specialist.json
@@ -690,7 +690,7 @@
     }
   },
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding code quality context (planning/implementation/evaluation)",
       "Plan/verify SOLID principles application",

--- a/packages/rules/.ai-rules/agents/data-engineer.json
+++ b/packages/rules/.ai-rules/agents/data-engineer.json
@@ -321,7 +321,7 @@
   },
 
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding current schema state",
       "Read existing migrations and models",

--- a/packages/rules/.ai-rules/agents/devops-engineer.json
+++ b/packages/rules/.ai-rules/agents/devops-engineer.json
@@ -31,7 +31,7 @@
   "infrastructure": {
     "containerization": {
       "docker": {
-        "base_image": "node:lts-alpine (프로젝트 버전에 맞춤)",
+        "base_image": "node:lts-alpine (match project version)",
         "build_strategy": "Multi-stage (builder + runner)",
         "current_setup": {
           "builder_stage": "Build and compile Next.js application",
@@ -52,8 +52,8 @@
         ]
       },
       "nodejs": {
-        "version": "프로젝트 package.json의 engines 참조",
-        "package_manager": "프로젝트 설정에 맞춤",
+        "version": "Reference project package.json engines",
+        "package_manager": "Match project configuration",
         "memory": {
           "heap_size": "4GB (--max-old-space-size=4096)",
           "reason": "Prevents out-of-memory during Next.js builds",
@@ -69,7 +69,7 @@
 
     "monitoring": {
       "datadog": {
-        "service_name": "프로젝트 설정에 맞춤",
+        "service_name": "Match project configuration",
         "components": {
           "apm": {
             "description": "Application Performance Monitoring for backend tracing",
@@ -109,7 +109,7 @@
           }
         },
         "environment_variables": {
-          "DD_SERVICE": "프로젝트명 - Service name identifier",
+          "DD_SERVICE": "Project name - Service name identifier",
           "DD_VERSION": "APP_VERSION - Deployment version tracking",
           "DD_APM_ENABLED": "true - Enable APM tracing",
           "DD_LOGS_INJECTION": "true - Inject trace info in logs",
@@ -257,7 +257,7 @@
   ],
 
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Analyze current infrastructure state first",
       "Explain optimization opportunities clearly",

--- a/packages/rules/.ai-rules/agents/documentation-specialist.json
+++ b/packages/rules/.ai-rules/agents/documentation-specialist.json
@@ -523,7 +523,7 @@
     }
   },
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding documentation context (planning/implementation/evaluation)",
       "Plan/review code comments for complex logic",

--- a/packages/rules/.ai-rules/agents/eval-mode.json
+++ b/packages/rules/.ai-rules/agents/eval-mode.json
@@ -1,6 +1,6 @@
 {
   "name": "Eval Mode Agent",
-  "description": "EVAL 모드 전용 에이전트 - 코드 품질 평가 및 개선안 제시에 특화",
+  "description": "EVAL mode agent - specialized for code quality evaluation and improvement suggestions",
 
   "model": {
     "preferred": "claude-opus-4-20250514",
@@ -12,22 +12,22 @@
     "mode": "EVAL",
     "purpose": "Mode Agent - delegates to Code Reviewer Agent",
     "expertise": [
-      "다차원 코드 품질 평가",
-      "증거 기반 분석 (웹 검색 검증)",
-      "리스크 평가 및 우선순위 설정",
-      "개선안 제시",
-      "프로덕션 준비도 검토"
+      "Multi-dimensional code quality evaluation",
+      "Evidence-based analysis (web search verification)",
+      "Risk assessment and prioritization",
+      "Improvement proposal",
+      "Production readiness review"
     ],
     "delegates_to": "code-reviewer",
     "responsibilities": [
-      "ACT 모드에서 구현된 코드의 종합적 품질 평가",
-      "코드 품질, 아키텍처, 성능, 보안, 접근성 등 다차원 분석",
-      "웹 검색을 통한 증거 기반 권장사항 제시",
-      "Critical/High/Medium/Low 우선순위로 리스크 분류",
-      "구체적이고 실행 가능한 개선 계획 제시",
-      "Todo 리스트 생성 (todo_write 도구 활용)",
-      "프로덕션 배포 차단 요소 식별",
-      "Anti-Sycophancy 원칙 적용 (객관적 평가, 문제점 우선 식별)"
+      "Comprehensive quality evaluation of code implemented in ACT mode",
+      "Multi-dimensional analysis: code quality, architecture, performance, security, accessibility",
+      "Provide evidence-based recommendations through web search",
+      "Classify risks by Critical/High/Medium/Low priority",
+      "Present specific and actionable improvement plans",
+      "Create todo list (using todo_write tool)",
+      "Identify production deployment blockers",
+      "Apply Anti-Sycophancy principles (objective evaluation, problem-first identification)"
     ]
   },
 
@@ -99,8 +99,8 @@
 
   "delegate_agent": {
     "primary": "code-reviewer",
-    "description": "이 Mode Agent는 Code Reviewer Agent의 evaluation 워크플로우를 활용합니다",
-    "integration": "Code Reviewer Agent의 multi-dimensional evaluation과 anti-sycophancy framework를 적용"
+    "description": "This Mode Agent utilizes the Code Reviewer Agent's evaluation workflow",
+    "integration": "Applies Code Reviewer Agent's multi-dimensional evaluation and anti-sycophancy framework"
   },
 
   "evaluation_structure": {
@@ -152,29 +152,29 @@
   },
 
   "communication": {
-    "language": "ko",
-    "style": "객관적이고 증거 기반의 분석적 평가",
-    "format": "구조화된 평가 보고서 형태, 개선점 우선 제시"
+    "language": "en",
+    "style": "Objective and evidence-based analytical evaluation",
+    "format": "Structured evaluation report format, improvements presented first"
   },
 
   "verification_guide": {
     "mode_compliance": [
-      "✅ '# Mode: EVAL' 표시 확인",
-      "✅ '## Agent : Code Reviewer' 표시 확인",
-      "✅ Korean 응답 확인",
-      "✅ Code Reviewer Agent의 evaluation 워크플로우 적용 확인",
-      "✅ Anti-Sycophancy 원칙 적용 확인 (금지 표현 미사용)",
-      "✅ 최소 3개 개선 영역 식별 확인",
-      "✅ 웹 검색 증거 포함 확인",
-      "✅ todo_write 도구로 개선 todo 리스트 생성 확인"
+      "✅ Verify '# Mode: EVAL' is displayed",
+      "✅ Verify '## Agent : Code Reviewer' is displayed",
+      "✅ Verify response in configured language",
+      "✅ Verify Code Reviewer Agent's evaluation workflow is applied",
+      "✅ Verify Anti-Sycophancy principles applied (no prohibited phrases used)",
+      "✅ Verify at least 3 improvement areas identified",
+      "✅ Verify web search evidence included",
+      "✅ Verify improvement todo list created with todo_write tool"
     ],
     "evaluation_quality": [
-      "✅ Critical Findings 테이블 (객관적 메트릭 포함)",
-      "✅ Devil's Advocate Analysis (실패 시나리오, 잘못된 가정)",
-      "✅ Impact Radius Analysis (의존성, 계약 변경, 부작용)",
-      "✅ Objective Assessment 테이블 (측정값 vs 목표)",
-      "✅ 우선순위별 개선 기회 (Critical/High/Medium/Low)",
-      "✅ 증거 기반 권장사항 (웹 검색 링크/참조)"
+      "✅ Critical Findings table (with objective metrics)",
+      "✅ Devil's Advocate Analysis (failure scenarios, wrong assumptions)",
+      "✅ Impact Radius Analysis (dependencies, contract changes, side effects)",
+      "✅ Objective Assessment table (measured vs target)",
+      "✅ Improvement opportunities by priority (Critical/High/Medium/Low)",
+      "✅ Evidence-based recommendations (web search links/references)"
     ]
   }
 }

--- a/packages/rules/.ai-rules/agents/frontend-developer.json
+++ b/packages/rules/.ai-rules/agents/frontend-developer.json
@@ -359,7 +359,7 @@
   },
 
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding current code state",
       "Read code files before making changes",

--- a/packages/rules/.ai-rules/agents/i18n-specialist.json
+++ b/packages/rules/.ai-rules/agents/i18n-specialist.json
@@ -368,7 +368,7 @@
     }
   },
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding i18n context (planning/implementation/evaluation)",
       "Plan/verify i18n library configuration",

--- a/packages/rules/.ai-rules/agents/mobile-developer.json
+++ b/packages/rules/.ai-rules/agents/mobile-developer.json
@@ -297,7 +297,7 @@
   },
 
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding target platforms",
       "Read existing project structure and patterns",

--- a/packages/rules/.ai-rules/agents/performance-specialist.json
+++ b/packages/rules/.ai-rules/agents/performance-specialist.json
@@ -509,7 +509,7 @@
     }
   },
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding performance context (planning/implementation/evaluation)",
       "Plan/analyze bundle size and rendering",

--- a/packages/rules/.ai-rules/agents/plan-mode.json
+++ b/packages/rules/.ai-rules/agents/plan-mode.json
@@ -1,6 +1,6 @@
 {
   "name": "Plan Mode Agent",
-  "description": "PLAN 모드 전용 에이전트 - 작업 계획 수립 및 설계에 특화",
+  "description": "PLAN mode agent - specialized for work planning and design",
 
   "model": {
     "preferred": "claude-opus-4-20250514",
@@ -12,21 +12,21 @@
     "mode": "PLAN",
     "purpose": "Mode Agent - delegates to Primary Developer Agent",
     "expertise": [
-      "작업 계획 수립",
-      "TDD 관점 설계",
-      "아키텍처 검토",
-      "Todo 리스트 생성",
-      "요구사항 분석"
+      "Work planning",
+      "TDD-oriented design",
+      "Architecture review",
+      "Todo list creation",
+      "Requirements analysis"
     ],
     "delegates_to": "frontend-developer",
     "responsibilities": [
-      "사용자 요구사항 분석 및 명확화",
-      "TDD 관점에서 테스트 케이스 우선 정의",
-      "구현 전 아키텍처 및 설계 검토",
-      "체계적인 구현 계획 수립",
-      "Todo 리스트 작성 (todo_write 도구 활용)",
-      "품질 기준 및 테스트 전략 계획",
-      "파일 구조 및 네이밍 컨벤션 계획"
+      "Analyze and clarify user requirements",
+      "Prioritize test case definition from TDD perspective",
+      "Review architecture and design before implementation",
+      "Establish systematic implementation plans",
+      "Create todo list (using todo_write tool)",
+      "Plan quality standards and test strategy",
+      "Plan file structure and naming conventions"
     ]
   },
 
@@ -84,25 +84,25 @@
 
   "delegate_agent": {
     "primary": "frontend-developer",
-    "description": "이 Mode Agent는 Frontend Developer Agent의 planning 워크플로우를 활용합니다",
-    "integration": "Frontend Developer Agent의 planning 섹션과 mandatory checklist를 적용"
+    "description": "This Mode Agent utilizes the Frontend Developer Agent's planning workflow",
+    "integration": "Applies Frontend Developer Agent's planning section and mandatory checklist"
   },
 
   "communication": {
-    "language": "ko",
-    "style": "계획 수립에 집중한 체계적 접근",
-    "format": "구조화된 markdown 형태로 명확한 섹션 구분"
+    "language": "en",
+    "style": "Systematic approach focused on planning",
+    "format": "Clear section separation in structured markdown format"
   },
 
   "verification_guide": {
     "mode_compliance": [
-      "✅ '# Mode: PLAN' 표시 확인",
-      "✅ '## Agent : Frontend Developer' (또는 적절한 delegate) 표시 확인",
-      "✅ Korean 응답 확인",
-      "✅ todo_write 도구로 todo 리스트 생성 확인",
-      "✅ 모든 todo 항목이 pending 상태로 생성됨 확인",
-      "✅ Delegate Agent의 planning 워크플로우 적용 확인",
-      "✅ 구조화된 계획 (Plan Overview, Implementation Steps, Quality Checklist 등) 확인"
+      "✅ Verify '# Mode: PLAN' is displayed",
+      "✅ Verify '## Agent : Frontend Developer' (or appropriate delegate) is displayed",
+      "✅ Verify response in configured language",
+      "✅ Verify todo list created with todo_write tool",
+      "✅ Verify all todo items created in pending status",
+      "✅ Verify Delegate Agent's planning workflow is applied",
+      "✅ Verify structured plan (Plan Overview, Implementation Steps, Quality Checklist, etc.)"
     ]
   }
 }

--- a/packages/rules/.ai-rules/agents/security-specialist.json
+++ b/packages/rules/.ai-rules/agents/security-specialist.json
@@ -446,7 +446,7 @@
     }
   },
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding security context (planning/implementation/evaluation)",
       "Plan/verify authentication implementation",

--- a/packages/rules/.ai-rules/agents/seo-specialist.json
+++ b/packages/rules/.ai-rules/agents/seo-specialist.json
@@ -407,7 +407,7 @@
     }
   },
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding SEO context (planning/implementation/evaluation)",
       "Plan/review metadata implementation",

--- a/packages/rules/.ai-rules/agents/solution-architect.json
+++ b/packages/rules/.ai-rules/agents/solution-architect.json
@@ -162,8 +162,8 @@
   },
 
   "communication": {
-    "language": "ko",
-    "style": "체계적이고 명확한 접근, 옵션 중심 설계",
+    "language": "en",
+    "style": "Systematic and clear approach, option-oriented design",
     "approach": [
       "Start with brainstorming skill",
       "Ask one question at a time",

--- a/packages/rules/.ai-rules/agents/technical-planner.json
+++ b/packages/rules/.ai-rules/agents/technical-planner.json
@@ -198,8 +198,8 @@
   },
 
   "communication": {
-    "language": "ko",
-    "style": "상세하고 실행 가능한 계획, TDD 중심",
+    "language": "en",
+    "style": "Detailed and actionable plans, TDD-focused",
     "approach": [
       "Start with writing-plans skill",
       "Provide complete code (no placeholders)",

--- a/packages/rules/.ai-rules/agents/test-strategy-specialist.json
+++ b/packages/rules/.ai-rules/agents/test-strategy-specialist.json
@@ -523,7 +523,7 @@
     }
   },
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding test context (planning/implementation/evaluation)",
       "Plan/verify TDD vs Test-After approach",

--- a/packages/rules/.ai-rules/agents/tooling-engineer.json
+++ b/packages/rules/.ai-rules/agents/tooling-engineer.json
@@ -178,7 +178,7 @@
   ],
 
   "communication": {
-    "language": "ko",
+    "language": "en",
     "style": "Technical and precise, focusing on configuration details",
     "approach": [
       "Start by understanding the current configuration state",

--- a/packages/rules/.ai-rules/agents/ui-ux-designer.json
+++ b/packages/rules/.ai-rules/agents/ui-ux-designer.json
@@ -493,7 +493,7 @@
   },
 
   "communication": {
-    "language": "Always respond in Korean (한국어)",
+    "language": "en",
     "approach": [
       "Start by understanding user goals and context",
       "Apply universal design principles (not system-specific)",


### PR DESCRIPTION
# Change default language from Korean to English

## 📋 Summary

This PR changes the project's default language from Korean (ko) to English (en) and updates language settings consistently across all agents, documentation, and codebase. This establishes English as the standard language while maintaining support for multiple languages through project configuration.

## 🎯 Motivation

- **Internationalization**: Make the project more accessible to international developers
- **Consistency**: Establish a single default language across all components
- **Flexibility**: Maintain multi-language support through project configuration
- **Documentation Clarity**: Use English as the standard for technical documentation
- **Type Safety**: Improve language code validation and type safety

## 🔧 Key Changes

### 1. Default Language Configuration

- Changed `DEFAULT_LANGUAGE_CODE` from `'ko'` to `'en'` in `keyword.types.ts`
- Updated `SUPPORTED_LANGUAGES` object to prioritize English as the first entry
- Updated all default language references in CLI initialization and test files

### 2. Agent Language Settings

- Updated all 33 agent JSON files to use `"language": "en"` instead of Korean-specific settings
- Changed language field from `"Always respond in Korean (한국어)"` to `"en"` for consistency
- Updated mode agents (PLAN, ACT, EVAL) to use English as default
- Updated all specialist agents (accessibility, architecture, backend, etc.) to English

### 3. Documentation Updates

- Replaced hardcoded Korean response instructions with project-configured language references
- Updated all adapter documentation (Claude Code, OpenCode, Kiro, Antigravity, Amazon Q) to reference project language setting
- Changed example prompts from Korean to English in documentation
- Updated workflow examples to use English prompts

### 4. Type Safety Improvements

- Added `SupportedLanguageCode` type derived from `SUPPORTED_LANGUAGES` keys
- Created `isValidLanguageCode()` type guard function for runtime validation
- Improved type annotations for `SUPPORTED_LANGUAGE_CODES` array
- Added comprehensive test coverage for language code validation

### 5. Code Comments and Messages

- Translated AUTO mode related comments from Korean to English
- Updated error messages and user-facing strings in AUTO formatter
- Changed test expectations to match English default language

### 6. Test Updates

- Updated all test files to expect `'en'` as default language
- Modified language prompt tests to verify English as first option
- Updated wizard tests to use English as default mock value

## ⚠️ Breaking Changes

**None** - This is a configuration change that affects default behavior but maintains backward compatibility. Projects can still configure their preferred language in `codingbuddy.config.js`.

## 📌 Migration Guide

### For Existing Projects

If you have an existing project configured with Korean language:

1. **No action required** - Your project configuration in `codingbuddy.config.js` will continue to work
2. **To use English**: Update your config:
   ```js
   // codingbuddy.config.js
   {
     basic: {
       language: 'en'  // Change from 'ko' to 'en' if desired
     }
   }
   ```

### For New Projects

- New projects initialized with `codingbuddy init` will default to English
- Users can still select their preferred language during initialization
- All language options remain available (en, ko, ja, zh, es)

## ✅ Testing

- ✅ All existing tests updated to reflect English default
- ✅ Language code validation tests added (`keyword.types.spec.ts`)
- ✅ Type guard function tested for valid and invalid language codes
- ✅ Default language constant verified in tests
- ✅ CLI initialization wizard tests updated

## 🔍 Impact Analysis

### Affected Components

1. **Agent System**: All 33 agents now default to English
2. **CLI Tools**: Initialization wizard defaults to English
3. **Documentation**: All examples and instructions use English
4. **Type System**: Improved type safety for language codes
5. **MCP Protocol**: Language field in responses defaults to English

### User Experience

- **New Users**: Will see English as the default language
- **Existing Users**: Can continue using their configured language
- **Documentation**: All examples are now in English for consistency
- **Error Messages**: AUTO mode messages now in English

## 📚 Related Changes

- Language selection remains available during `codingbuddy init`
- Project configuration file (`codingbuddy.config.js`) still supports all languages
- MCP `parse_mode` tool respects project language configuration
- All language codes (en, ko, ja, zh, es) remain supported

