### PR TITLE
primary agent resolution bugs and priority improvements

### DIFF
--- a/apps/mcp-server/src/config/config.schema.ts
+++ b/apps/mcp-server/src/config/config.schema.ts
@@ -72,6 +72,19 @@ export const TestStrategyConfigSchema = z.object({
 export const AIConfigSchema = z.object({
   defaultModel: z.string().optional(),
   primaryAgent: z.string().optional(),
+  /**
+   * List of agent names to exclude from automatic resolution.
+   * Useful for project-specific exclusions (e.g., exclude mobile-developer for backend-only projects).
+   *
+   * @example
+   * ```javascript
+   * ai: {
+   *   primaryAgent: 'agent-architect',
+   *   excludeAgents: ['mobile-developer', 'frontend-developer'],
+   * }
+   * ```
+   */
+  excludeAgents: z.array(z.string()).optional(),
 });
 
 export const AutoConfigSchema = z.object({

--- a/apps/mcp-server/src/keyword/keyword.module.ts
+++ b/apps/mcp-server/src/keyword/keyword.module.ts
@@ -35,12 +35,15 @@ export const KEYWORD_SERVICE = 'KEYWORD_SERVICE';
           return rulesService.getAgent(agentName);
         };
 
-        // Get primaryAgent from project config
+        // Get primaryAgent and excludeAgents from project config
         const getProjectConfig = async () => {
           try {
             const settings = await configService.getSettings();
-            if (settings.ai?.primaryAgent) {
-              return { primaryAgent: settings.ai.primaryAgent };
+            if (settings.ai?.primaryAgent || settings.ai?.excludeAgents) {
+              return {
+                primaryAgent: settings.ai.primaryAgent,
+                excludeAgents: settings.ai.excludeAgents,
+              };
             }
             return null;
           } catch (error) {


### PR DESCRIPTION
# Fix Primary Agent Resolution Bugs

## Summary

This PR fixes multiple bugs in the Primary Agent resolution system that caused incorrect agent matching, ignored project configuration, and triggered false positives from meta-discussion about agents.

## Changes

### 1. Fixed Priority Inversion (High Priority)

**Problem:** Project configuration was checked at step 10, after intent patterns, causing `primaryAgent` config to be ignored.

**Solution:** Moved project config check to step 3, immediately after explicit request and recommended agent.

```typescript
// Before (buggy order):
// 1. Explicit → 2. Recommended → 3-9. Intent patterns → 10. Config

// After (fixed order):
// 1. Explicit → 2. Recommended → 3. Config → 4. Meta-discussion → 5-11. Intent patterns
```

**File:** `src/keyword/primary-agent-resolver.ts:1127-1134`

### 2. Added Meta-Discussion Detection (High Priority)

**Problem:** Prompts discussing agent behavior (e.g., "Mobile Developer가 매칭되었어") incorrectly triggered those agents.

**Solution:** Added `META_AGENT_DISCUSSION_PATTERNS` and `isMetaAgentDiscussion()` method to detect and skip intent patterns for meta-discussion.

**Patterns Detected:**
- Korean particles after agent names: `Mobile Developer가/이/를/은/는`
- Agent matching/selection discussion: `에이전트 매칭`, `agent resolution`
- Primary Agent system discussion: `Primary Agent 선택`
- Agent activation issues: `에이전트 활성화 파이프라인`
- Agent debugging: `에이전트 버그 분석`

**File:** `src/keyword/primary-agent-resolver.ts:801-815, 1365-1369`

### 3. Reordered Intent Pattern Checks (Medium Priority)

**Problem:** `agent-architect` patterns were at position 7, after mobile patterns that could match "agent" or "develop" keywords.

**Solution:** Reordered `INTENT_PATTERN_CHECKS` to put `agent-architect` first and `mobile-developer` last.

```typescript
// New order:
1. agent-architect   // Prevents "Mobile Developer" text triggering mobile
2. tooling-engineer
3. platform-engineer
4. data-engineer
5. ai-ml-engineer
6. backend-developer
7. mobile-developer  // Last - greedy patterns
```

**File:** `src/keyword/primary-agent-resolver.ts:748-787`

### 4. Added Korean Agent Creation Patterns (Medium Priority)

**Problem:** Korean prompts for agent creation (`에이전트 만들어줘`) didn't match `agent-architect`.

**Solution:** Added patterns for `만들다` verb conjugations:

```typescript
{ pattern: /agent.?를?\s*만[들드]/i, confidence: 0.9 },  // "Agent를 만들"
{ pattern: /에이전트\s*만[들드]/i, confidence: 0.9 },    // "에이전트 만들"
```

**File:** `src/keyword/primary-agent-resolver.ts:667-677`

### 5. Added excludeAgents Config Support (Low Priority)

**Problem:** No way to exclude irrelevant agents from project-specific resolution.

**Solution:** Added `excludeAgents` field to config schema and `filterExcludedAgents()` method.

**Usage:**
```javascript
// codingbuddy.config.js
ai: {
  primaryAgent: 'agent-architect',
  excludeAgents: ['mobile-developer', 'frontend-developer']
}
```

**Files:**
- `src/config/config.schema.ts:75-88` - Schema definition with JSDoc
- `src/keyword/keyword.module.ts:42-46` - Wire to resolver
- `src/keyword/primary-agent-resolver.ts:967-990` - Filter implementation

### 6. Improved Default Fallback Logic

**Problem:** When default agent (`frontend-developer`) was excluded, the resolver still returned it.

**Solution:** Added fallback chain that uses first available agent when default is excluded.

```typescript
// If default is excluded, use first available agent
if (availableAgents.length > 0) {
  return this.createResult(availableAgents[0], 'default', 0.8, ...);
}
```

**File:** `src/keyword/primary-agent-resolver.ts:1181-1189`

## Test Plan

### New Tests Added (16 test cases)

**Bug Fix: Project config priority over intent patterns**
- [x] Uses project config primaryAgent over intent patterns
- [x] Uses project config over backend patterns

**Bug Fix: Meta-discussion detection**
- [x] Skips intent patterns when discussing agent matching issues
- [x] Skips intent patterns when discussing Primary Agent system
- [x] Skips intent patterns when discussing agent activation issues
- [x] Skips intent patterns when debugging agent behavior
- [x] Still matches actual work requests (not meta-discussion)

**Bug Fix: Agent-architect patterns now checked first**
- [x] Matches agent creation patterns before mobile patterns
- [x] Matches Korean agent creation pattern
- [x] Matches MCP server development
- [x] Matches specialist agent patterns
- [x] Matches primary agent resolution patterns

**Bug Fix: excludeAgents config support**
- [x] Excludes specified agents from resolution
- [x] Uses primaryAgent even with excludeAgents set
- [x] Ignores excludeAgents when empty array
- [x] Handles excludeAgents case-insensitively

## Security Considerations

- All regex patterns use bounded quantifiers (ReDoS safe)
- `META_AGENT_DISCUSSION_PATTERNS` use `.{0,20}` limit
- `excludeAgents` uses case-insensitive comparison (bypass prevention)
- Graceful error handling prevents information disclosure
- Existing ReDoS prevention tests (191 lines) all pass

## Breaking Changes

None. All changes are backwards compatible:
- `excludeAgents` is optional
- Resolution order change fixes bugs without breaking existing behavior
- New patterns are additive

## Checklist

- [x] All tests pass (194/194)
- [x] No new `any` types introduced
- [x] JSDoc added for new methods and fields
- [x] Error handling with graceful fallbacks
- [x] Korean language patterns tested
- [x] Security review completed (ReDoS safe)

---

Fixes #215
