### PR TITLE
Migrate all documentation references from `codingbuddy.config.js` to `codingbuddy.config.json`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,7 +40,7 @@ Paste any error messages here
 ## Configuration
 
 <details>
-<summary>codingbuddy.config.js</summary>
+<summary>codingbuddy.config.json</summary>
 
 ```javascript
 // Paste your config here (remove sensitive data)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,4 +90,4 @@ When working in this codebase, use these modes:
 
 ## Communication
 
-Follow the `language` setting in `codingbuddy.config.js` - use `get_project_config` MCP tool to retrieve current language setting.
+Follow the `language` setting in `codingbuddy.config.json` - use `get_project_config` MCP tool to retrieve current language setting.

--- a/README.es.md
+++ b/README.es.md
@@ -251,7 +251,7 @@ npm install -g codingbuddy
 
 ### Configuración del Modelo de IA
 
-Configure el modelo de IA predeterminado en `codingbuddy.config.js`:
+Configure el modelo de IA predeterminado en `codingbuddy.config.json`:
 
 ```javascript
 module.exports = {

--- a/README.ja.md
+++ b/README.ja.md
@@ -251,7 +251,7 @@ npm install -g codingbuddy
 
 ### AIモデル設定
 
-`codingbuddy.config.js`でデフォルトのAIモデルを設定します：
+`codingbuddy.config.json`でデフォルトのAIモデルを設定します：
 
 ```javascript
 module.exports = {

--- a/README.ko.md
+++ b/README.ko.md
@@ -251,7 +251,7 @@ npm install -g codingbuddy
 
 ### AI 모델 설정
 
-`codingbuddy.config.js`에서 기본 AI 모델을 설정합니다:
+`codingbuddy.config.json`에서 기본 AI 모델을 설정합니다:
 
 ```javascript
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ npm install -g codingbuddy
 
 ### AI Model Settings
 
-Configure the default AI model in `codingbuddy.config.js`:
+Configure the default AI model in `codingbuddy.config.json`:
 
 ```javascript
 module.exports = {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -251,7 +251,7 @@ npm install -g codingbuddy
 
 ### AI 模型设置
 
-在 `codingbuddy.config.js` 中配置默认 AI 模型：
+在 `codingbuddy.config.json` 中配置默认 AI 模型：
 
 ```javascript
 module.exports = {

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -10,7 +10,7 @@ A NestJS-based Model Context Protocol (MCP) server that provides AI coding assis
 # Initialize project configuration (AI-powered)
 npx codingbuddy init
 
-# This analyzes your project and creates codingbuddy.config.js
+# This analyzes your project and creates codingbuddy.config.json
 ```
 
 ## Features
@@ -272,7 +272,7 @@ npx codingbuddy init --api-key sk-...     # Pass API key directly
 
 ### Configuration File
 
-The `codingbuddy init` command creates a `codingbuddy.config.js` file:
+The `codingbuddy init` command creates a `codingbuddy.config.json` file:
 
 ```javascript
 module.exports = {
@@ -321,7 +321,7 @@ module.exports = {
 
 ```
 my-project/
-├── codingbuddy.config.js     # Main configuration
+├── codingbuddy.config.json     # Main configuration
 ├── .codingignore             # Files to ignore (gitignore syntax)
 └── .codingbuddy/             # Additional context (optional)
     └── context/

--- a/docs/api.md
+++ b/docs/api.md
@@ -1178,7 +1178,7 @@ Activate a specific specialist agent with project context.
 | `Resource not found: {uri}` | Requested rule file doesn't exist | Check file path in `packages/rules/.ai-rules/` |
 | `Agent '{name}' not found` | Invalid agent name | Use valid agent name from list |
 | `Tool not found: {name}` | Invalid tool name | Use one of: `search_rules`, `get_agent_details`, `parse_mode`, `get_project_config`, `suggest_config_updates`, `recommend_skills`, `list_skills`, `get_agent_system_prompt`, `prepare_parallel_agents`, `generate_checklist`, `analyze_task`, `read_context`, `update_context`, `create_session`, `get_session`, `get_active_session`, `update_session` |
-| `Failed to load project configuration` | Missing or invalid `codingbuddy.config.js` | Run `npx codingbuddy init` |
+| `Failed to load project configuration` | Missing or invalid `codingbuddy.config.json` | Run `npx codingbuddy init` |
 
 ---
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -4,26 +4,24 @@ This document describes the configuration schema for CodingBuddy. The configurat
 
 ## Quick Start
 
-Create a `codingbuddy.config.js` file in your project root:
+Create a `codingbuddy.config.json` file in your project root:
 
-```javascript
-module.exports = {
-  language: 'ko',
-  projectName: 'my-awesome-app',
-  techStack: {
-    frontend: ['React', 'TypeScript'],
-    backend: ['NestJS'],
-  },
-};
+```json
+{
+  "language": "ko",
+  "projectName": "my-awesome-app",
+  "techStack": {
+    "frontend": ["React", "TypeScript"],
+    "backend": ["NestJS"]
+  }
+}
 ```
 
 ## Configuration File Formats
 
-CodingBuddy supports multiple configuration file formats (in priority order):
+CodingBuddy supports only JSON configuration format:
 
-1. `codingbuddy.config.js` - JavaScript (recommended, supports dynamic values)
-2. `codingbuddy.config.json` - JSON
-3. `.codingbuddyrc` - RC file format
+1. `codingbuddy.config.json` - JSON (only supported format)
 
 ## Schema Reference
 
@@ -40,25 +38,26 @@ CodingBuddy supports multiple configuration file formats (in priority order):
 
 Configure your project's technology stack:
 
-```javascript
-techStack: {
-  // Basic (Nested)
-  languages: ['TypeScript', 'Python'],
-  frontend: ['React', 'Next.js', 'Tailwind CSS'],
-  backend: ['NestJS', 'Express'],
-  database: ['PostgreSQL', 'Redis'],
-  infrastructure: ['Docker', 'AWS', 'Kubernetes'],
-  tools: ['ESLint', 'Prettier', 'Husky'],
-
-  // Deep (Optional) - detailed tech info
-  details: {
-    'TypeScript': {
-      version: '5.x',
-      notes: 'Strict mode enabled'
+```json
+{
+  "techStack": {
+    "languages": ["TypeScript", "Python"],
+    "frontend": ["React", "Next.js", "Tailwind CSS"],
+    "backend": ["NestJS", "Express"],
+    "database": ["PostgreSQL", "Redis"],
+    "infrastructure": ["Docker", "AWS", "Kubernetes"],
+    "tools": ["ESLint", "Prettier", "Husky"],
+    "details": {
+      "TypeScript": {
+        "version": "5.x",
+        "notes": "Strict mode enabled"
+      }
     }
   }
 }
 ```
+
+> `details` is optional and provides deeper information about specific technologies.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -74,20 +73,21 @@ techStack: {
 
 Define your project's architecture:
 
-```javascript
-architecture: {
-  // Basic (Nested)
-  pattern: 'feature-sliced',
-  structure: ['src/', 'app/', 'features/', 'entities/', 'shared/'],
-  componentStyle: 'feature-based',
-
-  // Deep (Optional) - layer definitions
-  layers: [
-    { name: 'app', path: 'src/app', description: 'Application layer' },
-    { name: 'features', path: 'src/features', dependencies: ['entities', 'shared'] }
-  ]
+```json
+{
+  "architecture": {
+    "pattern": "feature-sliced",
+    "structure": ["src/", "app/", "features/", "entities/", "shared/"],
+    "componentStyle": "feature-based",
+    "layers": [
+      { "name": "app", "path": "src/app", "description": "Application layer" },
+      { "name": "features", "path": "src/features", "dependencies": ["entities", "shared"] }
+    ]
+  }
 }
 ```
+
+> `layers` is optional and provides detailed layer definitions with dependency information.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -100,28 +100,29 @@ architecture: {
 
 Specify coding conventions:
 
-```javascript
-conventions: {
-  // Basic (Nested)
-  style: 'airbnb',
-  naming: {
-    files: 'kebab-case',
-    components: 'PascalCase',
-    functions: 'camelCase',
-    variables: 'camelCase',
-    constants: 'UPPER_SNAKE_CASE'
-  },
-  importOrder: ['react', '@/', '~/', '.'],
-  maxLineLength: 100,
-  semicolons: true,
-  quotes: 'single',
-
-  // Deep (Optional) - custom rules
-  rules: {
-    'no-console': 'warn'
+```json
+{
+  "conventions": {
+    "style": "airbnb",
+    "naming": {
+      "files": "kebab-case",
+      "components": "PascalCase",
+      "functions": "camelCase",
+      "variables": "camelCase",
+      "constants": "UPPER_SNAKE_CASE"
+    },
+    "importOrder": ["react", "@/", "~/", "."],
+    "maxLineLength": 100,
+    "semicolons": true,
+    "quotes": "single",
+    "rules": {
+      "no-console": "warn"
+    }
   }
 }
 ```
+
+> `rules` is optional and allows custom linting rule overrides.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -137,14 +138,16 @@ conventions: {
 
 Configure testing approach:
 
-```javascript
-testStrategy: {
-  approach: 'tdd',
-  frameworks: ['vitest', 'playwright'],
-  coverage: 80,
-  unitTestPattern: 'colocated',
-  e2eDirectory: 'e2e/',
-  mockingStrategy: 'minimal'
+```json
+{
+  "testStrategy": {
+    "approach": "tdd",
+    "frameworks": ["vitest", "playwright"],
+    "coverage": 80,
+    "unitTestPattern": "colocated",
+    "e2eDirectory": "e2e/",
+    "mockingStrategy": "minimal"
+  }
 }
 ```
 
@@ -161,9 +164,11 @@ testStrategy: {
 
 Configure AI model settings:
 
-```javascript
-ai: {
-  defaultModel: 'claude-sonnet-4-20250514',
+```json
+{
+  "ai": {
+    "defaultModel": "claude-sonnet-4-20250514"
+  }
 }
 ```
 
@@ -181,99 +186,82 @@ When running `npx codingbuddy init`, you'll be prompted to select a default mode
 
 ### Additional Context
 
-```javascript
-// Key files AI should be aware of
-keyFiles: [
-  'src/core/types.ts',
-  'docs/architecture.md',
-  'CONTRIBUTING.md'
-],
-
-// Topics or areas to avoid
-avoid: [
-  'legacy-api',
-  'deprecated-module'
-],
-
-// Custom freeform context
-custom: {
-  team: 'Platform Team',
-  domain: 'E-commerce'
+```json
+{
+  "keyFiles": [
+    "src/core/types.ts",
+    "docs/architecture.md",
+    "CONTRIBUTING.md"
+  ],
+  "avoid": [
+    "legacy-api",
+    "deprecated-module"
+  ],
+  "custom": {
+    "team": "Platform Team",
+    "domain": "E-commerce"
+  }
 }
 ```
 
+- `keyFiles`: Key files AI should be aware of
+- `avoid`: Topics or areas to avoid
+- `custom`: Custom freeform context
+
 ## Complete Example
 
-```javascript
-// codingbuddy.config.js
-module.exports = {
-  // Basic
-  language: 'ko',
-  projectName: 'wishket-platform',
-  description: 'Freelancer marketplace platform',
-  repository: 'https://github.com/example/wishket-platform',
-
-  // Tech Stack
-  techStack: {
-    languages: ['TypeScript'],
-    frontend: ['React', 'Next.js', 'Tailwind CSS', 'React Query'],
-    backend: ['NestJS', 'TypeORM'],
-    database: ['PostgreSQL', 'Redis'],
-    infrastructure: ['Docker', 'AWS ECS', 'GitHub Actions'],
+```json
+{
+  "language": "ko",
+  "projectName": "wishket-platform",
+  "description": "Freelancer marketplace platform",
+  "repository": "https://github.com/example/wishket-platform",
+  "techStack": {
+    "languages": ["TypeScript"],
+    "frontend": ["React", "Next.js", "Tailwind CSS", "React Query"],
+    "backend": ["NestJS", "TypeORM"],
+    "database": ["PostgreSQL", "Redis"],
+    "infrastructure": ["Docker", "AWS ECS", "GitHub Actions"]
   },
-
-  // Architecture
-  architecture: {
-    pattern: 'feature-sliced',
-    structure: ['src/app', 'src/features', 'src/entities', 'src/shared'],
-    componentStyle: 'feature-based',
+  "architecture": {
+    "pattern": "feature-sliced",
+    "structure": ["src/app", "src/features", "src/entities", "src/shared"],
+    "componentStyle": "feature-based"
   },
-
-  // Conventions
-  conventions: {
-    style: 'airbnb',
-    naming: {
-      files: 'kebab-case',
-      components: 'PascalCase',
-      functions: 'camelCase',
+  "conventions": {
+    "style": "airbnb",
+    "naming": {
+      "files": "kebab-case",
+      "components": "PascalCase",
+      "functions": "camelCase"
     },
-    quotes: 'single',
-    semicolons: true,
+    "quotes": "single",
+    "semicolons": true
   },
-
-  // Test Strategy
-  testStrategy: {
-    approach: 'tdd',
-    frameworks: ['vitest', 'playwright'],
-    coverage: 80,
-    unitTestPattern: 'colocated',
-    mockingStrategy: 'minimal',
+  "testStrategy": {
+    "approach": "tdd",
+    "frameworks": ["vitest", "playwright"],
+    "coverage": 80,
+    "unitTestPattern": "colocated",
+    "mockingStrategy": "minimal"
   },
-
-  // AI Configuration
-  ai: {
-    defaultModel: 'claude-sonnet-4-20250514',
+  "ai": {
+    "defaultModel": "claude-sonnet-4-20250514"
   },
-
-  // Additional
-  keyFiles: ['src/shared/types/index.ts', 'docs/api.md'],
-  avoid: ['legacy-v1-api'],
-};
+  "keyFiles": ["src/shared/types/index.ts", "docs/api.md"],
+  "avoid": ["legacy-v1-api"]
+}
 ```
 
 ## TypeScript Types
 
-Import types for type-safe configuration:
+You can use TypeScript types for IDE autocomplete when authoring your JSON config:
 
 ```typescript
 import type { CodingBuddyConfig } from 'codingbuddy/config';
 
-const config: CodingBuddyConfig = {
-  language: 'en',
-  // ... IDE autocomplete works here
-};
-
-module.exports = config;
+// Use this type to validate your codingbuddy.config.json structure
+type Config = CodingBuddyConfig;
 ```
 
 ## Validation

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -20,53 +20,42 @@ Generate a configuration file using AI analysis:
 npx codingbuddy init
 ```
 
-This creates `codingbuddy.config.js` with settings based on your project.
+This creates `codingbuddy.config.json` with settings based on your project.
 
 ### Manual Configuration
 
-Create `codingbuddy.config.js` in your project root:
+Create `codingbuddy.config.json` in your project root:
 
-```javascript
-module.exports = {
-  // Response language (required)
-  language: 'ko',  // 'ko', 'en', 'ja', 'zh', etc.
-
-  // Project metadata
-  projectName: 'my-awesome-app',
-  description: 'A modern web application',
-
-  // Technology stack
-  techStack: {
-    languages: ['TypeScript'],
-    frontend: ['React', 'Next.js', 'Tailwind CSS'],
-    backend: ['Node.js', 'Prisma'],
-    database: ['PostgreSQL'],
-    tools: ['ESLint', 'Prettier', 'Vitest'],
+```json
+{
+  "language": "ko",
+  "projectName": "my-awesome-app",
+  "description": "A modern web application",
+  "techStack": {
+    "languages": ["TypeScript"],
+    "frontend": ["React", "Next.js", "Tailwind CSS"],
+    "backend": ["Node.js", "Prisma"],
+    "database": ["PostgreSQL"],
+    "tools": ["ESLint", "Prettier", "Vitest"]
   },
-
-  // Architecture pattern
-  architecture: {
-    pattern: 'feature-sliced-design',
-    structure: ['app', 'widgets', 'features', 'entities', 'shared'],
+  "architecture": {
+    "pattern": "feature-sliced-design",
+    "structure": ["app", "widgets", "features", "entities", "shared"]
   },
-
-  // Coding conventions
-  conventions: {
-    style: 'airbnb',
-    naming: {
-      files: 'kebab-case',
-      components: 'PascalCase',
-      functions: 'camelCase',
-    },
+  "conventions": {
+    "style": "airbnb",
+    "naming": {
+      "files": "kebab-case",
+      "components": "PascalCase",
+      "functions": "camelCase"
+    }
   },
-
-  // Testing strategy
-  testStrategy: {
-    approach: 'tdd',
-    frameworks: ['Vitest', 'Playwright'],
-    coverage: 80,
-  },
-};
+  "testStrategy": {
+    "approach": "tdd",
+    "frameworks": ["Vitest", "Playwright"],
+    "coverage": 80
+  }
+}
 ```
 
 ### Configuration Options
@@ -86,13 +75,15 @@ Response language for AI assistants.
 
 Define your project's technology stack:
 
-```javascript
-techStack: {
-  languages: ['TypeScript', 'Python'],
-  frontend: ['React', 'Next.js'],
-  backend: ['FastAPI', 'PostgreSQL'],
-  database: ['PostgreSQL', 'Redis'],
-  tools: ['Docker', 'GitHub Actions'],
+```json
+{
+  "techStack": {
+    "languages": ["TypeScript", "Python"],
+    "frontend": ["React", "Next.js"],
+    "backend": ["FastAPI", "PostgreSQL"],
+    "database": ["PostgreSQL", "Redis"],
+    "tools": ["Docker", "GitHub Actions"]
+  }
 }
 ```
 
@@ -100,23 +91,36 @@ techStack: {
 
 Define your architecture pattern:
 
-```javascript
-// Feature-Sliced Design
-architecture: {
-  pattern: 'feature-sliced-design',
-  structure: ['app', 'widgets', 'features', 'entities', 'shared'],
-}
+Feature-Sliced Design:
 
-// Clean Architecture
-architecture: {
-  pattern: 'clean-architecture',
-  structure: ['presentation', 'application', 'domain', 'infrastructure'],
+```json
+{
+  "architecture": {
+    "pattern": "feature-sliced-design",
+    "structure": ["app", "widgets", "features", "entities", "shared"]
+  }
 }
+```
 
-// Simple layers
-architecture: {
-  pattern: 'layered',
-  structure: ['controllers', 'services', 'repositories', 'models'],
+Clean Architecture:
+
+```json
+{
+  "architecture": {
+    "pattern": "clean-architecture",
+    "structure": ["presentation", "application", "domain", "infrastructure"]
+  }
+}
+```
+
+Simple layers:
+
+```json
+{
+  "architecture": {
+    "pattern": "layered",
+    "structure": ["controllers", "services", "repositories", "models"]
+  }
 }
 ```
 
@@ -124,15 +128,17 @@ architecture: {
 
 Define naming and style conventions:
 
-```javascript
-conventions: {
-  style: 'airbnb',  // ESLint config preset
-  naming: {
-    files: 'kebab-case',       // my-component.tsx
-    components: 'PascalCase',   // MyComponent
-    functions: 'camelCase',     // myFunction
-    constants: 'SCREAMING_SNAKE_CASE',  // MAX_RETRIES
-  },
+```json
+{
+  "conventions": {
+    "style": "airbnb",
+    "naming": {
+      "files": "kebab-case",
+      "components": "PascalCase",
+      "functions": "camelCase",
+      "constants": "SCREAMING_SNAKE_CASE"
+    }
+  }
 }
 ```
 
@@ -140,17 +146,19 @@ conventions: {
 
 Define your testing approach:
 
-```javascript
-testStrategy: {
-  approach: 'tdd',           // 'tdd' or 'test-after'
-  frameworks: ['Vitest', 'Playwright'],
-  coverage: 80,              // Target coverage percentage
+```json
+{
+  "testStrategy": {
+    "approach": "tdd",
+    "frameworks": ["Vitest", "Playwright"],
+    "coverage": 80
+  }
 }
 ```
 
-### JSON Format
+### Minimal Configuration
 
-You can also use `codingbuddy.config.json`:
+A minimal `codingbuddy.config.json` example:
 
 ```json
 {
@@ -438,7 +446,7 @@ For specialist agents, use the `modes` structure:
 1. **Backup your customizations**:
    ```bash
    cp -r .ai-rules .ai-rules.backup
-   cp codingbuddy.config.js codingbuddy.config.js.backup
+   cp codingbuddy.config.json codingbuddy.config.json.backup
    ```
 
 2. **Check release notes** for breaking changes

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,7 +111,7 @@ codingbuddy/
 ├── docs/                         # Documentation
 ├── CLAUDE.md                     # Claude Code instructions
 ├── CONTRIBUTING.md               # Contribution guidelines
-└── codingbuddy.config.js         # Project configuration (optional)
+└── codingbuddy.config.json         # Project configuration (optional)
 ```
 
 ### Module Architecture

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -166,7 +166,7 @@ Agent 'unknown-agent' not found.
 Failed to load project configuration
 ```
 
-**Cause**: `codingbuddy.config.js` not found in project root.
+**Cause**: `codingbuddy.config.json` not found in project root.
 
 **Resolution**:
 
@@ -175,7 +175,7 @@ Failed to load project configuration
 npx codingbuddy init
 
 # Or create manually
-touch codingbuddy.config.js
+touch codingbuddy.config.json
 ```
 
 ---
@@ -191,7 +191,7 @@ Configuration validation failed
 
 **Resolution**:
 
-Check your `codingbuddy.config.js` matches the expected schema:
+Check your `codingbuddy.config.json` matches the expected schema:
 
 ```javascript
 module.exports = {

--- a/docs/es/getting-started.md
+++ b/docs/es/getting-started.md
@@ -26,7 +26,7 @@ Pon en marcha Codingbuddy en minutos.
 npx codingbuddy init
 ```
 
-Este comando analiza tu proyecto y crea `codingbuddy.config.js` con:
+Este comando analiza tu proyecto y crea `codingbuddy.config.json` con:
 
 - Stack tecnológico detectado (lenguajes, frameworks, herramientas)
 - Patrones de arquitectura
@@ -88,7 +88,7 @@ IA: # Mode: PLAN
 
 ### Archivo de configuración generado
 
-El archivo `codingbuddy.config.js` personaliza el comportamiento de la IA:
+El archivo `codingbuddy.config.json` personaliza el comportamiento de la IA:
 
 ```javascript
 module.exports = {
@@ -134,7 +134,7 @@ Añade documentación específica del proyecto que la IA debería conocer:
 
 ```
 my-project/
-├── codingbuddy.config.js
+├── codingbuddy.config.json
 └── .codingbuddy/
     └── context/
         ├── architecture.md    # Documentación de arquitectura del sistema

--- a/docs/es/plugin-architecture.md
+++ b/docs/es/plugin-architecture.md
@@ -264,7 +264,7 @@ El contexto se persiste en `docs/codingbuddy/context.md`:
 }
 ```
 
-### Configuración del Proyecto (`codingbuddy.config.js`)
+### Configuración del Proyecto (`codingbuddy.config.json`)
 
 ```javascript
 module.exports = {

--- a/docs/es/plugin-faq.md
+++ b/docs/es/plugin-faq.md
@@ -199,7 +199,7 @@ Los agentes se seleccionan basándose en:
 
 1. **Contexto de la tarea**: Palabras clave en su prompt
 2. **Modo**: Diferentes agentes para PLAN vs ACT vs EVAL
-3. **Configuración**: Agentes personalizados en `codingbuddy.config.js`
+3. **Configuración**: Agentes personalizados en `codingbuddy.config.json`
 
 ### ¿Puedo usar múltiples agentes?
 
@@ -225,7 +225,7 @@ Use la herramienta MCP:
 
 ### ¿Cómo configuro el plugin?
 
-Cree `codingbuddy.config.js` en la raíz de su proyecto:
+Cree `codingbuddy.config.json` en la raíz de su proyecto:
 
 ```javascript
 module.exports = {

--- a/docs/es/plugin-guide.md
+++ b/docs/es/plugin-guide.md
@@ -231,7 +231,7 @@ Debería ver herramientas de CodingBuddy como:
 
 ### Configuración a Nivel de Proyecto
 
-Cree `codingbuddy.config.js` en la raíz de su proyecto:
+Cree `codingbuddy.config.json` en la raíz de su proyecto:
 
 ```javascript
 module.exports = {

--- a/docs/es/plugin-troubleshooting.md
+++ b/docs/es/plugin-troubleshooting.md
@@ -321,7 +321,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
    - Use PLAN para una funcionalidad a la vez
 
 2. **Reducir agentes especialistas**
-   - Configure menos especialistas en `codingbuddy.config.js`
+   - Configure menos especialistas en `codingbuddy.config.json`
    ```javascript
    module.exports = {
      specialists: ['security-specialist']  // Solo los esenciales
@@ -357,17 +357,17 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 ### La Configuración del Proyecto No Se Carga
 
-**Síntoma**: La configuración de `codingbuddy.config.js` no se aplica.
+**Síntoma**: La configuración de `codingbuddy.config.json` no se aplica.
 
 **Soluciones**:
 
 1. **Verificar ubicación del archivo**
    - Debe estar en la raíz del proyecto
-   - Nombrado exactamente `codingbuddy.config.js`
+   - Nombrado exactamente `codingbuddy.config.json`
 
 2. **Verificar sintaxis**
    ```bash
-   node -e "console.log(require('./codingbuddy.config.js'))"
+   node -e "console.log(require('./codingbuddy.config.json'))"
    ```
 
 3. **Verificar formato de exportación**
@@ -387,7 +387,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 1. **Establecer idioma en configuración**
    ```javascript
-   // codingbuddy.config.js
+   // codingbuddy.config.json
    module.exports = {
      language: 'es'  // 'en', 'ko', 'ja', 'zh', 'es'
    };

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ Get up and running with Codingbuddy in minutes.
 npx codingbuddy init
 ```
 
-This command analyzes your project and creates a `codingbuddy.config.js` file with:
+This command analyzes your project and creates a `codingbuddy.config.json` file with:
 
 - Detected tech stack (languages, frameworks, tools)
 - Architecture patterns
@@ -145,7 +145,7 @@ AI: # Mode: PLAN
 
 ### Generated Config File
 
-The `codingbuddy.config.js` file customizes AI behavior:
+The `codingbuddy.config.json` file customizes AI behavior:
 
 ```javascript
 module.exports = {
@@ -191,7 +191,7 @@ Add project-specific documentation that AI should know about:
 
 ```
 my-project/
-├── codingbuddy.config.js
+├── codingbuddy.config.json
 └── .codingbuddy/
     └── context/
         ├── architecture.md    # System architecture docs

--- a/docs/ja/getting-started.md
+++ b/docs/ja/getting-started.md
@@ -26,7 +26,7 @@
 npx codingbuddy init
 ```
 
-このコマンドはプロジェクトを分析し、以下を含む`codingbuddy.config.js`を作成します：
+このコマンドはプロジェクトを分析し、以下を含む`codingbuddy.config.json`を作成します：
 
 - 検出された技術スタック（言語、フレームワーク、ツール）
 - アーキテクチャパターン
@@ -88,7 +88,7 @@ AI：# Mode: PLAN
 
 ### 生成される設定ファイル
 
-`codingbuddy.config.js`ファイルでAIの動作をカスタマイズします：
+`codingbuddy.config.json`ファイルでAIの動作をカスタマイズします：
 
 ```javascript
 module.exports = {
@@ -134,7 +134,7 @@ AIが知っておくべきプロジェクト固有のドキュメントを追加
 
 ```
 my-project/
-├── codingbuddy.config.js
+├── codingbuddy.config.json
 └── .codingbuddy/
     └── context/
         ├── architecture.md    # システムアーキテクチャドキュメント

--- a/docs/ja/plugin-architecture.md
+++ b/docs/ja/plugin-architecture.md
@@ -264,7 +264,7 @@ sequenceDiagram
 }
 ```
 
-### プロジェクト設定（`codingbuddy.config.js`）
+### プロジェクト設定（`codingbuddy.config.json`）
 
 ```javascript
 module.exports = {

--- a/docs/ja/plugin-faq.md
+++ b/docs/ja/plugin-faq.md
@@ -199,7 +199,7 @@ EVAL                     → 実装をレビュー
 
 1. **タスクコンテキスト**: プロンプト内のキーワード
 2. **モード**: PLAN、ACT、EVAL で異なるエージェント
-3. **設定**: `codingbuddy.config.js` のカスタムエージェント
+3. **設定**: `codingbuddy.config.json` のカスタムエージェント
 
 ### 複数のエージェントを使用できますか？
 
@@ -225,7 +225,7 @@ MCP ツールを使用します：
 
 ### プラグインを設定するには？
 
-プロジェクトルートに `codingbuddy.config.js` を作成：
+プロジェクトルートに `codingbuddy.config.json` を作成：
 
 ```javascript
 module.exports = {

--- a/docs/ja/plugin-guide.md
+++ b/docs/ja/plugin-guide.md
@@ -231,7 +231,7 @@ Claude Code で利用可能なツールを確認します：
 
 ### プロジェクトレベル設定
 
-プロジェクトルートに `codingbuddy.config.js` を作成：
+プロジェクトルートに `codingbuddy.config.json` を作成：
 
 ```javascript
 module.exports = {

--- a/docs/ja/plugin-troubleshooting.md
+++ b/docs/ja/plugin-troubleshooting.md
@@ -320,7 +320,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
    - 一度に 1 つの機能に対して PLAN を使用
 
 2. **スペシャリストエージェントを減らす**
-   - `codingbuddy.config.js` でスペシャリストを減らす設定
+   - `codingbuddy.config.json` でスペシャリストを減らす設定
    ```javascript
    module.exports = {
      specialists: ['security-specialist']  // 必須のものだけ
@@ -356,17 +356,17 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 ### プロジェクト設定が読み込まれない
 
-**症状**: `codingbuddy.config.js` の設定が適用されない。
+**症状**: `codingbuddy.config.json` の設定が適用されない。
 
 **解決策**:
 
 1. **ファイルの場所を確認**
    - プロジェクトルートにある必要がある
-   - 正確に `codingbuddy.config.js` という名前
+   - 正確に `codingbuddy.config.json` という名前
 
 2. **構文を検証**
    ```bash
-   node -e "console.log(require('./codingbuddy.config.js'))"
+   node -e "console.log(require('./codingbuddy.config.json'))"
    ```
 
 3. **エクスポート形式を確認**
@@ -386,7 +386,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 1. **設定で言語を指定**
    ```javascript
-   // codingbuddy.config.js
+   // codingbuddy.config.json
    module.exports = {
      language: 'ja'  // 'en', 'ko', 'ja', 'zh', 'es'
    };

--- a/docs/ko/getting-started.md
+++ b/docs/ko/getting-started.md
@@ -26,7 +26,7 @@
 npx codingbuddy init
 ```
 
-이 명령어는 프로젝트를 분석하고 다음 내용이 포함된 `codingbuddy.config.js` 파일을 생성합니다:
+이 명령어는 프로젝트를 분석하고 다음 내용이 포함된 `codingbuddy.config.json` 파일을 생성합니다:
 
 - 감지된 기술 스택 (언어, 프레임워크, 도구)
 - 아키텍처 패턴
@@ -107,7 +107,7 @@ AI: # Mode: PLAN
 
 ### 생성된 설정 파일
 
-`codingbuddy.config.js` 파일로 AI 동작을 커스터마이징합니다:
+`codingbuddy.config.json` 파일로 AI 동작을 커스터마이징합니다:
 
 ```javascript
 module.exports = {
@@ -153,7 +153,7 @@ AI가 알아야 할 프로젝트별 문서를 추가합니다:
 
 ```
 my-project/
-├── codingbuddy.config.js
+├── codingbuddy.config.json
 └── .codingbuddy/
     └── context/
         ├── architecture.md    # 시스템 아키텍처 문서

--- a/docs/ko/plugin-architecture.md
+++ b/docs/ko/plugin-architecture.md
@@ -264,7 +264,7 @@ sequenceDiagram
 }
 ```
 
-### 프로젝트 설정 (`codingbuddy.config.js`)
+### 프로젝트 설정 (`codingbuddy.config.json`)
 
 ```javascript
 module.exports = {

--- a/docs/ko/plugin-faq.md
+++ b/docs/ko/plugin-faq.md
@@ -199,7 +199,7 @@ EVAL             → 구현 검토
 
 1. **작업 컨텍스트**: 프롬프트의 키워드
 2. **모드**: PLAN vs ACT vs EVAL에 따라 다른 에이전트
-3. **설정**: `codingbuddy.config.js`의 커스텀 에이전트
+3. **설정**: `codingbuddy.config.json`의 커스텀 에이전트
 
 ### 여러 에이전트를 사용할 수 있나요?
 
@@ -225,7 +225,7 @@ MCP 도구를 사용하세요:
 
 ### 플러그인을 어떻게 설정하나요?
 
-프로젝트 루트에 `codingbuddy.config.js` 생성:
+프로젝트 루트에 `codingbuddy.config.json` 생성:
 
 ```javascript
 module.exports = {

--- a/docs/ko/plugin-guide.md
+++ b/docs/ko/plugin-guide.md
@@ -231,7 +231,7 @@ Claude Code에서 사용 가능한 도구 확인:
 
 ### 프로젝트별 설정
 
-프로젝트 루트에 `codingbuddy.config.js` 생성:
+프로젝트 루트에 `codingbuddy.config.json` 생성:
 
 ```javascript
 module.exports = {

--- a/docs/ko/plugin-troubleshooting.md
+++ b/docs/ko/plugin-troubleshooting.md
@@ -319,7 +319,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
    - 한 번에 하나의 기능에 대해 PLAN 사용
 
 2. **전문가 에이전트 줄이기**
-   - `codingbuddy.config.js`에서 전문가 수 줄이기
+   - `codingbuddy.config.json`에서 전문가 수 줄이기
    ```javascript
    module.exports = {
      specialists: ['security-specialist']  // 필수적인 것만
@@ -355,17 +355,17 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 ### 프로젝트 설정이 로드되지 않음
 
-**증상**: `codingbuddy.config.js` 설정이 적용되지 않음.
+**증상**: `codingbuddy.config.json` 설정이 적용되지 않음.
 
 **해결 방법**:
 
 1. **파일 위치 확인**
    - 프로젝트 루트에 있어야 함
-   - 정확히 `codingbuddy.config.js`로 명명
+   - 정확히 `codingbuddy.config.json`로 명명
 
 2. **구문 확인**
    ```bash
-   node -e "console.log(require('./codingbuddy.config.js'))"
+   node -e "console.log(require('./codingbuddy.config.json'))"
    ```
 
 3. **내보내기 형식 확인**
@@ -385,7 +385,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 1. **설정에서 언어 설정**
    ```javascript
-   // codingbuddy.config.js
+   // codingbuddy.config.json
    module.exports = {
      language: 'ko'  // 'en', 'ko', 'ja', 'zh', 'es'
    };

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -95,7 +95,7 @@ npm install codingbuddy@latest
 
 ### 2. Verify Configuration
 
-Your existing `codingbuddy.config.js` remains compatible. No changes required.
+Your existing `codingbuddy.config.json` remains compatible. No changes required.
 
 ### 3. Optional: Install Claude Code Plugin
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -264,7 +264,7 @@ Context is persisted to `docs/codingbuddy/context.md`:
 }
 ```
 
-### Project Configuration (`codingbuddy.config.js`)
+### Project Configuration (`codingbuddy.config.json`)
 
 ```javascript
 module.exports = {

--- a/docs/plugin-faq.md
+++ b/docs/plugin-faq.md
@@ -199,7 +199,7 @@ Agents are selected based on:
 
 1. **Task context**: Keywords in your prompt
 2. **Mode**: Different agents for PLAN vs ACT vs EVAL
-3. **Configuration**: Custom agents in `codingbuddy.config.js`
+3. **Configuration**: Custom agents in `codingbuddy.config.json`
 
 ### Can I use multiple agents?
 
@@ -225,7 +225,7 @@ Use the MCP tool:
 
 ### How do I configure the plugin?
 
-Create `codingbuddy.config.js` in your project root:
+Create `codingbuddy.config.json` in your project root:
 
 ```javascript
 module.exports = {

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -231,7 +231,7 @@ You should see CodingBuddy tools like:
 
 ### Project-Level Configuration
 
-Create `codingbuddy.config.js` in your project root:
+Create `codingbuddy.config.json` in your project root:
 
 ```javascript
 module.exports = {

--- a/docs/plugin-troubleshooting.md
+++ b/docs/plugin-troubleshooting.md
@@ -320,7 +320,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
    - Use PLAN for one feature at a time
 
 2. **Reduce specialist agents**
-   - Configure fewer specialists in `codingbuddy.config.js`
+   - Configure fewer specialists in `codingbuddy.config.json`
    ```javascript
    module.exports = {
      specialists: ['security-specialist']  // Only essential ones
@@ -356,17 +356,17 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 ### Project Config Not Loading
 
-**Symptom**: `codingbuddy.config.js` settings not applied.
+**Symptom**: `codingbuddy.config.json` settings not applied.
 
 **Solutions**:
 
 1. **Check file location**
    - Must be in project root
-   - Named exactly `codingbuddy.config.js`
+   - Named exactly `codingbuddy.config.json`
 
 2. **Verify syntax**
    ```bash
-   node -e "console.log(require('./codingbuddy.config.js'))"
+   node -e "console.log(require('./codingbuddy.config.json'))"
    ```
 
 3. **Check export format**
@@ -386,7 +386,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 1. **Set language in config**
    ```javascript
-   // codingbuddy.config.js
+   // codingbuddy.config.json
    module.exports = {
      language: 'ko'  // 'en', 'ko', 'ja', 'zh', 'es'
    };

--- a/docs/pt-BR/plugin-architecture.md
+++ b/docs/pt-BR/plugin-architecture.md
@@ -264,7 +264,7 @@ O contexto e persistido em `docs/codingbuddy/context.md`:
 }
 ```
 
-### Configuração do Projeto (`codingbuddy.config.js`)
+### Configuração do Projeto (`codingbuddy.config.json`)
 
 ```javascript
 module.exports = {

--- a/docs/pt-BR/plugin-faq.md
+++ b/docs/pt-BR/plugin-faq.md
@@ -199,7 +199,7 @@ Agentes são selecionados com base ém:
 
 1. **Contexto da tarefa**: Palavras-chave no seu prompt
 2. **Modo**: Diferentes agentes para PLAN vs ACT vs EVAL
-3. **Configuração**: Agentes personalizados em `codingbuddy.config.js`
+3. **Configuração**: Agentes personalizados em `codingbuddy.config.json`
 
 ### Possó usar multiplos agentes?
 
@@ -225,7 +225,7 @@ Use a ferramenta MCP:
 
 ### Como configuro o plugin?
 
-Crie `codingbuddy.config.js` na raiz do seu projeto:
+Crie `codingbuddy.config.json` na raiz do seu projeto:
 
 ```javascript
 module.exports = {

--- a/docs/pt-BR/plugin-guide.md
+++ b/docs/pt-BR/plugin-guide.md
@@ -229,7 +229,7 @@ Você devera ver ferramentas do CodingBuddy como:
 
 ### Configuração em Nível de Projeto
 
-Crie `codingbuddy.config.js` na raiz do seu projeto:
+Crie `codingbuddy.config.json` na raiz do seu projeto:
 
 ```javascript
 module.exports = {

--- a/docs/pt-BR/plugin-troubleshooting.md
+++ b/docs/pt-BR/plugin-troubleshooting.md
@@ -320,7 +320,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
    - Usar PLAN para uma funcionalidade por vez
 
 2. **Reduzir agentes especialistas**
-   - Configurar menos especialistas em `codingbuddy.config.js`
+   - Configurar menos especialistas em `codingbuddy.config.json`
    ```javascript
    module.exports = {
      specialists: ['security-specialist']  // Apenas essenciais
@@ -356,17 +356,17 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 ### Configuração do Projeto Não Carrega
 
-**Sintoma**: Configurações de `codingbuddy.config.js` não aplicadas.
+**Sintoma**: Configurações de `codingbuddy.config.json` não aplicadas.
 
 **Soluções**:
 
 1. **Verificar localização do arquivo**
    - Deve estar na raiz do projeto
-   - Nomeado exatamente `codingbuddy.config.js`
+   - Nomeado exatamente `codingbuddy.config.json`
 
 2. **Verificar sintaxe**
    ```bash
-   node -e "console.log(require('./codingbuddy.config.js'))"
+   node -e "console.log(require('./codingbuddy.config.json'))"
    ```
 
 3. **Verificar formato de export**
@@ -386,7 +386,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 1. **Definir idioma na configuração**
    ```javascript
-   // codingbuddy.config.js
+   // codingbuddy.config.json
    module.exports = {
      language: 'ko'  // 'en', 'ko', 'ja', 'zh', 'es'
    };

--- a/docs/zh-CN/getting-started.md
+++ b/docs/zh-CN/getting-started.md
@@ -26,7 +26,7 @@
 npx codingbuddy init
 ```
 
-此命令会分析您的项目并创建 `codingbuddy.config.js` 文件，包含：
+此命令会分析您的项目并创建 `codingbuddy.config.json` 文件，包含：
 
 - 检测到的技术栈（语言、框架、工具）
 - 架构模式
@@ -88,7 +88,7 @@ AI：# Mode: PLAN
 
 ### 生成的配置文件
 
-`codingbuddy.config.js` 文件用于自定义 AI 行为：
+`codingbuddy.config.json` 文件用于自定义 AI 行为：
 
 ```javascript
 module.exports = {
@@ -134,7 +134,7 @@ module.exports = {
 
 ```
 my-project/
-├── codingbuddy.config.js
+├── codingbuddy.config.json
 └── .codingbuddy/
     └── context/
         ├── architecture.md    # 系统架构文档

--- a/docs/zh-CN/plugin-architecture.md
+++ b/docs/zh-CN/plugin-architecture.md
@@ -264,7 +264,7 @@ sequenceDiagram
 }
 ```
 
-### 项目配置（`codingbuddy.config.js`）
+### 项目配置（`codingbuddy.config.json`）
 
 ```javascript
 module.exports = {

--- a/docs/zh-CN/plugin-faq.md
+++ b/docs/zh-CN/plugin-faq.md
@@ -199,7 +199,7 @@ EVAL                     → 审查实现
 
 1. **任务上下文**：您提示中的关键词
 2. **模式**：PLAN vs ACT vs EVAL 使用不同的代理
-3. **配置**：`codingbuddy.config.js` 中的自定义代理
+3. **配置**：`codingbuddy.config.json` 中的自定义代理
 
 ### 可以使用多个代理吗？
 
@@ -225,7 +225,7 @@ EVAL with security and accessibility focus
 
 ### 如何配置插件？
 
-在您的项目根目录创建 `codingbuddy.config.js`：
+在您的项目根目录创建 `codingbuddy.config.json`：
 
 ```javascript
 module.exports = {

--- a/docs/zh-CN/plugin-guide.md
+++ b/docs/zh-CN/plugin-guide.md
@@ -231,7 +231,7 @@ PLAN implement a user login feature
 
 ### 项目级配置
 
-在您的项目根目录创建 `codingbuddy.config.js`：
+在您的项目根目录创建 `codingbuddy.config.json`：
 
 ```javascript
 module.exports = {

--- a/docs/zh-CN/plugin-troubleshooting.md
+++ b/docs/zh-CN/plugin-troubleshooting.md
@@ -321,7 +321,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
    - 每次 PLAN 一个功能
 
 2. **减少专家代理**
-   - 在 `codingbuddy.config.js` 中配置更少的专家
+   - 在 `codingbuddy.config.json` 中配置更少的专家
    ```javascript
    module.exports = {
      specialists: ['security-specialist']  // 只保留必要的
@@ -357,17 +357,17 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 ### 项目配置未加载
 
-**症状**：`codingbuddy.config.js` 设置未应用。
+**症状**：`codingbuddy.config.json` 设置未应用。
 
 **解决方案**：
 
 1. **检查文件位置**
    - 必须在项目根目录
-   - 文件名必须是 `codingbuddy.config.js`
+   - 文件名必须是 `codingbuddy.config.json`
 
 2. **验证语法**
    ```bash
-   node -e "console.log(require('./codingbuddy.config.js'))"
+   node -e "console.log(require('./codingbuddy.config.json'))"
    ```
 
 3. **检查导出格式**
@@ -387,7 +387,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
 
 1. **在配置中设置语言**
    ```javascript
-   // codingbuddy.config.js
+   // codingbuddy.config.json
    module.exports = {
      language: 'zh'  // 'en', 'ko', 'ja', 'zh', 'es'
    };

--- a/packages/rules/.ai-rules/adapters/antigravity.md
+++ b/packages/rules/.ai-rules/adapters/antigravity.md
@@ -300,7 +300,7 @@ task_boundary(
 
 ### Configuration
 
-Configure in `codingbuddy.config.js`:
+Configure in `codingbuddy.config.json`:
 
 ```javascript
 module.exports = {

--- a/packages/rules/.ai-rules/adapters/claude-code.md
+++ b/packages/rules/.ai-rules/adapters/claude-code.md
@@ -578,7 +578,7 @@ AUTO implement user authentication with JWT tokens
 
 ### Configuration
 
-Configure AUTO mode in `codingbuddy.config.js`:
+Configure AUTO mode in `codingbuddy.config.json`:
 
 ```javascript
 module.exports = {

--- a/packages/rules/.ai-rules/adapters/codex.md
+++ b/packages/rules/.ai-rules/adapters/codex.md
@@ -236,7 +236,7 @@ When using GitHub Copilot Chat with AUTO mode:
 
 ### Configuration
 
-Configure in `codingbuddy.config.js`:
+Configure in `codingbuddy.config.json`:
 
 ```javascript
 module.exports = {

--- a/packages/rules/.ai-rules/adapters/cursor.md
+++ b/packages/rules/.ai-rules/adapters/cursor.md
@@ -253,7 +253,7 @@ When AUTO keyword is detected, Cursor calls `parse_mode` MCP tool which returns 
 
 ### Configuration
 
-Configure in `codingbuddy.config.js`:
+Configure in `codingbuddy.config.json`:
 
 ```javascript
 module.exports = {

--- a/packages/rules/.ai-rules/adapters/kiro.md
+++ b/packages/rules/.ai-rules/adapters/kiro.md
@@ -219,7 +219,7 @@ Kiro: # Mode: AUTO (Iteration 1/3)
 
 ### Configuration
 
-Configure in `codingbuddy.config.js`:
+Configure in `codingbuddy.config.json`:
 
 ```javascript
 module.exports = {

--- a/packages/rules/.ai-rules/adapters/opencode.md
+++ b/packages/rules/.ai-rules/adapters/opencode.md
@@ -188,7 +188,7 @@ Once connected, you can use:
 
 OpenCode agents get language instructions dynamically from the MCP server:
 
-1. **Set language in codingbuddy.config.js:**
+1. **Set language in codingbuddy.config.json:**
    ```javascript
    module.exports = {
      language: 'ko',  // or 'en', 'ja', 'zh', 'es', etc.
@@ -236,7 +236,7 @@ The `parse_mode` tool now returns additional Mode Agent information and dynamic 
 ```
 
 **New Fields:**
-- `language`: Language code from codingbuddy.config.js
+- `language`: Language code from codingbuddy.config.json
 - `languageInstruction`: Formatted instruction text for AI assistants (🆕)
 - `agent`: Mode Agent name (plan-mode, act-mode, eval-mode)
 - `delegates_to`: Which specialist agent the Mode Agent delegates to
@@ -598,7 +598,7 @@ Loop or Exit
 
 ### Configuration
 
-Configure in `codingbuddy.config.js`:
+Configure in `codingbuddy.config.json`:
 
 ```javascript
 module.exports = {

--- a/packages/rules/.ai-rules/adapters/q.md
+++ b/packages/rules/.ai-rules/adapters/q.md
@@ -207,7 +207,7 @@ Amazon Q's AWS expertise complements AUTO mode:
 
 ### Configuration
 
-Configure in `codingbuddy.config.js`:
+Configure in `codingbuddy.config.json`:
 
 ```javascript
 module.exports = {

--- a/packages/rules/.ai-rules/agents/README.md
+++ b/packages/rules/.ai-rules/agents/README.md
@@ -626,7 +626,7 @@ Unified specialist agents organized by domain:
 
 **Expertise:**
 
-- Project Configuration (codingbuddy.config.js, .env)
+- Project Configuration (codingbuddy.config.json, .env)
 - TypeScript Configuration (tsconfig.json, paths)
 - Linting & Formatting (ESLint, Prettier, Stylelint)
 - Build Tools (Vite, Webpack, Next.js config, Rollup)

--- a/packages/rules/.ai-rules/agents/tooling-engineer.json
+++ b/packages/rules/.ai-rules/agents/tooling-engineer.json
@@ -5,7 +5,7 @@
     "title": "Tooling Engineer",
     "type": "primary",
     "expertise": [
-      "Project Configuration (codingbuddy.config.js, .env)",
+      "Project Configuration (codingbuddy.config.json, .env)",
       "TypeScript Configuration (tsconfig.json, paths)",
       "Linting & Formatting (ESLint, Prettier, Stylelint)",
       "Build Tools (Vite, Webpack, Next.js config, Rollup)",


### PR DESCRIPTION
# Migrate all documentation references from `codingbuddy.config.js` to `codingbuddy.config.json`

## Summary

- Update ~50 documentation files across 6 languages to replace `codingbuddy.config.js` references with `codingbuddy.config.json`
- Convert all JavaScript code examples (`module.exports`, unquoted keys, comments) to valid JSON format in `config-schema.md` and `customization.md`
- Remove outdated multi-format support messaging (`.js`, `.codingbuddyrc`) from config-schema documentation

## Motivation

Since v4.0.0, CodingBuddy exclusively uses JSON configuration (`codingbuddy.config.json`). The CLI already generates the correct format, but documentation still referenced the deprecated `.js` format, causing user confusion.

## Changes

### Filename reference updates (52 files)

Bulk replacement of `codingbuddy.config.js` → `codingbuddy.config.json` across:

| Category | Files | Languages |
|----------|-------|-----------|
| Root READMEs + CLAUDE.md | 7 | en, ko, ja, es, zh-CN |
| Getting Started guides | 6 | en, ko, ja, es, zh-CN |
| Plugin docs (guide, FAQ, architecture, troubleshooting) | 24 | en, ko, ja, es, zh-CN, pt-BR |
| AI Rules adapters | 7 | - |
| AI Rules agents | 2 | - |
| Other docs (api, errors, dev, migration) | 5 | en |
| Issue template | 1 | en |

### Code example conversions

**`docs/config-schema.md`:**
- Converted Quick Start from `module.exports = {...}` to JSON object
- Converted 7 section-level code examples from JavaScript to JSON format
- Changed "supports multiple formats" → "supports only JSON format"
- Removed `.codingbuddyrc` format option
- Updated TypeScript Types section to remove `module.exports` pattern

**`docs/customization.md`:**
- Converted Manual Configuration from `module.exports = {...}` to JSON object
- Converted 5 section-level code examples (techStack, architecture, conventions, testStrategy) to JSON
- Renamed "JSON Format" section → "Minimal Configuration" (removed misleading "also" wording)

### Intentionally excluded files

The following files retain `.config.js` references by design:

| File | Reason |
|------|--------|
| `CHANGELOG.md` (5 languages) | Historical migration records |
| `docs/bugs/language-config-ignored.md` | Historical bug report |
| `docs/plans/global-model-priority-implementation.md` | Historical planning document |
| `packages/rules/.ai-rules/CHANGELOG.md` | Historical changelog |
| `.gitignore` | Must ignore both old and new config filenames |
| `config.loader.ts` (`DEPRECATED_CONFIG_FILE_NAMES`) | Runtime deprecation warnings for users with legacy configs |
| Test files (`*.spec.ts`) | Tests for deprecated config detection logic |

## Test Plan

- [x] All 2663 tests pass (100 test files, 0 failures, 2 skipped)
- [x] No `jsonon` corruption from sed substring matching
- [x] Zero `codingbuddy.config.js` references in non-excluded documentation
- [x] Zero `module.exports` statements in config-schema.md and customization.md
- [x] All JSON code blocks contain valid JSON syntax (double-quoted keys, no trailing commas, no comments)
- [x] Source code files unchanged (config.writer.ts, config.loader.ts, init.command.ts verified)
- [x] Cross-language consistency verified (ko, ja, es spot-checked)

## Related

close #325 