### PR TITLE
Fix GitHub Pages Auto-Enablement in Marketplace Workflow

### DIFF
--- a/.github/workflows/marketplace.yml
+++ b/.github/workflows/marketplace.yml
@@ -103,6 +103,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        with:
+          enablement: true
 
       - name: Prepare marketplace directory
         run: |


### PR DESCRIPTION
# Fix GitHub Pages Auto-Enablement in Marketplace Workflow

## Summary

- Enable automatic GitHub Pages setup in marketplace deploy workflow
- Add `enablement: true` parameter to `actions/configure-pages` action

## Problem

The marketplace deploy workflow was failing with:
```
Error: Get Pages site failed. Please verify that the repository has Pages enabled
```

This occurred because GitHub Pages was not pre-configured in the repository settings, causing `actions/configure-pages` to fail when trying to access the non-existent Pages site.

## Solution

Added the `enablement: true` parameter to the `actions/configure-pages` step, which automatically creates and configures GitHub Pages when the workflow runs for the first time.

### Changes

```diff
- name: Setup Pages
  uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+ with:
+   enablement: true
```

## Why This Approach

1. **Zero manual configuration**: No need to manually enable GitHub Pages in repository settings
2. **Official solution**: The `enablement` parameter is the recommended approach from GitHub's `configure-pages` action documentation
3. **Idempotent**: Safe to run multiple times - if Pages is already enabled, it simply continues

## Test Plan

- [ ] Trigger the `marketplace-deploy` workflow manually via `workflow_dispatch`
- [ ] Verify the "Setup Pages" step completes successfully
- [ ] Verify the marketplace is deployed to GitHub Pages
- [ ] Confirm the marketplace URL is accessible

## Reference

Resolve #262 