### PR TITLE
Fix Config Language Setting Not Being Respected

### DIFF
--- a/.github/templates/marketplace-index.html
+++ b/.github/templates/marketplace-index.html
@@ -36,7 +36,10 @@
   <body>
     <h1>🚀 CodingBuddy Marketplace</h1>
     <p>Welcome to the CodingBuddy plugin marketplace for Claude Code.</p>
-    <p><strong>Note:</strong> This page is for informational purposes. To install the plugin, use the CLI commands below.</p>
+    <p>
+      <strong>Note:</strong> This page is for informational purposes. To install
+      the plugin, use the CLI commands below.
+    </p>
 
     <h2>Installation</h2>
     <pre><code># Add the marketplace (use GitHub repository format)
@@ -45,7 +48,13 @@ claude marketplace add JeremyDev87/codingbuddy
 # Install the plugin
 claude plugin install codingbuddy@jeremydev87</code></pre>
 
-    <p><em>⚠️ Do not use this page's URL directly with <code>claude marketplace add</code>. Use the GitHub repository format shown above.</em></p>
+    <p>
+      <em
+        >⚠️ Do not use this page's URL directly with
+        <code>claude marketplace add</code>. Use the GitHub repository format
+        shown above.</em
+      >
+    </p>
 
     <h2>Available Plugins</h2>
     <div class="plugin">

--- a/apps/mcp-server/src/diagnostic/diagnostic-log.service.spec.ts
+++ b/apps/mcp-server/src/diagnostic/diagnostic-log.service.spec.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DiagnosticLogService } from './diagnostic-log.service';
+import { ConfigService } from '../config/config.service';
+import * as fs from 'fs/promises';
+import { existsSync, mkdirSync } from 'fs';
+import * as path from 'path';
+
+vi.mock('fs/promises');
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+describe('DiagnosticLogService', () => {
+  let service: DiagnosticLogService;
+  let mockConfigService: ConfigService;
+
+  const TEST_PROJECT_ROOT = '/test/project';
+  const LOG_DIR = path.join(TEST_PROJECT_ROOT, 'docs/codingbuddy/log');
+  const LOG_FILE = path.join(LOG_DIR, 'diagnostic.log');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigService = {
+      getProjectRoot: vi.fn().mockReturnValue(TEST_PROJECT_ROOT),
+    } as unknown as ConfigService;
+
+    service = new DiagnosticLogService(mockConfigService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getLogDir', () => {
+    it('should return correct log directory path', () => {
+      const result = service.getLogDir();
+      expect(result).toBe(LOG_DIR);
+    });
+  });
+
+  describe('getLogFilePath', () => {
+    it('should return correct log file path', () => {
+      const result = service.getLogFilePath();
+      expect(result).toBe(LOG_FILE);
+    });
+  });
+
+  describe('log', () => {
+    it('should create log entry and write to file', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      const result = await service.log('info', 'test', 'Test message', {
+        key: 'value',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.filePath).toBe(LOG_FILE);
+      expect(mkdirSync).toHaveBeenCalledWith(LOG_DIR, { recursive: true });
+      expect(fs.writeFile).toHaveBeenCalled();
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.version).toBe('1.0.0');
+      expect(writtenContent.entries).toHaveLength(1);
+      expect(writtenContent.entries[0].level).toBe('info');
+      expect(writtenContent.entries[0].category).toBe('test');
+      expect(writtenContent.entries[0].message).toBe('Test message');
+    });
+
+    it('should append to existing log file', async () => {
+      const existingLog = {
+        version: '1.0.0',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        entries: [
+          {
+            timestamp: '2024-01-01T00:00:00.000Z',
+            level: 'info',
+            category: 'existing',
+            message: 'Existing entry',
+          },
+        ],
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(existingLog));
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      await service.log('warn', 'new', 'New entry');
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.entries).toHaveLength(2);
+    });
+
+    it('should handle write errors gracefully', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFile).mockRejectedValue(new Error('Write failed'));
+
+      const result = await service.log('error', 'test', 'Test message');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Write failed');
+    });
+  });
+
+  describe('convenience methods', () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    });
+
+    it('debug should log with debug level', async () => {
+      await service.debug('cat', 'msg');
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.entries[0].level).toBe('debug');
+    });
+
+    it('info should log with info level', async () => {
+      await service.info('cat', 'msg');
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.entries[0].level).toBe('info');
+    });
+
+    it('warn should log with warn level', async () => {
+      await service.warn('cat', 'msg');
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.entries[0].level).toBe('warn');
+    });
+
+    it('error should log with error level', async () => {
+      await service.error('cat', 'msg');
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.entries[0].level).toBe('error');
+    });
+  });
+
+  describe('logConfigLoading', () => {
+    beforeEach(() => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+    });
+
+    it('should log successful config loading', async () => {
+      await service.logConfigLoading(true, '/project', 'ko');
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.entries[0].level).toBe('info');
+      expect(writtenContent.entries[0].category).toBe('config');
+      expect(writtenContent.entries[0].context.configLanguage).toBe('ko');
+    });
+
+    it('should log failed config loading', async () => {
+      await service.logConfigLoading(
+        false,
+        '/project',
+        undefined,
+        'Config not found',
+      );
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls[0];
+      const writtenContent = JSON.parse(writeCall[1] as string);
+      expect(writtenContent.entries[0].level).toBe('warn');
+      expect(writtenContent.entries[0].context.error).toBe('Config not found');
+    });
+  });
+
+  describe('readLogs', () => {
+    it('should return empty array if file does not exist', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = await service.readLogs();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return log entries from file', async () => {
+      const logFile = {
+        version: '1.0.0',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        entries: [
+          {
+            timestamp: '2024-01-01T00:00:00.000Z',
+            level: 'info',
+            category: 'test',
+            message: 'Test',
+          },
+        ],
+      };
+
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(logFile));
+
+      const result = await service.readLogs();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].message).toBe('Test');
+    });
+  });
+
+  describe('clearLogs', () => {
+    it('should delete log file if exists', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      const result = await service.clearLogs();
+
+      expect(result.success).toBe(true);
+      expect(fs.unlink).toHaveBeenCalledWith(LOG_FILE);
+    });
+
+    it('should succeed even if file does not exist', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const result = await service.clearLogs();
+
+      expect(result.success).toBe(true);
+      expect(fs.unlink).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/mcp-server/src/diagnostic/diagnostic-log.service.ts
+++ b/apps/mcp-server/src/diagnostic/diagnostic-log.service.ts
@@ -1,0 +1,234 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'fs/promises';
+import { existsSync, mkdirSync } from 'fs';
+import * as path from 'path';
+import { ConfigService } from '../config/config.service';
+import {
+  LOG_DIR_PATH,
+  LOG_FILE_NAME,
+  LOG_SCHEMA_VERSION,
+  MAX_LOG_ENTRIES,
+  type DiagnosticLogEntry,
+  type DiagnosticLogFile,
+  type LogOperationResult,
+} from './diagnostic.types';
+
+/**
+ * DiagnosticLogService - File-based diagnostic logging
+ *
+ * Logs diagnostic information to docs/codingbuddy/log/ for debugging
+ * config loading and language resolution issues.
+ */
+@Injectable()
+export class DiagnosticLogService {
+  private readonly logger = new Logger(DiagnosticLogService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  /**
+   * Get the log directory path
+   */
+  getLogDir(): string {
+    const projectRoot = this.configService.getProjectRoot();
+    return path.join(projectRoot, LOG_DIR_PATH);
+  }
+
+  /**
+   * Get the log file path
+   */
+  getLogFilePath(): string {
+    return path.join(this.getLogDir(), LOG_FILE_NAME);
+  }
+
+  /**
+   * Ensure log directory exists
+   */
+  private ensureLogDir(): void {
+    const logDir = this.getLogDir();
+    if (!existsSync(logDir)) {
+      mkdirSync(logDir, { recursive: true });
+      this.logger.log(`Created log directory: ${logDir}`);
+    }
+  }
+
+  /**
+   * Load existing log file or create new one
+   */
+  private async loadOrCreateLogFile(): Promise<DiagnosticLogFile> {
+    const filePath = this.getLogFilePath();
+
+    if (existsSync(filePath)) {
+      try {
+        const content = await fs.readFile(filePath, 'utf-8');
+        const logFile = JSON.parse(content) as DiagnosticLogFile;
+
+        // Version check
+        if (logFile.version === LOG_SCHEMA_VERSION) {
+          return logFile;
+        }
+
+        // Version mismatch - create new file
+        this.logger.warn(`Log schema version mismatch, creating new log file`);
+      } catch {
+        this.logger.warn(`Failed to parse log file, creating new one`);
+      }
+    }
+
+    return {
+      version: LOG_SCHEMA_VERSION,
+      createdAt: new Date().toISOString(),
+      entries: [],
+    };
+  }
+
+  /**
+   * Write log entry to file
+   */
+  async log(
+    level: DiagnosticLogEntry['level'],
+    category: string,
+    message: string,
+    context?: Record<string, unknown>,
+  ): Promise<LogOperationResult> {
+    try {
+      this.ensureLogDir();
+
+      const logFile = await this.loadOrCreateLogFile();
+
+      const entry: DiagnosticLogEntry = {
+        timestamp: new Date().toISOString(),
+        level,
+        category,
+        message,
+        context,
+      };
+
+      logFile.entries.push(entry);
+
+      // Trim old entries if exceeds max
+      if (logFile.entries.length > MAX_LOG_ENTRIES) {
+        logFile.entries = logFile.entries.slice(-MAX_LOG_ENTRIES);
+      }
+
+      const filePath = this.getLogFilePath();
+      await fs.writeFile(filePath, JSON.stringify(logFile, null, 2), 'utf-8');
+
+      return { success: true, filePath };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Failed to write diagnostic log: ${errorMessage}`);
+      return { success: false, error: errorMessage };
+    }
+  }
+
+  /**
+   * Log debug message
+   */
+  async debug(
+    category: string,
+    message: string,
+    context?: Record<string, unknown>,
+  ): Promise<LogOperationResult> {
+    return this.log('debug', category, message, context);
+  }
+
+  /**
+   * Log info message
+   */
+  async info(
+    category: string,
+    message: string,
+    context?: Record<string, unknown>,
+  ): Promise<LogOperationResult> {
+    return this.log('info', category, message, context);
+  }
+
+  /**
+   * Log warning message
+   */
+  async warn(
+    category: string,
+    message: string,
+    context?: Record<string, unknown>,
+  ): Promise<LogOperationResult> {
+    return this.log('warn', category, message, context);
+  }
+
+  /**
+   * Log error message
+   */
+  async error(
+    category: string,
+    message: string,
+    context?: Record<string, unknown>,
+  ): Promise<LogOperationResult> {
+    return this.log('error', category, message, context);
+  }
+
+  /**
+   * Log config loading event
+   */
+  async logConfigLoading(
+    success: boolean,
+    projectRoot: string,
+    configLanguage?: string,
+    error?: string,
+  ): Promise<LogOperationResult> {
+    const level = success ? 'info' : 'warn';
+    const message = success
+      ? `Config loaded successfully`
+      : `Config loading failed or incomplete`;
+
+    return this.log(level, 'config', message, {
+      projectRoot,
+      configLanguage: configLanguage || null,
+      error: error || null,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Read all log entries
+   */
+  async readLogs(): Promise<DiagnosticLogEntry[]> {
+    try {
+      const filePath = this.getLogFilePath();
+
+      if (!existsSync(filePath)) {
+        return [];
+      }
+
+      const content = await fs.readFile(filePath, 'utf-8');
+      const logFile = JSON.parse(content) as DiagnosticLogFile;
+
+      return logFile.entries;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Failed to read diagnostic logs: ${errorMessage}`);
+      return [];
+    }
+  }
+
+  /**
+   * Clear all log entries
+   */
+  async clearLogs(): Promise<LogOperationResult> {
+    try {
+      const filePath = this.getLogFilePath();
+
+      if (existsSync(filePath)) {
+        await fs.unlink(filePath);
+        this.logger.log(`Cleared diagnostic log file: ${filePath}`);
+      }
+
+      return { success: true, filePath };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Failed to clear diagnostic logs: ${errorMessage}`);
+      return { success: false, error: errorMessage };
+    }
+  }
+}

--- a/apps/mcp-server/src/diagnostic/diagnostic.module.ts
+++ b/apps/mcp-server/src/diagnostic/diagnostic.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { DiagnosticLogService } from './diagnostic-log.service';
+import { CodingBuddyConfigModule } from '../config/config.module';
+
+@Module({
+  imports: [CodingBuddyConfigModule],
+  providers: [DiagnosticLogService],
+  exports: [DiagnosticLogService],
+})
+export class DiagnosticModule {}

--- a/apps/mcp-server/src/diagnostic/diagnostic.types.ts
+++ b/apps/mcp-server/src/diagnostic/diagnostic.types.ts
@@ -1,0 +1,48 @@
+/**
+ * Diagnostic log entry structure
+ */
+export interface DiagnosticLogEntry {
+  timestamp: string;
+  level: 'debug' | 'info' | 'warn' | 'error';
+  category: string;
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * Diagnostic log file structure
+ */
+export interface DiagnosticLogFile {
+  version: string;
+  createdAt: string;
+  entries: DiagnosticLogEntry[];
+}
+
+/**
+ * Log operation result
+ */
+export interface LogOperationResult {
+  success: boolean;
+  filePath?: string;
+  error?: string;
+}
+
+/**
+ * Log directory path (relative to project root)
+ */
+export const LOG_DIR_PATH = 'docs/codingbuddy/log';
+
+/**
+ * Log file name pattern
+ */
+export const LOG_FILE_NAME = 'diagnostic.log';
+
+/**
+ * Schema version for log file format
+ */
+export const LOG_SCHEMA_VERSION = '1.0.0';
+
+/**
+ * Maximum number of log entries to keep in a single file
+ */
+export const MAX_LOG_ENTRIES = 1000;

--- a/apps/mcp-server/src/diagnostic/index.ts
+++ b/apps/mcp-server/src/diagnostic/index.ts
@@ -1,0 +1,3 @@
+export * from './diagnostic.module';
+export * from './diagnostic-log.service';
+export * from './diagnostic.types';

--- a/apps/mcp-server/src/mcp/handlers/abstract-handler.integration.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/abstract-handler.integration.spec.ts
@@ -19,6 +19,7 @@ import { ModelResolverService } from '../../model/model-resolver.service';
 import { SessionService } from '../../session/session.service';
 import { StateService } from '../../state/state.service';
 import { ContextDocumentService } from '../../context/context-document.service';
+import { DiagnosticLogService } from '../../diagnostic/diagnostic-log.service';
 
 /**
  * Integration tests verifying all concrete handlers inherit
@@ -50,6 +51,7 @@ describe('Handler Security Integration', () => {
   let mockSessionService: SessionService;
   let mockStateService: StateService;
   let mockContextDocService: ContextDocumentService;
+  let mockDiagnosticLogService: DiagnosticLogService;
 
   beforeEach(() => {
     // Create mock services with minimal implementation
@@ -129,6 +131,15 @@ describe('Handler Security Integration', () => {
       contextExists: vi.fn().mockResolvedValue(true),
     } as unknown as ContextDocumentService;
 
+    mockDiagnosticLogService = {
+      logConfigLoading: vi.fn().mockResolvedValue({ success: true }),
+      log: vi.fn().mockResolvedValue({ success: true }),
+      debug: vi.fn().mockResolvedValue({ success: true }),
+      info: vi.fn().mockResolvedValue({ success: true }),
+      warn: vi.fn().mockResolvedValue({ success: true }),
+      error: vi.fn().mockResolvedValue({ success: true }),
+    } as unknown as DiagnosticLogService;
+
     // Initialize handlers
     agentHandler = new AgentHandler(mockAgentService);
     checklistHandler = new ChecklistContextHandler(
@@ -148,6 +159,7 @@ describe('Handler Security Integration', () => {
       mockSessionService,
       mockStateService,
       mockContextDocService,
+      mockDiagnosticLogService,
     );
     rulesHandler = new RulesHandler(mockRulesService);
     skillHandler = new SkillHandler(mockSkillRecommendationService);

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
@@ -7,6 +7,7 @@ import { ModelResolverService } from '../../model';
 import { SessionService } from '../../session/session.service';
 import { StateService } from '../../state/state.service';
 import { ContextDocumentService } from '../../context/context-document.service';
+import { DiagnosticLogService } from '../../diagnostic/diagnostic-log.service';
 
 describe('ModeHandler', () => {
   let handler: ModeHandler;
@@ -17,6 +18,7 @@ describe('ModeHandler', () => {
   let mockSessionService: SessionService;
   let mockStateService: StateService;
   let mockContextDocService: ContextDocumentService;
+  let mockDiagnosticLogService: DiagnosticLogService;
 
   const mockParseModeResult = {
     mode: 'PLAN',
@@ -37,6 +39,7 @@ describe('ModeHandler', () => {
 
     mockConfigService = {
       getLanguage: vi.fn().mockResolvedValue('ko'),
+      getProjectRoot: vi.fn().mockReturnValue('/test/project'),
       reload: vi.fn().mockResolvedValue({}),
     } as unknown as ConfigService;
 
@@ -117,6 +120,15 @@ describe('ModeHandler', () => {
       contextExists: vi.fn().mockResolvedValue(true),
     } as unknown as ContextDocumentService;
 
+    mockDiagnosticLogService = {
+      logConfigLoading: vi.fn().mockResolvedValue({ success: true }),
+      log: vi.fn().mockResolvedValue({ success: true }),
+      debug: vi.fn().mockResolvedValue({ success: true }),
+      info: vi.fn().mockResolvedValue({ success: true }),
+      warn: vi.fn().mockResolvedValue({ success: true }),
+      error: vi.fn().mockResolvedValue({ success: true }),
+    } as unknown as DiagnosticLogService;
+
     handler = new ModeHandler(
       mockKeywordService,
       mockConfigService,
@@ -125,6 +137,7 @@ describe('ModeHandler', () => {
       mockSessionService,
       mockStateService,
       mockContextDocService,
+      mockDiagnosticLogService,
     );
   });
 

--- a/apps/mcp-server/src/mcp/mcp.module.ts
+++ b/apps/mcp-server/src/mcp/mcp.module.ts
@@ -10,6 +10,7 @@ import { ChecklistModule } from '../checklist/checklist.module';
 import { ContextModule } from '../context/context.module';
 import { SessionModule } from '../session/session.module';
 import { StateModule } from '../state/state.module';
+import { DiagnosticModule } from '../diagnostic/diagnostic.module';
 import { SkillRecommendationService } from '../skill/skill-recommendation.service';
 import { LanguageService } from '../shared/language.service';
 import { ModelResolverService } from '../model';
@@ -51,6 +52,7 @@ const handlers = [
     ContextModule,
     SessionModule,
     StateModule,
+    DiagnosticModule,
   ],
   controllers: [McpController],
   providers: [

--- a/apps/mcp-server/src/mcp/mcp.service.spec.ts
+++ b/apps/mcp-server/src/mcp/mcp.service.spec.ts
@@ -23,6 +23,7 @@ import { ContextDocumentService } from '../context/context-document.service';
 import { ModelResolverService } from '../model';
 import { SessionService } from '../session/session.service';
 import { StateService } from '../state/state.service';
+import { DiagnosticLogService } from '../diagnostic/diagnostic-log.service';
 import type { ToolHandler } from './handlers';
 import {
   RulesHandler,
@@ -467,6 +468,7 @@ interface CreateMcpServiceOptions {
   modelResolverService?: Partial<ModelResolverService>;
   sessionService?: Partial<SessionService>;
   stateService?: Partial<StateService>;
+  diagnosticLogService?: Partial<DiagnosticLogService>;
 }
 
 function createMcpServiceWithHandlers(
@@ -494,6 +496,7 @@ function createMcpServiceWithHandlers(
       services.sessionService as SessionService,
       services.stateService as StateService,
       services.contextDocService as ContextDocumentService,
+      services.diagnosticLogService as DiagnosticLogService,
     ),
     new ChecklistContextHandler(
       services.checklistService as ChecklistService,
@@ -523,6 +526,7 @@ describe('McpService', () => {
   let mockModelResolverService: Partial<ModelResolverService>;
   let mockSessionService: Partial<SessionService>;
   let mockStateService: Partial<StateService>;
+  let mockDiagnosticLogService: Partial<DiagnosticLogService>;
 
   const testConfig: CodingBuddyConfig = {
     language: 'ko',
@@ -557,6 +561,14 @@ describe('McpService', () => {
     mockModelResolverService = createMockModelResolverService();
     mockSessionService = createMockSessionService();
     mockStateService = createMockStateService();
+    mockDiagnosticLogService = {
+      logConfigLoading: vi.fn().mockResolvedValue({ success: true }),
+      log: vi.fn().mockResolvedValue({ success: true }),
+      debug: vi.fn().mockResolvedValue({ success: true }),
+      info: vi.fn().mockResolvedValue({ success: true }),
+      warn: vi.fn().mockResolvedValue({ success: true }),
+      error: vi.fn().mockResolvedValue({ success: true }),
+    };
 
     // Store default mocks for use in helper function
     defaultMocks = {
@@ -574,6 +586,7 @@ describe('McpService', () => {
       modelResolverService: mockModelResolverService,
       sessionService: mockSessionService,
       stateService: mockStateService,
+      diagnosticLogService: mockDiagnosticLogService,
     };
 
     const mcpService = createMcpServiceWithHandlers(defaultMocks);

--- a/apps/mcp-server/src/session/session-lifecycle.integration.spec.ts
+++ b/apps/mcp-server/src/session/session-lifecycle.integration.spec.ts
@@ -7,6 +7,7 @@ import { LanguageService } from '../shared/language.service';
 import { ModelResolverService } from '../model/model-resolver.service';
 import { StateService } from '../state/state.service';
 import { ContextDocumentService } from '../context/context-document.service';
+import { DiagnosticLogService } from '../diagnostic/diagnostic-log.service';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -30,6 +31,7 @@ describe('Session Lifecycle Integration', () => {
   let mockLanguageService: LanguageService;
   let mockModelResolverService: ModelResolverService;
   let mockContextDocService: ContextDocumentService;
+  let mockDiagnosticLogService: DiagnosticLogService;
 
   let tempDir: string;
   let sessionsDir: string;
@@ -118,6 +120,16 @@ describe('Session Lifecycle Integration', () => {
       contextExists: vi.fn().mockResolvedValue(true),
     } as unknown as ContextDocumentService;
 
+    // Mock DiagnosticLogService
+    mockDiagnosticLogService = {
+      logConfigLoading: vi.fn().mockResolvedValue({ success: true }),
+      log: vi.fn().mockResolvedValue({ success: true }),
+      debug: vi.fn().mockResolvedValue({ success: true }),
+      info: vi.fn().mockResolvedValue({ success: true }),
+      warn: vi.fn().mockResolvedValue({ success: true }),
+      error: vi.fn().mockResolvedValue({ success: true }),
+    } as unknown as DiagnosticLogService;
+
     // Create ModeHandler with real SessionService
     modeHandler = new ModeHandler(
       mockKeywordService,
@@ -127,6 +139,7 @@ describe('Session Lifecycle Integration', () => {
       sessionService,
       mockStateService,
       mockContextDocService,
+      mockDiagnosticLogService,
     );
   });
 

--- a/packages/rules/.ai-rules/agents/accessibility-specialist.json
+++ b/packages/rules/.ai-rules/agents/accessibility-specialist.json
@@ -494,7 +494,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding accessibility context (planning/implementation/evaluation)",
       "Plan/verify WCAG 2.1 AA compliance",

--- a/packages/rules/.ai-rules/agents/act-mode.json
+++ b/packages/rules/.ai-rules/agents/act-mode.json
@@ -135,7 +135,6 @@
   },
 
   "communication": {
-    "language": "en",
     "style": "Execution-focused step-by-step progress reporting",
     "format": "Clearly display implementation progress and quality verification results"
   },

--- a/packages/rules/.ai-rules/agents/agent-architect.json
+++ b/packages/rules/.ai-rules/agents/agent-architect.json
@@ -182,7 +182,6 @@
   ],
 
   "communication": {
-    "language": "en",
     "style": "Systematic and clear approach, schema-driven design",
     "approach": [
       "Start by understanding agent requirements",

--- a/packages/rules/.ai-rules/agents/ai-ml-engineer.json
+++ b/packages/rules/.ai-rules/agents/ai-ml-engineer.json
@@ -725,7 +725,6 @@
   },
 
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding AI/ML requirements context",
       "Read existing AI integration code before changes",

--- a/packages/rules/.ai-rules/agents/architecture-specialist.json
+++ b/packages/rules/.ai-rules/agents/architecture-specialist.json
@@ -494,7 +494,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding architecture context (planning/implementation/evaluation)",
       "Plan/verify layer placement for all files",

--- a/packages/rules/.ai-rules/agents/backend-developer.json
+++ b/packages/rules/.ai-rules/agents/backend-developer.json
@@ -401,7 +401,6 @@
   },
 
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding current code state",
       "Read code files before making changes",

--- a/packages/rules/.ai-rules/agents/code-quality-specialist.json
+++ b/packages/rules/.ai-rules/agents/code-quality-specialist.json
@@ -690,7 +690,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding code quality context (planning/implementation/evaluation)",
       "Plan/verify SOLID principles application",

--- a/packages/rules/.ai-rules/agents/data-engineer.json
+++ b/packages/rules/.ai-rules/agents/data-engineer.json
@@ -321,7 +321,6 @@
   },
 
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding current schema state",
       "Read existing migrations and models",

--- a/packages/rules/.ai-rules/agents/devops-engineer.json
+++ b/packages/rules/.ai-rules/agents/devops-engineer.json
@@ -280,7 +280,6 @@
   ],
 
   "communication": {
-    "language": "en",
     "approach": [
       "Analyze current infrastructure state first",
       "Explain optimization opportunities clearly",

--- a/packages/rules/.ai-rules/agents/documentation-specialist.json
+++ b/packages/rules/.ai-rules/agents/documentation-specialist.json
@@ -523,7 +523,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding documentation context (planning/implementation/evaluation)",
       "Plan/review code comments for complex logic",

--- a/packages/rules/.ai-rules/agents/eval-mode.json
+++ b/packages/rules/.ai-rules/agents/eval-mode.json
@@ -170,7 +170,6 @@
   },
 
   "communication": {
-    "language": "en",
     "style": "Objective and evidence-based analytical evaluation",
     "format": "Structured evaluation report format, improvements presented first"
   },

--- a/packages/rules/.ai-rules/agents/event-architecture-specialist.json
+++ b/packages/rules/.ai-rules/agents/event-architecture-specialist.json
@@ -679,7 +679,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding event architecture context (sync vs async needs, consistency requirements)",
       "Plan/verify message broker selection and configuration",

--- a/packages/rules/.ai-rules/agents/frontend-developer.json
+++ b/packages/rules/.ai-rules/agents/frontend-developer.json
@@ -372,7 +372,6 @@
   },
 
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding current code state",
       "Read code files before making changes",

--- a/packages/rules/.ai-rules/agents/i18n-specialist.json
+++ b/packages/rules/.ai-rules/agents/i18n-specialist.json
@@ -368,7 +368,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding i18n context (planning/implementation/evaluation)",
       "Plan/verify i18n library configuration",

--- a/packages/rules/.ai-rules/agents/integration-specialist.json
+++ b/packages/rules/.ai-rules/agents/integration-specialist.json
@@ -549,7 +549,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding integration context (API type, webhook, OAuth)",
       "Plan/verify resilience patterns (retry, timeout, circuit breaker)",

--- a/packages/rules/.ai-rules/agents/migration-specialist.json
+++ b/packages/rules/.ai-rules/agents/migration-specialist.json
@@ -653,7 +653,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding migration context and scope",
       "Identify appropriate migration pattern",

--- a/packages/rules/.ai-rules/agents/mobile-developer.json
+++ b/packages/rules/.ai-rules/agents/mobile-developer.json
@@ -297,7 +297,6 @@
   },
 
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding target platforms",
       "Read existing project structure and patterns",

--- a/packages/rules/.ai-rules/agents/observability-specialist.json
+++ b/packages/rules/.ai-rules/agents/observability-specialist.json
@@ -718,7 +718,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding observability context (planning/implementation/evaluation)",
       "Plan/verify distributed tracing strategy",

--- a/packages/rules/.ai-rules/agents/performance-specialist.json
+++ b/packages/rules/.ai-rules/agents/performance-specialist.json
@@ -532,7 +532,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding performance context (planning/implementation/evaluation)",
       "Plan/analyze bundle size and rendering",

--- a/packages/rules/.ai-rules/agents/plan-mode.json
+++ b/packages/rules/.ai-rules/agents/plan-mode.json
@@ -89,7 +89,6 @@
   },
 
   "communication": {
-    "language": "en",
     "style": "Systematic approach focused on planning",
     "format": "Clear section separation in structured markdown format"
   },

--- a/packages/rules/.ai-rules/agents/platform-engineer.json
+++ b/packages/rules/.ai-rules/agents/platform-engineer.json
@@ -1197,7 +1197,6 @@
   },
 
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding current infrastructure state",
       "Review existing IaC before making changes",

--- a/packages/rules/.ai-rules/agents/security-specialist.json
+++ b/packages/rules/.ai-rules/agents/security-specialist.json
@@ -472,7 +472,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding security context (planning/implementation/evaluation)",
       "Plan/verify authentication implementation",

--- a/packages/rules/.ai-rules/agents/seo-specialist.json
+++ b/packages/rules/.ai-rules/agents/seo-specialist.json
@@ -407,7 +407,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding SEO context (planning/implementation/evaluation)",
       "Plan/review metadata implementation",

--- a/packages/rules/.ai-rules/agents/solution-architect.json
+++ b/packages/rules/.ai-rules/agents/solution-architect.json
@@ -162,7 +162,6 @@
   },
 
   "communication": {
-    "language": "en",
     "style": "Systematic and clear approach, option-oriented design",
     "approach": [
       "Start with brainstorming skill",

--- a/packages/rules/.ai-rules/agents/technical-planner.json
+++ b/packages/rules/.ai-rules/agents/technical-planner.json
@@ -198,7 +198,6 @@
   },
 
   "communication": {
-    "language": "en",
     "style": "Detailed and actionable plans, TDD-focused",
     "approach": [
       "Start with writing-plans skill",

--- a/packages/rules/.ai-rules/agents/test-strategy-specialist.json
+++ b/packages/rules/.ai-rules/agents/test-strategy-specialist.json
@@ -536,7 +536,6 @@
     }
   },
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding test context (planning/implementation/evaluation)",
       "Plan/verify TDD vs Test-After approach",

--- a/packages/rules/.ai-rules/agents/ui-ux-designer.json
+++ b/packages/rules/.ai-rules/agents/ui-ux-designer.json
@@ -493,7 +493,6 @@
   },
 
   "communication": {
-    "language": "en",
     "approach": [
       "Start by understanding user goals and context",
       "Apply universal design principles (not system-specific)",


### PR DESCRIPTION
# Fix Config Language Setting Not Being Respected

## Summary

- Remove hardcoded `"language": "en"` from 27 agent JSON files to allow config-based language resolution
- Add `DiagnosticLogService` for file-based logging to debug config loading issues
- Integrate diagnostic logging into `ModeHandler` for language resolution tracking

## Changes

### 1. Agent JSON Language Removal (27 files)

Removed the hardcoded `"language": "en"` field from the `communication` object in all agent JSON files:

## Test Plan

- [x] All 2570 existing tests pass
- [x] New `diagnostic-log.service.spec.ts` has 12 tests covering:
  - Log directory/file path resolution
  - Log entry creation and file writing
  - Appending to existing log files
  - Error handling for write failures
  - All convenience methods (debug, info, warn, error)
  - Config loading event logging
  - Log reading and clearing

## Breaking Changes

None. The removal of `"language": "en"` from agent JSON files is backward compatible because:
1. `mode.handler.ts:183` has a fallback: `const language = configLanguage || 'en'`
2. `rules.service.ts:140-143` overrides `communication.language` with config value when available

## Deployment Notes

After merging, rebuild and reinstall the MCP server to apply changes:

```bash
yarn workspace codingbuddy build
```

Then update Claude Code's MCP server configuration to use the rebuilt version.

---

## Related Issues

resolve #268 
