### PR TITLE
add path normalization and case-insensitive matching to isPathSafe()

### DIFF
--- a/packages/claude-code-plugin/src/utils.spec.ts
+++ b/packages/claude-code-plugin/src/utils.spec.ts
@@ -306,6 +306,49 @@ describe('utils', () => {
       expect(isPathSafe('/home/user/etcetera/file.txt')).toBe(true);
       expect(isPathSafe('/home/user/variable/file.txt')).toBe(true);
     });
+
+    it('rejects non-normalized paths that resolve to dangerous locations', () => {
+      // dot-segment bypass: /./etc/passwd -> /etc/passwd
+      expect(isPathSafe('/./etc/passwd')).toBe(false);
+      expect(isPathSafe('/./usr/bin/bash')).toBe(false);
+      expect(isPathSafe('/home/./user/.ssh/id_rsa')).toBe(false);
+
+      // multiple dot-segments
+      expect(isPathSafe('/tmp/safe/../../etc/passwd')).toBe(false);
+
+      // trailing dots
+      expect(isPathSafe('/etc/./passwd')).toBe(false);
+
+      // redundant separators (path.normalize handles these)
+      expect(isPathSafe('//etc//passwd')).toBe(false);
+    });
+
+    it('rejects mixed-case paths for user-sensitive directories', () => {
+      // SSH
+      expect(isPathSafe('/home/user/.SSH/id_rsa')).toBe(false);
+      expect(isPathSafe('/Users/dev/.Ssh/config')).toBe(false);
+      // AWS
+      expect(isPathSafe('/home/user/.AWS/credentials')).toBe(false);
+      // Config
+      expect(isPathSafe('/home/user/.Config/secrets')).toBe(false);
+      // Docker
+      expect(isPathSafe('/home/user/.Docker/config.json')).toBe(false);
+      // Environment files
+      expect(isPathSafe('/project/.ENV')).toBe(false);
+      expect(isPathSafe('/project/.Env.local')).toBe(false);
+      // Git credentials
+      expect(isPathSafe('/home/user/.GITCONFIG')).toBe(false);
+      expect(isPathSafe('/home/user/.Git-Credentials')).toBe(false);
+      // History
+      expect(isPathSafe('/home/user/.Bash_History')).toBe(false);
+      expect(isPathSafe('/home/user/.ZSH_HISTORY')).toBe(false);
+      // Other
+      expect(isPathSafe('/home/user/.NPMRC')).toBe(false);
+      expect(isPathSafe('/home/user/.Kube/config')).toBe(false);
+      expect(isPathSafe('/home/user/.Gnupg/private-keys-v1.d')).toBe(false);
+      expect(isPathSafe('/home/user/.Gcloud/credentials')).toBe(false);
+      expect(isPathSafe('/home/user/.Azure/config')).toBe(false);
+    });
   });
 
   // ============================================================================

--- a/packages/claude-code-plugin/src/utils.ts
+++ b/packages/claude-code-plugin/src/utils.ts
@@ -85,27 +85,27 @@ const DANGEROUS_PATH_PATTERNS: ReadonlyArray<RegExp> = [
   /^[A-Z]:\\Users\\[^\\]+\\AppData/i,
   /^[A-Z]:\\ProgramData/i,
   // User-sensitive directories (credentials, keys, configs)
-  /\/\.ssh\//, // SSH keys and config
-  /\/\.gnupg\//, // GPG keys
-  /\/\.aws\//, // AWS credentials
-  /\/\.kube\//, // Kubernetes config
-  /\/\.npmrc$/, // npm authentication tokens
-  /\/\.netrc$/, // FTP/HTTP credentials
-  /\/\.docker\//, // Docker config and credentials
+  /\/\.ssh\//i, // SSH keys and config
+  /\/\.gnupg\//i, // GPG keys
+  /\/\.aws\//i, // AWS credentials
+  /\/\.kube\//i, // Kubernetes config
+  /\/\.npmrc$/i, // npm authentication tokens
+  /\/\.netrc$/i, // FTP/HTTP credentials
+  /\/\.docker\//i, // Docker config and credentials
   // Additional user-sensitive paths
-  /\/\.config\//, // XDG config directory (contains many app secrets)
-  /\/\.password-store\//, // pass password manager
-  /\/\.bash_history$/, // Bash command history
-  /\/\.zsh_history$/, // Zsh command history
-  /\/\.gitconfig$/, // Git config (may contain credentials)
-  /\/\.git-credentials$/, // Git credential store
-  /\/\.env$/, // Environment variables (often contains secrets)
-  /\/\.env\.[^/]+$/, // .env.local, .env.production, etc.
-  /\/\.cargo\/credentials/, // Rust/Cargo credentials
-  /\/\.gem\/credentials/, // Ruby gem credentials
-  /\/\.pypirc$/, // Python PyPI credentials
-  /\/\.gcloud\//, // Google Cloud credentials
-  /\/\.azure\//, // Azure credentials
+  /\/\.config\//i, // XDG config directory (contains many app secrets)
+  /\/\.password-store\//i, // pass password manager
+  /\/\.bash_history$/i, // Bash command history
+  /\/\.zsh_history$/i, // Zsh command history
+  /\/\.gitconfig$/i, // Git config (may contain credentials)
+  /\/\.git-credentials$/i, // Git credential store
+  /\/\.env$/i, // Environment variables (often contains secrets)
+  /\/\.env\.[^/]+$/i, // .env.local, .env.production, etc.
+  /\/\.cargo\/credentials/i, // Rust/Cargo credentials
+  /\/\.gem\/credentials/i, // Ruby gem credentials
+  /\/\.pypirc$/i, // Python PyPI credentials
+  /\/\.gcloud\//i, // Google Cloud credentials
+  /\/\.azure\//i, // Azure credentials
 ];
 
 /**
@@ -192,12 +192,17 @@ export function validatePath(
  * Validates that a path doesn't contain path traversal sequences
  * Less strict than validatePath - just checks for obvious traversal
  *
+ * Normalizes the path before matching to prevent bypass via
+ * dot-segments (e.g., /./etc/passwd) or redundant separators.
+ * User-sensitive directory patterns use case-insensitive matching
+ * to prevent bypass on case-insensitive filesystems (macOS HFS+/APFS).
+ *
  * @param inputPath - The path to check
  * @returns true if path is safe, false if it contains traversal sequences
  */
 export function isPathSafe(inputPath: string): boolean {
-  // Use pre-compiled patterns for better performance
-  return !DANGEROUS_PATH_PATTERNS.some(pattern => pattern.test(inputPath));
+  const normalized = path.normalize(inputPath);
+  return !DANGEROUS_PATH_PATTERNS.some(pattern => pattern.test(normalized));
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #419 — `isPathSafe()` missing path normalization security issue.

- Add `path.normalize()` before regex pattern matching to prevent bypass via dot-segments (`/./etc/passwd`) and redundant separators (`//etc//passwd`)
- Add case-insensitive flag (`i`) to 21 user-sensitive directory patterns to prevent bypass on case-insensitive filesystems (macOS HFS+/APFS)
- Add tests for both normalization and mixed-case bypass vectors

## Problem

`isPathSafe()` did not normalize input paths before pattern matching, allowing three bypass vectors:

| # | Vulnerability | Bypass Example | Impact |
|---|--------------|----------------|--------|
| 1 | No `path.normalize()` | `/./etc/passwd` bypasses `/^\/etc\//` | Dot-segments bypass pattern matching |
| 2 | Case-sensitive user dir patterns | `/home/user/.SSH/id_rsa` bypasses `/.ssh/` | macOS HFS+/APFS case-insensitive bypass |

> **Note:** Symlink resolution is intentionally out of scope — `isPathSafe()` is a lightweight string check; symlinks are handled by `validatePath()` with `followSymlinks` option.

## Changes

| File | Change |
|------|--------|
| `utils.ts:198-201` | Add `path.normalize()` call before pattern matching |
| `utils.ts:87-108` | Add `i` flag to 21 user-sensitive directory patterns |
| `utils.ts:191-197` | Update JSDoc with normalization/case-insensitive behavior |
| `utils.spec.ts` | Add 2 test cases (normalization bypass, mixed-case bypass) |

## Test Plan

- [x] New test: rejects non-normalized paths (`/./etc/passwd`, `//etc//passwd`, etc.)
- [x] New test: rejects mixed-case user-sensitive paths (`.SSH`, `.Config`, `.AWS`, etc.)
- [x] All 54 existing `isPathSafe` tests still pass
- [x] Full test suite: 71 tests pass
- [x] TypeScript build: `tsc --noEmit` no errors
- [x] Backward compatible: no API signature changes