### PR TITLE
add AgentsShowcase widget with filter and search

### DIFF
--- a/apps/landing-page/__tests__/__helpers__/next-intl-mock.ts
+++ b/apps/landing-page/__tests__/__helpers__/next-intl-mock.ts
@@ -1,0 +1,30 @@
+import { vi } from 'vitest';
+
+/**
+ * Shared mock for next-intl useTranslations hook.
+ * Import this file in test files that render components using next-intl.
+ *
+ * Usage: import '@/__tests__/__helpers__/next-intl-mock';
+ */
+vi.mock('next-intl', () => ({
+  useTranslations: () => {
+    const translations: Record<string, string> = {
+      title: 'AI Specialist Agents',
+      subtitle: '29 specialized AI agents',
+      filter: 'Filter by category',
+      search: 'Search agents...',
+      allCategories: 'All Categories',
+      noResults: 'No agents found matching your criteria',
+      'categories.Planning': 'Planning',
+      'categories.Development': 'Development',
+      'categories.Review': 'Review',
+      'categories.Security': 'Security',
+      'categories.UX': 'UX',
+    };
+    const t = (key: string, params?: Record<string, unknown>) => {
+      if (key === 'count') return `${params?.count} agents`;
+      return translations[key] ?? key;
+    };
+    return t;
+  },
+}));

--- a/apps/landing-page/__tests__/accessibility/page.test.tsx
+++ b/apps/landing-page/__tests__/accessibility/page.test.tsx
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { run } from 'axe-core';
+import '@/__tests__/__helpers__/next-intl-mock';
 import { AgentsShowcase } from '@/widgets/AgentsShowcase';
 import { CodeExample } from '@/widgets/CodeExample';
 import { QuickStart } from '@/widgets/QuickStart';

--- a/apps/landing-page/__tests__/i18n/messages.test.ts
+++ b/apps/landing-page/__tests__/i18n/messages.test.ts
@@ -5,8 +5,44 @@ import zhCN from '../../messages/zh-CN.json';
 import ja from '../../messages/ja.json';
 import es from '../../messages/es.json';
 
-const allMessages = { en, ko, 'zh-CN': zhCN, ja, es };
+interface MessageMap {
+  [key: string]: string | MessageMap;
+}
+type Messages = Record<string, MessageMap>;
+
+const allMessages: Record<string, Messages> = {
+  en: en as Messages,
+  ko: ko as Messages,
+  'zh-CN': zhCN as Messages,
+  ja: ja as Messages,
+  es: es as Messages,
+};
 const referenceKeys = Object.keys(en);
+
+/** Recursively extract sorted keys from a nested object */
+function getKeysDeep(obj: MessageMap, prefix = ''): string[] {
+  const keys: string[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    keys.push(path);
+    if (typeof value === 'object' && value !== null) {
+      keys.push(...getKeysDeep(value as MessageMap, path));
+    }
+  }
+  return keys.sort();
+}
+
+/** Recursively check no empty string values */
+function checkNoEmptyValues(obj: MessageMap, locale: string, prefix: string) {
+  for (const [key, value] of Object.entries(obj)) {
+    const path = `${prefix}.${key}`;
+    if (typeof value === 'string') {
+      expect(value, `${locale}.${path} is empty`).not.toBe('');
+    } else if (typeof value === 'object' && value !== null) {
+      checkNoEmptyValues(value as MessageMap, locale, path);
+    }
+  }
+}
 
 describe('message files', () => {
   test('all locales have identical top-level keys', () => {
@@ -19,14 +55,11 @@ describe('message files', () => {
   });
 
   test('all locales have identical nested keys for each section', () => {
+    const ref = allMessages.en;
     for (const section of referenceKeys) {
-      const refNestedKeys = Object.keys(
-        (en as Record<string, Record<string, string>>)[section],
-      ).sort();
+      const refNestedKeys = getKeysDeep(ref[section] as MessageMap);
       for (const [locale, messages] of Object.entries(allMessages)) {
-        const nestedKeys = Object.keys(
-          (messages as Record<string, Record<string, string>>)[section],
-        ).sort();
+        const nestedKeys = getKeysDeep(messages[section] as MessageMap);
         expect(nestedKeys, `${locale}.${section} keys mismatch`).toEqual(
           refNestedKeys,
         );
@@ -36,12 +69,8 @@ describe('message files', () => {
 
   test('no empty string values in any locale', () => {
     for (const [locale, messages] of Object.entries(allMessages)) {
-      for (const [section, content] of Object.entries(
-        messages as Record<string, Record<string, string>>,
-      )) {
-        for (const [key, value] of Object.entries(content)) {
-          expect(value, `${locale}.${section}.${key} is empty`).not.toBe('');
-        }
+      for (const [section, content] of Object.entries(messages)) {
+        checkNoEmptyValues(content as MessageMap, locale, section);
       }
     }
   });

--- a/apps/landing-page/__tests__/widgets/AgentsShowcase.test.tsx
+++ b/apps/landing-page/__tests__/widgets/AgentsShowcase.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@/__tests__/__helpers__/next-intl-mock';
 import { AgentsShowcase } from '@/widgets/AgentsShowcase';
 
 describe('AgentsShowcase', () => {
@@ -8,7 +10,7 @@ describe('AgentsShowcase', () => {
     expect(screen.getByTestId('agents-showcase')).toBeInTheDocument();
   });
 
-  it('should render with Korean locale', () => {
+  it('should set lang attribute matching locale', () => {
     render(<AgentsShowcase locale="ko" />);
     expect(screen.getByTestId('agents-showcase')).toHaveAttribute('lang', 'ko');
   });
@@ -16,7 +18,7 @@ describe('AgentsShowcase', () => {
   it('should display section heading', () => {
     render(<AgentsShowcase locale="en" />);
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
-      'AI Agents',
+      'AI Specialist Agents',
     );
   });
 
@@ -24,14 +26,44 @@ describe('AgentsShowcase', () => {
     render(<AgentsShowcase locale="en" />);
     const section = screen.getByTestId('agents-showcase');
     expect(section).toHaveAttribute('aria-labelledby', 'agents-heading');
-    expect(screen.getByText('AI Agents')).toHaveAttribute(
-      'id',
-      'agents-heading',
-    );
   });
 
-  it('should set lang attribute matching locale', () => {
+  it('should render agent cards', () => {
     render(<AgentsShowcase locale="en" />);
-    expect(screen.getByTestId('agents-showcase')).toHaveAttribute('lang', 'en');
+    expect(screen.getByText('Frontend Developer')).toBeInTheDocument();
+    expect(screen.getByText('Security Specialist')).toBeInTheDocument();
+  });
+
+  it('should display agent count', () => {
+    render(<AgentsShowcase locale="en" />);
+    expect(screen.getByText('29 agents')).toBeInTheDocument();
+  });
+
+  it('should display search input', () => {
+    render(<AgentsShowcase locale="en" />);
+    expect(screen.getByPlaceholderText('Search agents...')).toBeInTheDocument();
+  });
+
+  it('should filter agents by search query', async () => {
+    const user = userEvent.setup();
+    render(<AgentsShowcase locale="en" />);
+
+    const searchInput = screen.getByPlaceholderText('Search agents...');
+    await user.type(searchInput, 'frontend');
+
+    expect(screen.getByText('Frontend Developer')).toBeInTheDocument();
+    expect(screen.queryByText('Security Specialist')).not.toBeInTheDocument();
+  });
+
+  it('should show no results message when search has no matches', async () => {
+    const user = userEvent.setup();
+    render(<AgentsShowcase locale="en" />);
+
+    const searchInput = screen.getByPlaceholderText('Search agents...');
+    await user.type(searchInput, 'xyznonexistent');
+
+    expect(
+      screen.getByText('No agents found matching your criteria'),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/landing-page/__tests__/widgets/AgentsShowcase/AgentCard.test.tsx
+++ b/apps/landing-page/__tests__/widgets/AgentsShowcase/AgentCard.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AgentCard } from '@/widgets/AgentsShowcase/ui/AgentCard';
+import type { Agent } from '@/types';
+
+const mockAgent: Agent = {
+  id: 'frontend-developer',
+  name: 'Frontend Developer',
+  description: 'Modern React/Next.js specialist',
+  category: 'Development',
+  icon: '⚛️',
+  tags: ['React', 'Next.js', 'TypeScript'],
+  expertise: ['React', 'TypeScript'],
+};
+
+describe('AgentCard', () => {
+  it('should render agent name', () => {
+    render(<AgentCard agent={mockAgent} />);
+    expect(screen.getByText('Frontend Developer')).toBeInTheDocument();
+  });
+
+  it('should render agent description', () => {
+    render(<AgentCard agent={mockAgent} />);
+    expect(
+      screen.getByText('Modern React/Next.js specialist'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render agent icon with aria-hidden', () => {
+    render(<AgentCard agent={mockAgent} />);
+    const icon = screen.getByText('⚛️');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(icon).toHaveAttribute('role', 'img');
+  });
+
+  it('should render category badge with raw category when no translation', () => {
+    render(<AgentCard agent={mockAgent} />);
+    expect(screen.getByText('Development')).toBeInTheDocument();
+  });
+
+  it('should render translated category when translatedCategory is provided', () => {
+    render(<AgentCard agent={mockAgent} translatedCategory="개발" />);
+    expect(screen.getByText('개발')).toBeInTheDocument();
+    expect(screen.queryByText('Development')).not.toBeInTheDocument();
+  });
+
+  it('should render all tags as badges', () => {
+    render(<AgentCard agent={mockAgent} />);
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('Next.js')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+  });
+});

--- a/apps/landing-page/__tests__/widgets/AgentsShowcase/FilterBar.test.tsx
+++ b/apps/landing-page/__tests__/widgets/AgentsShowcase/FilterBar.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FilterBar } from '@/widgets/AgentsShowcase/ui/FilterBar';
+
+const defaultTranslations = {
+  filter: 'Filter by category',
+  search: 'Search agents...',
+  allCategories: 'All Categories',
+  categories: {
+    Planning: 'Planning',
+    Development: 'Development',
+    Review: 'Review',
+    Security: 'Security',
+    UX: 'UX',
+  } as const,
+};
+
+describe('FilterBar', () => {
+  it('should render search input with placeholder', () => {
+    render(
+      <FilterBar
+        category="all"
+        onCategoryChange={vi.fn()}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        translations={defaultTranslations}
+      />,
+    );
+    expect(screen.getByPlaceholderText('Search agents...')).toBeInTheDocument();
+  });
+
+  it('should render search input with aria-label', () => {
+    render(
+      <FilterBar
+        category="all"
+        onCategoryChange={vi.fn()}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        translations={defaultTranslations}
+      />,
+    );
+    expect(screen.getByLabelText('Search agents...')).toBeInTheDocument();
+  });
+
+  it('should render select with aria-label', () => {
+    render(
+      <FilterBar
+        category="all"
+        onCategoryChange={vi.fn()}
+        searchQuery=""
+        onSearchChange={vi.fn()}
+        translations={defaultTranslations}
+      />,
+    );
+    expect(screen.getByLabelText('Filter by category')).toBeInTheDocument();
+  });
+
+  it('should call onSearchChange when typing', async () => {
+    const onSearchChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FilterBar
+        category="all"
+        onCategoryChange={vi.fn()}
+        searchQuery=""
+        onSearchChange={onSearchChange}
+        translations={defaultTranslations}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText('Search agents...');
+    await user.type(input, 'test');
+
+    expect(onSearchChange).toHaveBeenCalled();
+  });
+
+  it('should display current search query value', () => {
+    render(
+      <FilterBar
+        category="all"
+        onCategoryChange={vi.fn()}
+        searchQuery="frontend"
+        onSearchChange={vi.fn()}
+        translations={defaultTranslations}
+      />,
+    );
+    expect(screen.getByDisplayValue('frontend')).toBeInTheDocument();
+  });
+});

--- a/apps/landing-page/__tests__/widgets/AgentsShowcase/useAgentFilter.hook.test.ts
+++ b/apps/landing-page/__tests__/widgets/AgentsShowcase/useAgentFilter.hook.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAgentFilter } from '@/widgets/AgentsShowcase/hooks/useAgentFilter';
+import type { Agent } from '@/types';
+
+const mockAgents: Agent[] = [
+  {
+    id: 'frontend-developer',
+    name: 'Frontend Developer',
+    description: 'React/Next.js specialist',
+    category: 'Development',
+    icon: '⚛️',
+    tags: ['React', 'Next.js'],
+    expertise: ['React', 'TypeScript'],
+  },
+  {
+    id: 'security-specialist',
+    name: 'Security Specialist',
+    description: 'Security expert',
+    category: 'Security',
+    icon: '🔒',
+    tags: ['Security', 'OWASP'],
+    expertise: ['Security Audit'],
+  },
+  {
+    id: 'ui-ux-designer',
+    name: 'UI/UX Designer',
+    description: 'Design specialist',
+    category: 'UX',
+    icon: '🎨',
+    tags: ['UI Design', 'UX'],
+    expertise: ['UI Design'],
+  },
+];
+
+describe('useAgentFilter hook', () => {
+  it('should return all agents initially', () => {
+    const { result } = renderHook(() => useAgentFilter(mockAgents));
+    expect(result.current.filteredAgents).toHaveLength(3);
+    expect(result.current.category).toBe('all');
+    expect(result.current.searchQuery).toBe('');
+  });
+
+  it('should filter by category when setCategory is called', () => {
+    const { result } = renderHook(() => useAgentFilter(mockAgents));
+
+    act(() => {
+      result.current.setCategory('Development');
+    });
+
+    expect(result.current.filteredAgents).toHaveLength(1);
+    expect(result.current.filteredAgents[0].id).toBe('frontend-developer');
+    expect(result.current.category).toBe('Development');
+  });
+
+  it('should filter by search query when setSearchQuery is called', () => {
+    const { result } = renderHook(() => useAgentFilter(mockAgents));
+
+    act(() => {
+      result.current.setSearchQuery('security');
+    });
+
+    expect(result.current.filteredAgents).toHaveLength(1);
+    expect(result.current.filteredAgents[0].id).toBe('security-specialist');
+  });
+
+  it('should combine category and search filters', () => {
+    const { result } = renderHook(() => useAgentFilter(mockAgents));
+
+    act(() => {
+      result.current.setCategory('Development');
+      result.current.setSearchQuery('react');
+    });
+
+    expect(result.current.filteredAgents).toHaveLength(1);
+    expect(result.current.filteredAgents[0].id).toBe('frontend-developer');
+  });
+
+  it('should reset filters correctly', () => {
+    const { result } = renderHook(() => useAgentFilter(mockAgents));
+
+    act(() => {
+      result.current.setCategory('Security');
+    });
+    expect(result.current.filteredAgents).toHaveLength(1);
+
+    act(() => {
+      result.current.setCategory('all');
+    });
+    expect(result.current.filteredAgents).toHaveLength(3);
+  });
+});

--- a/apps/landing-page/__tests__/widgets/AgentsShowcase/useAgentFilter.test.ts
+++ b/apps/landing-page/__tests__/widgets/AgentsShowcase/useAgentFilter.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import type { Agent } from '@/types';
+import { filterAgents } from '@/widgets/AgentsShowcase/hooks/useAgentFilter';
+
+const mockAgents: Agent[] = [
+  {
+    id: 'frontend-developer',
+    name: 'Frontend Developer',
+    description: 'React/Next.js specialist',
+    category: 'Development',
+    icon: '⚛️',
+    tags: ['React', 'Next.js'],
+    expertise: ['React', 'TypeScript'],
+  },
+  {
+    id: 'security-specialist',
+    name: 'Security Specialist',
+    description: 'Security expert for vulnerability assessment',
+    category: 'Security',
+    icon: '🔒',
+    tags: ['Security', 'OWASP'],
+    expertise: ['Security Audit'],
+  },
+  {
+    id: 'ui-ux-designer',
+    name: 'UI/UX Designer',
+    description: 'Design specialist',
+    category: 'UX',
+    icon: '🎨',
+    tags: ['UI Design', 'UX'],
+    expertise: ['UI Design'],
+  },
+];
+
+describe('filterAgents', () => {
+  it('should return all agents when no filters applied', () => {
+    const result = filterAgents(mockAgents, {});
+    expect(result).toHaveLength(3);
+  });
+
+  it('should return all agents when category is "all"', () => {
+    const result = filterAgents(mockAgents, { category: 'all' });
+    expect(result).toHaveLength(3);
+  });
+
+  it('should filter by category', () => {
+    const result = filterAgents(mockAgents, { category: 'Development' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('frontend-developer');
+  });
+
+  it('should filter by search query matching name (case-insensitive)', () => {
+    const result = filterAgents(mockAgents, { searchQuery: 'frontend' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('frontend-developer');
+  });
+
+  it('should filter by search query matching description', () => {
+    const result = filterAgents(mockAgents, { searchQuery: 'vulnerability' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('security-specialist');
+  });
+
+  it('should filter by search query matching tags', () => {
+    const result = filterAgents(mockAgents, { searchQuery: 'OWASP' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('security-specialist');
+  });
+
+  it('should combine category and search filters', () => {
+    const result = filterAgents(mockAgents, {
+      category: 'Development',
+      searchQuery: 'react',
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('frontend-developer');
+  });
+
+  it('should return empty array when no matches', () => {
+    const result = filterAgents(mockAgents, { searchQuery: 'nonexistent' });
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle empty search query as no filter', () => {
+    const result = filterAgents(mockAgents, { searchQuery: '' });
+    expect(result).toHaveLength(3);
+  });
+
+  it('should trim search query whitespace', () => {
+    const result = filterAgents(mockAgents, { searchQuery: '  frontend  ' });
+    expect(result).toHaveLength(1);
+  });
+});

--- a/apps/landing-page/messages/en.json
+++ b/apps/landing-page/messages/en.json
@@ -6,9 +6,20 @@
     "cta": "Get Started"
   },
   "agents": {
-    "title": "AI Agents",
+    "title": "AI Specialist Agents",
+    "subtitle": "29 specialized AI agents to enhance your development workflow",
     "filter": "Filter by category",
-    "search": "Search agents..."
+    "search": "Search agents...",
+    "allCategories": "All Categories",
+    "noResults": "No agents found matching your criteria",
+    "categories": {
+      "Planning": "Planning",
+      "Development": "Development",
+      "Review": "Review",
+      "Security": "Security",
+      "UX": "UX"
+    },
+    "count": "{count} agents"
   },
   "codeExample": {
     "title": "Code Example",

--- a/apps/landing-page/messages/es.json
+++ b/apps/landing-page/messages/es.json
@@ -6,9 +6,20 @@
     "cta": "Comenzar"
   },
   "agents": {
-    "title": "Agentes IA",
+    "title": "Agentes AI Especializados",
+    "subtitle": "29 agentes AI especializados para mejorar tu flujo de desarrollo",
     "filter": "Filtrar por categoría",
-    "search": "Buscar agentes..."
+    "search": "Buscar agentes...",
+    "allCategories": "Todas las categorías",
+    "noResults": "No se encontraron agentes que coincidan con los criterios",
+    "categories": {
+      "Planning": "Planificación",
+      "Development": "Desarrollo",
+      "Review": "Revisión",
+      "Security": "Seguridad",
+      "UX": "UX"
+    },
+    "count": "{count} agentes"
   },
   "codeExample": {
     "title": "Ejemplo de Código",

--- a/apps/landing-page/messages/ja.json
+++ b/apps/landing-page/messages/ja.json
@@ -6,9 +6,20 @@
     "cta": "始める"
   },
   "agents": {
-    "title": "AIエージェント",
+    "title": "AI専門エージェント",
+    "subtitle": "開発ワークフローを強化する29の専門AIエージェント",
     "filter": "カテゴリで絞り込み",
-    "search": "エージェントを検索..."
+    "search": "エージェントを検索...",
+    "allCategories": "すべてのカテゴリ",
+    "noResults": "条件に一致するエージェントが見つかりません",
+    "categories": {
+      "Planning": "企画",
+      "Development": "開発",
+      "Review": "レビュー",
+      "Security": "セキュリティ",
+      "UX": "UX"
+    },
+    "count": "{count}エージェント"
   },
   "codeExample": {
     "title": "コード例",

--- a/apps/landing-page/messages/ko.json
+++ b/apps/landing-page/messages/ko.json
@@ -6,9 +6,20 @@
     "cta": "시작하기"
   },
   "agents": {
-    "title": "AI 에이전트",
+    "title": "AI 전문 에이전트",
+    "subtitle": "개발 워크플로우를 향상시키는 29개의 전문 AI 에이전트",
     "filter": "카테고리별 필터",
-    "search": "에이전트 검색..."
+    "search": "에이전트 검색...",
+    "allCategories": "전체 카테고리",
+    "noResults": "조건에 맞는 에이전트를 찾을 수 없습니다",
+    "categories": {
+      "Planning": "기획",
+      "Development": "개발",
+      "Review": "리뷰",
+      "Security": "보안",
+      "UX": "UX"
+    },
+    "count": "{count}개 에이전트"
   },
   "codeExample": {
     "title": "코드 예시",

--- a/apps/landing-page/messages/zh-CN.json
+++ b/apps/landing-page/messages/zh-CN.json
@@ -6,9 +6,20 @@
     "cta": "开始使用"
   },
   "agents": {
-    "title": "AI 代理",
+    "title": "AI 专业代理",
+    "subtitle": "29个专业AI代理，提升您的开发工作流程",
     "filter": "按类别筛选",
-    "search": "搜索代理..."
+    "search": "搜索代理...",
+    "allCategories": "所有类别",
+    "noResults": "未找到符合条件的代理",
+    "categories": {
+      "Planning": "规划",
+      "Development": "开发",
+      "Review": "审查",
+      "Security": "安全",
+      "UX": "用户体验"
+    },
+    "count": "{count}个代理"
   },
   "codeExample": {
     "title": "代码示例",

--- a/apps/landing-page/widgets/AgentsShowcase/data/agents.ts
+++ b/apps/landing-page/widgets/AgentsShowcase/data/agents.ts
@@ -1,0 +1,304 @@
+import type { Agent } from '@/types';
+
+export const agents: Agent[] = [
+  // === Planning (5) ===
+  {
+    id: 'plan-mode',
+    name: 'Plan Mode Agent',
+    description: 'Specialized for work planning and design',
+    category: 'Planning',
+    icon: '📋',
+    tags: ['Planning', 'Design'],
+    expertise: ['Work Planning', 'Design Strategy'],
+  },
+  {
+    id: 'technical-planner',
+    name: 'Technical Planner',
+    description:
+      'Low-level implementation planning with TDD and bite-sized tasks',
+    category: 'Planning',
+    icon: '🗺️',
+    tags: ['TDD', 'Task Decomposition'],
+    expertise: [
+      'Implementation Planning',
+      'TDD Strategy',
+      'Task Decomposition',
+    ],
+  },
+  {
+    id: 'architecture-specialist',
+    name: 'Architecture Specialist',
+    description:
+      'Architecture expert for Planning, Implementation, and Evaluation',
+    category: 'Planning',
+    icon: '🏛️',
+    tags: ['Architecture', 'System Design'],
+    expertise: ['System Architecture', 'Design Patterns', 'Scalability'],
+  },
+  {
+    id: 'solution-architect',
+    name: 'Solution Architect',
+    description:
+      'High-level system design and architecture planning specialist',
+    category: 'Planning',
+    icon: '🔷',
+    tags: ['System Design', 'Architecture'],
+    expertise: [
+      'Solution Design',
+      'Technical Strategy',
+      'Architecture Planning',
+    ],
+  },
+  {
+    id: 'migration-specialist',
+    name: 'Migration Specialist',
+    description:
+      'Cross-cutting migration coordinator for legacy system modernization',
+    category: 'Planning',
+    icon: '🔄',
+    tags: ['Migration', 'Modernization'],
+    expertise: ['Legacy Migration', 'Framework Upgrades', 'Data Migration'],
+  },
+
+  // === Development (12) ===
+  {
+    id: 'act-mode',
+    name: 'Act Mode Agent',
+    description: 'Specialized for actual implementation execution',
+    category: 'Development',
+    icon: '⚡',
+    tags: ['Implementation', 'Execution'],
+    expertise: ['Code Implementation', 'TDD Execution'],
+  },
+  {
+    id: 'frontend-developer',
+    name: 'Frontend Developer',
+    description:
+      'Modern React/Next.js specialist with Server Components, TDD, and accessibility',
+    category: 'Development',
+    icon: '⚛️',
+    tags: ['React', 'Next.js', 'TypeScript'],
+    expertise: ['React', 'Next.js App Router', 'TypeScript', 'TDD'],
+  },
+  {
+    id: 'backend-developer',
+    name: 'Backend Developer',
+    description:
+      'Language-agnostic backend specialist with Clean Architecture and TDD',
+    category: 'Development',
+    icon: '🖥️',
+    tags: ['Backend', 'Clean Architecture'],
+    expertise: ['Clean Architecture', 'API Design', 'TDD', 'Security'],
+  },
+  {
+    id: 'mobile-developer',
+    name: 'Mobile Developer',
+    description: 'Cross-platform and native mobile specialist',
+    category: 'Development',
+    icon: '📱',
+    tags: ['React Native', 'Flutter', 'iOS'],
+    expertise: ['React Native', 'Flutter', 'iOS', 'Android'],
+  },
+  {
+    id: 'data-engineer',
+    name: 'Data Engineer',
+    description:
+      'Data specialist focused on database design, schema optimization, and migrations',
+    category: 'Development',
+    icon: '🗄️',
+    tags: ['Database', 'Schema', 'Migration'],
+    expertise: ['Database Design', 'Schema Optimization', 'Data Migration'],
+  },
+  {
+    id: 'devops-engineer',
+    name: 'DevOps Engineer',
+    description:
+      'Docker, Datadog monitoring, and Next.js deployment specialist',
+    category: 'Development',
+    icon: '🚀',
+    tags: ['Docker', 'CI/CD', 'Monitoring'],
+    expertise: ['Docker', 'Datadog', 'Next.js Deployment', 'CI/CD'],
+  },
+  {
+    id: 'tooling-engineer',
+    name: 'Tooling Engineer',
+    description:
+      'Project configuration, build tools, and development environment specialist',
+    category: 'Development',
+    icon: '🔧',
+    tags: ['Build Tools', 'Config', 'DX'],
+    expertise: ['Build Configuration', 'Development Tools', 'DX Optimization'],
+  },
+  {
+    id: 'platform-engineer',
+    name: 'Platform Engineer',
+    description:
+      'Cloud-native infrastructure expert for Planning, Implementation, and Evaluation',
+    category: 'Development',
+    icon: '☁️',
+    tags: ['Cloud', 'Infrastructure', 'K8s'],
+    expertise: ['Cloud Infrastructure', 'Kubernetes', 'Platform Design'],
+  },
+  {
+    id: 'agent-architect',
+    name: 'Agent Architect',
+    description:
+      'Primary Agent for creating, validating, and managing AI agent configurations',
+    category: 'Development',
+    icon: '🤖',
+    tags: ['AI Agents', 'Configuration'],
+    expertise: ['Agent Design', 'AI Configuration', 'Agent Validation'],
+  },
+  {
+    id: 'ai-ml-engineer',
+    name: 'AI/ML Engineer',
+    description:
+      'AI/ML expert for Planning, Implementation, and Evaluation modes',
+    category: 'Development',
+    icon: '🧠',
+    tags: ['AI', 'ML', 'Deep Learning'],
+    expertise: ['Machine Learning', 'Deep Learning', 'AI Systems'],
+  },
+  {
+    id: 'event-architecture-specialist',
+    name: 'Event Architecture Specialist',
+    description: 'Event-driven architecture specialist for real-time systems',
+    category: 'Development',
+    icon: '📨',
+    tags: ['Event-Driven', 'Real-Time'],
+    expertise: ['Event-Driven Architecture', 'WebSocket', 'SSE'],
+  },
+  {
+    id: 'integration-specialist',
+    name: 'Integration Specialist',
+    description:
+      'External service integration specialist for APIs and third-party services',
+    category: 'Development',
+    icon: '🔗',
+    tags: ['API', 'Integration', 'Third-Party'],
+    expertise: ['API Integration', 'Third-Party Services', 'OAuth'],
+  },
+
+  // === Review (5) ===
+  {
+    id: 'eval-mode',
+    name: 'Eval Mode Agent',
+    description:
+      'Specialized for code quality evaluation and improvement suggestions',
+    category: 'Review',
+    icon: '🔍',
+    tags: ['Evaluation', 'Quality'],
+    expertise: [
+      'Code Evaluation',
+      'Quality Assessment',
+      'Improvement Suggestions',
+    ],
+  },
+  {
+    id: 'code-reviewer',
+    name: 'Code Reviewer',
+    description:
+      'Senior software engineer specializing in comprehensive code quality evaluation',
+    category: 'Review',
+    icon: '👀',
+    tags: ['Code Review', 'Quality'],
+    expertise: ['Code Review', 'Best Practices', 'Quality Standards'],
+  },
+  {
+    id: 'code-quality-specialist',
+    name: 'Code Quality Specialist',
+    description:
+      'Code quality expert for linting, formatting, and best practices',
+    category: 'Review',
+    icon: '📏',
+    tags: ['Linting', 'Standards', 'SOLID'],
+    expertise: ['Code Quality', 'Linting', 'SOLID Principles'],
+  },
+  {
+    id: 'test-strategy-specialist',
+    name: 'Test Strategy Specialist',
+    description: 'Test strategy expert for comprehensive testing approaches',
+    category: 'Review',
+    icon: '🧪',
+    tags: ['Testing', 'TDD', 'Strategy'],
+    expertise: ['Test Strategy', 'TDD', 'Integration Testing'],
+  },
+  {
+    id: 'documentation-specialist',
+    name: 'Documentation Specialist',
+    description: 'Documentation expert for technical writing and API docs',
+    category: 'Review',
+    icon: '📝',
+    tags: ['Documentation', 'Technical Writing'],
+    expertise: ['Technical Writing', 'API Documentation', 'README'],
+  },
+
+  // === Security (2) ===
+  {
+    id: 'security-specialist',
+    name: 'Security Specialist',
+    description:
+      'Security expert for vulnerability assessment and secure coding',
+    category: 'Security',
+    icon: '🔒',
+    tags: ['Security', 'OWASP', 'Audit'],
+    expertise: ['Security Audit', 'OWASP', 'Secure Coding'],
+  },
+  {
+    id: 'observability-specialist',
+    name: 'Observability Specialist',
+    description: 'Observability expert for monitoring, logging, and alerting',
+    category: 'Security',
+    icon: '📊',
+    tags: ['Monitoring', 'Logging', 'Alerting'],
+    expertise: ['Monitoring', 'Logging', 'Distributed Tracing'],
+  },
+
+  // === UX (5) ===
+  {
+    id: 'ui-ux-designer',
+    name: 'UI/UX Designer',
+    description: 'UI/UX design specialist based on universal design principles',
+    category: 'UX',
+    icon: '🎨',
+    tags: ['UI Design', 'UX', 'Accessibility'],
+    expertise: ['UI Design', 'UX Research', 'Design Systems'],
+  },
+  {
+    id: 'accessibility-specialist',
+    name: 'Accessibility Specialist',
+    description:
+      'Accessibility expert for WCAG compliance and inclusive design',
+    category: 'UX',
+    icon: '♿',
+    tags: ['A11y', 'WCAG', 'Inclusive Design'],
+    expertise: ['WCAG', 'Screen Readers', 'Keyboard Navigation'],
+  },
+  {
+    id: 'performance-specialist',
+    name: 'Performance Specialist',
+    description: 'Performance expert for optimization and profiling',
+    category: 'UX',
+    icon: '⚡',
+    tags: ['Performance', 'Optimization', 'Core Web Vitals'],
+    expertise: ['Performance Optimization', 'Core Web Vitals', 'Profiling'],
+  },
+  {
+    id: 'seo-specialist',
+    name: 'SEO Specialist',
+    description: 'SEO expert for search engine optimization and meta tags',
+    category: 'UX',
+    icon: '🔎',
+    tags: ['SEO', 'Meta Tags', 'Structured Data'],
+    expertise: ['SEO', 'Meta Tags', 'Structured Data', 'Site Performance'],
+  },
+  {
+    id: 'i18n-specialist',
+    name: 'i18n Specialist',
+    description: 'Internationalization expert for multi-language support',
+    category: 'UX',
+    icon: '🌐',
+    tags: ['i18n', 'L10n', 'Multi-Language'],
+    expertise: ['Internationalization', 'Localization', 'RTL Support'],
+  },
+];

--- a/apps/landing-page/widgets/AgentsShowcase/hooks/useAgentFilter.ts
+++ b/apps/landing-page/widgets/AgentsShowcase/hooks/useAgentFilter.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { Agent, AgentCategory } from '@/types';
+import { filterAgents } from '../lib/filterAgents';
+
+export { filterAgents } from '../lib/filterAgents';
+
+/** React hook - manages filter state and returns filtered agents */
+export function useAgentFilter(agents: Agent[]) {
+  const [category, setCategory] = useState<AgentCategory | 'all'>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredAgents = useMemo(
+    () => filterAgents(agents, { category, searchQuery }),
+    [agents, category, searchQuery],
+  );
+
+  return {
+    filteredAgents,
+    category,
+    setCategory,
+    searchQuery,
+    setSearchQuery,
+  };
+}

--- a/apps/landing-page/widgets/AgentsShowcase/index.tsx
+++ b/apps/landing-page/widgets/AgentsShowcase/index.tsx
@@ -1,12 +1,74 @@
-import type { WidgetProps } from '@/types';
+'use client';
 
-export const AgentsShowcase = ({ locale }: WidgetProps) => (
-  <section
-    data-testid="agents-showcase"
-    lang={locale}
-    aria-labelledby="agents-heading"
-  >
-    <h2 id="agents-heading">AI Agents</h2>
-    <p>Agents showcase widget - coming soon</p>
-  </section>
-);
+import { useTranslations } from 'next-intl';
+import type { AgentCategory, WidgetProps } from '@/types';
+import { agents } from './data/agents';
+import { useAgentFilter } from './hooks/useAgentFilter';
+import { AgentCard } from './ui/AgentCard';
+import { FilterBar } from './ui/FilterBar';
+
+export const AgentsShowcase = ({ locale }: WidgetProps) => {
+  const t = useTranslations('agents');
+
+  const { filteredAgents, category, setCategory, searchQuery, setSearchQuery } =
+    useAgentFilter(agents);
+
+  const translations = {
+    filter: t('filter'),
+    search: t('search'),
+    allCategories: t('allCategories'),
+    categories: {
+      Planning: t('categories.Planning'),
+      Development: t('categories.Development'),
+      Review: t('categories.Review'),
+      Security: t('categories.Security'),
+      UX: t('categories.UX'),
+    } as Record<AgentCategory, string>,
+  };
+
+  return (
+    <section
+      data-testid="agents-showcase"
+      lang={locale}
+      aria-labelledby="agents-heading"
+      className="mx-auto w-full max-w-6xl px-4 py-16"
+    >
+      <div className="mb-8 text-center">
+        <h2 id="agents-heading" className="text-3xl font-bold tracking-tight">
+          {t('title')}
+        </h2>
+        <p className="text-muted-foreground mt-2">{t('subtitle')}</p>
+      </div>
+
+      <div className="mb-6">
+        <FilterBar
+          category={category}
+          onCategoryChange={setCategory}
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          translations={translations}
+        />
+      </div>
+
+      <p className="text-muted-foreground mb-4 text-sm" aria-live="polite">
+        {t('count', { count: filteredAgents.length })}
+      </p>
+
+      {filteredAgents.length > 0 ? (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filteredAgents.map(agent => (
+            <AgentCard
+              key={agent.id}
+              agent={agent}
+              translatedCategory={translations.categories[agent.category]}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-muted-foreground py-12 text-center" role="status">
+          {t('noResults')}
+        </p>
+      )}
+    </section>
+  );
+};

--- a/apps/landing-page/widgets/AgentsShowcase/lib/filterAgents.ts
+++ b/apps/landing-page/widgets/AgentsShowcase/lib/filterAgents.ts
@@ -1,0 +1,26 @@
+import type { Agent, AgentFilter } from '@/types';
+
+/** Pure function - filters agents by category and search query */
+export function filterAgents(agents: Agent[], filter: AgentFilter): Agent[] {
+  return agents.filter(agent => {
+    // Category filter
+    if (filter.category && filter.category !== 'all') {
+      if (agent.category !== filter.category) return false;
+    }
+
+    // Search query filter
+    const query = filter.searchQuery?.trim().toLowerCase();
+    if (query) {
+      const matchesName = agent.name.toLowerCase().includes(query);
+      const matchesDescription = agent.description
+        .toLowerCase()
+        .includes(query);
+      const matchesTags = agent.tags.some(tag =>
+        tag.toLowerCase().includes(query),
+      );
+      if (!matchesName && !matchesDescription && !matchesTags) return false;
+    }
+
+    return true;
+  });
+}

--- a/apps/landing-page/widgets/AgentsShowcase/ui/AgentCard.tsx
+++ b/apps/landing-page/widgets/AgentsShowcase/ui/AgentCard.tsx
@@ -1,0 +1,43 @@
+import type { Agent } from '@/types';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+interface AgentCardProps {
+  agent: Agent;
+  /** Translated category label for i18n display */
+  translatedCategory?: string;
+}
+
+export const AgentCard = ({ agent, translatedCategory }: AgentCardProps) => (
+  <Card className="transition-shadow hover:shadow-md">
+    <CardHeader>
+      <div className="flex items-center gap-3">
+        <span className="text-2xl" role="img" aria-hidden="true">
+          {agent.icon}
+        </span>
+        <div className="min-w-0 flex-1">
+          <CardTitle className="text-base">{agent.name}</CardTitle>
+          <Badge variant="secondary" className="mt-1 text-xs">
+            {translatedCategory ?? agent.category}
+          </Badge>
+        </div>
+      </div>
+    </CardHeader>
+    <CardContent>
+      <CardDescription className="mb-3">{agent.description}</CardDescription>
+      <div className="flex flex-wrap gap-1">
+        {agent.tags.map(tag => (
+          <Badge key={tag} variant="outline" className="text-xs">
+            {tag}
+          </Badge>
+        ))}
+      </div>
+    </CardContent>
+  </Card>
+);

--- a/apps/landing-page/widgets/AgentsShowcase/ui/FilterBar.tsx
+++ b/apps/landing-page/widgets/AgentsShowcase/ui/FilterBar.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Search } from 'lucide-react';
+import type { AgentCategory } from '@/types';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const CATEGORIES: AgentCategory[] = [
+  'Planning',
+  'Development',
+  'Review',
+  'Security',
+  'UX',
+];
+
+interface FilterBarProps {
+  category: AgentCategory | 'all';
+  onCategoryChange: (value: AgentCategory | 'all') => void;
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  translations: {
+    filter: string;
+    search: string;
+    allCategories: string;
+    categories: Record<AgentCategory, string>;
+  };
+}
+
+export const FilterBar = ({
+  category,
+  onCategoryChange,
+  searchQuery,
+  onSearchChange,
+  translations: t,
+}: FilterBarProps) => (
+  <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+    <Select
+      value={category}
+      onValueChange={value => onCategoryChange(value as AgentCategory | 'all')}
+    >
+      <SelectTrigger className="w-full sm:w-[200px]" aria-label={t.filter}>
+        <SelectValue placeholder={t.filter} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">{t.allCategories}</SelectItem>
+        {CATEGORIES.map(cat => (
+          <SelectItem key={cat} value={cat}>
+            {t.categories[cat]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+    <div className="relative flex-1">
+      <Search className="text-muted-foreground absolute left-3 top-1/2 size-4 -translate-y-1/2" />
+      <Input
+        type="search"
+        placeholder={t.search}
+        value={searchQuery}
+        onChange={e => onSearchChange(e.target.value)}
+        className="pl-9"
+        aria-label={t.search}
+      />
+    </div>
+  </div>
+);


### PR DESCRIPTION
## Summary

Implements the AgentsShowcase widget for the landing page, displaying 29 AI specialist agents with interactive filtering and search capabilities.

Closes #315

## Changes

### Widget Components
- **`data/agents.ts`** - Define all 29 agent entries with id, name, description, category, icon, and tags
- **`lib/filterAgents.ts`** - Pure function for filtering agents by category and search query
- **`hooks/useAgentFilter.ts`** - React hook wrapping filter state and memoized results
- **`ui/AgentCard.tsx`** - Card component displaying agent info with category badge and tags
- **`ui/FilterBar.tsx`** - Category dropdown (Select) and search input with icon
- **`index.tsx`** - Main widget integrating all components with responsive grid layout (1/2/3 columns)

### i18n
- Extended message files for all 5 locales (en, ko, ja, es, zh-CN) with new keys: `subtitle`, `allCategories`, `noResults`, `categories.*`, `count`

### Tests
- **`__helpers__/next-intl-mock.ts`** - Shared mock for next-intl `useTranslations`
- **`AgentsShowcase.test.tsx`** - Widget integration tests (rendering, search filtering, no results)
- **`AgentCard.test.tsx`** - Card component unit tests
- **`FilterBar.test.tsx`** - Filter bar component unit tests
- **`useAgentFilter.test.ts`** - Pure filter function unit tests
- **`useAgentFilter.hook.test.ts`** - Hook integration tests with renderHook
- **`messages.test.ts`** - Updated to support deeply nested i18n key validation

## Test plan

- [ ] All existing tests pass (`yarn workspace landing-page test`)
- [ ] AgentsShowcase renders 29 agent cards in default view
- [ ] Category filter narrows displayed agents correctly
- [ ] Search input filters agents by name, description, and tags
- [ ] "No results" message displays when no agents match criteria
- [ ] Agent count updates dynamically with filter/search
- [ ] i18n messages are complete and consistent across all 5 locales
- [ ] Responsive grid layout works (1 col mobile, 2 col tablet, 3 col desktop)