### PR TITLE
prevent NestJS logging from breaking MCP protocol in stdio mode

### DIFF
--- a/apps/mcp-server/src/mcp/mcp.service.ts
+++ b/apps/mcp-server/src/mcp/mcp.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnModuleInit, Logger, Inject } from '@nestjs/common';
+import { Injectable, OnModuleInit, Inject } from '@nestjs/common';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -20,7 +20,6 @@ import { TOOL_HANDLERS } from './handlers';
 @Injectable()
 export class McpService implements OnModuleInit {
   private server: Server;
-  private readonly logger = new Logger(McpService.name);
 
   constructor(
     private rulesService: RulesService,
@@ -51,7 +50,7 @@ export class McpService implements OnModuleInit {
   async startStdio() {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
-    this.logger.log('MCP Server connected via Stdio');
+    // Note: Do not log here - stdout is reserved for MCP JSON-RPC messages
   }
 
   getServer() {


### PR DESCRIPTION
# Fix: Prevent NestJS logging from breaking MCP protocol in stdio mode

## 📋 Summary

This PR fixes a critical issue where NestJS Logger outputs ANSI color codes to stdout, breaking MCP JSON-RPC protocol communication in stdio mode. The fix disables NestJS logging in stdio mode while maintaining full logging functionality in SSE mode, and provides an optional debug logging mechanism via stderr for troubleshooting.

## 🐛 Problem

When MCP clients (such as Claude Desktop) connect to the codingbuddy MCP server, the connection fails with the following error:

```
Unexpected token '\x1B', "\x1B[32m[Nest"... is not valid JSON
```

### Root Cause

- **MCP Protocol Requirement**: MCP uses stdio (stdin/stdout) for communication, and stdout must contain only JSON-RPC messages
- **NestJS Logger Behavior**: NestJS Logger outputs ANSI color codes (`\x1B[32m`) along with log messages to stdout
- **Protocol Violation**: MCP clients attempt to parse these colored log messages as JSON, causing connection failures

### Impact

- **Connection Failures**: MCP clients cannot establish connections to the server
- **Protocol Non-Compliance**: Server violates MCP protocol specification
- **User Experience**: Users cannot use the MCP server with standard MCP clients

## 🔧 Solution

### 1. Disable NestJS Logger in Stdio Mode

**Implementation:**
- Add `logger: false` option to `NestFactory.createApplicationContext()` in stdio mode
- Prevents NestJS from outputting any log messages to stdout
- Ensures stdout contains only JSON-RPC messages

**Code Change:**
```typescript
// Before
const app = await NestFactory.createApplicationContext(AppModule);

// After
const app = await NestFactory.createApplicationContext(AppModule, {
  logger: false,  // Disable logger in stdio mode
});
```

### 2. Remove Logger Calls in Stdio Mode

**Implementation:**
- Remove all `logger.log()` calls in stdio mode execution path
- Remove Logger instance from `McpService` class
- Add comments explaining why logging is disabled

**Benefits:**
- No ANSI color codes in stdout
- Clean JSON-RPC protocol compliance
- No interference with MCP client parsing

### 3. Dynamic Logger Import for SSE Mode

**Implementation:**
- Use dynamic import for Logger only in SSE mode
- Maintains full logging functionality in SSE mode (HTTP-based, no protocol conflict)
- Reduces bundle size for stdio mode

**Code Change:**
```typescript
// Before
import { Logger } from '@nestjs/common';
const logger = new Logger('Bootstrap');

// After (SSE mode only)
const { Logger } = await import('@nestjs/common');
const logger = new Logger('Bootstrap');
```

### 4. Optional Debug Logging via stderr

**Implementation:**
- Add `debugLog()` function that outputs to stderr (not stdout)
- Controlled by `MCP_DEBUG=1` environment variable
- Provides debugging capability without breaking protocol

**Usage:**
```bash
MCP_DEBUG=1 npx codingbuddy@latest mcp
```

**Benefits:**
- Debugging capability when needed
- Does not interfere with MCP protocol (stderr is separate from stdout)
- Opt-in mechanism (disabled by default)

## 🔧 Key Changes

### 1. Bootstrap Function (`main.ts`)

- **Removed**: Top-level Logger import
- **Added**: Dynamic Logger import (SSE mode only)
- **Added**: `debugLog()` function for optional stderr logging
- **Modified**: Disable logger in stdio mode with `logger: false`
- **Removed**: Logger calls in stdio mode execution path

### 2. McpService (`mcp.service.ts`)

- **Removed**: Logger import and instance
- **Removed**: Logger calls in `startStdio()` method
- **Added**: Comment explaining why logging is disabled

### 3. Debug Logging

- **New Function**: `debugLog()` for stderr-based debugging
- **Environment Variable**: `MCP_DEBUG=1` to enable debug output
- **Output Target**: stderr (does not interfere with stdout JSON-RPC)

## ⚠️ Breaking Changes

**None** - All changes are backward compatible. Existing functionality remains unchanged.

## 📌 Impact Analysis

### Before Fix

| Mode | Logger Behavior | MCP Protocol | Status |
|------|----------------|--------------|--------|
| Stdio | ANSI codes to stdout | ❌ Broken | Connection fails |
| SSE | Normal logging | ✅ Works | No impact |

### After Fix

| Mode | Logger Behavior | MCP Protocol | Status |
|------|----------------|--------------|--------|
| Stdio | Disabled (stderr debug available) | ✅ Compliant | Connection succeeds |
| SSE | Full logging (HTTP-based) | ✅ Works | No change |

### User Experience

- **Before**: MCP clients cannot connect, connection errors
- **After**: MCP clients connect successfully, protocol compliant
- **Debugging**: Optional stderr logging available when needed

## 🔍 Implementation Details

### Stdio Mode Protocol Compliance

**MCP Protocol Requirements:**
- stdout: Only JSON-RPC messages
- stdin: JSON-RPC requests from client
- stderr: Can be used for logging/debugging (optional)

**Our Implementation:**
- stdout: Pure JSON-RPC messages only
- stderr: Optional debug output (via `MCP_DEBUG=1`)
- No ANSI color codes in stdout
- No log messages in stdout

### SSE Mode (No Changes)

**SSE Mode Characteristics:**
- Uses HTTP/SSE for communication
- Logging goes to HTTP response or console (not stdio)
- No protocol conflict with logging
- Full NestJS logging functionality maintained

### Debug Logging Strategy

**When to Use:**
- Troubleshooting connection issues
- Development and testing
- Debugging server startup

**How to Use:**
```bash
# Enable debug logging
MCP_DEBUG=1 npx codingbuddy@latest mcp

# Normal operation (no debug output)
npx codingbuddy@latest mcp
```

**Output Format:**
```
[codingbuddy] Starting in stdio mode...
[codingbuddy] MCP Server connected via stdio
```

## ✅ Testing

### Protocol Compliance

- ✅ stdout contains only JSON-RPC messages
- ✅ No ANSI color codes in stdout
- ✅ No log messages in stdout
- ✅ MCP clients can parse all stdout output as JSON

### Functionality

- ✅ SSE mode logging works normally
- ✅ Stdio mode connects successfully
- ✅ Debug logging works when enabled
- ✅ Debug logging disabled by default

### Compatibility

- ✅ Backward compatible with existing code
- ✅ No breaking changes
- ✅ SSE mode unaffected

## 📚 Documentation Updates

- Added comments explaining why logging is disabled in stdio mode
- Documented `debugLog()` function usage
- Added note about MCP protocol requirements
- Explained stderr vs stdout separation

## 🔗 Related

- Resolves #174
- Fixes MCP protocol compliance issue
- Enables successful connections with MCP clients
- Maintains debugging capability via stderr
