### PR TITLE
pin release-drafter to SHA and align setup action versions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,12 +11,12 @@ runs:
   using: 'composite'
   steps:
     - name: Setup node.js
-      uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Restore dependencies from cache
-      uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
           node_modules

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

- Pin `release-drafter/release-drafter` from mutable tag `@v6` to commit SHA `@6db134d` to mitigate supply chain attack risk
- Upgrade `actions/setup-node` from v6.0.0 to v6.2.0 in composite setup action to match individual workflows
- Upgrade `actions/cache` from v5.0.0 to v5.0.3 in composite setup action to match individual workflows

## Changes

| Action | Before | After |
|--------|--------|-------|
| `release-drafter/release-drafter` | `@v6` (mutable tag) | `@6db134d` (SHA pinned) |
| `actions/setup-node` | `@2028fbc5` (v6.0.0) | `@6044e13b` (v6.2.0) |
| `actions/cache` | `@a783357` (v5.0.0) | `@cdf6c1fa` (v5.0.3) |

## Affected Files

- `.github/workflows/release-drafter.yml` (line 16)
- `.github/actions/setup/action.yml` (lines 14, 19)

## Verification

- [x] SHA for `release-drafter` v6 tag confirmed via GitHub API
- [x] All `actions/setup-node` references now consistently use v6.2.0 across repo
- [x] All `actions/cache` references now consistently use v5.0.3 across repo
- [x] Zero mutable tag (`@vN`) references remaining in `.github/` directory

## Test Plan

- [ ] CI workflows run successfully on this PR
- [ ] Release drafter creates draft release on merge to master

Closes #408