### PR TITLE
fix typo 'codebuddy' to 'codingbuddy' in dev path patterns

### DIFF
--- a/packages/claude-code-plugin/hooks/session-start.py
+++ b/packages/claude-code-plugin/hooks/session-start.py
@@ -209,10 +209,10 @@ def _find_source_from_dev(home: Path) -> Optional[Path]:
     Security: Uses Path.resolve() to prevent symlink traversal attacks.
     """
     dev_patterns = [
-        "workspace/codebuddy/packages/claude-code-plugin/hooks",
-        "dev/codebuddy/packages/claude-code-plugin/hooks",
-        "projects/codebuddy/packages/claude-code-plugin/hooks",
-        "code/codebuddy/packages/claude-code-plugin/hooks",
+        "workspace/codingbuddy/packages/claude-code-plugin/hooks",
+        "dev/codingbuddy/packages/claude-code-plugin/hooks",
+        "projects/codingbuddy/packages/claude-code-plugin/hooks",
+        "code/codingbuddy/packages/claude-code-plugin/hooks",
     ]
 
     for pattern in dev_patterns:

--- a/packages/claude-code-plugin/hooks/test_session_start.py
+++ b/packages/claude-code-plugin/hooks/test_session_start.py
@@ -60,6 +60,22 @@ class TestFindPluginSource:
                     # Compare resolved paths (implementation now resolves symlinks)
                     assert result == source_file.resolve()
 
+    def test_finds_source_from_dev_workspace(self):
+        """Test finding source from dev workspace directory pattern."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+
+            # Create mock dev workspace structure
+            dev_dir = home / "workspace/codingbuddy/packages/claude-code-plugin/hooks"
+            dev_dir.mkdir(parents=True)
+            source_file = dev_dir / "user-prompt-submit.py"
+            source_file.write_text("# mock hook")
+
+            with patch.dict(os.environ, {"CLAUDE_PLUGIN_DIR": ""}, clear=False):
+                with patch.object(Path, "home", return_value=home):
+                    result = session_hook.find_plugin_source()
+                    assert result == source_file.resolve()
+
     def test_returns_none_when_no_source_found(self):
         """Test returns None when no source file found anywhere."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Fix typo in `_find_source_from_dev()` where all 4 dev path patterns used `codebuddy` instead of `codingbuddy`, making the entire dev fallback path dead code
- Add test case to verify dev workspace path detection works correctly

## Changes

- `packages/claude-code-plugin/hooks/session-start.py`: Replace `codebuddy` with `codingbuddy` in all 4 dev path patterns (lines 212-215)
- `packages/claude-code-plugin/hooks/test_session_start.py`: Add `test_finds_source_from_dev_workspace` to cover the dev workspace directory pattern

## Test plan

- [x] Existing tests pass
- [x] New test verifies dev workspace path pattern matches correctly

Closes #405