### PR TITLE
Auto-update .gitignore during codingbuddy init

### DIFF
--- a/apps/mcp-server/src/cli/init/gitignore.utils.spec.ts
+++ b/apps/mcp-server/src/cli/init/gitignore.utils.spec.ts
@@ -1,0 +1,245 @@
+/**
+ * Gitignore Utilities Tests
+ *
+ * TDD tests for .gitignore manipulation functions
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import {
+  ensureGitignoreEntries,
+  GitignoreWriteError,
+  GitignoreReadError,
+  type GitignoreEntry,
+} from './gitignore.utils';
+
+// Mock fs module with memfs
+vi.mock('fs', async () => {
+  const memfs = await import('memfs');
+  return memfs.fs;
+});
+
+vi.mock('fs/promises', async () => {
+  const memfs = await import('memfs');
+  return memfs.fs.promises;
+});
+
+describe('ensureGitignoreEntries', () => {
+  const projectRoot = '/test-project';
+
+  beforeEach(() => {
+    vol.reset();
+    vol.mkdirSync(projectRoot, { recursive: true });
+  });
+
+  describe('when .gitignore does not exist', () => {
+    it('creates .gitignore with entries and comment', async () => {
+      const entries: GitignoreEntry[] = [
+        {
+          pattern: 'docs/codingbuddy/context.md',
+          comment: '# Codingbuddy (local workspace)',
+        },
+        { pattern: 'docs/codingbuddy/sessions/' },
+      ];
+
+      const result = await ensureGitignoreEntries(projectRoot, entries);
+
+      expect(result.added).toEqual([
+        'docs/codingbuddy/context.md',
+        'docs/codingbuddy/sessions/',
+      ]);
+      expect(result.alreadyExists).toEqual([]);
+
+      const content = vol.readFileSync(`${projectRoot}/.gitignore`, 'utf-8');
+      expect(content).toContain('# Codingbuddy (local workspace)');
+      expect(content).toContain('docs/codingbuddy/context.md');
+      expect(content).toContain('docs/codingbuddy/sessions/');
+    });
+  });
+
+  describe('when .gitignore exists', () => {
+    it('appends entries to existing content', async () => {
+      vol.writeFileSync(
+        `${projectRoot}/.gitignore`,
+        '# Existing content\nnode_modules/\n',
+      );
+
+      const entries: GitignoreEntry[] = [
+        {
+          pattern: 'docs/codingbuddy/context.md',
+          comment: '# Codingbuddy (local workspace)',
+        },
+      ];
+
+      const result = await ensureGitignoreEntries(projectRoot, entries);
+
+      expect(result.added).toEqual(['docs/codingbuddy/context.md']);
+
+      const content = vol.readFileSync(`${projectRoot}/.gitignore`, 'utf-8');
+      expect(content).toContain('# Existing content');
+      expect(content).toContain('node_modules/');
+      expect(content).toContain('# Codingbuddy (local workspace)');
+      expect(content).toContain('docs/codingbuddy/context.md');
+    });
+
+    it('does not duplicate existing entries', async () => {
+      vol.writeFileSync(
+        `${projectRoot}/.gitignore`,
+        'node_modules/\ndocs/codingbuddy/context.md\n',
+      );
+
+      const entries: GitignoreEntry[] = [
+        { pattern: 'docs/codingbuddy/context.md', comment: '# Codingbuddy' },
+        { pattern: 'docs/codingbuddy/sessions/' },
+      ];
+
+      const result = await ensureGitignoreEntries(projectRoot, entries);
+
+      expect(result.added).toEqual(['docs/codingbuddy/sessions/']);
+      expect(result.alreadyExists).toEqual(['docs/codingbuddy/context.md']);
+
+      const content = vol.readFileSync(
+        `${projectRoot}/.gitignore`,
+        'utf-8',
+      ) as string;
+      // Should not have duplicate
+      const matches = content.match(/docs\/codingbuddy\/context\.md/g);
+      expect(matches?.length).toBe(1);
+    });
+
+    it('handles entries without trailing newline', async () => {
+      vol.writeFileSync(`${projectRoot}/.gitignore`, 'node_modules/');
+
+      const entries: GitignoreEntry[] = [
+        { pattern: 'dist/', comment: '# Build output' },
+      ];
+
+      const result = await ensureGitignoreEntries(projectRoot, entries);
+
+      expect(result.added).toEqual(['dist/']);
+
+      const content = vol.readFileSync(`${projectRoot}/.gitignore`, 'utf-8');
+      expect(content).toContain('node_modules/');
+      expect(content).toContain('dist/');
+      // Should have newline between existing and new
+      expect(content).toMatch(/node_modules\/\n/);
+    });
+  });
+
+  describe('when all entries already exist', () => {
+    it('returns empty added array', async () => {
+      vol.writeFileSync(
+        `${projectRoot}/.gitignore`,
+        'docs/codingbuddy/context.md\ndocs/codingbuddy/sessions/\n',
+      );
+
+      const entries: GitignoreEntry[] = [
+        { pattern: 'docs/codingbuddy/context.md' },
+        { pattern: 'docs/codingbuddy/sessions/' },
+      ];
+
+      const result = await ensureGitignoreEntries(projectRoot, entries);
+
+      expect(result.added).toEqual([]);
+      expect(result.alreadyExists).toEqual([
+        'docs/codingbuddy/context.md',
+        'docs/codingbuddy/sessions/',
+      ]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws GitignoreWriteError when file write fails', async () => {
+      // Try to write to a path that doesn't exist (no parent directory)
+      const invalidProjectRoot = '/non-existent-parent/project';
+
+      const entries: GitignoreEntry[] = [{ pattern: 'new-entry/' }];
+
+      await expect(
+        ensureGitignoreEntries(invalidProjectRoot, entries),
+      ).rejects.toThrow('Failed to update .gitignore');
+    });
+
+    it('includes original error message in GitignoreWriteError', async () => {
+      const invalidProjectRoot = '/non-existent-parent/project';
+
+      const entries: GitignoreEntry[] = [{ pattern: 'new-entry/' }];
+
+      try {
+        await ensureGitignoreEntries(invalidProjectRoot, entries);
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GitignoreWriteError);
+        expect((error as GitignoreWriteError).message).toContain(
+          'Failed to update .gitignore',
+        );
+        expect((error as GitignoreWriteError).cause).toBeDefined();
+      }
+    });
+
+    it('throws GitignoreReadError when file read fails', async () => {
+      // Create a directory with same name as .gitignore to cause read error
+      vol.mkdirSync(`${projectRoot}/.gitignore`, { recursive: true });
+
+      const entries: GitignoreEntry[] = [{ pattern: 'new-entry/' }];
+
+      await expect(
+        ensureGitignoreEntries(projectRoot, entries),
+      ).rejects.toThrow('Failed to read .gitignore');
+    });
+
+    it('includes original error in GitignoreReadError', async () => {
+      vol.mkdirSync(`${projectRoot}/.gitignore`, { recursive: true });
+
+      const entries: GitignoreEntry[] = [{ pattern: 'new-entry/' }];
+
+      try {
+        await ensureGitignoreEntries(projectRoot, entries);
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GitignoreReadError);
+        expect((error as GitignoreReadError).message).toContain(
+          'Failed to read .gitignore',
+        );
+        expect((error as GitignoreReadError).cause).toBeDefined();
+      }
+    });
+  });
+
+  describe('comment handling', () => {
+    it('only adds comment once for grouped entries', async () => {
+      const entries: GitignoreEntry[] = [
+        {
+          pattern: 'docs/codingbuddy/context.md',
+          comment: '# Codingbuddy (local workspace)',
+        },
+        { pattern: 'docs/codingbuddy/sessions/' },
+      ];
+
+      await ensureGitignoreEntries(projectRoot, entries);
+
+      const content = vol.readFileSync(
+        `${projectRoot}/.gitignore`,
+        'utf-8',
+      ) as string;
+      const commentMatches = content.match(
+        /# Codingbuddy \(local workspace\)/g,
+      );
+      expect(commentMatches?.length).toBe(1);
+    });
+
+    it('adds blank line before comment section', async () => {
+      vol.writeFileSync(`${projectRoot}/.gitignore`, 'node_modules/\n');
+
+      const entries: GitignoreEntry[] = [
+        { pattern: 'dist/', comment: '# Build' },
+      ];
+
+      await ensureGitignoreEntries(projectRoot, entries);
+
+      const content = vol.readFileSync(`${projectRoot}/.gitignore`, 'utf-8');
+      // Should have blank line before comment
+      expect(content).toMatch(/node_modules\/\n\n# Build/);
+    });
+  });
+});

--- a/apps/mcp-server/src/cli/init/gitignore.utils.ts
+++ b/apps/mcp-server/src/cli/init/gitignore.utils.ts
@@ -1,0 +1,153 @@
+/**
+ * Gitignore Utilities
+ *
+ * Functions for manipulating .gitignore files
+ */
+
+import { existsSync } from 'fs';
+import { readFile, writeFile } from 'fs/promises';
+import * as path from 'path';
+
+/**
+ * Error thrown when .gitignore file cannot be read
+ */
+export class GitignoreReadError extends Error {
+  readonly cause: unknown;
+
+  constructor(gitignorePath: string, cause: unknown) {
+    const message = `Failed to read .gitignore at ${gitignorePath}`;
+    super(message);
+    this.name = 'GitignoreReadError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * Error thrown when .gitignore file cannot be written
+ */
+export class GitignoreWriteError extends Error {
+  readonly cause: unknown;
+
+  constructor(gitignorePath: string, cause: unknown) {
+    const message = `Failed to update .gitignore at ${gitignorePath}`;
+    super(message);
+    this.name = 'GitignoreWriteError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * Entry to add to .gitignore
+ */
+export interface GitignoreEntry {
+  /** Pattern to add (e.g., 'node_modules/', 'dist/') */
+  pattern: string;
+  /** Optional comment to add before the entry (only first entry's comment is used) */
+  comment?: string;
+}
+
+/**
+ * Result of ensureGitignoreEntries operation
+ */
+export interface EnsureGitignoreResult {
+  /** Patterns that were added */
+  added: string[];
+  /** Patterns that already existed */
+  alreadyExists: string[];
+}
+
+/**
+ * Check if a pattern exists in gitignore content
+ */
+function patternExists(content: string, pattern: string): boolean {
+  const lines = content.split('\n');
+  return lines.some(line => line.trim() === pattern);
+}
+
+/**
+ * Ensure entries exist in .gitignore file
+ *
+ * - Creates .gitignore if it doesn't exist
+ * - Adds entries that don't already exist
+ * - Groups entries under a single comment (from first entry with comment)
+ * - Preserves existing content
+ *
+ * @param projectRoot - Project root directory
+ * @param entries - Entries to ensure in .gitignore
+ * @returns Result with added and already existing patterns
+ * @throws {GitignoreReadError} When an existing .gitignore file cannot be read
+ * @throws {GitignoreWriteError} When the .gitignore file cannot be written (e.g., permission denied, disk full)
+ */
+export async function ensureGitignoreEntries(
+  projectRoot: string,
+  entries: GitignoreEntry[],
+): Promise<EnsureGitignoreResult> {
+  const gitignorePath = path.join(projectRoot, '.gitignore');
+  const result: EnsureGitignoreResult = {
+    added: [],
+    alreadyExists: [],
+  };
+
+  // Read existing content or start with empty
+  let existingContent = '';
+  if (existsSync(gitignorePath)) {
+    try {
+      existingContent = await readFile(gitignorePath, 'utf-8');
+    } catch (error) {
+      throw new GitignoreReadError(gitignorePath, error);
+    }
+  }
+
+  // Categorize entries
+  for (const entry of entries) {
+    if (patternExists(existingContent, entry.pattern)) {
+      result.alreadyExists.push(entry.pattern);
+    } else {
+      result.added.push(entry.pattern);
+    }
+  }
+
+  // If nothing to add, return early
+  if (result.added.length === 0) {
+    return result;
+  }
+
+  // Build new content section
+  const newLines: string[] = [];
+
+  // Get comment from first entry that has one
+  const comment = entries.find(e => e.comment)?.comment;
+  if (comment) {
+    newLines.push(comment);
+  }
+
+  // Add patterns that need to be added
+  for (const pattern of result.added) {
+    newLines.push(pattern);
+  }
+
+  // Build final content
+  let finalContent = existingContent;
+
+  // Ensure existing content ends with newline
+  if (finalContent.length > 0 && !finalContent.endsWith('\n')) {
+    finalContent += '\n';
+  }
+
+  // Add blank line before new section if there's existing content
+  if (finalContent.length > 0) {
+    finalContent += '\n';
+  }
+
+  // Append new lines
+  finalContent += newLines.join('\n') + '\n';
+
+  // Write file
+  try {
+    await writeFile(gitignorePath, finalContent, 'utf-8');
+  } catch (error) {
+    throw new GitignoreWriteError(gitignorePath, error);
+  }
+
+  return result;
+}

--- a/apps/mcp-server/src/cli/init/index.ts
+++ b/apps/mcp-server/src/cli/init/index.ts
@@ -7,3 +7,10 @@ export {
   CONFIG_FILE_NAMES,
 } from './config.writer';
 export type { ConfigFormat, WriteConfigOptions } from './config.writer';
+export {
+  ensureGitignoreEntries,
+  GitignoreReadError,
+  GitignoreWriteError,
+} from './gitignore.utils';
+export type { GitignoreEntry, EnsureGitignoreResult } from './gitignore.utils';
+export { CODINGBUDDY_GITIGNORE_ENTRIES } from './init.constants';

--- a/apps/mcp-server/src/cli/init/init.command.spec.ts
+++ b/apps/mcp-server/src/cli/init/init.command.spec.ts
@@ -14,6 +14,7 @@ const {
   mockWizardDataToConfig,
   mockRenderConfigObjectAsJs,
   mockRenderConfigObjectAsJson,
+  mockEnsureGitignoreEntries,
 } = vi.hoisted(() => ({
   mockAnalyzeProject: vi.fn(),
   mockGenerate: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockWizardDataToConfig: vi.fn(),
   mockRenderConfigObjectAsJs: vi.fn(),
   mockRenderConfigObjectAsJson: vi.fn(),
+  mockEnsureGitignoreEntries: vi.fn(),
 }));
 
 // Mock all modules
@@ -51,6 +53,10 @@ vi.mock('./templates', () => ({
 vi.mock('./init.wizard', () => ({
   runInitWizard: mockRunInitWizard,
   wizardDataToConfig: mockWizardDataToConfig,
+}));
+
+vi.mock('./gitignore.utils', () => ({
+  ensureGitignoreEntries: mockEnsureGitignoreEntries,
 }));
 
 vi.mock('../utils/console', () => ({
@@ -147,6 +153,10 @@ describe('init.command', () => {
     mockWizardDataToConfig.mockReturnValue(mockConfig);
     mockRenderConfigObjectAsJs.mockReturnValue('// rendered config');
     mockRenderConfigObjectAsJson.mockReturnValue('{}');
+    mockEnsureGitignoreEntries.mockResolvedValue({
+      added: [],
+      alreadyExists: [],
+    });
   });
 
   describe('getApiKey', () => {

--- a/apps/mcp-server/src/cli/init/init.command.ts
+++ b/apps/mcp-server/src/cli/init/init.command.ts
@@ -12,6 +12,8 @@ import { findExistingConfig, writeConfig } from './config.writer';
 import { createConsoleUtils } from '../utils/console';
 import { renderConfigObjectAsJs, renderConfigObjectAsJson } from './templates';
 import { runInitWizard, wizardDataToConfig } from './init.wizard';
+import { ensureGitignoreEntries } from './gitignore.utils';
+import { CODINGBUDDY_GITIGNORE_ENTRIES } from './init.constants';
 import type { InitOptions, InitResult } from '../cli.types';
 
 /**
@@ -106,6 +108,18 @@ async function runTemplateInit(
 
   console.log.success(`Configuration saved to ${configPath}`);
 
+  // Step 5: Update .gitignore
+  const gitignoreResult = await ensureGitignoreEntries(
+    options.projectRoot,
+    CODINGBUDDY_GITIGNORE_ENTRIES,
+  );
+  if (gitignoreResult.added.length > 0) {
+    console.log.step(
+      '📝',
+      `Updated .gitignore: ${gitignoreResult.added.join(', ')}`,
+    );
+  }
+
   // Success message
   console.log.success('');
   console.log.step('✅', `codingbuddy.config.${options.format} created!`);
@@ -169,6 +183,18 @@ async function runAiInit(
   });
 
   console.log.success(`Configuration saved to ${configPath}`);
+
+  // Step 4: Update .gitignore
+  const gitignoreResult = await ensureGitignoreEntries(
+    options.projectRoot,
+    CODINGBUDDY_GITIGNORE_ENTRIES,
+  );
+  if (gitignoreResult.added.length > 0) {
+    console.log.step(
+      '📝',
+      `Updated .gitignore: ${gitignoreResult.added.join(', ')}`,
+    );
+  }
 
   // Success message
   console.log.success('');

--- a/apps/mcp-server/src/cli/init/init.constants.ts
+++ b/apps/mcp-server/src/cli/init/init.constants.ts
@@ -1,0 +1,21 @@
+/**
+ * Init Command Constants
+ *
+ * Constants used by the codingbuddy init command
+ */
+
+import type { GitignoreEntry } from './gitignore.utils';
+
+/**
+ * Default gitignore entries for codingbuddy
+ *
+ * These entries are added to .gitignore during `codingbuddy init`
+ * to exclude local workspace files from version control.
+ */
+export const CODINGBUDDY_GITIGNORE_ENTRIES: GitignoreEntry[] = [
+  {
+    pattern: 'docs/codingbuddy/context.md',
+    comment: '# Codingbuddy (local workspace)',
+  },
+  { pattern: 'docs/codingbuddy/sessions/' },
+];


### PR DESCRIPTION
# Auto-update .gitignore during codingbuddy init

## Summary

- Add automatic `.gitignore` updates when running `codingbuddy init`
- Exclude `docs/codingbuddy/context.md` and `docs/codingbuddy/sessions/` from version control
- Implement with TDD approach achieving 100% test coverage

## Implementation Details

### ensureGitignoreEntries Function

```typescript
export async function ensureGitignoreEntries(
  projectRoot: string,
  entries: GitignoreEntry[],
): Promise<EnsureGitignoreResult>
```

**Behavior:**
- Creates `.gitignore` if it doesn't exist
- Appends entries that don't already exist
- Groups entries under a single comment
- Preserves existing content
- Returns result indicating which entries were added vs already existed

### Error Handling

Two custom error classes with cause chain support:
- `GitignoreReadError` - thrown when existing `.gitignore` cannot be read
- `GitignoreWriteError` - thrown when `.gitignore` cannot be written

### Test Coverage

| Category | Tests |
|----------|-------|
| File creation | 1 |
| Append to existing | 3 |
| Duplicate prevention | 1 |
| Error handling (read) | 2 |
| Error handling (write) | 2 |
| Comment handling | 2 |
| **Total** | **11** |

## Test Plan

- [x] Run `yarn test` - all 2444 tests passing
- [x] Verify gitignore.utils.ts has 100% coverage
- [x] Manual test: run `codingbuddy init` in a new project
- [x] Manual test: run `codingbuddy init` in a project with existing .gitignore
- [x] Manual test: run `codingbuddy init` where entries already exist

## Screenshots / Examples

**Before (no .gitignore):**
```
$ npx codingbuddy init
...
📝 Updated .gitignore: docs/codingbuddy/context.md, docs/codingbuddy/sessions/
✅ codingbuddy.config.js created!
```

**After (.gitignore content):**
```gitignore
# Codingbuddy (local workspace)
docs/codingbuddy/context.md
docs/codingbuddy/sessions/
```

**When entries already exist:**
```
$ npx codingbuddy init --force
...
✅ codingbuddy.config.js created!
```
(No "Updated .gitignore" message since entries already exist)
