### PR TITLE
fix agent count mismatch across documentation (#421)

### DIFF
--- a/.claude/rules/custom-instructions.md
+++ b/.claude/rules/custom-instructions.md
@@ -46,11 +46,10 @@ Follow the common rules defined in `packages/rules/.ai-rules/` for consistency a
 
 **Source**: `packages/rules/.ai-rules/agents/`
 
-**Available Specialists** (12 agents):
-- Frontend Developer, Code Reviewer
-- Architecture, Test Strategy, Performance, Security
-- Accessibility, SEO, Design System, Documentation
-- Code Quality, DevOps Engineer
+**Available Agents** (26 agents + 4 mode agents):
+- **Primary**: Solution Architect, Technical Planner, Frontend Developer, Backend Developer, Mobile Developer, Data Engineer, Agent Architect, Platform Engineer, Tooling Engineer, AI/ML Engineer, DevOps Engineer
+- **Domain**: Architecture, Test Strategy, Performance, Security, Accessibility, SEO, UI/UX Design, Documentation, Integration, Event Architecture, Observability, Migration, i18n
+- **Core/Utility**: Code Reviewer, Code Quality
 
 See [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md) for details.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ codingbuddy/
 │   └── rules/           # AI coding rules package (codingbuddy-rules)
 │       └── .ai-rules/   # Shared AI coding rules (single source of truth)
 │           ├── rules/   # Core rules (workflow, project, augmented-coding)
-│           ├── agents/  # 12 specialist agent definitions (JSON)
+│           ├── agents/  # 30 agent definitions (JSON)
 │           └── adapters/# Tool-specific integration guides
 ├── .cursor/             # Cursor AI config
 ├── .claude/             # Claude Code config

--- a/docs/es/plugin-architecture.md
+++ b/docs/es/plugin-architecture.md
@@ -109,7 +109,7 @@ graph TB
 │   ├── frontend-developer.json
 │   ├── backend-developer.json
 │   ├── security-specialist.json
-│   └── ... (12+ agentes)
+│   └── ... (30 agentes)
 ├── skills/           # Flujos de trabajo reutilizables (Markdown)
 │   ├── tdd.md
 │   ├── debugging.md

--- a/docs/ko/plugin-architecture.md
+++ b/docs/ko/plugin-architecture.md
@@ -109,7 +109,7 @@ graph TB
 │   ├── frontend-developer.json
 │   ├── backend-developer.json
 │   ├── security-specialist.json
-│   └── ... (12개 이상의 에이전트)
+│   └── ... (30개의 에이전트)
 ├── skills/           # 재사용 가능한 워크플로우 (Markdown)
 │   ├── tdd.md
 │   ├── debugging.md

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -109,7 +109,7 @@ graph TB
 │   ├── frontend-developer.json
 │   ├── backend-developer.json
 │   ├── security-specialist.json
-│   └── ... (12+ agents)
+│   └── ... (30 agents)
 ├── skills/           # Reusable workflows (Markdown)
 │   ├── tdd.md
 │   ├── debugging.md

--- a/docs/pt-BR/plugin-architecture.md
+++ b/docs/pt-BR/plugin-architecture.md
@@ -109,7 +109,7 @@ graph TB
 │   ├── frontend-developer.json
 │   ├── backend-developer.json
 │   ├── security-specialist.json
-│   └── ... (12+ agentes)
+│   └── ... (30 agentes)
 ├── skills/           # Fluxos de trabalho reutilizaveis (Markdown)
 │   ├── tdd.md
 │   ├── debugging.md

--- a/docs/pt-BR/plugin-faq.md
+++ b/docs/pt-BR/plugin-faq.md
@@ -18,7 +18,7 @@ Perguntas frequentes sobre o Plugin CodingBuddy para Claude Code.
 CodingBuddy e um sistema Multi-AI Rules que fornece práticas de codificação consistentes entre assistentes de IA. Ele inclui:
 
 - **Modos de Fluxo de Trabalho**: PLAN/ACT/EVAL/AUTO para desenvolvimento estruturado
-- **Agentes Especialistas**: 12+ especialistas de dominio (seguranca, performance, acessibilidade, etc.)
+- **Agentes Especialistas**: 30 agentes de dominio (seguranca, performance, acessibilidade, etc.)
 - **Habilidades**: Fluxos de trabalho reutilizaveis (TDD, debugging, design de API, etc.)
 - **Checklists**: Verificações de qualidade especificas por dominio
 


### PR DESCRIPTION
## Summary

Fixes #421

Documentation claimed "12 specialist agent definitions" but the `packages/rules/.ai-rules/agents/` directory actually contains **30 JSON agent files**:

- **Mode Agents (4)**: plan-mode, act-mode, eval-mode, auto-mode
- **Primary Agents (11)**: solution-architect, technical-planner, frontend-developer, backend-developer, mobile-developer, data-engineer, agent-architect, platform-engineer, tooling-engineer, ai-ml-engineer, devops-engineer
- **Domain Specialists (13)**: accessibility, architecture, ui-ux-designer, documentation, integration, event-architecture, observability, migration, performance, security, seo, test-strategy, i18n
- **Core/Utility (2)**: code-reviewer, code-quality-specialist

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | `12 specialist agent definitions` → `30 agent definitions` |
| `.claude/rules/custom-instructions.md` | `(12 agents)` → `(26 agents + 4 mode agents)` with categorized list |
| `docs/plugin-architecture.md` | `12+ agents` → `30 agents` |
| `docs/ko/plugin-architecture.md` | `12개 이상의 에이전트` → `30개의 에이전트` |
| `docs/es/plugin-architecture.md` | `12+ agentes` → `30 agentes` |
| `docs/pt-BR/plugin-architecture.md` | `12+ agentes` → `30 agentes` |
| `docs/pt-BR/plugin-faq.md` | `12+ especialistas` → `30 agentes` |

**Note**: `CHANGELOG.md` was intentionally not modified as it is a historical record.

## Test plan

- [x] Verified actual file count: `ls packages/rules/.ai-rules/agents/*.json | wc -l` → 30
- [x] Verified no remaining "12 agent" references in `.md` files (except historical CHANGELOG.md)
- [x] All 4 language variants (en, ko, es, pt-BR) synchronized