### PR TITLE
remove duplicate version sync logic

### DIFF
--- a/docs/plans/2026-02-16-remove-duplicate-version-sync.md
+++ b/docs/plans/2026-02-16-remove-duplicate-version-sync.md
@@ -1,0 +1,248 @@
+# [#418] Plugin: 중복 버전 동기화 로직 제거 구현 계획
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `build.ts`와 `sync-version.js`에 중복된 `syncVersion()` 로직을 제거하여, 빌드 시 버전 동기화가 한 번만 실행되도록 한다.
+
+**Architecture:** `prebuild` 훅(`sync-version.js`)이 버전 동기화의 유일한 진입점으로 유지된다. `build.ts`에서 `syncVersion()`을 제거하고 README 생성만 담당하도록 변경한다.
+
+**Tech Stack:** TypeScript, Node.js, Vitest
+
+---
+
+## 현재 상태 분석
+
+**문제:** `yarn build` 실행 시 버전 동기화가 2번 실행됨
+
+```
+yarn build
+  → prebuild: node scripts/sync-version.js  (1차 동기화)
+  → ts-node scripts/build.ts                (2차 동기화 - 중복!)
+```
+
+**영향 파일:**
+- `packages/claude-code-plugin/scripts/build.ts` (lines 34-102: `syncVersion()`)
+- `packages/claude-code-plugin/scripts/sync-version.js` (lines 22-72: `syncVersion()`)
+- `packages/claude-code-plugin/scripts/build.spec.ts` (테스트 업데이트 필요)
+
+**해결 방향:** Option 1 채택 - `build.ts`에서 `syncVersion()` 제거, `sync-version.js`를 유일한 동기화 스크립트로 유지
+
+---
+
+## Task 1: `build.ts`에서 `syncVersion()` 제거
+
+**Files:**
+- Modify: `packages/claude-code-plugin/scripts/build.ts:34-102` (syncVersion 함수 삭제)
+- Modify: `packages/claude-code-plugin/scripts/build.ts:211-266` (main 함수 업데이트)
+
+**Step 1: `syncVersion()` 함수 전체 삭제**
+
+`build.ts`에서 `syncVersion()` 함수(lines 34-102)를 삭제한다.
+
+**Step 2: `main()` 함수에서 syncVersion 호출 및 스텝 번호 업데이트**
+
+```typescript
+async function main(): Promise<void> {
+  console.log('╔════════════════════════════════════════════════════════════╗');
+  console.log('║         CodingBuddy Claude Code Plugin Builder             ║');
+  console.log('╚════════════════════════════════════════════════════════════╝');
+  console.log('');
+  console.log('ℹ️  Version sync handled by prebuild script (sync-version.js)');
+  console.log('');
+
+  const results: BuildResult[] = [];
+
+  // Step 1: Generate README
+  console.log('📖 Step 1: Generating README...');
+  results.push(createReadme());
+
+  // Summary
+  console.log('\n════════════════════════════════════════════════════════════');
+  console.log('Build Summary');
+  console.log('════════════════════════════════════════════════════════════\n');
+
+  let allSuccess = true;
+  for (const result of results) {
+    const status = result.success ? '✅' : '❌';
+    console.log(`${status} ${result.step}`);
+
+    for (const detail of result.details) {
+      console.log(`   ${detail}`);
+    }
+    for (const error of result.errors) {
+      console.log(`   ❗ ${error}`);
+    }
+
+    if (!result.success) {
+      allSuccess = false;
+    }
+  }
+
+  console.log('\n════════════════════════════════════════════════════════════');
+  if (allSuccess) {
+    console.log('✨ Build completed successfully!');
+    console.log(`\nOutput directory: ${ROOT_DIR}`);
+    console.log('  ├── .claude-plugin/  (plugin manifest)');
+    console.log('  ├── .mcp.json        (MCP server configuration)');
+    console.log('  └── README.md        (plugin documentation)');
+    console.log(
+      '\nNote: Agents, commands, and skills are provided by MCP server',
+    );
+    console.log(
+      '      from packages/rules/.ai-rules/ (single source of truth)',
+    );
+  } else {
+    console.log('❌ Build completed with errors');
+    process.exit(1);
+  }
+}
+```
+
+**Step 3: 사용되지 않는 MCP_SERVER_DIR 상수 확인 후 삭제 (다른 곳에서 미사용 시)**
+
+`MCP_SERVER_DIR`이 `syncVersion()`에서만 사용되는지 확인하고, 다른 곳에서 참조하지 않으면 삭제한다.
+
+**Step 4: 테스트 실행하여 기존 테스트 통과 확인**
+
+Run: `yarn workspace codingbuddy-claude-plugin test`
+Expected: 일부 테스트는 아직 실패 가능 (Task 2에서 테스트 업데이트 예정)
+
+**Step 5: Commit**
+
+```bash
+git add packages/claude-code-plugin/scripts/build.ts
+git commit -m "refactor(plugin): remove duplicate syncVersion from build.ts (#418)"
+```
+
+---
+
+## Task 2: `build.spec.ts` 테스트 업데이트
+
+**Files:**
+- Modify: `packages/claude-code-plugin/scripts/build.spec.ts`
+
+**Step 1: `BuildResult` "Version Sync" shape 테스트 제거**
+
+`BuildResult interface consistency` describe 블록에서 "has correct shape for version sync" 테스트를 삭제한다. `build.ts`에서 더 이상 Version Sync 단계가 없으므로 해당 테스트는 불필요하다.
+
+또한 "captures errors correctly" 테스트에서 'Version Sync'를 참조하는 부분을 'README Generation'으로 변경한다.
+
+**Step 2: `peerDependencies sync logic` 테스트를 새 파일로 이동 준비**
+
+이 테스트들은 `sync-version.js`의 로직을 검증하므로, `build.spec.ts`에서 제거하고 Task 3에서 `sync-version.spec.ts`에 추가한다.
+
+**Step 3: 테스트 실행**
+
+Run: `yarn workspace codingbuddy-claude-plugin test`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add packages/claude-code-plugin/scripts/build.spec.ts
+git commit -m "test(plugin): update build.spec.ts after syncVersion removal (#418)"
+```
+
+---
+
+## Task 3: `sync-version.spec.ts` 테스트 작성
+
+**Files:**
+- Create: `packages/claude-code-plugin/scripts/sync-version.spec.ts`
+
+**Step 1: 실패하는 테스트 작성**
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('sync-version script', () => {
+  describe('peerDependencies computation logic', () => {
+    function computeExpectedPeer(version: string): string {
+      const [major, minor] = version.split('.');
+      return `^${major}.${minor}.0`;
+    }
+
+    it('computes correct peerDependencies from version', () => {
+      expect(computeExpectedPeer('4.0.1')).toBe('^4.0.0');
+      expect(computeExpectedPeer('4.1.0')).toBe('^4.1.0');
+      expect(computeExpectedPeer('5.2.3')).toBe('^5.2.0');
+    });
+
+    it('detects peerDependencies mismatch when version already matches', () => {
+      const currentVersion = '4.0.1';
+      const stalePeer = '^3.0.0';
+      const expectedPeer = computeExpectedPeer(currentVersion);
+
+      expect(stalePeer).not.toBe(expectedPeer);
+      expect(expectedPeer).toBe('^4.0.0');
+    });
+  });
+
+  describe('syncVersion integration', () => {
+    // sync-version.js를 child_process로 실행하여 동작 검증
+    // 파일 시스템 mock을 사용한 통합 테스트
+  });
+});
+```
+
+**Step 2: 테스트 실행하여 통과 확인**
+
+Run: `yarn workspace codingbuddy-claude-plugin test`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add packages/claude-code-plugin/scripts/sync-version.spec.ts
+git commit -m "test(plugin): add sync-version.spec.ts with peerDeps logic tests (#418)"
+```
+
+---
+
+## Task 4: 빌드 검증 (수동)
+
+**Step 1: `yarn build` 실행하여 동기화가 한 번만 실행되는지 확인**
+
+Run: `yarn workspace codingbuddy-claude-plugin build`
+Expected:
+- `[sync-version]` 로그가 **prebuild 단계에서 1번만** 출력
+- `build.ts`에서 `Version Sync` 단계 로그 없음
+- README.md 정상 생성
+
+**Step 2: 동기화된 버전이 정확한지 확인**
+
+```bash
+# MCP server 버전과 plugin 버전이 일치하는지 확인
+node -e "
+  const mcp = require('./apps/mcp-server/package.json');
+  const plugin = require('./packages/claude-code-plugin/package.json');
+  console.log('MCP:', mcp.version);
+  console.log('Plugin:', plugin.version);
+  console.log('Match:', mcp.version === plugin.version);
+"
+```
+
+**Step 3: 전체 테스트 스위트 실행**
+
+Run: `yarn workspace codingbuddy-claude-plugin test`
+Expected: ALL PASS
+
+---
+
+## 변경 요약
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `scripts/build.ts` | `syncVersion()` 함수 삭제, `main()` 스텝 번호 변경, `MCP_SERVER_DIR` 삭제 |
+| `scripts/build.spec.ts` | "Version Sync" shape 테스트 제거, peerDeps 로직 테스트 제거 |
+| `scripts/sync-version.spec.ts` | 신규 생성 - peerDeps 계산 로직 테스트 |
+| `package.json` | 변경 없음 (`prebuild` 스크립트 유지) |
+
+## 실행 후 확인
+
+- [ ] `yarn build`에서 버전 동기화가 1번만 실행됨
+- [ ] 동기화된 버전이 MCP server와 일치함
+- [ ] 모든 테스트 통과
+- [ ] lint/typecheck 통과

--- a/packages/claude-code-plugin/scripts/build.spec.ts
+++ b/packages/claude-code-plugin/scripts/build.spec.ts
@@ -94,34 +94,6 @@ describe('build script orchestration', () => {
   });
 
   // ============================================================================
-  // peerDependencies Sync Logic
-  // ============================================================================
-  describe('peerDependencies sync logic', () => {
-    function computeExpectedPeer(version: string): string {
-      const [major, minor] = version.split('.');
-      return `^${major}.${minor}.0`;
-    }
-
-    it('computes correct peerDependencies from version', () => {
-      expect(computeExpectedPeer('4.0.1')).toBe('^4.0.0');
-      expect(computeExpectedPeer('4.1.0')).toBe('^4.1.0');
-      expect(computeExpectedPeer('5.2.3')).toBe('^5.2.0');
-    });
-
-    it('detects peerDependencies mismatch when version already matches', () => {
-      const currentVersion = '4.0.1';
-      const pluginVersion = '4.0.1';
-      const stalePeer = '^3.0.0';
-      const expectedPeer = computeExpectedPeer(currentVersion);
-
-      // version matches but peer is stale - this was the bug in #409
-      expect(pluginVersion).toBe(currentVersion);
-      expect(stalePeer).not.toBe(expectedPeer);
-      expect(expectedPeer).toBe('^4.0.0');
-    });
-  });
-
-  // ============================================================================
   // BuildResult Interface
   // ============================================================================
   describe('BuildResult interface consistency', () => {
@@ -131,20 +103,6 @@ describe('build script orchestration', () => {
       details: string[];
       errors: string[];
     }
-
-    it('has correct shape for version sync', () => {
-      const buildResult: BuildResult = {
-        step: 'Version Sync',
-        success: true,
-        details: ['package.json updated to 2.4.1'],
-        errors: [],
-      };
-
-      expect(buildResult.step).toBe('Version Sync');
-      expect(buildResult.success).toBe(true);
-      expect(buildResult.details).toContain('package.json updated to 2.4.1');
-      expect(buildResult.errors).toHaveLength(0);
-    });
 
     it('has correct shape for README generation', () => {
       const buildResult: BuildResult = {
@@ -162,14 +120,14 @@ describe('build script orchestration', () => {
 
     it('captures errors correctly', () => {
       const buildResult: BuildResult = {
-        step: 'Version Sync',
+        step: 'README Generation',
         success: false,
         details: [],
-        errors: ['MCP server package.json not found'],
+        errors: ['Failed to write README.md'],
       };
 
       expect(buildResult.success).toBe(false);
-      expect(buildResult.errors).toContain('MCP server package.json not found');
+      expect(buildResult.errors).toContain('Failed to write README.md');
     });
   });
 });

--- a/packages/claude-code-plugin/scripts/build.ts
+++ b/packages/claude-code-plugin/scripts/build.ts
@@ -3,8 +3,9 @@
  * Build Script for Claude Code Plugin
  *
  * Orchestrates the plugin build process:
- * 1. Sync version from MCP server
- * 2. Generate README
+ * 1. Generate README
+ *
+ * Version sync is handled by the prebuild script (sync-version.js).
  *
  * Note: Agents, commands, and skills are NOT generated here.
  * They live in packages/rules/.ai-rules/ (single source of truth).
@@ -22,83 +23,12 @@ import { getErrorMessage } from '../src/utils';
 
 // Paths
 const ROOT_DIR = path.resolve(__dirname, '..');
-const MCP_SERVER_DIR = path.resolve(__dirname, '../../..', 'apps/mcp-server');
 
 interface BuildResult {
   step: string;
   success: boolean;
   details: string[];
   errors: string[];
-}
-
-function syncVersion(): BuildResult {
-  const result: BuildResult = {
-    step: 'Version Sync',
-    success: true,
-    details: [],
-    errors: [],
-  };
-
-  try {
-    const mcpPkgPath = path.join(MCP_SERVER_DIR, 'package.json');
-    const pluginPkgPath = path.join(ROOT_DIR, 'package.json');
-    const manifestPath = path.join(ROOT_DIR, '.claude-plugin', 'plugin.json');
-
-    if (!fs.existsSync(mcpPkgPath)) {
-      result.errors.push('MCP server package.json not found');
-      result.success = false;
-      return result;
-    }
-
-    const mcpPkg = JSON.parse(fs.readFileSync(mcpPkgPath, 'utf8'));
-    const version = mcpPkg.version;
-
-    // Update plugin package.json
-    const pluginPkg = JSON.parse(fs.readFileSync(pluginPkgPath, 'utf8'));
-    let pkgChanged = false;
-
-    if (pluginPkg.version !== version) {
-      pluginPkg.version = version;
-      pkgChanged = true;
-      result.details.push(`package.json version updated to ${version}`);
-    }
-
-    // Always check peerDependencies (even if version already matches)
-    const [major, minor] = version.split('.');
-    const expectedPeer = `^${major}.${minor}.0`;
-    pluginPkg.peerDependencies = pluginPkg.peerDependencies || {};
-    if (pluginPkg.peerDependencies.codingbuddy !== expectedPeer) {
-      pluginPkg.peerDependencies.codingbuddy = expectedPeer;
-      pkgChanged = true;
-      result.details.push(
-        `peerDependencies.codingbuddy updated to ${expectedPeer}`,
-      );
-    }
-
-    if (pkgChanged) {
-      fs.writeFileSync(
-        pluginPkgPath,
-        JSON.stringify(pluginPkg, null, 2) + '\n',
-      );
-    } else {
-      result.details.push(`package.json already at ${version}`);
-    }
-
-    // Update manifest
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-    if (manifest.version !== version) {
-      manifest.version = version;
-      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
-      result.details.push(`plugin.json updated to ${version}`);
-    } else {
-      result.details.push(`plugin.json already at ${version}`);
-    }
-  } catch (error) {
-    result.success = false;
-    result.errors.push(getErrorMessage(error));
-  }
-
-  return result;
 }
 
 function createReadme(): BuildResult {
@@ -214,14 +144,13 @@ async function main(): Promise<void> {
   console.log('╚════════════════════════════════════════════════════════════╝');
   console.log('');
 
+  console.log('ℹ️  Version sync handled by prebuild script (sync-version.js)');
+  console.log('');
+
   const results: BuildResult[] = [];
 
-  // Step 1: Version Sync
-  console.log('📦 Step 1: Syncing version...');
-  results.push(syncVersion());
-
-  // Step 2: Generate README
-  console.log('📖 Step 2: Generating README...');
+  // Step 1: Generate README
+  console.log('📖 Step 1: Generating README...');
   results.push(createReadme());
 
   // Summary

--- a/packages/claude-code-plugin/scripts/sync-version.spec.ts
+++ b/packages/claude-code-plugin/scripts/sync-version.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit Tests for Version Sync Script
+ *
+ * Tests the version synchronization logic used by sync-version.js (prebuild script).
+ * Validates peerDependencies computation and version matching behavior.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('sync-version script', () => {
+  // ============================================================================
+  // peerDependencies Computation Logic
+  // ============================================================================
+  describe('peerDependencies computation logic', () => {
+    function computeExpectedPeer(version: string): string {
+      const [major, minor] = version.split('.');
+      return `^${major}.${minor}.0`;
+    }
+
+    it('computes correct peerDependencies from version', () => {
+      expect(computeExpectedPeer('4.0.1')).toBe('^4.0.0');
+      expect(computeExpectedPeer('4.1.0')).toBe('^4.1.0');
+      expect(computeExpectedPeer('5.2.3')).toBe('^5.2.0');
+    });
+
+    it('handles major version changes', () => {
+      expect(computeExpectedPeer('1.0.0')).toBe('^1.0.0');
+      expect(computeExpectedPeer('10.5.2')).toBe('^10.5.0');
+    });
+
+    it('detects peerDependencies mismatch when version already matches', () => {
+      const currentVersion = '4.0.1';
+      const pluginVersion = '4.0.1';
+      const stalePeer = '^3.0.0';
+      const expectedPeer = computeExpectedPeer(currentVersion);
+
+      // version matches but peer is stale - this was the bug in #409
+      expect(pluginVersion).toBe(currentVersion);
+      expect(stalePeer).not.toBe(expectedPeer);
+      expect(expectedPeer).toBe('^4.0.0');
+    });
+  });
+
+  // ============================================================================
+  // Version Change Detection Logic
+  // ============================================================================
+  describe('version change detection logic', () => {
+    function needsUpdate(current: string, target: string): boolean {
+      return current !== target;
+    }
+
+    it('detects when plugin version differs from MCP server version', () => {
+      expect(needsUpdate('4.0.1', '4.1.0')).toBe(true);
+    });
+
+    it('detects when versions are already in sync', () => {
+      expect(needsUpdate('4.0.1', '4.0.1')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #418

- Remove duplicate `syncVersion()` from `build.ts` — version sync is now handled solely by the `prebuild` script (`sync-version.js`)
- Move peerDependencies computation tests from `build.spec.ts` to new `sync-version.spec.ts`
- Remove stale "Version Sync" BuildResult shape test from `build.spec.ts`

### Before

```
yarn build
  → prebuild: sync-version.js   (1st sync)
  → build.ts: syncVersion()     (2nd sync — duplicate)
```

### After

```
yarn build
  → prebuild: sync-version.js   (single sync)
  → build.ts                    (README generation only)
```

## Changes

| File | Change |
|------|--------|
| `scripts/build.ts` | Remove `syncVersion()` function, `MCP_SERVER_DIR` constant, update JSDoc and step numbering |
| `scripts/build.spec.ts` | Remove "Version Sync" shape test and peerDeps logic tests |
| `scripts/sync-version.spec.ts` | New — peerDeps computation and version change detection tests |

## Test plan

- [x] `yarn workspace codingbuddy-claude-plugin test` — 69 tests passed (3 files)
- [x] `yarn workspace codingbuddy-claude-plugin typecheck` — no errors
- [x] `yarn workspace codingbuddy-claude-plugin build` — version sync runs once (prebuild only), README generated successfully