### PR TITLE
add self-hosted fonts with next/font

### DIFF
--- a/apps/landing-page/src/app/globals.css
+++ b/apps/landing-page/src/app/globals.css
@@ -6,8 +6,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-inter);
+  --font-mono: var(--font-jetbrains-mono);
   --color-chart-5: var(--chart-5);
   --color-chart-4: var(--chart-4);
   --color-chart-3: var(--chart-3);

--- a/apps/landing-page/src/app/layout.tsx
+++ b/apps/landing-page/src/app/layout.tsx
@@ -1,21 +1,21 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Inter, JetBrains_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
 import { CookieConsent } from '@/components/cookie-consent';
 import './globals.css';
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const inter = Inter({
+  variable: '--font-inter',
   subsets: ['latin'],
   display: 'swap',
   preload: true,
   adjustFontFallback: true,
 });
 
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
+const jetbrainsMono = JetBrains_Mono({
+  variable: '--font-jetbrains-mono',
   subsets: ['latin'],
   display: 'swap',
   preload: false,
@@ -36,7 +36,7 @@ const RootLayout = ({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}
       >
         <ThemeProvider
           attribute="class"


### PR DESCRIPTION
## Summary
- Replace default Geist/Geist_Mono fonts with **Inter** (sans-serif) and **JetBrains Mono** (monospace) using `next/font/google`
- Update CSS variable references in `globals.css` (`--font-inter`, `--font-jetbrains-mono`)
- Configure `display: swap` for optimal font loading performance

## Changes
- **`apps/landing-page/src/app/layout.tsx`**: Replace `Geist`/`Geist_Mono` imports and instances with `Inter`/`JetBrains_Mono`, update CSS variable names
- **`apps/landing-page/src/app/globals.css`**: Update `--font-sans` and `--font-mono` to reference the new CSS variables

## Test plan
- [ ] Verify Inter font loads correctly as the default sans-serif
- [ ] Verify JetBrains Mono loads correctly for monospace/code blocks
- [ ] Confirm `display: swap` prevents FOIT (Flash of Invisible Text)
- [ ] Check no layout shift from font loading
- [ ] Build passes without errors

Closes #314