### PR TITLE
Fix parse_mode to Reload Config for Correct Language Settings

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
@@ -30,6 +30,7 @@ describe('ModeHandler', () => {
 
     mockConfigService = {
       getLanguage: vi.fn().mockResolvedValue('ko'),
+      reload: vi.fn().mockResolvedValue({}),
     } as unknown as ConfigService;
 
     mockLanguageService = {
@@ -126,6 +127,24 @@ describe('ModeHandler', () => {
           'ACT implement feature',
           undefined,
         );
+      });
+
+      it('should reload config before getting language to ensure fresh settings', async () => {
+        await handler.handle('parse_mode', {
+          prompt: 'PLAN test',
+        });
+
+        // Verify reload is called
+        expect(mockConfigService.reload).toHaveBeenCalled();
+
+        // Verify reload is called before getLanguage
+        const reloadCallOrder =
+          (mockConfigService.reload as ReturnType<typeof vi.fn>).mock
+            .invocationCallOrder[0] ?? 0;
+        const getLanguageCallOrder =
+          (mockConfigService.getLanguage as ReturnType<typeof vi.fn>).mock
+            .invocationCallOrder[0] ?? 0;
+        expect(reloadCallOrder).toBeLessThan(getLanguageCallOrder);
       });
 
       it('should include language and languageInstruction in response', async () => {

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.ts
@@ -69,6 +69,10 @@ export class ModeHandler extends AbstractHandler {
       extractRequiredString(args, 'recommended_agent') ?? undefined;
 
     try {
+      // Always reload config to ensure fresh language settings
+      // This prevents stale config from MCP server startup location issues
+      await this.configService.reload();
+
       const options = recommendedAgent
         ? { recommendedActAgent: recommendedAgent }
         : undefined;

--- a/docs/tickets/auto-mode-keyword-recognition-pr.md
+++ b/docs/tickets/auto-mode-keyword-recognition-pr.md
@@ -1,0 +1,95 @@
+# PR: Add AUTO Mode Documentation Across All AI Tool Configurations
+
+## Summary
+
+This PR fixes the AUTO mode keyword recognition issue by updating all AI tool configuration files to include AUTO as a recognized workflow mode keyword, along with its localized variants.
+
+## Problem
+
+Users attempting to use AUTO mode (`AUTO: <task>`) found that AI tools did not recognize the keyword and failed to trigger the autonomous workflow cycle. The root cause was that AUTO was missing from the keyword detection rules in all AI tool configuration files.
+
+## Solution
+
+### 1. Updated AI Tool Configuration Files (7 files)
+
+Added AUTO mode to keyword detection in all tool-specific configuration files:
+
+| File | Changes |
+|------|---------|
+| `.antigravity/rules/instructions.md` | Added AUTO to workflow modes and keyword detection |
+| `.claude/rules/custom-instructions.md` | Added AUTO to mandatory keyword list with localized variants |
+| `.codex/rules/system-prompt.md` | Added AUTO to mode documentation |
+| `.cursor/rules/auto-agent.mdc` | Added AUTO and localized variants (자동, 自動, 自动, AUTOMÁTICO) |
+| `.cursor/rules/imports.mdc` | Added AUTO to workflow and required actions |
+| `.kiro/rules/guidelines.md` | Added AUTO to keyword detection |
+| `.q/rules/customizations.md` | Added AUTO to keyword detection |
+
+### 2. Added Test Coverage
+
+Added 3 new test cases to `apps/mcp-server/src/keyword/rule-filter.spec.ts`:
+
+```typescript
+it('should return full content for AUTO mode (no filtering)')
+it('should not add filtered view note for AUTO mode')
+it('should preserve full content length for AUTO mode')
+```
+
+Also updated the sample test data (`SAMPLE_CORE_MD`) to include an Auto Mode section.
+
+### 3. Added Code Documentation
+
+Added comprehensive JSDoc comments to `apps/mcp-server/src/keyword/rule-filter.ts` explaining the AUTO mode design decision:
+
+- Why AUTO mode uses `null` markers (no filtering)
+- Rationale: AUTO mode cycles through all phases and needs access to all mode documentation
+
+### 4. Updated Adapter Documentation
+
+Updated `packages/rules/.ai-rules/adapters/antigravity.md` with AUTO mode section including:
+- Triggering AUTO mode
+- Localized keyword variants
+- Example usage
+- Workflow explanation
+
+## Files Changed
+
+```
+ .antigravity/rules/instructions.md                 |  9 +++--
+ .claude/rules/custom-instructions.md               | 13 +++++--
+ .codex/rules/system-prompt.md                      |  7 +++-
+ .cursor/rules/auto-agent.mdc                       |  2 +-
+ .cursor/rules/imports.mdc                          |  3 +-
+ .kiro/rules/guidelines.md                          |  5 ++-
+ .q/rules/customizations.md                         |  5 ++-
+ apps/mcp-server/src/keyword/rule-filter.spec.ts    | 45 +++++++++++++++++++++-
+ apps/mcp-server/src/keyword/rule-filter.ts         | 16 +++++++-
+ docs/plans/2025-12-17-codex-adapter-configuration.md |  4 +-
+ packages/rules/.ai-rules/adapters/antigravity.md   |  8 ++--
+ 11 files changed, 94 insertions(+), 23 deletions(-)
+```
+
+## Testing
+
+### Automated Tests
+- ✅ All 15 rule-filter tests passing
+- ✅ 3 new AUTO mode tests added and passing
+
+### Manual Verification
+- Verified AUTO keyword in all configuration files
+- Verified localized variants included where applicable
+- Verified documentation consistency across adapters
+
+## Checklist
+
+- [x] All AI tool configs updated with AUTO keyword
+- [x] Localized variants included (자동, 自動, 自动, AUTOMÁTICO)
+- [x] Test coverage added for AUTO mode filtering
+- [x] Code documentation added explaining design decisions
+- [x] Adapter documentation updated
+- [x] All tests passing
+
+## Related
+
+- Fixes: AUTO mode keyword not recognized
+- Related to: Keyword Invocation feature
+- Affects: All AI tool integrations (Claude Code, Cursor, Antigravity, Codex, Q, Kiro)

--- a/docs/tickets/auto-mode-keyword-recognition.md
+++ b/docs/tickets/auto-mode-keyword-recognition.md
@@ -1,0 +1,63 @@
+# AUTO Mode Keyword Not Recognized Across AI Tools
+
+## Problem Statement
+
+When users attempt to use AUTO mode with the keyword `AUTO:` (e.g., `AUTO: Build a new payment feature`), the AI tools fail to recognize it as a valid workflow mode keyword.
+
+## Expected Behavior
+
+- User types `AUTO: <task description>`
+- AI tool recognizes `AUTO` as a workflow mode keyword
+- `parse_mode` MCP tool is called automatically
+- AI enters AUTO mode and cycles through PLAN → ACT → EVAL phases autonomously
+
+## Actual Behavior
+
+- User types `AUTO: <task description>`
+- AI tool does NOT recognize `AUTO` as a keyword
+- `parse_mode` MCP tool is NOT called
+- AI treats the message as a regular prompt, ignoring the AUTO mode intent
+
+## Root Cause Analysis
+
+The AUTO keyword was missing from the mandatory keyword detection lists in AI tool configuration files. While the MCP server's `parse_mode` tool correctly supports AUTO mode, the AI tool configurations only listed `PLAN`, `ACT`, and `EVAL` as recognized keywords.
+
+### Affected Files
+
+| AI Tool | Configuration File | Issue |
+|---------|-------------------|-------|
+| Claude Code | `.claude/rules/custom-instructions.md` | AUTO missing from keyword list |
+| Cursor | `.cursor/rules/*.mdc` | AUTO missing from keyword detection |
+| Antigravity | `.antigravity/rules/instructions.md` | AUTO missing from workflow modes |
+| Codex | `.codex/rules/system-prompt.md` | AUTO missing from mode documentation |
+| Amazon Q | `.q/rules/customizations.md` | AUTO missing from keyword list |
+| Kiro | `.kiro/rules/guidelines.md` | AUTO missing from keyword list |
+
+### Test Coverage Gap
+
+The `rule-filter.spec.ts` test file lacked test cases for AUTO mode filtering behavior, making this gap harder to detect during development.
+
+## Impact
+
+- Users cannot use AUTO mode despite it being a documented feature
+- Autonomous workflow (PLAN → ACT → EVAL cycling) is inaccessible
+- Inconsistent behavior across AI tools
+- User frustration when documented features don't work
+
+## Acceptance Criteria
+
+1. All AI tool configuration files include AUTO in keyword detection
+2. Localized variants (자동, 自動, 自动, AUTOMÁTICO) are also recognized
+3. Test coverage exists for AUTO mode filtering behavior
+4. Code documentation explains AUTO mode design decisions
+
+## Priority
+
+**High** - Core feature broken, affects user workflow
+
+## Labels
+
+- `bug`
+- `documentation`
+- `ai-tools`
+- `workflow`


### PR DESCRIPTION
# Fix parse_mode to Reload Config for Correct Language Settings

## Summary

This PR fixes the language configuration issue where `parse_mode` ignored the user's `language` setting in `codingbuddy.config.js`. The fix ensures config is reloaded on every `parse_mode` call, guaranteeing fresh settings are always used.

## Problem

Users with `language: 'ko'` (or other non-English languages) in their `codingbuddy.config.js` were receiving English language instructions from the `parse_mode` tool. The root cause was that the MCP server often starts from a different directory than the project root, causing the config file to not be found during initial load.

## Solution

### Simple and Effective Approach

Instead of implementing complex cache-busting or ESM module reload logic, we adopted a simpler approach: **reload config from disk on every `parse_mode` call**.

This works because:
1. `parse_mode` is called once per user input (low frequency)
2. Disk I/O overhead is negligible for a single config file read
3. Guarantees fresh config without complex caching logic
4. Works regardless of MCP server startup location

## Testing

### Automated Tests
- All 1815 tests passing
- New test verifies reload is called before getLanguage
- Test verifies call order to ensure proper sequencing

### Manual Verification
1. Set `language: 'ko'` in `codingbuddy.config.js`
2. Start MCP server from any directory
3. Call `parse_mode` tool
4. Verify response contains `languageInstruction: "Please respond in Korean."`

## Design Decisions

### Why Reload on Every Call?

| Approach | Pros | Cons |
|----------|------|------|
| **Reload every call** (chosen) | Simple, reliable, always fresh | Minor disk I/O per call |
| Cache with TTL | Less I/O | Complex, stale window exists |
| ESM cache busting | One-time reload | Complex, Node.js version dependent |
| Manual `set_project_root` | User control | Requires user action, poor UX |

The "reload every call" approach was chosen because:
- `parse_mode` is called infrequently (once per user message)
- Disk I/O for a small config file is negligible (<1ms)
- Eliminates all caching-related bugs
- Simple code is easier to maintain

### Error Handling

The `reload()` method internally calls `loadProjectConfig()` which has graceful error handling:
- If config file is missing: falls back to empty config `{}`
- If config file is invalid: logs error, falls back to empty config
- No exceptions propagate to break the `parse_mode` flow

## Checklist

- [x] Config reloads before language is retrieved
- [x] Test verifies reload call and ordering
- [x] All existing tests pass
- [x] No breaking changes to public API
- [x] Error handling is graceful
