### PR TITLE
Dynamic Agent Language Configuration

### DIFF
--- a/apps/mcp-server/src/rules/rules.types.ts
+++ b/apps/mcp-server/src/rules/rules.types.ts
@@ -1,5 +1,12 @@
 export type RuleSource = 'custom' | 'default';
 
+export interface AgentCommunication {
+  language?: string;
+  style?: string;
+  approach?: string[];
+  [key: string]: unknown; // Allow additional fields for extensibility
+}
+
 export interface AgentProfile {
   name: string;
   description: string;
@@ -9,6 +16,7 @@ export interface AgentProfile {
     tech_stack_reference?: string;
     responsibilities?: string[];
   };
+  communication?: AgentCommunication;
   source?: RuleSource;
   [key: string]: unknown; // Allow additional fields (passthrough)
 }


### PR DESCRIPTION
# Dynamic Agent Language Configuration

## Summary

This PR makes agent language settings dynamic by allowing `codingbuddy.config.js` to override the hardcoded `communication.language` in agent JSON files.

## Changes

### Core Implementation

**`apps/mcp-server/src/rules/rules.service.ts`**
- Modified `getAgent()` to call `configService.getLanguage()` after loading agent profile
- Overrides `agent.communication.language` with config language when available
- Added graceful error handling with logging when `getLanguage()` fails
- Includes agent name in error logs for easier debugging

### Type Definitions

**`apps/mcp-server/src/rules/rules.types.ts`**
- Added `AgentCommunication` interface with explicit type definitions:
  - `language?: string`
  - `style?: string`
  - `approach?: string[]`
  - `[key: string]: unknown` (for extensibility)
- Updated `AgentProfile` to include `communication?: AgentCommunication`

### Test Coverage

**`apps/mcp-server/src/rules/rules.service.spec.ts`**
- Added 5 new test cases for language override functionality:
  - Override communication.language with config language
  - Preserve agent language when config has no language
  - Create communication object with config language when agent has none
  - Not modify agent when both config and agent have no language
  - Return agent with original language when `getLanguage()` fails

## Test Results

```
Test Files  1 passed (1)
Tests       50 passed (50)
```

## How It Works

```typescript
// Before: Agent always returns hardcoded language
agent.communication.language // "en"

// After: Agent returns config language if available
const configLanguage = await this.configService.getLanguage();
if (configLanguage) {
  agent.communication = {
    ...agent.communication,
    language: configLanguage,  // "ko" from config
  };
}
```

## Backward Compatibility

- If `codingbuddy.config.js` has no `language` setting, agent's default language is preserved
- If agent has no `communication` field, it's created with config language
- If `getLanguage()` fails, agent's original language is used (graceful degradation)

## Files Changed

| File | Change |
|------|--------|
| `src/rules/rules.service.ts` | Override logic + error handling |
| `src/rules/rules.types.ts` | `AgentCommunication` interface |
| `src/rules/rules.service.spec.ts` | 5 new test cases |

## Related

close #220 
