### PR TITLE
add missing dirs to vitest coverage include (#414)

### DIFF
--- a/apps/landing-page/vitest.config.ts
+++ b/apps/landing-page/vitest.config.ts
@@ -23,6 +23,9 @@ export default defineConfig({
         'app/**/*.{ts,tsx}',
         'hooks/**/*.ts',
         'lib/**/*.ts',
+        'components/**/*.{ts,tsx}',
+        'sections/**/*.{ts,tsx}',
+        'i18n/**/*.ts',
       ],
       exclude: [
         '**/__tests__/**',


### PR DESCRIPTION
## Summary

- Add `components/**/*.{ts,tsx}`, `sections/**/*.{ts,tsx}`, and `i18n/**/*.ts` to vitest coverage `include` config
- Existing `components/ui/**` exclude remains intact (shadcn/ui components stay excluded)
- No changes to exclude patterns — existing rules already handle edge cases (`i18n.ts` root file, `components/ui/`, etc.)

Closes #414

## Test plan

- [x] All 224 existing tests pass (37 test files)
- [x] Coverage report now includes `components/`, `sections/`, `i18n/` directories
- [x] `components/ui/` (shadcn/ui) correctly excluded from coverage report
- [x] Run `yarn workspace landing-page test --coverage` and verify new directories appear