### PR TITLE
remove unconditional Analytics/SpeedInsights from layout

### DIFF
--- a/apps/landing-page/__tests__/app/layout.test.tsx
+++ b/apps/landing-page/__tests__/app/layout.test.tsx
@@ -1,17 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
 
 vi.mock('next/font/google', () => ({
   Inter: () => ({ variable: '--font-inter' }),
   JetBrains_Mono: () => ({ variable: '--font-jetbrains-mono' }),
-}));
-
-vi.mock('@vercel/analytics/next', () => ({
-  Analytics: () => <div data-testid="vercel-analytics" />,
-}));
-
-vi.mock('@vercel/speed-insights/next', () => ({
-  SpeedInsights: () => <div data-testid="vercel-speed-insights" />,
 }));
 
 vi.mock('@/components/theme-provider', () => ({
@@ -35,21 +26,5 @@ describe('RootLayout', () => {
     const layoutModule = await import('@/src/app/layout');
     expect(layoutModule.metadata).toBeDefined();
     expect(layoutModule.metadata.title).toContain('Codingbuddy');
-  });
-
-  it('should render Analytics and SpeedInsights components', async () => {
-    const { default: RootLayout } = await import('@/src/app/layout');
-    const { container } = render(
-      <RootLayout>
-        <main>Test</main>
-      </RootLayout>,
-    );
-
-    expect(
-      container.querySelector('[data-testid="vercel-analytics"]'),
-    ).not.toBeNull();
-    expect(
-      container.querySelector('[data-testid="vercel-speed-insights"]'),
-    ).not.toBeNull();
   });
 });

--- a/apps/landing-page/src/app/layout.tsx
+++ b/apps/landing-page/src/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import { Inter, JetBrains_Mono } from 'next/font/google';
-import { Analytics } from '@vercel/analytics/next';
-import { SpeedInsights } from '@vercel/speed-insights/next';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/sonner';
 import './globals.css';
@@ -57,8 +55,6 @@ const RootLayout = ({
           {children}
           <Toaster />
         </ThemeProvider>
-        <Analytics />
-        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- Remove `<Analytics />` and `<SpeedInsights />` from `layout.tsx` that were rendering unconditionally without cookie consent (GDPR violation)
- Remove related test mocks and test case that validated the now-removed components
- Analytics/SpeedInsights should only render via `CookieConsent` component after user grants permission

## Changes

### `apps/landing-page/src/app/layout.tsx`
- Removed `@vercel/analytics/next` and `@vercel/speed-insights/next` imports
- Removed `<Analytics />` and `<SpeedInsights />` from the layout body

### `apps/landing-page/__tests__/app/layout.test.tsx`
- Removed `@vercel/analytics/next` and `@vercel/speed-insights/next` mocks
- Removed test case `should render Analytics and SpeedInsights components`
- Removed unused `render` import

## Test plan

- [ ] Before cookie consent: verify no Analytics/SpeedInsights network requests
- [ ] After cookie consent: verify only 1 set of network requests (from CookieConsent component)
- [ ] All existing tests pass

Closes #402