### PR TITLE
improve prompt test coverage from 60% to 90%

### DIFF
--- a/apps/mcp-server/src/cli/init/prompts/architecture-prompt.spec.ts
+++ b/apps/mcp-server/src/cli/init/prompts/architecture-prompt.spec.ts
@@ -2,14 +2,24 @@
  * Architecture Prompt Tests
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   PATTERN_CHOICES,
   COMPONENT_STYLE_CHOICES,
+  promptArchitectureSettings,
   type ArchitectureSettings,
 } from './architecture-prompt';
 
+// Mock @inquirer/prompts
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn(),
+}));
+
 describe('architecture-prompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('PATTERN_CHOICES', () => {
     it('should include monorepo', () => {
       const mono = PATTERN_CHOICES.find(c => c.value === 'monorepo');
@@ -24,6 +34,23 @@ describe('architecture-prompt', () => {
     it('should include layered', () => {
       const layered = PATTERN_CHOICES.find(c => c.value === 'layered');
       expect(layered).toBeDefined();
+    });
+
+    it('should include clean architecture', () => {
+      const clean = PATTERN_CHOICES.find(c => c.value === 'clean');
+      expect(clean).toBeDefined();
+    });
+
+    it('should include microservices', () => {
+      const micro = PATTERN_CHOICES.find(c => c.value === 'microservices');
+      expect(micro).toBeDefined();
+    });
+
+    it('should have descriptions for all choices', () => {
+      for (const choice of PATTERN_CHOICES) {
+        expect(choice.description).toBeDefined();
+        expect(typeof choice.description).toBe('string');
+      }
     });
   });
 
@@ -44,6 +71,13 @@ describe('architecture-prompt', () => {
       const grouped = COMPONENT_STYLE_CHOICES.find(c => c.value === 'grouped');
       expect(grouped).toBeDefined();
     });
+
+    it('should have descriptions for all choices', () => {
+      for (const choice of COMPONENT_STYLE_CHOICES) {
+        expect(choice.description).toBeDefined();
+        expect(typeof choice.description).toBe('string');
+      }
+    });
   });
 
   describe('ArchitectureSettings type', () => {
@@ -55,6 +89,132 @@ describe('architecture-prompt', () => {
 
       expect(settings.pattern).toBe('monorepo');
       expect(settings.componentStyle).toBe('feature-based');
+    });
+  });
+
+  describe('promptArchitectureSettings', () => {
+    it('should call select for pattern and componentStyle', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      mockSelect
+        .mockResolvedValueOnce('modular')
+        .mockResolvedValueOnce('feature-based');
+
+      await promptArchitectureSettings();
+
+      expect(mockSelect).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return user selections', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      mockSelect
+        .mockResolvedValueOnce('monorepo')
+        .mockResolvedValueOnce('grouped');
+
+      const result = await promptArchitectureSettings();
+
+      expect(result).toEqual({
+        pattern: 'monorepo',
+        componentStyle: 'grouped',
+      });
+    });
+
+    it('should use default values when no options provided', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      mockSelect
+        .mockResolvedValueOnce('modular')
+        .mockResolvedValueOnce('feature-based');
+
+      await promptArchitectureSettings();
+
+      expect(mockSelect).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          message: 'Select architecture pattern:',
+          choices: PATTERN_CHOICES,
+          default: 'modular',
+        }),
+      );
+
+      expect(mockSelect).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          message: 'Select component organization style:',
+          choices: COMPONENT_STYLE_CHOICES,
+          default: 'feature-based',
+        }),
+      );
+    });
+
+    it('should use detected options as defaults', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      mockSelect.mockResolvedValueOnce('clean').mockResolvedValueOnce('flat');
+
+      await promptArchitectureSettings({
+        detectedPattern: 'clean',
+        detectedComponentStyle: 'flat',
+      });
+
+      expect(mockSelect).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          default: 'clean',
+        }),
+      );
+
+      expect(mockSelect).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          default: 'flat',
+        }),
+      );
+    });
+
+    it('should handle all pattern options', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      const patterns = [
+        'monorepo',
+        'modular',
+        'layered',
+        'clean',
+        'microservices',
+      ];
+
+      for (const pattern of patterns) {
+        vi.clearAllMocks();
+        mockSelect
+          .mockResolvedValueOnce(pattern)
+          .mockResolvedValueOnce('feature-based');
+
+        const result = await promptArchitectureSettings();
+        expect(result.pattern).toBe(pattern);
+      }
+    });
+
+    it('should handle all component style options', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      const styles = ['feature-based', 'flat', 'grouped'];
+
+      for (const style of styles) {
+        vi.clearAllMocks();
+        mockSelect
+          .mockResolvedValueOnce('modular')
+          .mockResolvedValueOnce(style);
+
+        const result = await promptArchitectureSettings();
+        expect(result.componentStyle).toBe(style);
+      }
     });
   });
 });

--- a/apps/mcp-server/src/cli/init/prompts/conventions-prompt.spec.ts
+++ b/apps/mcp-server/src/cli/init/prompts/conventions-prompt.spec.ts
@@ -2,15 +2,25 @@
  * Conventions Prompt Tests
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   FILE_NAMING_CHOICES,
   QUOTES_CHOICES,
   SEMICOLONS_CHOICES,
+  promptConventionsSettings,
   type ConventionsSettings,
 } from './conventions-prompt';
 
+// Mock @inquirer/prompts
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn(),
+}));
+
 describe('conventions-prompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('FILE_NAMING_CHOICES', () => {
     it('should include kebab-case', () => {
       const kebab = FILE_NAMING_CHOICES.find(c => c.value === 'kebab-case');
@@ -26,6 +36,18 @@ describe('conventions-prompt', () => {
       const pascal = FILE_NAMING_CHOICES.find(c => c.value === 'PascalCase');
       expect(pascal).toBeDefined();
     });
+
+    it('should include snake_case', () => {
+      const snake = FILE_NAMING_CHOICES.find(c => c.value === 'snake_case');
+      expect(snake).toBeDefined();
+    });
+
+    it('should have descriptions for all choices', () => {
+      for (const choice of FILE_NAMING_CHOICES) {
+        expect(choice.description).toBeDefined();
+        expect(typeof choice.description).toBe('string');
+      }
+    });
   });
 
   describe('QUOTES_CHOICES', () => {
@@ -38,6 +60,13 @@ describe('conventions-prompt', () => {
       const double = QUOTES_CHOICES.find(c => c.value === 'double');
       expect(double).toBeDefined();
     });
+
+    it('should have descriptions for all choices', () => {
+      for (const choice of QUOTES_CHOICES) {
+        expect(choice.description).toBeDefined();
+        expect(typeof choice.description).toBe('string');
+      }
+    });
   });
 
   describe('SEMICOLONS_CHOICES', () => {
@@ -49,6 +78,13 @@ describe('conventions-prompt', () => {
     it('should include false (without semicolons)', () => {
       const withoutSemi = SEMICOLONS_CHOICES.find(c => c.value === false);
       expect(withoutSemi).toBeDefined();
+    });
+
+    it('should have descriptions for all choices', () => {
+      for (const choice of SEMICOLONS_CHOICES) {
+        expect(choice.description).toBeDefined();
+        expect(typeof choice.description).toBe('string');
+      }
     });
   });
 
@@ -63,6 +99,170 @@ describe('conventions-prompt', () => {
       expect(settings.fileNaming).toBe('kebab-case');
       expect(settings.quotes).toBe('single');
       expect(settings.semicolons).toBe(true);
+    });
+  });
+
+  describe('promptConventionsSettings', () => {
+    it('should call select for all three options', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      mockSelect
+        .mockResolvedValueOnce('kebab-case')
+        .mockResolvedValueOnce('single')
+        .mockResolvedValueOnce(true);
+
+      await promptConventionsSettings();
+
+      expect(mockSelect).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return user selections', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      mockSelect
+        .mockResolvedValueOnce('PascalCase')
+        .mockResolvedValueOnce('double')
+        .mockResolvedValueOnce(false);
+
+      const result = await promptConventionsSettings();
+
+      expect(result).toEqual({
+        fileNaming: 'PascalCase',
+        quotes: 'double',
+        semicolons: false,
+      });
+    });
+
+    it('should use default values when no options provided', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      mockSelect
+        .mockResolvedValueOnce('kebab-case')
+        .mockResolvedValueOnce('single')
+        .mockResolvedValueOnce(true);
+
+      await promptConventionsSettings();
+
+      expect(mockSelect).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          message: 'Select file naming convention:',
+          choices: FILE_NAMING_CHOICES,
+          default: 'kebab-case',
+        }),
+      );
+
+      expect(mockSelect).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          message: 'Select quote style:',
+          choices: QUOTES_CHOICES,
+          default: 'single',
+        }),
+      );
+
+      expect(mockSelect).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          message: 'Use semicolons?',
+          choices: SEMICOLONS_CHOICES,
+          default: true,
+        }),
+      );
+    });
+
+    it('should use detected options as defaults', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      mockSelect
+        .mockResolvedValueOnce('camelCase')
+        .mockResolvedValueOnce('double')
+        .mockResolvedValueOnce(false);
+
+      await promptConventionsSettings({
+        detectedFileNaming: 'camelCase',
+        detectedQuotes: 'double',
+        detectedSemicolons: false,
+      });
+
+      expect(mockSelect).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          default: 'camelCase',
+        }),
+      );
+
+      expect(mockSelect).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          default: 'double',
+        }),
+      );
+
+      expect(mockSelect).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          default: false,
+        }),
+      );
+    });
+
+    it('should handle all file naming options', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      const namings = ['kebab-case', 'camelCase', 'PascalCase', 'snake_case'];
+
+      for (const naming of namings) {
+        vi.clearAllMocks();
+        mockSelect
+          .mockResolvedValueOnce(naming)
+          .mockResolvedValueOnce('single')
+          .mockResolvedValueOnce(true);
+
+        const result = await promptConventionsSettings();
+        expect(result.fileNaming).toBe(naming);
+      }
+    });
+
+    it('should handle all quote style options', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      const quoteStyles = ['single', 'double'] as const;
+
+      for (const quotes of quoteStyles) {
+        vi.clearAllMocks();
+        mockSelect
+          .mockResolvedValueOnce('kebab-case')
+          .mockResolvedValueOnce(quotes)
+          .mockResolvedValueOnce(true);
+
+        const result = await promptConventionsSettings();
+        expect(result.quotes).toBe(quotes);
+      }
+    });
+
+    it('should handle all semicolon options', async () => {
+      const { select } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+
+      const semiOptions = [true, false];
+
+      for (const semi of semiOptions) {
+        vi.clearAllMocks();
+        mockSelect
+          .mockResolvedValueOnce('kebab-case')
+          .mockResolvedValueOnce('single')
+          .mockResolvedValueOnce(semi);
+
+        const result = await promptConventionsSettings();
+        expect(result.semicolons).toBe(semi);
+      }
     });
   });
 });

--- a/apps/mcp-server/src/cli/init/prompts/tech-stack-prompt.spec.ts
+++ b/apps/mcp-server/src/cli/init/prompts/tech-stack-prompt.spec.ts
@@ -4,16 +4,28 @@
  * Tests for tech stack selection prompts (languages, frontend, backend, tools)
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   LANGUAGE_CHOICES,
   FRONTEND_CHOICES,
   BACKEND_CHOICES,
   TOOL_CHOICES,
+  getChoicesWithDefaults,
+  promptTechStackSettings,
   type TechStackSettings,
+  type StackChoice,
 } from './tech-stack-prompt';
 
+// Mock @inquirer/prompts
+vi.mock('@inquirer/prompts', () => ({
+  checkbox: vi.fn(),
+}));
+
 describe('tech-stack-prompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('LANGUAGE_CHOICES', () => {
     it('should include TypeScript', () => {
       const ts = LANGUAGE_CHOICES.find(c => c.value === 'TypeScript');
@@ -29,6 +41,13 @@ describe('tech-stack-prompt', () => {
     it('should include Python', () => {
       const py = LANGUAGE_CHOICES.find(c => c.value === 'Python');
       expect(py).toBeDefined();
+    });
+
+    it('should have name and value for all choices', () => {
+      for (const choice of LANGUAGE_CHOICES) {
+        expect(choice.name).toBeDefined();
+        expect(choice.value).toBeDefined();
+      }
     });
   });
 
@@ -47,6 +66,16 @@ describe('tech-stack-prompt', () => {
       const vue = FRONTEND_CHOICES.find(c => c.value === 'Vue');
       expect(vue).toBeDefined();
     });
+
+    it('should include all major frameworks', () => {
+      const values = FRONTEND_CHOICES.map(c => c.value);
+      expect(values).toContain('React');
+      expect(values).toContain('Next.js');
+      expect(values).toContain('Vue');
+      expect(values).toContain('Nuxt');
+      expect(values).toContain('Svelte');
+      expect(values).toContain('Angular');
+    });
   });
 
   describe('BACKEND_CHOICES', () => {
@@ -63,6 +92,16 @@ describe('tech-stack-prompt', () => {
     it('should include FastAPI', () => {
       const fastapi = BACKEND_CHOICES.find(c => c.value === 'FastAPI');
       expect(fastapi).toBeDefined();
+    });
+
+    it('should include all major frameworks', () => {
+      const values = BACKEND_CHOICES.map(c => c.value);
+      expect(values).toContain('NestJS');
+      expect(values).toContain('Express');
+      expect(values).toContain('Fastify');
+      expect(values).toContain('FastAPI');
+      expect(values).toContain('Django');
+      expect(values).toContain('Spring Boot');
     });
   });
 
@@ -81,6 +120,16 @@ describe('tech-stack-prompt', () => {
       const prettier = TOOL_CHOICES.find(c => c.value === 'Prettier');
       expect(prettier).toBeDefined();
     });
+
+    it('should include all common tools', () => {
+      const values = TOOL_CHOICES.map(c => c.value);
+      expect(values).toContain('Vitest');
+      expect(values).toContain('Jest');
+      expect(values).toContain('ESLint');
+      expect(values).toContain('Prettier');
+      expect(values).toContain('Docker');
+      expect(values).toContain('GitHub Actions');
+    });
   });
 
   describe('TechStackSettings type', () => {
@@ -96,6 +145,193 @@ describe('tech-stack-prompt', () => {
       expect(settings.frontend).toContain('React');
       expect(settings.backend).toContain('NestJS');
       expect(settings.tools).toContain('Vitest');
+    });
+  });
+
+  describe('getChoicesWithDefaults', () => {
+    it('should return choices with detected items pre-checked', () => {
+      const choices: StackChoice[] = [
+        { name: 'Option A', value: 'a' },
+        { name: 'Option B', value: 'b' },
+        { name: 'Option C', value: 'c' },
+      ];
+      const detected = ['a', 'c'];
+
+      const result = getChoicesWithDefaults(choices, detected);
+
+      expect(result[0].checked).toBe(true);
+      expect(result[1].checked).toBe(false);
+      expect(result[2].checked).toBe(true);
+    });
+
+    it('should return all unchecked when detected is empty', () => {
+      const choices: StackChoice[] = [
+        { name: 'Option A', value: 'a' },
+        { name: 'Option B', value: 'b' },
+      ];
+
+      const result = getChoicesWithDefaults(choices, []);
+
+      expect(result[0].checked).toBe(false);
+      expect(result[1].checked).toBe(false);
+    });
+
+    it('should return all unchecked when detected is undefined', () => {
+      const choices: StackChoice[] = [
+        { name: 'Option A', value: 'a' },
+        { name: 'Option B', value: 'b' },
+      ];
+
+      const result = getChoicesWithDefaults(choices);
+
+      expect(result[0].checked).toBe(false);
+      expect(result[1].checked).toBe(false);
+    });
+
+    it('should preserve original choice properties', () => {
+      const choices: StackChoice[] = [{ name: 'Option A', value: 'a' }];
+
+      const result = getChoicesWithDefaults(choices, ['a']);
+
+      expect(result[0].name).toBe('Option A');
+      expect(result[0].value).toBe('a');
+      expect(result[0].checked).toBe(true);
+    });
+
+    it('should handle empty choices array', () => {
+      const result = getChoicesWithDefaults([], ['a']);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle non-matching detected values', () => {
+      const choices: StackChoice[] = [
+        { name: 'Option A', value: 'a' },
+        { name: 'Option B', value: 'b' },
+      ];
+
+      const result = getChoicesWithDefaults(choices, ['x', 'y']);
+
+      expect(result[0].checked).toBe(false);
+      expect(result[1].checked).toBe(false);
+    });
+  });
+
+  describe('promptTechStackSettings', () => {
+    it('should call checkbox for all categories', async () => {
+      const { checkbox } = await import('@inquirer/prompts');
+      const mockCheckbox = vi.mocked(checkbox);
+
+      mockCheckbox
+        .mockResolvedValueOnce(['TypeScript'])
+        .mockResolvedValueOnce(['React'])
+        .mockResolvedValueOnce(['NestJS'])
+        .mockResolvedValueOnce(['Vitest']);
+
+      await promptTechStackSettings();
+
+      expect(mockCheckbox).toHaveBeenCalledTimes(4);
+    });
+
+    it('should return all selected values', async () => {
+      const { checkbox } = await import('@inquirer/prompts');
+      const mockCheckbox = vi.mocked(checkbox);
+
+      mockCheckbox
+        .mockResolvedValueOnce(['TypeScript', 'JavaScript'])
+        .mockResolvedValueOnce(['React', 'Next.js'])
+        .mockResolvedValueOnce(['NestJS', 'Express'])
+        .mockResolvedValueOnce(['Vitest', 'ESLint', 'Prettier']);
+
+      const result = await promptTechStackSettings();
+
+      expect(result.languages).toEqual(['TypeScript', 'JavaScript']);
+      expect(result.frontend).toEqual(['React', 'Next.js']);
+      expect(result.backend).toEqual(['NestJS', 'Express']);
+      expect(result.tools).toEqual(['Vitest', 'ESLint', 'Prettier']);
+    });
+
+    it('should handle empty selections', async () => {
+      const { checkbox } = await import('@inquirer/prompts');
+      const mockCheckbox = vi.mocked(checkbox);
+
+      mockCheckbox
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const result = await promptTechStackSettings();
+
+      expect(result.languages).toEqual([]);
+      expect(result.frontend).toEqual([]);
+      expect(result.backend).toEqual([]);
+      expect(result.tools).toEqual([]);
+    });
+
+    it('should pass detected options to getChoicesWithDefaults', async () => {
+      const { checkbox } = await import('@inquirer/prompts');
+      const mockCheckbox = vi.mocked(checkbox);
+
+      mockCheckbox
+        .mockResolvedValueOnce(['TypeScript'])
+        .mockResolvedValueOnce(['React'])
+        .mockResolvedValueOnce(['NestJS'])
+        .mockResolvedValueOnce(['Vitest']);
+
+      await promptTechStackSettings({
+        detectedLanguages: ['TypeScript'],
+        detectedFrontend: ['React'],
+        detectedBackend: ['NestJS'],
+        detectedTools: ['Vitest'],
+      });
+
+      // First call should have TypeScript pre-checked
+      expect(mockCheckbox).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          message: 'Select programming languages:',
+          choices: expect.arrayContaining([
+            expect.objectContaining({ value: 'TypeScript', checked: true }),
+          ]),
+        }),
+      );
+    });
+
+    it('should use correct messages for each prompt', async () => {
+      const { checkbox } = await import('@inquirer/prompts');
+      const mockCheckbox = vi.mocked(checkbox);
+
+      mockCheckbox.mockResolvedValue([]);
+
+      await promptTechStackSettings();
+
+      expect(mockCheckbox).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          message: 'Select programming languages:',
+        }),
+      );
+
+      expect(mockCheckbox).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          message: 'Select frontend frameworks:',
+        }),
+      );
+
+      expect(mockCheckbox).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          message: 'Select backend frameworks:',
+        }),
+      );
+
+      expect(mockCheckbox).toHaveBeenNthCalledWith(
+        4,
+        expect.objectContaining({
+          message: 'Select tools:',
+        }),
+      );
     });
   });
 });

--- a/apps/mcp-server/src/cli/init/prompts/tech-stack-prompt.ts
+++ b/apps/mcp-server/src/cli/init/prompts/tech-stack-prompt.ts
@@ -91,7 +91,7 @@ export interface TechStackPromptOptions {
 /**
  * Get choices with detected items pre-checked
  */
-function getChoicesWithDefaults(
+export function getChoicesWithDefaults(
   choices: StackChoice[],
   detected: string[] = [],
 ): StackChoice[] {

--- a/apps/mcp-server/src/cli/init/prompts/test-strategy-prompt.spec.ts
+++ b/apps/mcp-server/src/cli/init/prompts/test-strategy-prompt.spec.ts
@@ -2,15 +2,27 @@
  * Test Strategy Prompt Tests
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   APPROACH_CHOICES,
   MOCKING_STRATEGY_CHOICES,
   DEFAULT_COVERAGE,
+  validateCoverage,
+  promptTestStrategySettings,
   type TestStrategySettings,
 } from './test-strategy-prompt';
 
+// Mock @inquirer/prompts
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn(),
+  input: vi.fn(),
+}));
+
 describe('test-strategy-prompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('APPROACH_CHOICES', () => {
     it('should include tdd', () => {
       const tdd = APPROACH_CHOICES.find(c => c.value === 'tdd');
@@ -30,6 +42,13 @@ describe('test-strategy-prompt', () => {
     it('should include mixed', () => {
       const mixed = APPROACH_CHOICES.find(c => c.value === 'mixed');
       expect(mixed).toBeDefined();
+    });
+
+    it('should have descriptions for all choices', () => {
+      for (const choice of APPROACH_CHOICES) {
+        expect(choice.description).toBeDefined();
+        expect(typeof choice.description).toBe('string');
+      }
     });
   });
 
@@ -52,6 +71,13 @@ describe('test-strategy-prompt', () => {
       );
       expect(noMocks).toBeDefined();
     });
+
+    it('should have descriptions for all choices', () => {
+      for (const choice of MOCKING_STRATEGY_CHOICES) {
+        expect(choice.description).toBeDefined();
+        expect(typeof choice.description).toBe('string');
+      }
+    });
   });
 
   describe('DEFAULT_COVERAGE', () => {
@@ -71,6 +97,185 @@ describe('test-strategy-prompt', () => {
       expect(settings.approach).toBe('tdd');
       expect(settings.coverage).toBe(90);
       expect(settings.mockingStrategy).toBe('minimal');
+    });
+  });
+
+  describe('validateCoverage', () => {
+    it('should accept valid coverage values', () => {
+      expect(validateCoverage('90')).toBe(true);
+      expect(validateCoverage('0')).toBe(true);
+      expect(validateCoverage('100')).toBe(true);
+      expect(validateCoverage('50')).toBe(true);
+    });
+
+    it('should reject values below 0', () => {
+      const result = validateCoverage('-1');
+      expect(result).not.toBe(true);
+      expect(typeof result).toBe('string');
+      expect(result).toContain('0 and 100');
+    });
+
+    it('should reject values above 100', () => {
+      const result = validateCoverage('101');
+      expect(result).not.toBe(true);
+      expect(typeof result).toBe('string');
+    });
+
+    it('should reject non-numeric values', () => {
+      const result = validateCoverage('abc');
+      expect(result).not.toBe(true);
+      expect(typeof result).toBe('string');
+    });
+
+    it('should reject empty string', () => {
+      const result = validateCoverage('');
+      expect(result).not.toBe(true);
+    });
+
+    it('should accept boundary values', () => {
+      expect(validateCoverage('0')).toBe(true);
+      expect(validateCoverage('100')).toBe(true);
+    });
+  });
+
+  describe('promptTestStrategySettings', () => {
+    it('should call prompts with correct default parameters', async () => {
+      const { select, input } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+      const mockInput = vi.mocked(input);
+
+      mockSelect.mockResolvedValueOnce('tdd').mockResolvedValueOnce('minimal');
+      mockInput.mockResolvedValueOnce('90');
+
+      await promptTestStrategySettings();
+
+      expect(mockSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Select test approach:',
+          choices: APPROACH_CHOICES,
+          default: 'tdd',
+        }),
+      );
+
+      expect(mockInput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Target test coverage (%):',
+          default: '90',
+          validate: validateCoverage,
+        }),
+      );
+
+      expect(mockSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Select mocking strategy:',
+          choices: MOCKING_STRATEGY_CHOICES,
+          default: 'minimal',
+        }),
+      );
+    });
+
+    it('should return user selections', async () => {
+      const { select, input } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+      const mockInput = vi.mocked(input);
+
+      mockSelect
+        .mockResolvedValueOnce('bdd')
+        .mockResolvedValueOnce('extensive');
+      mockInput.mockResolvedValueOnce('80');
+
+      const result = await promptTestStrategySettings();
+
+      expect(result).toEqual({
+        approach: 'bdd',
+        coverage: 80,
+        mockingStrategy: 'extensive',
+      });
+    });
+
+    it('should use detected options as defaults', async () => {
+      const { select, input } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+      const mockInput = vi.mocked(input);
+
+      mockSelect
+        .mockResolvedValueOnce('mixed')
+        .mockResolvedValueOnce('no-mocks');
+      mockInput.mockResolvedValueOnce('85');
+
+      await promptTestStrategySettings({
+        detectedApproach: 'mixed',
+        detectedCoverage: 85,
+        detectedMockingStrategy: 'no-mocks',
+      });
+
+      expect(mockSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          default: 'mixed',
+        }),
+      );
+
+      expect(mockInput).toHaveBeenCalledWith(
+        expect.objectContaining({
+          default: '85',
+        }),
+      );
+
+      expect(mockSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          default: 'no-mocks',
+        }),
+      );
+    });
+
+    it('should parse coverage as integer', async () => {
+      const { select, input } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+      const mockInput = vi.mocked(input);
+
+      mockSelect.mockResolvedValueOnce('tdd').mockResolvedValueOnce('minimal');
+      mockInput.mockResolvedValueOnce('75');
+
+      const result = await promptTestStrategySettings();
+
+      expect(result.coverage).toBe(75);
+      expect(typeof result.coverage).toBe('number');
+    });
+
+    it('should handle all approach options', async () => {
+      const { select, input } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+      const mockInput = vi.mocked(input);
+
+      const approaches = ['tdd', 'bdd', 'test-after', 'mixed'] as const;
+
+      for (const approach of approaches) {
+        vi.clearAllMocks();
+        mockSelect
+          .mockResolvedValueOnce(approach)
+          .mockResolvedValueOnce('minimal');
+        mockInput.mockResolvedValueOnce('90');
+
+        const result = await promptTestStrategySettings();
+        expect(result.approach).toBe(approach);
+      }
+    });
+
+    it('should handle all mocking strategy options', async () => {
+      const { select, input } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+      const mockInput = vi.mocked(input);
+
+      const strategies = ['minimal', 'extensive', 'no-mocks'] as const;
+
+      for (const strategy of strategies) {
+        vi.clearAllMocks();
+        mockSelect.mockResolvedValueOnce('tdd').mockResolvedValueOnce(strategy);
+        mockInput.mockResolvedValueOnce('90');
+
+        const result = await promptTestStrategySettings();
+        expect(result.mockingStrategy).toBe(strategy);
+      }
     });
   });
 });

--- a/apps/mcp-server/src/cli/init/prompts/test-strategy-prompt.ts
+++ b/apps/mcp-server/src/cli/init/prompts/test-strategy-prompt.ts
@@ -30,6 +30,19 @@ export interface TestStrategySettings {
 export const DEFAULT_COVERAGE = 90;
 
 /**
+ * Validate coverage input value
+ * @param value - Input value to validate
+ * @returns true if valid, error message string if invalid
+ */
+export function validateCoverage(value: string): true | string {
+  const num = parseInt(value, 10);
+  if (isNaN(num) || num < 0 || num > 100) {
+    return 'Please enter a number between 0 and 100';
+  }
+  return true;
+}
+
+/**
  * Test approach choices
  */
 export const APPROACH_CHOICES: TestChoice<TestStrategySettings['approach']>[] =
@@ -106,13 +119,7 @@ export async function promptTestStrategySettings(
   const coverageInput = await input({
     message: 'Target test coverage (%):',
     default: String(options.detectedCoverage ?? DEFAULT_COVERAGE),
-    validate: value => {
-      const num = parseInt(value, 10);
-      if (isNaN(num) || num < 0 || num > 100) {
-        return 'Please enter a number between 0 and 100';
-      }
-      return true;
-    },
+    validate: validateCoverage,
   });
   const coverage = parseInt(coverageInput, 10);
 


### PR DESCRIPTION
# Improve CLI Prompt Test Coverage

## Summary

This PR significantly improves test coverage for the CLI initialization prompts, addressing critical coverage gaps in user-facing code paths.

- Increased `cli/init/prompts` folder coverage from **~60% to 90.66%**
- Added **50 new tests** across 4 prompt modules
- Achieved **100% coverage** on all 4 target files

## Changes

### Test Files Modified

| File | Tests Added | Coverage Change |
|------|-------------|-----------------|
| test-strategy-prompt.spec.ts | +14 (9→23) | 25% → 100% |
| tech-stack-prompt.spec.ts | +15 (13→28) | 36% → 100% |
| architecture-prompt.spec.ts | +10 (7→17) | 40% → 100% |
| conventions-prompt.spec.ts | +11 (8→19) | 43% → 100% |

### Source Files Modified

**test-strategy-prompt.ts**
- Extracted `validateCoverage()` function from inline validation for testability
- Function now exported for direct unit testing

**tech-stack-prompt.ts**
- Exported `getChoicesWithDefaults()` function (previously private)
- Enables testing of choice merging logic

## Test Coverage Details

### New Test Categories Added

1. **Constant/Choice Validation**
   - Verify all expected options exist in choice arrays
   - Ensure descriptions are present for all choices

2. **Type Contract Tests**
   - Validate settings interfaces have required fields
   - Type-safe assertions for all return values

3. **Validation Function Tests**
   - Boundary value testing (0, 100 for coverage)
   - Invalid input handling (negative, >100, non-numeric, empty)
   - Error message content verification

4. **Prompt Function Tests**
   - Default parameter verification
   - User selection return value validation
   - Detected options as defaults behavior
   - All option combination handling

### Mocking Strategy

- Only external dependency `@inquirer/prompts` is mocked
- Internal logic tested directly without mocks
- Follows project's minimal mocking principle

## Test Plan

```bash
# Run all prompt tests
yarn test src/cli/init/prompts/

# Run with coverage
yarn test:cov src/cli/init/prompts/
```

### Results

```
Test Files  8 passed (8)
Tests       126 passed (126)
Duration    294ms

cli/init/prompts coverage: 90.66%
```

## Breaking Changes

None. All changes are additive (new tests) or internal refactoring (function extraction).

## Checklist

- [x] Tests pass locally
- [x] Coverage targets met (85%+ achieved, got 90.66%)
- [x] No new lint warnings
- [x] Follows project test conventions
- [x] All 4 target files at 100% coverage

## Related

- Part of Code Quality Improvement Plan Phase 2
- Ticket: CLI Prompt Test Coverage Improvement
