### PR TITLE
Auto-Include Skills and Agents in parse_mode Response

### DIFF
--- a/apps/mcp-server/src/config/config.schema.ts
+++ b/apps/mcp-server/src/config/config.schema.ts
@@ -85,6 +85,19 @@ export const AIConfigSchema = z.object({
    * ```
    */
   excludeAgents: z.array(z.string()).optional(),
+  /**
+   * Maximum number of skills to auto-include in parse_mode response.
+   * Limits response size while providing relevant skill content.
+   * Default: 3
+   *
+   * @example
+   * ```javascript
+   * ai: {
+   *   maxIncludedSkills: 5,
+   * }
+   * ```
+   */
+  maxIncludedSkills: z.number().int().min(0).max(10).optional(),
 });
 
 export const AutoConfigSchema = z.object({

--- a/apps/mcp-server/src/keyword/keyword.module.ts
+++ b/apps/mcp-server/src/keyword/keyword.module.ts
@@ -3,21 +3,33 @@ import { CodingBuddyConfigModule as AppConfigModule } from '../config/config.mod
 import { ConfigService } from '../config/config.service';
 import { RulesModule } from '../rules/rules.module';
 import { RulesService } from '../rules/rules.service';
+import { SkillModule } from '../skill/skill.module';
+import { SkillRecommendationService } from '../skill/skill-recommendation.service';
+import { AgentModule } from '../agent/agent.module';
+import { AgentService } from '../agent/agent.service';
 import { normalizeAgentName } from '../shared/agent.utils';
-import { KeywordService } from './keyword.service';
+import {
+  KeywordService,
+  type KeywordServiceOptions,
+  type SkillRecommendationInfo,
+  type SkillContentInfo,
+  type AgentSystemPromptInfo,
+} from './keyword.service';
 import { PrimaryAgentResolver } from './primary-agent-resolver';
-import type { KeywordModesConfig } from './keyword.types';
+import type { KeywordModesConfig, Mode } from './keyword.types';
 
 export const KEYWORD_SERVICE = 'KEYWORD_SERVICE';
 
 @Module({
-  imports: [RulesModule, AppConfigModule],
+  imports: [RulesModule, AppConfigModule, SkillModule, AgentModule],
   providers: [
     {
       provide: KEYWORD_SERVICE,
       useFactory: (
         rulesService: RulesService,
         configService: ConfigService,
+        skillRecommendationService: SkillRecommendationService,
+        agentService: AgentService,
       ) => {
         const logger = new Logger('KeywordModule');
 
@@ -90,15 +102,99 @@ export const KEYWORD_SERVICE = 'KEYWORD_SERVICE';
           }
         };
 
-        return new KeywordService(
-          loadConfig,
-          loadRule,
-          loadAgent,
+        // NEW: Skill recommendation function for auto-inclusion
+        const getSkillRecommendations = (
+          prompt: string,
+        ): SkillRecommendationInfo[] => {
+          try {
+            const result = skillRecommendationService.recommendSkills(prompt);
+            return result.recommendations.map(rec => ({
+              skillName: rec.skillName,
+              confidence: rec.confidence,
+              matchedPatterns: rec.matchedPatterns,
+              description: rec.description,
+            }));
+          } catch (error) {
+            logger.debug(
+              `Failed to get skill recommendations: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            );
+            return [];
+          }
+        };
+
+        // NEW: Skill content loading function for auto-inclusion
+        const loadSkillContent = async (
+          skillName: string,
+        ): Promise<SkillContentInfo | null> => {
+          try {
+            const skill = await rulesService.getSkill(skillName);
+            return {
+              name: skill.name,
+              description: skill.description,
+              content: skill.content,
+            };
+          } catch (error) {
+            logger.debug(
+              `Failed to load skill content for '${skillName}': ${error instanceof Error ? error.message : 'Unknown error'}`,
+            );
+            return null;
+          }
+        };
+
+        // NEW: Agent system prompt loading function for auto-inclusion
+        const loadAgentSystemPrompt = async (
+          agentName: string,
+          mode: Mode,
+        ): Promise<AgentSystemPromptInfo | null> => {
+          try {
+            const result = await agentService.getAgentSystemPrompt(agentName, {
+              mode,
+            });
+            return {
+              agentName: result.agentName,
+              displayName: result.displayName,
+              systemPrompt: result.systemPrompt,
+              description: result.description,
+            };
+          } catch (error) {
+            logger.debug(
+              `Failed to load agent system prompt for '${agentName}': ${error instanceof Error ? error.message : 'Unknown error'}`,
+            );
+            return null;
+          }
+        };
+
+        // NEW: Get max included skills from config
+        const getMaxIncludedSkills = async (): Promise<number | null> => {
+          try {
+            const settings = await configService.getSettings();
+            return settings.ai?.maxIncludedSkills ?? null;
+          } catch (error) {
+            logger.debug(
+              `Failed to load maxIncludedSkills: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            );
+            return null;
+          }
+        };
+
+        // Group optional dependencies in options object
+        const options: KeywordServiceOptions = {
           primaryAgentResolver,
-          loadAutoConfig,
-        );
+          loadAutoConfigFn: loadAutoConfig,
+          getSkillRecommendationsFn: getSkillRecommendations,
+          loadSkillContentFn: loadSkillContent,
+          loadAgentSystemPromptFn: loadAgentSystemPrompt,
+          getMaxIncludedSkillsFn: getMaxIncludedSkills,
+        };
+
+        return new KeywordService(loadConfig, loadRule, loadAgent, options);
       },
-      inject: [RulesService, ConfigService],
+      inject: [
+        RulesService,
+        ConfigService,
+        SkillRecommendationService,
+        AgentService,
+      ],
     },
   ],
   exports: [KEYWORD_SERVICE],

--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -245,6 +245,36 @@ export interface ParallelAgentRecommendation {
   hint: string;
 }
 
+/**
+ * Skill content included in parse_mode response for forced execution.
+ * When AI clients receive this, they have the full skill content
+ * without needing additional tool calls.
+ */
+export interface IncludedSkill {
+  /** Skill name (e.g., 'brainstorming', 'test-driven-development') */
+  name: string;
+  /** Human-readable description */
+  description: string;
+  /** Full skill instructions content (markdown) */
+  content: string;
+  /** Why this skill was included */
+  reason: string;
+}
+
+/**
+ * Agent system prompt included in parse_mode response for forced execution.
+ * When AI clients receive this, they have the full agent context
+ * without needing additional tool calls.
+ */
+export interface IncludedAgent {
+  /** Agent name (e.g., 'frontend-developer', 'code-reviewer') */
+  name: string;
+  /** Full system prompt for the agent */
+  systemPrompt: string;
+  /** Agent's areas of expertise */
+  expertise: string[];
+}
+
 /** Source of Primary Agent selection */
 export type PrimaryAgentSource =
   | 'explicit'
@@ -294,6 +324,13 @@ export interface AutoConfig {
   /** Maximum PLAN → ACT → EVAL iterations */
   maxIterations: number;
 }
+
+/**
+ * Default maximum number of skills to auto-include in parse_mode response.
+ * Limits response size while providing relevant skill content.
+ * Can be overridden via project config `ai.maxIncludedSkills`.
+ */
+export const DEFAULT_MAX_INCLUDED_SKILLS = 3;
 
 /**
  * Task complexity classification for SRP (Structured Reasoning Process).
@@ -367,6 +404,18 @@ export interface ParseModeResult {
   complexity?: ComplexityClassification;
   /** @apiProperty External API - do not rename. SRP instructions (only when complexity is COMPLEX) */
   srpInstructions?: string;
+  /**
+   * @apiProperty External API - do not rename.
+   * Auto-included skills based on prompt analysis.
+   * AI clients should execute these skills without additional tool calls.
+   */
+  included_skills?: IncludedSkill[];
+  /**
+   * @apiProperty External API - do not rename.
+   * Auto-included primary agent with full system prompt.
+   * AI clients should adopt this agent's persona without additional tool calls.
+   */
+  included_agent?: IncludedAgent;
 }
 
 export interface ModeConfig {

--- a/apps/mcp-server/src/mcp/handlers/abstract-handler.integration.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/abstract-handler.integration.spec.ts
@@ -93,6 +93,11 @@ describe('Handler Security Integration', () => {
     mockRulesService = {
       searchRules: vi.fn().mockResolvedValue([]),
       getAgent: vi.fn().mockResolvedValue({ name: 'test-agent' }),
+      getSkill: vi.fn().mockResolvedValue({
+        name: 'test-skill',
+        description: 'Test skill',
+        content: 'Test content',
+      }),
     } as unknown as RulesService;
 
     mockLanguageService = {
@@ -162,7 +167,10 @@ describe('Handler Security Integration', () => {
       mockDiagnosticLogService,
     );
     rulesHandler = new RulesHandler(mockRulesService);
-    skillHandler = new SkillHandler(mockSkillRecommendationService);
+    skillHandler = new SkillHandler(
+      mockSkillRecommendationService,
+      mockRulesService,
+    );
   });
 
   describe('__proto__ pollution protection', () => {

--- a/apps/mcp-server/src/mcp/mcp.service.spec.ts
+++ b/apps/mcp-server/src/mcp/mcp.service.spec.ts
@@ -486,6 +486,7 @@ function createMcpServiceWithHandlers(
     ),
     new SkillHandler(
       services.skillRecommendationService as SkillRecommendationService,
+      services.rulesService as RulesService,
     ),
     new AgentHandler(services.agentService as AgentService),
     new ModeHandler(

--- a/apps/mcp-server/src/skill/index.ts
+++ b/apps/mcp-server/src/skill/index.ts
@@ -5,6 +5,9 @@
  * Supports multilingual keyword matching (EN, KO, JA, ZH, ES).
  */
 
+// Module
+export { SkillModule } from './skill.module';
+
 // Types
 export * from './skill-recommendation.types';
 

--- a/apps/mcp-server/src/skill/skill.module.ts
+++ b/apps/mcp-server/src/skill/skill.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { SkillRecommendationService } from './skill-recommendation.service';
+
+@Module({
+  providers: [SkillRecommendationService],
+  exports: [SkillRecommendationService],
+})
+export class SkillModule {}


### PR DESCRIPTION
# Auto-Include Skills and Agents in parse_mode Response

## Summary

- Auto-include recommended skills with full content in `parse_mode` response
- Auto-include primary agent system prompt in `parse_mode` response
- Add new `get_skill` MCP tool for explicit skill retrieval
- Refactor constructor to use options pattern for cleaner API
- Add runtime configuration for `maxIncludedSkills`
- Create `SkillModule` for proper NestJS dependency injection
- Add skill operations to `RulesService`

## Problem

MCP server's `parse_mode` tool only returned instructions about which skills and agents to use, requiring AI clients to make additional tool calls. This resulted in workflows often being skipped or partially executed.

## Solution

### 1. Auto-Include Skills

When `parse_mode` is called, it now:
1. Analyzes the prompt using `SkillRecommendationService`
2. Loads full content for recommended skills (up to configurable limit)
3. Returns skills in `included_skills` array with name, description, content, and reason

```typescript
interface IncludedSkill {
  name: string;
  description: string;
  content: string;  // Full skill instructions
  reason: string;   // Why this skill was included
}
```

### 2. Auto-Include Agent

For modes that delegate to a primary agent (PLAN, ACT, EVAL), the response now includes:
1. Full agent system prompt loaded via `AgentService`
2. Agent expertise areas for context

```typescript
interface IncludedAgent {
  name: string;
  systemPrompt: string;  // Full agent context
  expertise: string[];
}
```

### 3. New get_skill MCP Tool

Added `get_skill` tool to `SkillHandler`:
- Input: `skillName` (required)
- Output: Full skill definition including name, description, and content
- Validates skill name format
- Returns helpful error messages for not found or invalid skills

### 4. Constructor Options Pattern

Reduced constructor parameters from 8 to 4 by grouping optional dependencies:

**Before:**
```typescript
constructor(
  loadConfigFn, loadRuleFn, loadAgentInfoFn,
  primaryAgentResolver, loadAutoConfigFn,
  getSkillRecommendationsFn, loadSkillContentFn, loadAgentSystemPromptFn
)
```

**After:**
```typescript
constructor(
  loadConfigFn, loadRuleFn, loadAgentInfoFn?,
  options?: KeywordServiceOptions
)

interface KeywordServiceOptions {
  primaryAgentResolver?: PrimaryAgentResolver;
  loadAutoConfigFn?: () => Promise<AutoConfig | null>;
  getSkillRecommendationsFn?: (prompt: string) => SkillRecommendationInfo[];
  loadSkillContentFn?: (skillName: string) => Promise<SkillContentInfo | null>;
  loadAgentSystemPromptFn?: (agentName: string, mode: Mode) => Promise<AgentSystemPromptInfo | null>;
  getMaxIncludedSkillsFn?: () => Promise<number | null>;
}
```

### 5. Runtime Configuration

Added `getMaxIncludedSkillsFn` that reads from project config:
- Default: 3 skills (`DEFAULT_MAX_INCLUDED_SKILLS`)
- Configurable via `settings.ai.maxIncludedSkills`

### 6. SkillModule

Created new NestJS module for skill services:
```typescript
@Module({
  providers: [SkillRecommendationService],
  exports: [SkillRecommendationService],
})
export class SkillModule {}
```

### 7. RulesService Skill Operations

Added skill operations to `RulesService`:
- `getSkill(name)`: Get skill by name with validation
- `listSkillsFromDir()`: List all available skills from directory
- Security: Validates skill name format (`/^[a-z0-9-]+$/`) and path safety

## Changes

| File | Changes |
|------|---------|
| `keyword.service.ts` | Options pattern, auto-include logic, 4 new helper types, 4 new methods |
| `keyword.module.ts` | Factory updates, SkillModule/AgentModule imports, 4 new callback functions |
| `keyword.types.ts` | `IncludedSkill`, `IncludedAgent` interfaces, `DEFAULT_MAX_INCLUDED_SKILLS` constant, `ParseModeResult` extensions |
| `keyword.service.spec.ts` | 20+ test constructor updates, 665 lines of new tests for auto-inclusion |
| `skill.handler.ts` | New `get_skill` tool, `RulesService` dependency |
| `skill.handler.spec.ts` | Tests for `get_skill` tool |
| `rules.service.ts` | `getSkill()`, `listSkillsFromDir()` methods |
| `skill.module.ts` | New NestJS module for skill services |
| `skill/index.ts` | Export `SkillModule` |

## Test Plan

- [x] All 2701 existing tests pass
- [x] Branch coverage: 90.8% (exceeds 90% target)
- [x] New tests for auto-included skills (8 test cases)
- [x] New tests for auto-included agent (5 test cases)
- [x] New tests for combined skills and agent (1 test case)
- [x] New tests for runtime config edge cases (3 test cases)
- [x] New tests for get_skill tool (3 test cases)
- [x] Backward compatibility verified (existing tests unchanged behavior)

## Performance Considerations

- Skills and agent loaded in parallel using `Promise.all`
- Graceful fallback on loading failures (doesn't block response)
- Configurable limit prevents excessive response size
- Skill name validation prevents unnecessary file system access

## Breaking Changes

- `KeywordService` constructor signature changed to use options object
- All test instantiations updated to new pattern

