### PR TITLE
use sort_version_dirs() in test instead of built-in sorted()

### DIFF
--- a/packages/claude-code-plugin/hooks/test_session_start.py
+++ b/packages/claude-code-plugin/hooks/test_session_start.py
@@ -222,18 +222,13 @@ class TestVersionSorting:
                 hooks_dir.mkdir(parents=True)
                 (hooks_dir / "user-prompt-submit.py").write_text(f"# version {v}")
 
-            # Get sorted directories (as the function does)
-            version_dirs = sorted(
-                [d for d in base.iterdir() if d.is_dir()],
-                reverse=True
+            # Use actual sort_version_dirs() for semantic version sorting
+            version_dirs = session_hook.sort_version_dirs(
+                [d for d in base.iterdir() if d.is_dir()]
             )
 
-            # Note: String sorting will give wrong order for semantic versions
-            # This test documents the current behavior
             dir_names = [d.name for d in version_dirs]
-            # With string sorting: ['3.0.0', '2.0.0', '10.0.0', '1.0.0']
-            # Expected with semver: ['10.0.0', '3.0.0', '2.0.0', '1.0.0']
-            assert dir_names[0] == "3.0.0"  # Current behavior (string sort)
+            assert dir_names == ["10.0.0", "3.0.0", "2.0.0", "1.0.0"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fix `TestVersionSorting.test_sorts_versions_correctly` to use the actual `sort_version_dirs()` function instead of Python's built-in `sorted()`
- The test was validating wrong behavior: string sorting placed `"3.0.0"` before `"10.0.0"`
- Now correctly asserts semantic version order: `10.0.0 > 3.0.0 > 2.0.0 > 1.0.0`

## Test plan

- [ ] Run `python -m pytest packages/claude-code-plugin/hooks/test_session_start.py::TestVersionSorting -v`
- [ ] Verify semantic version order: 10.0.0 > 3.0.0 > 2.0.0 > 1.0.0

Closes #406