### PR TITLE
add gitignore entries and ENABLE_TOOL_SEARCH in Claude global settings

### DIFF
--- a/apps/mcp-server/src/cli/init/claude-settings.utils.spec.ts
+++ b/apps/mcp-server/src/cli/init/claude-settings.utils.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * Claude Settings Utilities Tests
+ *
+ * TDD tests for ~/.claude/settings.json manipulation
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import {
+  ensureClaudeSettingsEnv,
+  ClaudeSettingsReadError,
+  ClaudeSettingsWriteError,
+} from './claude-settings.utils';
+
+// Mock fs module with memfs
+vi.mock('fs', async () => {
+  const memfs = await import('memfs');
+  return memfs.fs;
+});
+
+vi.mock('fs/promises', async () => {
+  const memfs = await import('memfs');
+  return memfs.fs.promises;
+});
+
+// Mock os.homedir
+vi.mock('os', () => ({
+  homedir: () => '/mock-home',
+}));
+
+describe('ensureClaudeSettingsEnv', () => {
+  const claudeDir = '/mock-home/.claude';
+  const settingsPath = '/mock-home/.claude/settings.json';
+
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  describe('when ~/.claude/settings.json does not exist', () => {
+    it('creates settings file with env entries', async () => {
+      vol.mkdirSync(claudeDir, { recursive: true });
+
+      const result = await ensureClaudeSettingsEnv({
+        ENABLE_TOOL_SEARCH: 'false',
+      });
+
+      expect(result.added).toEqual(['ENABLE_TOOL_SEARCH']);
+      expect(result.alreadyExists).toEqual([]);
+
+      const content = JSON.parse(
+        vol.readFileSync(settingsPath, 'utf-8') as string,
+      );
+      expect(content).toEqual({
+        env: {
+          ENABLE_TOOL_SEARCH: 'false',
+        },
+      });
+    });
+
+    it('creates ~/.claude directory if it does not exist', async () => {
+      // No directory created beforehand
+      vol.mkdirSync('/mock-home', { recursive: true });
+
+      const result = await ensureClaudeSettingsEnv({
+        ENABLE_TOOL_SEARCH: 'false',
+      });
+
+      expect(result.added).toEqual(['ENABLE_TOOL_SEARCH']);
+
+      const content = JSON.parse(
+        vol.readFileSync(settingsPath, 'utf-8') as string,
+      );
+      expect(content.env.ENABLE_TOOL_SEARCH).toBe('false');
+    });
+  });
+
+  describe('when settings.json exists with other env vars', () => {
+    it('merges new env entries preserving existing ones', async () => {
+      vol.mkdirSync(claudeDir, { recursive: true });
+      vol.writeFileSync(
+        settingsPath,
+        JSON.stringify(
+          {
+            env: {
+              EXISTING_VAR: 'keep-me',
+            },
+            language: 'ko',
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = await ensureClaudeSettingsEnv({
+        ENABLE_TOOL_SEARCH: 'false',
+      });
+
+      expect(result.added).toEqual(['ENABLE_TOOL_SEARCH']);
+
+      const content = JSON.parse(
+        vol.readFileSync(settingsPath, 'utf-8') as string,
+      );
+      expect(content.env.EXISTING_VAR).toBe('keep-me');
+      expect(content.env.ENABLE_TOOL_SEARCH).toBe('false');
+      expect(content.language).toBe('ko');
+    });
+  });
+
+  describe('when env key already exists', () => {
+    it('does not overwrite existing env key', async () => {
+      vol.mkdirSync(claudeDir, { recursive: true });
+      vol.writeFileSync(
+        settingsPath,
+        JSON.stringify(
+          {
+            env: {
+              ENABLE_TOOL_SEARCH: 'true',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = await ensureClaudeSettingsEnv({
+        ENABLE_TOOL_SEARCH: 'false',
+      });
+
+      expect(result.added).toEqual([]);
+      expect(result.alreadyExists).toEqual(['ENABLE_TOOL_SEARCH']);
+
+      const content = JSON.parse(
+        vol.readFileSync(settingsPath, 'utf-8') as string,
+      );
+      // Should NOT be overwritten
+      expect(content.env.ENABLE_TOOL_SEARCH).toBe('true');
+    });
+  });
+
+  describe('when settings.json exists without env section', () => {
+    it('adds env section with entries', async () => {
+      vol.mkdirSync(claudeDir, { recursive: true });
+      vol.writeFileSync(
+        settingsPath,
+        JSON.stringify(
+          {
+            language: 'ko',
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = await ensureClaudeSettingsEnv({
+        ENABLE_TOOL_SEARCH: 'false',
+      });
+
+      expect(result.added).toEqual(['ENABLE_TOOL_SEARCH']);
+
+      const content = JSON.parse(
+        vol.readFileSync(settingsPath, 'utf-8') as string,
+      );
+      expect(content.env.ENABLE_TOOL_SEARCH).toBe('false');
+      expect(content.language).toBe('ko');
+    });
+  });
+
+  describe('multiple entries', () => {
+    it('adds multiple env entries at once', async () => {
+      vol.mkdirSync(claudeDir, { recursive: true });
+
+      const result = await ensureClaudeSettingsEnv({
+        ENABLE_TOOL_SEARCH: 'false',
+        ANOTHER_SETTING: 'value',
+      });
+
+      expect(result.added).toEqual(['ENABLE_TOOL_SEARCH', 'ANOTHER_SETTING']);
+
+      const content = JSON.parse(
+        vol.readFileSync(settingsPath, 'utf-8') as string,
+      );
+      expect(content.env.ENABLE_TOOL_SEARCH).toBe('false');
+      expect(content.env.ANOTHER_SETTING).toBe('value');
+    });
+
+    it('handles mix of new and existing entries', async () => {
+      vol.mkdirSync(claudeDir, { recursive: true });
+      vol.writeFileSync(
+        settingsPath,
+        JSON.stringify(
+          {
+            env: {
+              ENABLE_TOOL_SEARCH: 'true',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = await ensureClaudeSettingsEnv({
+        ENABLE_TOOL_SEARCH: 'false',
+        NEW_SETTING: 'new-value',
+      });
+
+      expect(result.added).toEqual(['NEW_SETTING']);
+      expect(result.alreadyExists).toEqual(['ENABLE_TOOL_SEARCH']);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws ClaudeSettingsReadError when file contains invalid JSON', async () => {
+      vol.mkdirSync(claudeDir, { recursive: true });
+      vol.writeFileSync(settingsPath, 'not valid json{{{');
+
+      await expect(
+        ensureClaudeSettingsEnv({ ENABLE_TOOL_SEARCH: 'false' }),
+      ).rejects.toThrow(ClaudeSettingsReadError);
+    });
+
+    it('throws ClaudeSettingsWriteError when directory cannot be created', async () => {
+      // Create a file where ~/.claude directory should be, blocking mkdir
+      vol.mkdirSync('/mock-home', { recursive: true });
+      vol.writeFileSync('/mock-home/.claude', 'blocking file');
+
+      await expect(
+        ensureClaudeSettingsEnv({ ENABLE_TOOL_SEARCH: 'false' }),
+      ).rejects.toThrow(ClaudeSettingsWriteError);
+    });
+  });
+
+  describe('when no entries to add', () => {
+    it('returns early without writing', async () => {
+      vol.mkdirSync(claudeDir, { recursive: true });
+      vol.writeFileSync(
+        settingsPath,
+        JSON.stringify(
+          {
+            env: {
+              ENABLE_TOOL_SEARCH: 'false',
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const result = await ensureClaudeSettingsEnv({
+        ENABLE_TOOL_SEARCH: 'false',
+      });
+
+      expect(result.added).toEqual([]);
+      expect(result.alreadyExists).toEqual(['ENABLE_TOOL_SEARCH']);
+    });
+  });
+});

--- a/apps/mcp-server/src/cli/init/claude-settings.utils.ts
+++ b/apps/mcp-server/src/cli/init/claude-settings.utils.ts
@@ -1,0 +1,118 @@
+/**
+ * Claude Settings Utilities
+ *
+ * Functions for manipulating ~/.claude/settings.json
+ */
+
+import { existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import * as path from 'path';
+
+export class ClaudeSettingsReadError extends Error {
+  readonly cause: unknown;
+
+  constructor(settingsPath: string, cause: unknown) {
+    const message = `Failed to read Claude settings at ${settingsPath}`;
+    super(message);
+    this.name = 'ClaudeSettingsReadError';
+    this.cause = cause;
+  }
+}
+
+export class ClaudeSettingsWriteError extends Error {
+  readonly cause: unknown;
+
+  constructor(settingsPath: string, cause: unknown) {
+    const message = `Failed to write Claude settings at ${settingsPath}`;
+    super(message);
+    this.name = 'ClaudeSettingsWriteError';
+    this.cause = cause;
+  }
+}
+
+export interface EnsureClaudeSettingsResult {
+  /** Env keys that were added */
+  added: string[];
+  /** Env keys that already existed */
+  alreadyExists: string[];
+}
+
+/**
+ * Ensure env entries exist in ~/.claude/settings.json
+ *
+ * - Creates ~/.claude directory if it doesn't exist
+ * - Creates settings.json if it doesn't exist
+ * - Adds env entries that don't already exist
+ * - Preserves all existing settings and env values
+ *
+ * @param envEntries - Key-value pairs to ensure in env section
+ * @returns Result with added and already existing keys
+ * @throws {ClaudeSettingsReadError} When settings.json contains invalid JSON
+ * @throws {ClaudeSettingsWriteError} When settings.json cannot be written
+ */
+export async function ensureClaudeSettingsEnv(
+  envEntries: Record<string, string>,
+): Promise<EnsureClaudeSettingsResult> {
+  const claudeDir = path.join(homedir(), '.claude');
+  const settingsPath = path.join(claudeDir, 'settings.json');
+
+  const result: EnsureClaudeSettingsResult = {
+    added: [],
+    alreadyExists: [],
+  };
+
+  // Read existing settings or start with empty object
+  let settings: Record<string, unknown> = {};
+
+  if (existsSync(settingsPath)) {
+    try {
+      const content = await readFile(settingsPath, 'utf-8');
+      settings = JSON.parse(content);
+    } catch (error) {
+      throw new ClaudeSettingsReadError(settingsPath, error);
+    }
+  }
+
+  // Ensure env section exists
+  if (!settings.env || typeof settings.env !== 'object') {
+    settings.env = {};
+  }
+
+  const env = settings.env as Record<string, string>;
+
+  // Categorize entries
+  for (const [key, value] of Object.entries(envEntries)) {
+    if (key in env) {
+      result.alreadyExists.push(key);
+    } else {
+      result.added.push(key);
+      env[key] = value;
+    }
+  }
+
+  // If nothing to add, return early
+  if (result.added.length === 0) {
+    return result;
+  }
+
+  // Ensure ~/.claude directory exists
+  try {
+    await mkdir(claudeDir, { recursive: true });
+  } catch (error) {
+    throw new ClaudeSettingsWriteError(settingsPath, error);
+  }
+
+  // Write settings
+  try {
+    await writeFile(
+      settingsPath,
+      JSON.stringify(settings, null, 2) + '\n',
+      'utf-8',
+    );
+  } catch (error) {
+    throw new ClaudeSettingsWriteError(settingsPath, error);
+  }
+
+  return result;
+}

--- a/apps/mcp-server/src/cli/init/init.command.spec.ts
+++ b/apps/mcp-server/src/cli/init/init.command.spec.ts
@@ -14,6 +14,7 @@ const {
   mockWizardDataToConfig,
   mockRenderConfigObjectAsJson,
   mockEnsureGitignoreEntries,
+  mockEnsureClaudeSettingsEnv,
 } = vi.hoisted(() => ({
   mockAnalyzeProject: vi.fn(),
   mockGenerate: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockWizardDataToConfig: vi.fn(),
   mockRenderConfigObjectAsJson: vi.fn(),
   mockEnsureGitignoreEntries: vi.fn(),
+  mockEnsureClaudeSettingsEnv: vi.fn(),
 }));
 
 // Mock all modules
@@ -54,6 +56,10 @@ vi.mock('./init.wizard', () => ({
 
 vi.mock('./gitignore.utils', () => ({
   ensureGitignoreEntries: mockEnsureGitignoreEntries,
+}));
+
+vi.mock('./claude-settings.utils', () => ({
+  ensureClaudeSettingsEnv: mockEnsureClaudeSettingsEnv,
 }));
 
 vi.mock('../utils/console', () => ({
@@ -150,6 +156,10 @@ describe('init.command', () => {
     mockWizardDataToConfig.mockReturnValue(mockConfig);
     mockRenderConfigObjectAsJson.mockReturnValue('{}');
     mockEnsureGitignoreEntries.mockResolvedValue({
+      added: [],
+      alreadyExists: [],
+    });
+    mockEnsureClaudeSettingsEnv.mockResolvedValue({
       added: [],
       alreadyExists: [],
     });
@@ -295,6 +305,19 @@ describe('init.command', () => {
       });
     });
 
+    it('should call ensureClaudeSettingsEnv with env entries', async () => {
+      const options: InitOptions = {
+        projectRoot: '/project',
+        force: false,
+      };
+
+      await runInit(options);
+
+      expect(mockEnsureClaudeSettingsEnv).toHaveBeenCalledWith({
+        ENABLE_TOOL_SEARCH: 'false',
+      });
+    });
+
     it('should handle wizard cancellation', async () => {
       mockRunInitWizard.mockResolvedValue(null);
 
@@ -337,6 +360,21 @@ describe('init.command', () => {
       expect(result.success).toBe(true);
       expect(mockGenerate).toHaveBeenCalledWith(mockAnalysis);
       expect(mockRunInitWizard).not.toHaveBeenCalled();
+    });
+
+    it('should call ensureClaudeSettingsEnv in AI mode', async () => {
+      const options: InitOptions = {
+        projectRoot: '/project',
+        force: false,
+        useAi: true,
+        apiKey: 'test-key',
+      };
+
+      await runInit(options);
+
+      expect(mockEnsureClaudeSettingsEnv).toHaveBeenCalledWith({
+        ENABLE_TOOL_SEARCH: 'false',
+      });
     });
 
     it('should write config without raw option in AI mode', async () => {

--- a/apps/mcp-server/src/cli/init/init.command.ts
+++ b/apps/mcp-server/src/cli/init/init.command.ts
@@ -13,7 +13,11 @@ import { createConsoleUtils } from '../utils/console';
 import { renderConfigObjectAsJson } from './templates';
 import { runInitWizard, wizardDataToConfig } from './init.wizard';
 import { ensureGitignoreEntries } from './gitignore.utils';
-import { CODINGBUDDY_GITIGNORE_ENTRIES } from './init.constants';
+import { ensureClaudeSettingsEnv } from './claude-settings.utils';
+import {
+  CODINGBUDDY_GITIGNORE_ENTRIES,
+  CLAUDE_SETTINGS_ENV_ENTRIES,
+} from './init.constants';
 import type { InitOptions, InitResult } from '../cli.types';
 
 /**
@@ -61,6 +65,35 @@ export function getApiKey(options: InitOptions): string | null {
 }
 
 /**
+ * Post-write steps: update .gitignore and Claude global settings
+ */
+async function ensureWorkspaceSettings(
+  projectRoot: string,
+  console: ReturnType<typeof createConsoleUtils>,
+): Promise<void> {
+  const gitignoreResult = await ensureGitignoreEntries(
+    projectRoot,
+    CODINGBUDDY_GITIGNORE_ENTRIES,
+  );
+  if (gitignoreResult.added.length > 0) {
+    console.log.step(
+      '📝',
+      `Updated .gitignore: ${gitignoreResult.added.join(', ')}`,
+    );
+  }
+
+  const claudeSettingsResult = await ensureClaudeSettingsEnv(
+    CLAUDE_SETTINGS_ENV_ENTRIES,
+  );
+  if (claudeSettingsResult.added.length > 0) {
+    console.log.step(
+      '⚙️',
+      `Updated Claude settings: ${claudeSettingsResult.added.join(', ')}`,
+    );
+  }
+}
+
+/**
  * Run the init command with template-based generation (default)
  */
 async function runTemplateInit(
@@ -105,17 +138,8 @@ async function runTemplateInit(
 
   console.log.success(`Configuration saved to ${configPath}`);
 
-  // Step 5: Update .gitignore
-  const gitignoreResult = await ensureGitignoreEntries(
-    options.projectRoot,
-    CODINGBUDDY_GITIGNORE_ENTRIES,
-  );
-  if (gitignoreResult.added.length > 0) {
-    console.log.step(
-      '📝',
-      `Updated .gitignore: ${gitignoreResult.added.join(', ')}`,
-    );
-  }
+  // Step 5: Update .gitignore and Claude settings
+  await ensureWorkspaceSettings(options.projectRoot, console);
 
   // Success message
   console.log.success('');
@@ -179,17 +203,8 @@ async function runAiInit(
 
   console.log.success(`Configuration saved to ${configPath}`);
 
-  // Step 4: Update .gitignore
-  const gitignoreResult = await ensureGitignoreEntries(
-    options.projectRoot,
-    CODINGBUDDY_GITIGNORE_ENTRIES,
-  );
-  if (gitignoreResult.added.length > 0) {
-    console.log.step(
-      '📝',
-      `Updated .gitignore: ${gitignoreResult.added.join(', ')}`,
-    );
-  }
+  // Step 4: Update .gitignore and Claude settings
+  await ensureWorkspaceSettings(options.projectRoot, console);
 
   // Success message
   console.log.success('');

--- a/apps/mcp-server/src/cli/init/init.constants.ts
+++ b/apps/mcp-server/src/cli/init/init.constants.ts
@@ -7,6 +7,16 @@
 import type { GitignoreEntry } from './gitignore.utils';
 
 /**
+ * Default Claude Code global env settings
+ *
+ * These entries are added to ~/.claude/settings.json env section
+ * during `codingbuddy init` to configure Claude Code behavior.
+ */
+export const CLAUDE_SETTINGS_ENV_ENTRIES: Record<string, string> = {
+  ENABLE_TOOL_SEARCH: 'false',
+};
+
+/**
  * Default gitignore entries for codingbuddy
  *
  * These entries are added to .gitignore during `codingbuddy init`
@@ -14,7 +24,13 @@ import type { GitignoreEntry } from './gitignore.utils';
  */
 export const CODINGBUDDY_GITIGNORE_ENTRIES: GitignoreEntry[] = [
   {
-    pattern: 'docs/codingbuddy/context.md',
+    pattern: 'codingbuddy.config.json',
     comment: '# Codingbuddy (local workspace)',
+  },
+  {
+    pattern: 'docs/codingbuddy/context.md',
+  },
+  {
+    pattern: '.codingbuddy/',
   },
 ];


### PR DESCRIPTION
## Summary

- Expand `.gitignore` entries to include `codingbuddy.config.json`, `docs/codingbuddy/context.md`, and `.codingbuddy/` during `codingbuddy init`
- Create `ensureClaudeSettingsEnv` utility that idempotently adds `ENABLE_TOOL_SEARCH=false` to `~/.claude/settings.json`
- Extract `ensureWorkspaceSettings` helper to share gitignore and Claude settings steps across both template and AI init flows

## Changes

| File | Description |
|------|-------------|
| `init.constants.ts` | Add `CLAUDE_SETTINGS_ENV_ENTRIES` constant, expand `CODINGBUDDY_GITIGNORE_ENTRIES` to 3 entries |
| `claude-settings.utils.ts` | New utility for `~/.claude/settings.json` manipulation with idempotent merge, directory creation, and typed errors |
| `claude-settings.utils.spec.ts` | 10 tests with memfs for filesystem isolation (create, merge, preserve existing, multiple entries, error handling) |
| `init.command.ts` | Extract `ensureWorkspaceSettings` helper, integrate Claude settings step in both template and AI flows |
| `init.command.spec.ts` | Add mock for `claude-settings.utils`, add 2 integration tests for template and AI modes |

## Key behaviors

- **Idempotent**: Existing `.gitignore` entries and `ENABLE_TOOL_SEARCH` values are preserved, not overwritten
- **Safe**: Creates `~/.claude/` directory if missing, preserves all existing settings.json content
- **Error handling**: Typed `ClaudeSettingsReadError` and `ClaudeSettingsWriteError` for clear diagnostics
- **No duplication**: Shared `ensureWorkspaceSettings` helper eliminates repeated code between template and AI init paths

## Test plan

- [x] 10 unit tests for `ensureClaudeSettingsEnv` (memfs-based filesystem isolation)
- [x] 23 tests for `init.command` (including 2 new integration tests)
- [x] Full test suite passes (3296 tests)
- [x] `tsc --noEmit` passes with no errors

Closes #327