### PR TITLE
remove production console.log in instrumentation (#425)

### DIFF
--- a/apps/landing-page/src/instrumentation.ts
+++ b/apps/landing-page/src/instrumentation.ts
@@ -1,13 +1,10 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     // Server-side instrumentation
-    console.log('[Instrumentation] Server runtime registered');
-
     // Future: Add OpenTelemetry, Sentry server-side initialization
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {
     // Edge runtime instrumentation
-    console.log('[Instrumentation] Edge runtime registered');
   }
 }


### PR DESCRIPTION
## Summary

- Remove `console.log` statements from `apps/landing-page/src/instrumentation.ts` that were executing in production and adding noise to server logs
- Retain placeholder comments for future OpenTelemetry/Sentry integration

Closes #425

## Changes

- **`apps/landing-page/src/instrumentation.ts`**: Remove 2 `console.log` calls (lines 4, 11)

## Test Plan

- [x] Production build passes without errors
- [x] No remaining `console.log` in instrumentation file