### PR TITLE
replace top-level ink import with local TuiInstance interface

### DIFF
--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -4,7 +4,11 @@ import type { INestApplicationContext } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { McpService } from './mcp/mcp.service';
 import { hasTuiFlag } from './tui/cli-flags';
-import type { Instance } from 'ink';
+
+/** Minimal subset of Ink's Instance used for lifecycle management */
+interface TuiInstance {
+  readonly unmount: () => void;
+}
 
 /**
  * Parse CORS origin configuration from environment variable
@@ -47,7 +51,7 @@ function debugLog(message: string): void {
  * Unmounts the Ink application and closes NestJS on SIGINT/SIGTERM
  */
 function setupGracefulShutdown(
-  instance: Instance,
+  instance: TuiInstance,
   app: INestApplicationContext,
 ): void {
   let shuttingDown = false;


### PR DESCRIPTION
## Summary

- Replace `import type { Instance } from 'ink'` with a local `TuiInstance` interface in `main.ts`
- Fix `yarn start:dev --tui` crash caused by ts-node failing to resolve ink's ESM package exports under `moduleResolution: node`
- Decouple `main.ts` from ink's type system — only `setupGracefulShutdown` needs `unmount()`

## Problem

ink v6 uses ESM `package.json` exports which are not resolvable under `moduleResolution: "node"` (CommonJS). The ambient declaration at `src/tui/ink.d.ts` is included by `tsc` via the `include: ["src/**/*"]` glob, but `ts-node` compiles on-demand from the entry point and never loads it.

**Result:** `yarn build` succeeds but `yarn start:dev --tui` crashes with:
```
error TS2307: Cannot find module 'ink' or its corresponding type declarations.
```

## Fix

Define a minimal `TuiInstance` interface in `main.ts` with only the `unmount()` method actually used by `setupGracefulShutdown`. This is also architecturally cleaner — `main.ts` should not depend directly on ink types.

## Test plan

- [x] `yarn workspace codingbuddy test` — 105 files, 2702 tests passed
- [x] `yarn build` — compiles without errors
- [x] `yarn start:dev --tui` — starts without crash (exit 142 = SIGALRM timeout, expected)
- [x] `yarn start:tui` — starts without crash