### PR TITLE
docs: update documentation for v3.0.0 release

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -53,6 +53,16 @@ Añade a la configuración de Claude Desktop (`~/Library/Application Support/Cla
 }
 ```
 
+### Plugin de Claude Code (Opcional)
+
+Para invocación nativa de habilidades en Claude Code:
+
+```bash
+npm install codingbuddy-claude-plugin
+```
+
+El plugin proporciona acceso directo a los flujos de trabajo PLAN/ACT/EVAL y agentes especialistas sin configuración MCP.
+
 [Guía completa de inicio →](docs/es/getting-started.md)
 
 ## Herramientas de IA compatibles
@@ -84,10 +94,10 @@ Añade a la configuración de Claude Desktop (`~/Library/Application Support/Cla
 
 Consulta el diagrama de arquitectura de arriba para una visión general del sistema de agentes de 3 capas:
 
-- **Layer 1 (Agentes de Modo)**: Ciclo de flujo de trabajo PLAN → ACT → EVAL
-- **Layer 2 (Agentes Principales)**: Solution Architect, Technical Planner, Frontend/Backend/Mobile/Data Developer, Tooling Engineer, Agent Architect, Code Reviewer, DevOps
-- **Layer 3 (Especialistas)**: 10 expertos de dominio (Seguridad, Rendimiento, Accesibilidad, i18n, etc.)
-- **Habilidades**: Capacidades reutilizables (TDD, Depuración, Brainstorming, etc.)
+- **Layer 1 (Agentes de Modo)**: Ciclo de flujo de trabajo PLAN → ACT → EVAL → AUTO
+- **Layer 2 (Agentes Principales)**: Solution Architect, Technical Planner, Frontend/Backend/Mobile/Data Developer, Platform Engineer, Tooling Engineer, AI/ML Engineer, Agent Architect, Code Reviewer, DevOps
+- **Layer 3 (Especialistas)**: 14 expertos de dominio (Seguridad, Rendimiento, Accesibilidad, i18n, Observabilidad, Migración, Arquitectura de Eventos, Integración, etc.)
+- **Habilidades**: 14 capacidades reutilizables (TDD, Depuración, Brainstorming, Migración de Base de Datos, Respuesta a Incidentes, etc.)
 
 Todas las configuraciones de herramientas de IA referencian el mismo directorio `packages/rules/.ai-rules/`. Cambia las reglas una vez, y todas las herramientas siguen los estándares actualizados.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -53,6 +53,16 @@ Claude Desktop設定に追加（`~/Library/Application Support/Claude/claude_des
 }
 ```
 
+### Claude Code プラグイン（オプション）
+
+Claude Codeでネイティブスキル呼び出しを使用する場合：
+
+```bash
+npm install codingbuddy-claude-plugin
+```
+
+このプラグインは、MCP設定なしでPLAN/ACT/EVALワークフローとスペシャリストエージェントに直接アクセスできます。
+
 [詳細なセットアップガイド →](docs/ja/getting-started.md)
 
 ## 対応AIツール
@@ -84,10 +94,10 @@ Claude Desktop設定に追加（`~/Library/Application Support/Claude/claude_des
 
 上記のアーキテクチャ図で3層エージェントシステムの全体像をご確認ください：
 
-- **Layer 1（モードエージェント）**：PLAN → ACT → EVAL ワークフローサイクル
-- **Layer 2（主要エージェント）**：Solution Architect、Technical Planner、Frontend/Backend/Mobile/Data Developer、Tooling Engineer、Agent Architect、Code Reviewer、DevOps
-- **Layer 3（スペシャリスト）**：10名のドメイン専門家（セキュリティ、パフォーマンス、アクセシビリティ、i18nなど）
-- **スキル**：再利用可能な機能（TDD、デバッグ、ブレインストーミングなど）
+- **Layer 1（モードエージェント）**：PLAN → ACT → EVAL → AUTO ワークフローサイクル
+- **Layer 2（主要エージェント）**：Solution Architect、Technical Planner、Frontend/Backend/Mobile/Data Developer、Platform Engineer、Tooling Engineer、AI/ML Engineer、Agent Architect、Code Reviewer、DevOps
+- **Layer 3（スペシャリスト）**：14名のドメイン専門家（セキュリティ、パフォーマンス、アクセシビリティ、i18n、オブザーバビリティ、マイグレーション、イベントアーキテクチャ、インテグレーションなど）
+- **スキル**：14個の再利用可能な機能（TDD、デバッグ、ブレインストーミング、データベースマイグレーション、インシデント対応など）
 
 すべてのAIツール設定が同じ`packages/rules/.ai-rules/`ディレクトリを参照します。ルールを一度変更すれば、すべてのツールが更新された標準に従います。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -53,6 +53,16 @@ Claude Desktop 설정 파일에 추가 (`~/Library/Application Support/Claude/cl
 }
 ```
 
+### Claude Code 플러그인 (선택)
+
+Claude Code에서 네이티브 스킬 호출을 위해:
+
+```bash
+npm install codingbuddy-claude-plugin
+```
+
+이 플러그인은 MCP 설정 없이 PLAN/ACT/EVAL 워크플로우와 전문가 에이전트에 직접 접근할 수 있게 해줍니다.
+
 [전체 시작 가이드 →](docs/ko/getting-started.md)
 
 ## 지원 AI 도구
@@ -84,10 +94,10 @@ Claude Desktop 설정 파일에 추가 (`~/Library/Application Support/Claude/cl
 
 위 아키텍처 다이어그램에서 3계층 에이전트 시스템의 전체 구조를 확인하세요:
 
-- **Layer 1 (모드 에이전트)**: PLAN → ACT → EVAL 워크플로우 사이클
-- **Layer 2 (주요 에이전트)**: Solution Architect, Technical Planner, Frontend/Backend/Mobile/Data Developer, Tooling Engineer, Agent Architect, Code Reviewer, DevOps
-- **Layer 3 (전문가)**: 10명의 도메인 전문가 (보안, 성능, 접근성, i18n 등)
-- **스킬**: 재사용 가능한 기능 (TDD, 디버깅, 브레인스토밍 등)
+- **Layer 1 (모드 에이전트)**: PLAN → ACT → EVAL → AUTO 워크플로우 사이클
+- **Layer 2 (주요 에이전트)**: Solution Architect, Technical Planner, Frontend/Backend/Mobile/Data Developer, Platform Engineer, Tooling Engineer, AI/ML Engineer, Agent Architect, Code Reviewer, DevOps
+- **Layer 3 (전문가)**: 14명의 도메인 전문가 (보안, 성능, 접근성, i18n, 관측 가능성, 마이그레이션, 이벤트 아키텍처, 통합 등)
+- **스킬**: 14개의 재사용 가능한 기능 (TDD, 디버깅, 브레인스토밍, 데이터베이스 마이그레이션, 인시던트 대응 등)
 
 모든 AI 도구 설정이 동일한 `packages/rules/.ai-rules/` 디렉토리를 참조합니다. 규칙을 한 번 수정하면 모든 도구가 업데이트된 표준을 따릅니다.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ Add to Claude Desktop config (`~/Library/Application Support/Claude/claude_deskt
 }
 ```
 
+### Claude Code Plugin (Optional)
+
+For native skill invocation in Claude Code:
+
+```bash
+npm install codingbuddy-claude-plugin
+```
+
+The plugin provides direct access to PLAN/ACT/EVAL workflows and specialist agents without MCP configuration.
+
 [Full Getting Started Guide →](docs/getting-started.md)
 
 ## Supported AI Tools
@@ -84,10 +94,10 @@ Add to Claude Desktop config (`~/Library/Application Support/Claude/claude_deskt
 
 See the architecture diagram above for a visual overview of the 3-layer agent system:
 
-- **Layer 1 (Mode Agents)**: PLAN → ACT → EVAL workflow cycle
-- **Layer 2 (Primary Agents)**: Solution Architect, Technical Planner, Frontend/Backend/Mobile/Data Developer, Tooling Engineer, Agent Architect, Code Reviewer, DevOps
-- **Layer 3 (Specialists)**: 10 domain experts (Security, Performance, Accessibility, i18n, etc.)
-- **Skills**: Reusable capabilities (TDD, Debugging, Brainstorming, etc.)
+- **Layer 1 (Mode Agents)**: PLAN → ACT → EVAL → AUTO workflow cycle
+- **Layer 2 (Primary Agents)**: Solution Architect, Technical Planner, Frontend/Backend/Mobile/Data Developer, Platform Engineer, Tooling Engineer, AI/ML Engineer, Agent Architect, Code Reviewer, DevOps
+- **Layer 3 (Specialists)**: 14 domain experts (Security, Performance, Accessibility, i18n, Observability, Migration, Event Architecture, Integration, etc.)
+- **Skills**: 14 reusable capabilities (TDD, Debugging, Brainstorming, Database Migration, Incident Response, etc.)
 
 All AI tool configurations reference the same `packages/rules/.ai-rules/` directory. Change the rules once, and every tool follows the updated standards.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,6 +53,16 @@ npx codingbuddy init
 }
 ```
 
+### Claude Code 插件（可选）
+
+在 Claude Code 中使用原生技能调用：
+
+```bash
+npm install codingbuddy-claude-plugin
+```
+
+该插件提供无需 MCP 配置即可直接访问 PLAN/ACT/EVAL 工作流和专家代理的功能。
+
 [完整入门指南 →](docs/zh-CN/getting-started.md)
 
 ## 支持的 AI 工具
@@ -84,10 +94,10 @@ npx codingbuddy init
 
 请参阅上方架构图，了解三层代理系统的完整概览：
 
-- **Layer 1（模式代理）**：PLAN → ACT → EVAL 工作流程循环
-- **Layer 2（主要代理）**：Solution Architect、Technical Planner、Frontend/Backend/Mobile/Data Developer、Tooling Engineer、Agent Architect、Code Reviewer、DevOps
-- **Layer 3（专家）**：10位领域专家（安全、性能、可访问性、i18n等）
-- **技能**：可复用功能（TDD、调试、头脑风暴等）
+- **Layer 1（模式代理）**：PLAN → ACT → EVAL → AUTO 工作流程循环
+- **Layer 2（主要代理）**：Solution Architect、Technical Planner、Frontend/Backend/Mobile/Data Developer、Platform Engineer、Tooling Engineer、AI/ML Engineer、Agent Architect、Code Reviewer、DevOps
+- **Layer 3（专家）**：14位领域专家（安全、性能、可访问性、i18n、可观测性、迁移、事件架构、集成等）
+- **技能**：14个可复用功能（TDD、调试、头脑风暴、数据库迁移、事件响应等）
 
 所有 AI 工具配置都引用同一个 `packages/rules/.ai-rules/` 目录。只需修改一次规则，所有工具都会遵循更新后的标准。
 

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "description": "Multi-AI Rules MCP Server - One source of truth for AI coding rules across all AI assistants",
   "author": "JeremyDev87",
   "license": "MIT",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,9 @@ This command analyzes your project and creates a `codingbuddy.config.js` file wi
 
 #### AI Model Selection
 
-During initialization, you'll be prompted to select a default AI model (Claude Sonnet 4, Opus 4, or Haiku 3.5 - not recommended). Your selection is saved to `ai.defaultModel` in the config file.
+During initialization, you'll be prompted to select a default AI model (Claude Sonnet 4, Opus 4, or Haiku 3.5). Your selection is saved to `ai.defaultModel` in the config file.
+
+> **Note**: Haiku 3.5 is not recommended for complex coding tasks due to its smaller context window and reduced capability for multi-step reasoning. Use Sonnet 4 or Opus 4 for best results.
 
 See [AI Configuration](./config-schema.md#ai-configuration-ai) for detailed model options and characteristics.
 
@@ -89,6 +91,16 @@ Add Codingbuddy to your AI assistant. Here's an example for Claude Desktop:
 ```
 
 For other AI tools, see [Supported Tools](./supported-tools.md).
+
+### Alternative: Claude Code Plugin
+
+For native skill invocation in Claude Code without MCP configuration:
+
+```bash
+npm install codingbuddy-claude-plugin
+```
+
+The plugin provides direct access to PLAN/ACT/EVAL workflows and specialist agents.
 
 ### Step 3: Start Coding
 
@@ -253,6 +265,10 @@ Available specialists:
 - `ui-ux-designer` - UI/UX design
 - `documentation-specialist` - Documentation
 - `code-quality-specialist` - Code standards
+- `integration-specialist` - External API integrations
+- `event-architecture-specialist` - Message queues, Event Sourcing
+- `observability-specialist` - Distributed tracing, SLI/SLO
+- `migration-specialist` - Legacy modernization, zero-downtime migrations
 - See [full agent list](../packages/rules/.ai-rules/agents/README.md)
 
 ## Next Steps

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -1,0 +1,147 @@
+# Migration Guide: v2.x to v3.0.0
+
+This guide helps you migrate from Codingbuddy v2.x to v3.0.0.
+
+## Overview
+
+v3.0.0 introduces several major improvements:
+
+- **Context Document System**: Persistent cross-mode context
+- **Claude Code Plugin**: Native skill invocation
+- **6 New Skills**: Performance optimization, database migration, etc.
+- **4 New Specialists**: Migration, observability, event architecture, integration
+
+## Breaking Changes
+
+### 1. Context Document System
+
+**What Changed:**
+
+Previous session-based context is replaced with a fixed-file approach at `docs/codingbuddy/context.md`.
+
+**Why:**
+
+Long conversations can trigger "context compaction" where earlier conversation history is summarized. The Context Document System ensures PLAN decisions persist into ACT mode even after compaction.
+
+**Migration Steps:**
+
+1. The file `docs/codingbuddy/context.md` will be auto-created when you use `parse_mode` in PLAN mode
+2. No action required - the system handles creation and updates automatically
+3. **We recommend** adding `docs/codingbuddy/` to your `.gitignore`. Context documents may contain sensitive project information, code snippets, or decisions that should not be exposed in version control.
+
+```bash
+# Add to .gitignore (recommended)
+echo "docs/codingbuddy/" >> .gitignore
+```
+
+### 2. New MCP Tools
+
+**New tools added:**
+
+| Tool | Purpose |
+|------|---------|
+| `read_context` | Read the current context document |
+| `update_context` | Update context document (PLAN resets, ACT/EVAL appends) |
+| `create_session` | Create a new session document |
+| `get_session` | Get a session document by ID |
+| `get_active_session` | Get the most recent active session |
+| `update_session` | Update a session document |
+
+**No migration required** - these are additive features.
+
+## New Features
+
+### Claude Code Plugin
+
+For native skill invocation in Claude Code:
+
+```bash
+npm install codingbuddy-claude-plugin
+```
+
+This is optional - the MCP server continues to work without it.
+
+### New Skills
+
+| Skill | Description |
+|-------|-------------|
+| `performance-optimization` | Profiling-first performance optimization |
+| `database-migration` | Zero-downtime schema changes |
+| `dependency-management` | Systematic package updates, CVE response |
+| `incident-response` | Organizational incident handling |
+| `pr-review` | Evidence-based PR review |
+| `refactoring` | Tidy First structured refactoring |
+
+### New Specialist Agents
+
+| Agent | Description |
+|-------|-------------|
+| `migration-specialist` | Legacy modernization, zero-downtime migrations |
+| `observability-specialist` | OpenTelemetry, SLI/SLO frameworks |
+| `event-architecture-specialist` | Message queues, Saga patterns |
+| `integration-specialist` | External API integrations, retry strategies |
+
+## Upgrade Steps
+
+### 1. Update Dependencies
+
+```bash
+# Update codingbuddy
+npm update codingbuddy
+
+# Or reinstall
+npm install codingbuddy@latest
+```
+
+### 2. Verify Configuration
+
+Your existing `codingbuddy.config.js` remains compatible. No changes required.
+
+### 3. Optional: Install Claude Code Plugin
+
+```bash
+npm install codingbuddy-claude-plugin
+```
+
+### 4. Test Your Setup
+
+```bash
+# Verify MCP server works
+npx codingbuddy mcp
+```
+
+## Deprecations
+
+### Removed in v3.0.0
+
+None - v3.0.0 is additive.
+
+### Deprecated (will be removed in v4.0.0)
+
+| Feature | Replacement |
+|---------|-------------|
+| `set_project_root` tool | Configure in MCP settings or use `--project-root` CLI flag |
+
+## Troubleshooting
+
+### Context Document Not Created
+
+If `docs/codingbuddy/context.md` is not created:
+
+1. Ensure you're using PLAN mode: `PLAN: your task`
+2. Check that `parse_mode` MCP tool is being called
+3. Verify write permissions to project directory
+
+### Plugin Not Found
+
+If Claude Code can't find the plugin:
+
+1. Ensure `codingbuddy-claude-plugin` is installed
+2. Check that `codingbuddy` is installed globally or in project
+3. Restart Claude Code after installation
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/JeremyDev87/codingbuddy/issues)
+- [Documentation](https://github.com/JeremyDev87/codingbuddy/tree/main/docs)
+- [API Reference](./api.md)

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-claude-plugin",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "description": "Claude Code Plugin for CodingBuddy - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills",
   "author": "JeremyDev87",
   "license": "MIT",
@@ -46,7 +46,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "codingbuddy": "^2.4.0"
+    "codingbuddy": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "codingbuddy": {

--- a/packages/rules/.ai-rules/CHANGELOG.md
+++ b/packages/rules/.ai-rules/CHANGELOG.md
@@ -5,6 +5,128 @@ All notable changes to the Multi-AI Coding Assistant Common Rules System will be
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-01-17
+
+### Added
+
+- **Claude Code Plugin** (`codingbuddy-claude-plugin`)
+  - Native skill invocation for Claude Code
+  - PLAN/ACT/EVAL workflow integration
+  - Specialist agents support
+  - Install via `npm install codingbuddy-claude-plugin`
+
+- **New Skills (6 skills)**
+  - `performance-optimization`: Profiling-first optimization workflow
+  - `database-migration`: Zero-downtime schema changes with expand-contract patterns
+  - `dependency-management`: Systematic package updates, CVE response, license compliance
+  - `incident-response`: Organizational incident handling with severity classification
+  - `pr-review`: Systematic, evidence-based PR review with anti-sycophancy principles
+  - `refactoring`: Tidy First structured refactoring workflow
+
+- **New Domain Specialists (4 agents)**
+  - `migration-specialist`: Strangler Fig, legacy modernization, zero-downtime migrations
+  - `observability-specialist`: OpenTelemetry, distributed tracing, SLI/SLO frameworks
+  - `event-architecture-specialist`: Message queues, Saga patterns, real-time communication
+  - `integration-specialist`: External API integrations, retry strategies, circuit breakers
+
+- **Context Document System**
+  - Fixed file `docs/codingbuddy/context.md` persists PLAN → ACT → EVAL context
+  - Survives context compaction in long conversations
+  - `read_context` / `update_context` MCP tools
+  - Automatic PLAN mode reset, ACT/EVAL mode append behavior
+
+- **Session Document Feature**
+  - `create_session` / `get_session` / `get_active_session` / `update_session` MCP tools
+  - i18n support for session documents
+  - Auto-session creation for PLAN/AUTO modes
+
+- **MCP Server Improvements**
+  - Auto-detect project root via `roots/list` MCP capability
+  - Auto-update `.gitignore` during `codingbuddy init`
+  - AUTO mode keyword recognition across all AI tools
+  - Improved async utilities and slug generation
+
+### Changed
+
+- **Architecture Refactoring**
+  - Strategy pattern for agent resolution (ADR-001)
+  - Session module decomposition (ADR-002)
+  - Context Document System design (ADR-003)
+  - Extracted shared test utilities to common files
+  - Keyword, session, and pattern strategy module extraction
+
+- **Test Coverage Improvements**
+  - CLI prompt test coverage: 60% → 90%
+  - Comprehensive ContextDocumentService tests
+  - Shared test utilities for reusability
+
+- **Primary Agent Resolution**
+  - Bug fixes for resolution priority
+  - Agent language now follows project config
+
+### Fixed
+
+- Context loss after conversation compaction (Context Document System)
+- `parse_mode` language configuration not applied
+- AUTO mode keyword recognition bug
+- Primary agent resolution priority bugs
+
+### Breaking Changes
+
+- **Context Document System**: Previous session-based context is replaced with fixed-file approach
+- Requires `docs/codingbuddy/context.md` for cross-mode persistence
+
+---
+
+## [2.4.1] - 2026-01-15
+
+### Fixed
+
+- Canary deployment timestamp mismatch
+
+---
+
+## [2.4.0] - 2026-01-14
+
+### Added
+
+- Integration Specialist Agent pipeline activation
+- Delegation rules for specialist agents
+
+---
+
+## [2.3.0] - 2026-01-12
+
+### Added
+
+- File-based state persistence (hybrid approach)
+- Auto-session creation for PLAN/AUTO modes
+- Session caching improvements
+
+---
+
+## [2.2.0] - 2026-01-10
+
+### Added
+
+- Session document feature for PLAN → ACT agent recommendation persistence
+- i18n support for session documents
+
+### Fixed
+
+- `parse_mode` language configuration issues
+
+---
+
+## [2.1.0] - 2026-01-08
+
+### Added
+
+- AUTO mode keyword recognition across all AI tools
+- Agent language follows project config setting
+
+---
+
 ## [2.0.0] - 2026-01-06
 
 ### Added

--- a/packages/rules/.ai-rules/skills/README.md
+++ b/packages/rules/.ai-rules/skills/README.md
@@ -19,6 +19,7 @@ Reusable workflows for consistent development practices.
 | subagent-driven-development | Execute plans with independent tasks in current session | In-session plan execution |
 | systematic-debugging | Systematic approach before proposing fixes | Encountering bugs or failures |
 | test-driven-development | Write tests first, then minimal code to pass | Before implementing features |
+| performance-optimization | Profiling-first performance optimization workflow | Performance issues, bottleneck analysis, optimization |
 | writing-plans | Create implementation plans before coding | Multi-step tasks with specs |
 
 ## Skill Format
@@ -127,6 +128,9 @@ EOF
 │   ├── escalation-matrix.md
 │   ├── postmortem-template.md
 │   └── severity-classification.md
+├── performance-optimization/
+│   ├── SKILL.md
+│   └── documentation-template.md
 ├── pr-review/
 │   └── SKILL.md
 ├── refactoring/

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-rules",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "description": "AI coding rules for consistent practices across AI assistants",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
# v3.0.0 Documentation Update

## Summary

- Update all documentation for v3.0.0 release
- Add migration guide for breaking Context Document System change
- Document Claude Code Plugin, 6 new skills, and 4 new specialists
- Sync all 5 language README versions

## Test Plan

- [ ] Verify all package.json versions show 3.0.0
- [ ] Verify CHANGELOG entries are in correct chronological order
- [ ] Verify migration guide renders correctly on GitHub
- [ ] Verify all README links work
- [ ] Verify API docs tool list is complete
- [ ] Run `npx codingbuddy mcp` to verify server starts

## Breaking Changes

**Context Document System**: Previous session-based context is replaced with fixed-file approach at `docs/codingbuddy/context.md`. Users should add `docs/codingbuddy/` to `.gitignore`.

## Related

- Implements documentation requirements for v3.0.0 release
- Closes documentation gap from v2.0.0 to v3.0.0

---


