### PR TITLE
Fix Marketplace Add Command Documentation

### DIFF
--- a/.github/templates/marketplace-index.html
+++ b/.github/templates/marketplace-index.html
@@ -35,14 +35,17 @@
   </head>
   <body>
     <h1>🚀 CodingBuddy Marketplace</h1>
-    <p>This is a Claude Code plugin marketplace.</p>
+    <p>Welcome to the CodingBuddy plugin marketplace for Claude Code.</p>
+    <p><strong>Note:</strong> This page is for informational purposes. To install the plugin, use the CLI commands below.</p>
 
     <h2>Installation</h2>
-    <pre><code># Add this marketplace
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+    <pre><code># Add the marketplace (use GitHub repository format)
+claude marketplace add JeremyDev87/codingbuddy
 
 # Install the plugin
 claude plugin install codingbuddy@jeremydev87</code></pre>
+
+    <p><em>⚠️ Do not use this page's URL directly with <code>claude marketplace add</code>. Use the GitHub repository format shown above.</em></p>
 
     <h2>Available Plugins</h2>
     <div class="plugin">

--- a/.github/workflows/marketplace.yml
+++ b/.github/workflows/marketplace.yml
@@ -169,8 +169,8 @@ jobs:
 
           echo "🎉 Marketplace deployed!"
           echo ""
-          echo "Marketplace URL: $PAGE_URL"
+          echo "Landing page URL: $PAGE_URL"
           echo ""
           echo "To use this marketplace:"
-          echo "  claude marketplace add $PAGE_URL"
+          echo "  claude marketplace add JeremyDev87/codingbuddy"
           echo "  claude plugin install codingbuddy@jeremydev87"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For enhanced integration with Claude Code:
 
 ```bash
 # 1. Add the marketplace
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. Install the plugin
 claude plugin install codingbuddy@jeremydev87
@@ -67,6 +67,8 @@ claude plugin install codingbuddy@jeremydev87
 # 3. Install MCP server for full functionality
 npm install -g codingbuddy
 ```
+
+> **Migration Note**: If you previously used `claude marketplace add https://jeremydev87.github.io/codingbuddy`, please remove it and use the GitHub repository format shown above. The URL format is deprecated.
 
 The plugin provides:
 - **Workflow Modes**: PLAN/ACT/EVAL/AUTO structured development

--- a/docs/es/plugin-architecture.md
+++ b/docs/es/plugin-architecture.md
@@ -288,7 +288,7 @@ Si el CLI `codingbuddy` no está instalado:
 ### Configuración Recomendada
 
 Para funcionalidad completa:
-1. Agregar marketplace: `claude marketplace add https://jeremydev87.github.io/codingbuddy`
+1. Agregar marketplace: `claude marketplace add JeremyDev87/codingbuddy`
 2. Instalar plugin: `claude plugin install codingbuddy@jeremydev87`
 3. Instalar servidor MCP: `npm install -g codingbuddy`
 4. Configurar MCP en la configuración de Claude

--- a/docs/es/plugin-faq.md
+++ b/docs/es/plugin-faq.md
@@ -63,7 +63,7 @@ Todas las herramientas comparten las mismas reglas de `packages/rules/.ai-rules/
 
 ```bash
 # 1. Agregar el marketplace
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. Instalar el plugin
 claude plugin install codingbuddy@jeremydev87

--- a/docs/es/plugin-guide.md
+++ b/docs/es/plugin-guide.md
@@ -37,11 +37,13 @@ La forma más sencilla de instalar el plugin:
 
 ```bash
 # 1. Agregar el marketplace
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. Instalar el plugin
 claude plugin install codingbuddy@jeremydev87
 ```
+
+> **Nota de Migración**: Si anteriormente usó `claude marketplace add https://jeremydev87.github.io/codingbuddy`, elimine el marketplace antiguo y use el formato de repositorio de GitHub mostrado arriba. El formato de URL está obsoleto.
 
 Esto automáticamente:
 - Descarga la última versión del plugin

--- a/docs/es/plugin-troubleshooting.md
+++ b/docs/es/plugin-troubleshooting.md
@@ -83,6 +83,63 @@ Soluciones a problemas comunes al usar el Plugin de CodingBuddy para Claude Code
 
 ---
 
+## Problemas del Marketplace
+
+### Error "Invalid marketplace schema"
+
+**Síntoma**: `claude marketplace add` falla con:
+```
+✘ Failed to add marketplace: Invalid marketplace schema from URL: : Invalid input: expected object, received string
+```
+
+**Causa**: Usando formato de URL en lugar del formato de repositorio de GitHub.
+
+**Solución**:
+```bash
+# Incorrecto (formato URL - obsoleto)
+claude marketplace add https://jeremydev87.github.io/codingbuddy
+
+# Correcto (formato de repositorio GitHub)
+claude marketplace add JeremyDev87/codingbuddy
+```
+
+### Migración desde Formato URL
+
+Si anteriormente agregó el marketplace usando el formato URL:
+
+```bash
+# 1. Eliminar marketplace antiguo
+claude marketplace remove https://jeremydev87.github.io/codingbuddy
+
+# 2. Agregar con formato correcto
+claude marketplace add JeremyDev87/codingbuddy
+
+# 3. Reinstalar el plugin
+claude plugin install codingbuddy@jeremydev87
+```
+
+### Marketplace No Encontrado
+
+**Síntoma**: `claude marketplace add JeremyDev87/codingbuddy` falla con "not found"
+
+**Soluciones**:
+
+1. **Verificar ortografía y mayúsculas/minúsculas**
+   - Nombre de usuario GitHub: `JeremyDev87` (distingue mayúsculas)
+   - Repositorio: `codingbuddy`
+
+2. **Verificar conectividad de red**
+   ```bash
+   curl -I https://github.com/JeremyDev87/codingbuddy
+   ```
+
+3. **Actualizar Claude Code**
+   ```bash
+   npm update -g @anthropic-ai/claude-code
+   ```
+
+---
+
 ## Problemas de Conexión MCP
 
 ### El Servidor MCP No Conecta

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,7 @@ For enhanced integration with Claude Code, install the dedicated plugin:
 
 ```bash
 # 1. Add the marketplace
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. Install the plugin
 claude plugin install codingbuddy@jeremydev87

--- a/docs/ja/plugin-architecture.md
+++ b/docs/ja/plugin-architecture.md
@@ -288,7 +288,7 @@ module.exports = {
 ### 推奨セットアップ
 
 完全な機能を利用するには：
-1. マーケットプレイスを追加: `claude marketplace add https://jeremydev87.github.io/codingbuddy`
+1. マーケットプレイスを追加: `claude marketplace add JeremyDev87/codingbuddy`
 2. プラグインをインストール: `claude plugin install codingbuddy@jeremydev87`
 3. MCP サーバーをインストール: `npm install -g codingbuddy`
 4. Claude 設定で MCP を構成

--- a/docs/ja/plugin-faq.md
+++ b/docs/ja/plugin-faq.md
@@ -63,7 +63,7 @@ CodingBuddy は、AI アシスタント間で一貫したコーディングプ�
 
 ```bash
 # 1. マーケットプレイスを追加
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. プラグインをインストール
 claude plugin install codingbuddy@jeremydev87

--- a/docs/ja/plugin-guide.md
+++ b/docs/ja/plugin-guide.md
@@ -37,11 +37,13 @@ claude --version
 
 ```bash
 # 1. マーケットプレイスを追加
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. プラグインをインストール
 claude plugin install codingbuddy@jeremydev87
 ```
+
+> **移行に関する注意**: 以前 `claude marketplace add https://jeremydev87.github.io/codingbuddy` を使用していた場合は、古いマーケットプレイスを削除し、上記の GitHub リポジトリ形式を使用してください。URL 形式は非推奨です。
 
 これにより自動的に：
 - 最新バージョンのプラグインをダウンロード

--- a/docs/ja/plugin-troubleshooting.md
+++ b/docs/ja/plugin-troubleshooting.md
@@ -83,6 +83,63 @@ CodingBuddy Claude Code プラグイン使用時のよくある問題の解決�
 
 ---
 
+## マーケットプレイスの問題
+
+### 「Invalid marketplace schema」エラー
+
+**症状**: `claude marketplace add` 実行時に以下のエラーが発生：
+```
+✘ Failed to add marketplace: Invalid marketplace schema from URL: : Invalid input: expected object, received string
+```
+
+**原因**: GitHub リポジトリ形式ではなく URL 形式を使用している。
+
+**解決方法**:
+```bash
+# 間違い（URL 形式 - 非推奨）
+claude marketplace add https://jeremydev87.github.io/codingbuddy
+
+# 正しい（GitHub リポジトリ形式）
+claude marketplace add JeremyDev87/codingbuddy
+```
+
+### URL 形式からの移行
+
+以前 URL 形式でマーケットプレイスを追加した場合：
+
+```bash
+# 1. 古いマーケットプレイスを削除
+claude marketplace remove https://jeremydev87.github.io/codingbuddy
+
+# 2. 正しい形式で追加
+claude marketplace add JeremyDev87/codingbuddy
+
+# 3. プラグインを再インストール
+claude plugin install codingbuddy@jeremydev87
+```
+
+### マーケットプレイスが見つからない
+
+**症状**: `claude marketplace add JeremyDev87/codingbuddy` 実行時に「not found」エラー
+
+**解決方法**:
+
+1. **スペルと大文字小文字を確認**
+   - GitHub ユーザー名: `JeremyDev87`（大文字小文字を区別）
+   - リポジトリ: `codingbuddy`
+
+2. **ネットワーク接続を確認**
+   ```bash
+   curl -I https://github.com/JeremyDev87/codingbuddy
+   ```
+
+3. **Claude Code を更新**
+   ```bash
+   npm update -g @anthropic-ai/claude-code
+   ```
+
+---
+
 ## MCP 接続の問題
 
 ### MCP サーバーが接続されない

--- a/docs/ko/plugin-architecture.md
+++ b/docs/ko/plugin-architecture.md
@@ -288,7 +288,7 @@ module.exports = {
 ### 권장 설정
 
 모든 기능을 사용하려면:
-1. 마켓플레이스 추가: `claude marketplace add https://jeremydev87.github.io/codingbuddy`
+1. 마켓플레이스 추가: `claude marketplace add JeremyDev87/codingbuddy`
 2. 플러그인 설치: `claude plugin install codingbuddy@jeremydev87`
 3. MCP 서버 설치: `npm install -g codingbuddy`
 4. Claude 설정에 MCP 구성

--- a/docs/ko/plugin-faq.md
+++ b/docs/ko/plugin-faq.md
@@ -63,7 +63,7 @@ CodingBuddy는 AI 어시스턴트 전반에 걸쳐 일관된 코딩 관행을 �
 
 ```bash
 # 1. 마켓플레이스 추가
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. 플러그인 설치
 claude plugin install codingbuddy@jeremydev87

--- a/docs/ko/plugin-guide.md
+++ b/docs/ko/plugin-guide.md
@@ -37,11 +37,13 @@ claude --version
 
 ```bash
 # 1. 마켓플레이스 추가
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. 플러그인 설치
 claude plugin install codingbuddy@jeremydev87
 ```
+
+> **마이그레이션 안내**: 이전에 `claude marketplace add https://jeremydev87.github.io/codingbuddy` 명령을 사용하셨다면, 기존 마켓플레이스를 제거하고 위에 표시된 GitHub 저장소 형식을 사용해 주세요. URL 형식은 더 이상 지원되지 않습니다.
 
 이 명령어는 자동으로:
 - 최신 플러그인 버전 다운로드

--- a/docs/ko/plugin-troubleshooting.md
+++ b/docs/ko/plugin-troubleshooting.md
@@ -83,6 +83,63 @@ CodingBuddy Claude Code 플러그인 사용 시 발생하는 일반적인 문제
 
 ---
 
+## 마켓플레이스 문제
+
+### "Invalid marketplace schema" 오류
+
+**증상**: `claude marketplace add` 실행 시 다음 오류 발생:
+```
+✘ Failed to add marketplace: Invalid marketplace schema from URL: : Invalid input: expected object, received string
+```
+
+**원인**: GitHub 저장소 형식 대신 URL 형식을 사용함.
+
+**해결 방법**:
+```bash
+# 잘못된 형식 (URL 형식 - 더 이상 지원 안 함)
+claude marketplace add https://jeremydev87.github.io/codingbuddy
+
+# 올바른 형식 (GitHub 저장소 형식)
+claude marketplace add JeremyDev87/codingbuddy
+```
+
+### URL 형식에서 마이그레이션
+
+이전에 URL 형식으로 마켓플레이스를 추가했다면:
+
+```bash
+# 1. 기존 마켓플레이스 제거
+claude marketplace remove https://jeremydev87.github.io/codingbuddy
+
+# 2. 올바른 형식으로 추가
+claude marketplace add JeremyDev87/codingbuddy
+
+# 3. 플러그인 재설치
+claude plugin install codingbuddy@jeremydev87
+```
+
+### 마켓플레이스를 찾을 수 없음
+
+**증상**: `claude marketplace add JeremyDev87/codingbuddy` 실행 시 "not found" 오류
+
+**해결 방법**:
+
+1. **철자와 대소문자 확인**
+   - GitHub 사용자명: `JeremyDev87` (대소문자 구분)
+   - 저장소: `codingbuddy`
+
+2. **네트워크 연결 확인**
+   ```bash
+   curl -I https://github.com/JeremyDev87/codingbuddy
+   ```
+
+3. **Claude Code 업데이트**
+   ```bash
+   npm update -g @anthropic-ai/claude-code
+   ```
+
+---
+
 ## MCP 연결 문제
 
 ### MCP 서버 연결 안 됨

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -288,7 +288,7 @@ If the `codingbuddy` CLI is not installed:
 ### Recommended Setup
 
 For full functionality:
-1. Add marketplace: `claude marketplace add https://jeremydev87.github.io/codingbuddy`
+1. Add marketplace: `claude marketplace add JeremyDev87/codingbuddy`
 2. Install plugin: `claude plugin install codingbuddy@jeremydev87`
 3. Install MCP server: `npm install -g codingbuddy`
 4. Configure MCP in Claude settings

--- a/docs/plugin-faq.md
+++ b/docs/plugin-faq.md
@@ -63,7 +63,7 @@ All tools share the same rules from `packages/rules/.ai-rules/`.
 
 ```bash
 # 1. Add the marketplace
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. Install the plugin
 claude plugin install codingbuddy@jeremydev87

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -37,11 +37,13 @@ The simplest way to install the plugin:
 
 ```bash
 # 1. Add the marketplace
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. Install the plugin
 claude plugin install codingbuddy@jeremydev87
 ```
+
+> **Migration Note**: If you previously used `claude marketplace add https://jeremydev87.github.io/codingbuddy`, please remove the old marketplace and use the GitHub repository format shown above. The URL format is deprecated.
 
 This automatically:
 - Downloads the latest plugin version

--- a/docs/plugin-troubleshooting.md
+++ b/docs/plugin-troubleshooting.md
@@ -83,6 +83,63 @@ Solutions to common issues when using the CodingBuddy Claude Code Plugin.
 
 ---
 
+## Marketplace Issues
+
+### "Invalid marketplace schema" Error
+
+**Symptom**: `claude marketplace add` fails with:
+```
+✘ Failed to add marketplace: Invalid marketplace schema from URL: : Invalid input: expected object, received string
+```
+
+**Cause**: Using URL format instead of GitHub repository format.
+
+**Solution**:
+```bash
+# Wrong (URL format - deprecated)
+claude marketplace add https://jeremydev87.github.io/codingbuddy
+
+# Correct (GitHub repository format)
+claude marketplace add JeremyDev87/codingbuddy
+```
+
+### Migrating from URL Format
+
+If you previously added the marketplace using the URL format:
+
+```bash
+# 1. Remove old marketplace
+claude marketplace remove https://jeremydev87.github.io/codingbuddy
+
+# 2. Add with correct format
+claude marketplace add JeremyDev87/codingbuddy
+
+# 3. Reinstall the plugin
+claude plugin install codingbuddy@jeremydev87
+```
+
+### Marketplace Not Found
+
+**Symptom**: `claude marketplace add JeremyDev87/codingbuddy` fails with "not found"
+
+**Solutions**:
+
+1. **Check spelling and case**
+   - GitHub username: `JeremyDev87` (case-sensitive)
+   - Repository: `codingbuddy`
+
+2. **Verify network connectivity**
+   ```bash
+   curl -I https://github.com/JeremyDev87/codingbuddy
+   ```
+
+3. **Update Claude Code**
+   ```bash
+   npm update -g @anthropic-ai/claude-code
+   ```
+
+---
+
 ## MCP Connection Issues
 
 ### MCP Server Not Connecting

--- a/docs/pt-BR/plugin-architecture.md
+++ b/docs/pt-BR/plugin-architecture.md
@@ -288,7 +288,7 @@ Se o CLI `codingbuddy` não está instalado:
 ### Configuração Recomendada
 
 Para funcionalidade completa:
-1. Adicionar marketplace: `claude marketplace add https://jeremydev87.github.io/codingbuddy`
+1. Adicionar marketplace: `claude marketplace add JeremyDev87/codingbuddy`
 2. Instalar plugin: `claude plugin install codingbuddy@jeremydev87`
 3. Instalar servidor MCP: `npm install -g codingbuddy`
 4. Configurar MCP nas configurações do Claude

--- a/docs/pt-BR/plugin-faq.md
+++ b/docs/pt-BR/plugin-faq.md
@@ -63,7 +63,7 @@ Todas as ferramentas compartilham as mesmas regras de `packages/rules/.ai-rules/
 
 ```bash
 # 1. Adicionar o marketplace
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. Instalar o plugin
 claude plugin install codingbuddy@jeremydev87

--- a/docs/pt-BR/plugin-guide.md
+++ b/docs/pt-BR/plugin-guide.md
@@ -37,11 +37,13 @@ A forma mais simples de instalar o plugin:
 
 ```bash
 # 1. Adicionar o marketplace
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. Instalar o plugin
 claude plugin install codingbuddy@jeremydev87
 ```
+
+> **Nota de Migração**: Se você usou anteriormente `claude marketplace add https://jeremydev87.github.io/codingbuddy`, remova o marketplace antigo e use o formato de repositório do GitHub mostrado acima. O formato de URL está descontinuado.
 
 Isso automaticamente:
 - Baixa a versão mais recente do plugin

--- a/docs/pt-BR/plugin-troubleshooting.md
+++ b/docs/pt-BR/plugin-troubleshooting.md
@@ -83,6 +83,63 @@ Soluções para problemas comuns ao usar o Plugin CodingBuddy para Claude Code.
 
 ---
 
+## Problemas do Marketplace
+
+### Erro "Invalid marketplace schema"
+
+**Sintoma**: `claude marketplace add` falha com:
+```
+✘ Failed to add marketplace: Invalid marketplace schema from URL: : Invalid input: expected object, received string
+```
+
+**Causa**: Usando formato de URL em vez do formato de repositório do GitHub.
+
+**Solução**:
+```bash
+# Incorreto (formato URL - descontinuado)
+claude marketplace add https://jeremydev87.github.io/codingbuddy
+
+# Correto (formato de repositório GitHub)
+claude marketplace add JeremyDev87/codingbuddy
+```
+
+### Migrando do Formato URL
+
+Se você adicionou anteriormente o marketplace usando o formato URL:
+
+```bash
+# 1. Remover marketplace antigo
+claude marketplace remove https://jeremydev87.github.io/codingbuddy
+
+# 2. Adicionar com formato correto
+claude marketplace add JeremyDev87/codingbuddy
+
+# 3. Reinstalar o plugin
+claude plugin install codingbuddy@jeremydev87
+```
+
+### Marketplace Não Encontrado
+
+**Sintoma**: `claude marketplace add JeremyDev87/codingbuddy` falha com "not found"
+
+**Soluções**:
+
+1. **Verificar ortografia e maiúsculas/minúsculas**
+   - Nome de usuário GitHub: `JeremyDev87` (diferencia maiúsculas)
+   - Repositório: `codingbuddy`
+
+2. **Verificar conectividade de rede**
+   ```bash
+   curl -I https://github.com/JeremyDev87/codingbuddy
+   ```
+
+3. **Atualizar Claude Code**
+   ```bash
+   npm update -g @anthropic-ai/claude-code
+   ```
+
+---
+
 ## Problemas de Conexão MCP
 
 ### Servidor MCP Não Conecta

--- a/docs/zh-CN/plugin-architecture.md
+++ b/docs/zh-CN/plugin-architecture.md
@@ -288,7 +288,7 @@ module.exports = {
 ### 推荐设置
 
 要获得完整功能：
-1. 添加市场：`claude marketplace add https://jeremydev87.github.io/codingbuddy`
+1. 添加市场：`claude marketplace add JeremyDev87/codingbuddy`
 2. 安装插件：`claude plugin install codingbuddy@jeremydev87`
 3. 安装 MCP 服务器：`npm install -g codingbuddy`
 4. 在 Claude 设置中配置 MCP

--- a/docs/zh-CN/plugin-faq.md
+++ b/docs/zh-CN/plugin-faq.md
@@ -63,7 +63,7 @@ CodingBuddy 是一个多 AI 规则系统，为 AI 助手提供一致的编码实
 
 ```bash
 # 1. 添加市场
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. 安装插件
 claude plugin install codingbuddy@jeremydev87

--- a/docs/zh-CN/plugin-guide.md
+++ b/docs/zh-CN/plugin-guide.md
@@ -37,11 +37,13 @@ claude --version
 
 ```bash
 # 1. 添加市场
-claude marketplace add https://jeremydev87.github.io/codingbuddy
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. 安装插件
 claude plugin install codingbuddy@jeremydev87
 ```
+
+> **迁移说明**：如果您之前使用 `claude marketplace add https://jeremydev87.github.io/codingbuddy`，请删除旧的市场并使用上面显示的 GitHub 仓库格式。URL 格式已弃用。
 
 此命令会自动：
 - 下载最新版本的插件

--- a/docs/zh-CN/plugin-troubleshooting.md
+++ b/docs/zh-CN/plugin-troubleshooting.md
@@ -83,6 +83,63 @@
 
 ---
 
+## 市场问题
+
+### "Invalid marketplace schema" 错误
+
+**症状**：执行 `claude marketplace add` 时出现以下错误：
+```
+✘ Failed to add marketplace: Invalid marketplace schema from URL: : Invalid input: expected object, received string
+```
+
+**原因**：使用了 URL 格式而不是 GitHub 仓库格式。
+
+**解决方法**：
+```bash
+# 错误（URL 格式 - 已弃用）
+claude marketplace add https://jeremydev87.github.io/codingbuddy
+
+# 正确（GitHub 仓库格式）
+claude marketplace add JeremyDev87/codingbuddy
+```
+
+### 从 URL 格式迁移
+
+如果您之前使用 URL 格式添加了市场：
+
+```bash
+# 1. 删除旧市场
+claude marketplace remove https://jeremydev87.github.io/codingbuddy
+
+# 2. 使用正确格式添加
+claude marketplace add JeremyDev87/codingbuddy
+
+# 3. 重新安装插件
+claude plugin install codingbuddy@jeremydev87
+```
+
+### 找不到市场
+
+**症状**：执行 `claude marketplace add JeremyDev87/codingbuddy` 时出现 "not found" 错误
+
+**解决方法**：
+
+1. **检查拼写和大小写**
+   - GitHub 用户名：`JeremyDev87`（区分大小写）
+   - 仓库：`codingbuddy`
+
+2. **验证网络连接**
+   ```bash
+   curl -I https://github.com/JeremyDev87/codingbuddy
+   ```
+
+3. **更新 Claude Code**
+   ```bash
+   npm update -g @anthropic-ai/claude-code
+   ```
+
+---
+
 ## MCP 连接问题
 
 ### MCP 服务器无法连接

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -7,8 +7,8 @@ Multi-AI Rules for consistent coding practices - PLAN/ACT/EVAL workflow, special
 ## Installation
 
 ```bash
-# 1. Add the self-hosted marketplace
-claude marketplace add https://github.com/JeremyDev87/codingbuddy
+# 1. Add the marketplace
+claude marketplace add JeremyDev87/codingbuddy
 
 # 2. Install the plugin
 claude plugin install codingbuddy@jeremydev87


### PR DESCRIPTION
# Fix Marketplace Add Command Documentation

## Summary

Updates all documentation to use the correct GitHub repository format for the `claude marketplace add` command, adds migration notes for existing users, and includes comprehensive troubleshooting guidance.

## Problem

The documented command `claude marketplace add https://jeremydev87.github.io/codingbuddy` fails with:

```
✘ Failed to add marketplace: Invalid marketplace schema from URL: : Invalid input: expected object, received string
```

## Solution

Changed the marketplace add command format from URL to GitHub repository:

```bash
# Before (broken)
claude marketplace add https://jeremydev87.github.io/codingbuddy

# After (working)
claude marketplace add JeremyDev87/codingbuddy
```

## Testing

Verified the fix works:

```bash
$ claude marketplace add JeremyDev87/codingbuddy
✔ Marketplace 'jeremydev87' added successfully

$ claude plugin install codingbuddy@jeremydev87
✔ Plugin 'codingbuddy@jeremydev87' installed successfully
```

## Checklist

- [x] Documentation updated (all 6 languages)
- [x] Migration notes added
- [x] Troubleshooting guide updated
- [x] GitHub Pages landing page updated
- [x] CI workflow output message updated
- [x] Command verified working

## Related Issues

resolve #264

