### PR TITLE
Fix Dependabot + Yarn Lockfile Synchronization Issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 10
+    versioning-strategy: increase
     labels:
       - 'dependencies'
       - 'security'
@@ -30,6 +31,7 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 10
+    versioning-strategy: increase
     labels:
       - 'dependencies'
       - 'security'
@@ -50,6 +52,7 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 10
+    versioning-strategy: increase
     labels:
       - 'dependencies'
       - 'security'

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -35,6 +35,7 @@ jobs:
           node-version: '24'
 
       - name: Restore dependencies from cache
+        id: cache
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -48,7 +48,6 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
   # ─────────────── CI Jobs (parallel) ───────────────


### PR DESCRIPTION
# Fix Dependabot + Yarn Lockfile Synchronization Issues

## Summary

This PR fixes the CI pipeline failures caused by Dependabot updating `package.json` without updating `yarn.lock`, and ensures consistent lockfile validation across all workflows.

## Changes

### 1. Dependabot Configuration (`.github/dependabot.yml`)

Added `versioning-strategy: increase` to all npm package ecosystems:

- `/apps/mcp-server`
- `/packages/rules`
- `/packages/claude-code-plugin`

This instructs Dependabot to update both the manifest (`package.json`) and lockfile (`yarn.lock`) when creating PRs.

### 2. Dev Workflow (`.github/workflows/dev.yml`)

Removed the conditional check that skipped `yarn install` when cache was hit:

```diff
- if: steps.cache.outputs.cache-hit != 'true'
```

**Before**: Install only ran on cache miss, allowing out-of-sync lockfiles to pass undetected.

**After**: Install always runs with `--immutable`, ensuring lockfile integrity is validated on every CI run.

### 3. Canary Workflow (`.github/workflows/canary.yml`)

Added `id: cache` to the cache restoration step for consistency with `dev.yml`.

## Why These Changes?

| Problem | Solution |
|---------|----------|
| Dependabot doesn't update `yarn.lock` | `versioning-strategy: increase` forces lockfile updates |
| `dev.yml` passes with stale lockfile | Remove conditional install to always validate |
| Inconsistent workflow patterns | Align cache step structure across workflows |

## Testing

### Local Verification
```bash
# Simulate out-of-sync state
# 1. Manually edit package.json version range
# 2. Run: yarn install --immutable
# Expected: Error "The lockfile would have been modified"
```

### CI Verification
- [ ] Push to feature branch → `dev.yml` should pass (lockfile is in sync)
- [ ] Wait for next Dependabot PR → Should include `yarn.lock` changes
- [ ] Merge to master → `canary.yml` should pass

## Impact

- **No breaking changes**: All changes are additive or remove unused code paths
- **CI time**: Minimal increase (~2-5 seconds for lockfile validation on cache hit)
- **Security**: Maintains `--immutable` flag to prevent unauthorized lockfile modifications

## Related Issues

- Fixes failing Dependabot PRs on `canary.yml`
- Prevents false-positive CI passes on `dev.yml`

## Checklist

- [x] Dependabot config updated for all npm ecosystems
- [x] `dev.yml` always validates lockfile integrity
- [x] `canary.yml` maintains consistent structure
- [x] No security implications (--immutable preserved)
- [x] Backwards compatible
