### PR TITLE
bump version to 4.1.0 and update CHANGELOGs

### DIFF
--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -5,6 +5,67 @@ Todos los cambios notables de este proyecto se documentarán en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-02-17
+
+### Agregado
+
+- **Panel TUI**: UI de terminal basada en Ink (componentes Header, AgentCard, AgentTree, AgentGrid, StatusBar, ProgressBar)
+- **TUI EventBus**: Sistema de eventos basado en EventEmitter2 con hooks React `useEventBus` y `useAgentState`
+- **TUI IPC**: Proceso independiente con comunicación interprocesos via Unix Domain Socket
+- **Diseño TUI Compacto**: Diseño de línea única optimizado para terminales de 24 líneas
+- **TUI Interceptor**: Capa de despacho de herramientas MCP para actualizaciones de UI en tiempo real
+- **Página de Destino**: Página de destino multilingüe (5 idiomas) basada en Next.js 16
+  - Arquitectura Widget Slot (widgets AgentsShowcase, CodeExample, QuickStart)
+  - Biblioteca de componentes shadcn/ui con temas y consentimiento de cookies
+  - Fuentes auto-hospedadas via `next/font`
+  - Configuración i18n next-intl con rutas paralelas y diseño de slot de localización
+  - Secciones estáticas: Hero, Problem, Solution, FAQ
+  - Encabezado (selector de idioma, alternador de tema), Footer y mejoras de accesibilidad
+  - Configuración de despliegue en Vercel con integración de analíticas
+  - Datos estructurados JSON-LD para SEO (#424)
+  - Declaración de accesibilidad WCAG 2.1 AA
+- **MCP Server**: Autenticación Bearer token para endpoints SSE (#416)
+- **Sistema de Agentes**: Herramienta `dispatch_agents` y auto-despacho en respuesta `parse_mode` (#328)
+- **Patrones de Intent**: Patrones de intent `frontend-developer` y `devops-engineer` añadidos
+- **Modo EVAL**: Soporte de `recommendedActAgent` en modo EVAL (#361)
+
+### Cambiado
+
+- **Prettier**: Reformateo de toda la base de código con `printWidth: 100` (#423)
+- **MCP Server**: Extracción de módulos compartidos `rules-core` y `keyword-core` (#415)
+- **Plugin**: Eliminación de `syncVersion` duplicado del script de build (#418)
+
+### Corregido
+
+- plugin `isPathSafe()` normalización de rutas y coincidencia insensible a mayúsculas (#419)
+- MCP server lógica de fusión `findLastIndex` en `appendContext` (#410)
+- MCP server manejador de rechazo de Promise no capturada en `bootstrap()`
+- MCP server validación en tiempo de ejecución de type assertion inseguras (#411)
+- Página de destino atributo `html lang` establecido desde locale en renderizado del servidor (#412)
+- Página de destino eliminación del meta-paquete radix-ui, uso directo de `@radix-ui/react-dialog` (#413)
+- `validate-rules.sh` referencia de ruta `.ai-rules` actualizada (#422)
+- Resolución basada en intent de keyword omite project config en modo recomendación
+- plugin corrección de typo `codebuddy` → `codingbuddy`
+- CI release-drafter fijado a SHA y versiones de setup action alineadas
+
+### Documentación
+
+- Guía de usuario TUI, arquitectura y documentación de resolución de problemas
+- README de página de destino con guía de despliegue y estructura del proyecto
+- Corrección de desajuste en conteo de agentes en la documentación (#421)
+- Documentación de variable de entorno MCP_SSE_TOKEN (#416)
+- Plan de implementación JSON-LD (#424)
+
+### Pruebas
+
+- Pruebas de context-document handler (#417)
+- Pruebas de integración TUI EventBus-UI, App root y transport
+- Pruebas de verificación de rendimiento y estabilidad TUI
+- Pruebas de root layout y CSP headers de página de destino
+- Pruebas de async server component de página de destino
+
+---
+
 ## [4.0.1] - 2026-02-04
 
 ### Agregado

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,67 @@
 このドキュメントは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) の形式に基づいており、
 [セマンティック バージョニング](https://semver.org/lang/ja/spec/v2.0.0.html) に準拠しています。
 
+## [4.1.0] - 2026-02-17
+
+### 追加
+
+- **TUI ダッシュボード**: Ink ベースのターミナル UI（Header、AgentCard、AgentTree、AgentGrid、StatusBar、ProgressBar コンポーネント）
+- **TUI EventBus**: EventEmitter2 ベースのイベントシステム、`useEventBus` および `useAgentState` React フック
+- **TUI IPC**: Unix Domain Socket ベースのスタンドアロンプロセス間通信
+- **TUI コンパクトデザイン**: 24行ターミナルに最適化されたシングルラインレイアウト
+- **TUI Interceptor**: リアルタイム UI 更新のための MCP ツールディスパッチレイヤー
+- **ランディングページ**: Next.js 16 ベースの多言語（5言語）ランディングページ
+  - Widget Slot アーキテクチャ（AgentsShowcase、CodeExample、QuickStart ウィジェット）
+  - shadcn/ui コンポーネントライブラリ、テーマおよびクッキー同意
+  - `next/font` によるセルフホスティングフォント
+  - next-intl i18n 設定、パラレルルートおよびロケールスロットレイアウト
+  - 静的セクション: Hero、Problem、Solution、FAQ
+  - ヘッダー（言語セレクター、テーマトグル）、Footer およびアクセシビリティ改善
+  - Vercel デプロイ設定およびアナリティクス統合
+  - SEO のための JSON-LD 構造化データ (#424)
+  - WCAG 2.1 AA アクセシビリティ声明
+- **MCP Server**: SSE エンドポイントの Bearer トークン認証 (#416)
+- **Agent システム**: `dispatch_agents` ツールおよび `parse_mode` 自動ディスパッチ (#328)
+- **Intent パターン**: `frontend-developer`、`devops-engineer` インテントパターン追加
+- **EVAL モード**: EVAL モードでの `recommendedActAgent` サポート (#361)
+
+### 変更
+
+- **Prettier**: `printWidth: 100` でコードベース全体をリフォーマット (#423)
+- **MCP Server**: `rules-core`、`keyword-core` 共有モジュール分離 (#415)
+- **Plugin**: build スクリプトから重複する `syncVersion` を削除 (#418)
+
+### 修正
+
+- plugin `isPathSafe()` パス正規化および大文字小文字を無視するマッチング (#419)
+- MCP server `appendContext` `findLastIndex` マージロジック (#410)
+- MCP server `bootstrap()` 未処理の Promise rejection ハンドラー
+- MCP server unsafe type assertion ランタイム検証 (#411)
+- ランディングページ `html lang` 属性をサーバーレンダー時にロケールから設定 (#412)
+- ランディングページ radix-ui メタパッケージを削除、`@radix-ui/react-dialog` を直接使用 (#413)
+- `validate-rules.sh` `.ai-rules` パス参照を修正 (#422)
+- keyword intent ベース解決で推奨モード時に project config をスキップ
+- plugin タイポ `codebuddy` → `codingbuddy` 修正
+- CI release-drafter を SHA に固定し、setup action バージョンを整合
+
+### ドキュメント
+
+- TUI ユーザーガイド、アーキテクチャ、トラブルシューティングドキュメント
+- ランディングページ README にデプロイガイドとプロジェクト構成を追加
+- ドキュメント全体のエージェント数の不一致を修正 (#421)
+- MCP_SSE_TOKEN 環境変数のドキュメント (#416)
+- JSON-LD 実装計画 (#424)
+
+### テスト
+
+- context-document handler テスト追加 (#417)
+- TUI EventBus-UI、App root、transport 統合テスト
+- TUI パフォーマンスおよび安定性検証テスト
+- ランディングページ root layout および CSP headers テスト
+- ランディングページ async server component テスト
+
+---
+
 ## [4.0.1] - 2026-02-04
 
 ### 追加

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -5,6 +5,67 @@
 이 문서는 [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형식을 따르며,
 [Semantic Versioning](https://semver.org/lang/ko/spec/v2.0.0.html)을 준수합니다.
 
+## [4.1.0] - 2026-02-17
+
+### 추가됨
+
+- **TUI 대시보드**: Ink 기반 터미널 UI (Header, AgentCard, AgentTree, AgentGrid, StatusBar, ProgressBar 컴포넌트)
+- **TUI EventBus**: EventEmitter2 기반 이벤트 시스템, `useEventBus` 및 `useAgentState` React 훅
+- **TUI IPC**: Unix Domain Socket 기반 독립 프로세스 통신
+- **TUI 컴팩트 디자인**: 24줄 터미널에 최적화된 단일 라인 레이아웃
+- **TUI Interceptor**: 실시간 UI 업데이트를 위한 MCP 도구 디스패치 레이어
+- **Landing Page**: Next.js 16 기반 다국어(5개국어) 랜딩 페이지
+  - Widget Slot 아키텍처 (AgentsShowcase, CodeExample, QuickStart 위젯)
+  - shadcn/ui 컴포넌트 라이브러리, 테마 및 쿠키 동의
+  - `next/font`를 통한 셀프호스팅 폰트
+  - next-intl i18n 설정, 병렬 라우트 및 로케일 슬롯 레이아웃
+  - 정적 섹션: Hero, Problem, Solution, FAQ
+  - 헤더 (언어 선택기, 테마 토글), Footer 및 접근성 개선
+  - Vercel 배포 설정 및 애널리틱스 통합
+  - SEO를 위한 JSON-LD 구조화 데이터 (#424)
+  - WCAG 2.1 AA 접근성 명세
+- **MCP Server**: SSE 엔드포인트 Bearer token 인증 (#416)
+- **Agent 시스템**: `dispatch_agents` 도구 및 `parse_mode` 자동 디스패치 (#328)
+- **Intent 패턴**: `frontend-developer`, `devops-engineer` 인텐트 패턴 추가
+- **EVAL 모드**: EVAL 모드에서 `recommendedActAgent` 지원 (#361)
+
+### 변경됨
+
+- **Prettier**: `printWidth: 100`으로 전체 코드베이스 리포맷 (#423)
+- **MCP Server**: `rules-core`, `keyword-core` 공유 모듈 분리 (#415)
+- **Plugin**: build 스크립트에서 중복 `syncVersion` 제거 (#418)
+
+### 수정됨
+
+- plugin `isPathSafe()` 경로 정규화 및 대소문자 무시 매칭 (#419)
+- MCP server `appendContext` `findLastIndex` 병합 로직 (#410)
+- MCP server `bootstrap()` 미처리 Promise rejection 핸들러
+- MCP server unsafe type assertion 런타임 검증 (#411)
+- Landing Page `html lang` 속성 서버 렌더 시 로케일에서 설정 (#412)
+- Landing Page radix-ui 메타패키지 제거, `@radix-ui/react-dialog` 직접 사용 (#413)
+- `validate-rules.sh` `.ai-rules` 경로 참조 수정 (#422)
+- keyword intent 기반 해상도에서 추천 모드 시 project config 스킵
+- plugin 타이포 `codebuddy` → `codingbuddy` 수정
+- CI release-drafter SHA 고정 및 setup action 버전 정렬
+
+### 문서
+
+- TUI 사용자 가이드, 아키텍처, 트러블슈팅 문서
+- Landing Page README에 배포 가이드 및 프로젝트 구조 추가
+- 문서 전체의 에이전트 수 불일치 수정 (#421)
+- MCP_SSE_TOKEN 환경 변수 문서화 (#416)
+- JSON-LD 구현 계획 (#424)
+
+### 테스트
+
+- context-document handler 테스트 추가 (#417)
+- TUI EventBus-UI, App root, transport 통합 테스트
+- TUI 성능 및 안정성 검증 테스트
+- Landing Page root layout 및 CSP headers 테스트
+- Landing Page async server component 테스트
+
+---
+
 ## [4.0.1] - 2026-02-04
 
 ### 추가됨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-02-17
+
+### Added
+
+- **TUI Dashboard**: Ink-based terminal UI with Header, AgentCard, AgentTree, AgentGrid, StatusBar, and ProgressBar components
+- **TUI EventBus**: EventEmitter2-based event system with `useEventBus` and `useAgentState` React hooks
+- **TUI IPC**: Standalone TUI process with Unix Domain Socket inter-process communication
+- **TUI Compact Design**: Single-line layout optimized for 24-line terminals
+- **TUI Interceptor**: MCP tool dispatch layer for real-time UI updates
+- **Landing Page**: Next.js 16 multilingual (5 languages) landing page with production-ready setup
+  - Widget Slot architecture (AgentsShowcase, CodeExample, QuickStart widgets)
+  - shadcn/ui component library with theming and cookie consent
+  - Self-hosted fonts via `next/font`
+  - next-intl i18n configuration with parallel routes and locale slot layout
+  - Static sections: Hero, Problem, Solution, FAQ
+  - Header with language selector and theme toggle, Footer with accessibility improvements
+  - Vercel deployment configuration with analytics integration
+  - JSON-LD structured data for SEO (#424)
+  - WCAG 2.1 AA accessibility statement
+- **MCP Server**: Bearer token authentication for SSE endpoints (#416)
+- **Agent System**: `dispatch_agents` tool and auto-dispatch in `parse_mode` response (#328)
+- **Intent Patterns**: Added `frontend-developer` and `devops-engineer` intent patterns for recommendation
+- **EVAL Mode**: `recommendedActAgent` support in EVAL mode (#361)
+
+### Changed
+
+- **Prettier**: Reformatted entire codebase with `printWidth: 100` (#423)
+- **MCP Server**: Extracted shared `rules-core` and `keyword-core` modules (#415)
+- **Plugin**: Removed duplicate `syncVersion` from build script (#418)
+
+### Fixed
+
+- Plugin `isPathSafe()` path normalization and case-insensitive matching (#419)
+- MCP server `appendContext` `findLastIndex` merge logic (#410)
+- MCP server `bootstrap()` unhandled Promise rejection handler
+- MCP server unsafe type assertion runtime validation (#411)
+- Landing page `html lang` attribute set from locale at server render time (#412)
+- Landing page removed radix-ui meta-package, using `@radix-ui/react-dialog` directly (#413)
+- `validate-rules.sh` updated to reference correct `.ai-rules` path (#422)
+- Keyword intent-based resolution skips project config in recommendation mode
+- Plugin typo `codebuddy` corrected to `codingbuddy` in dev path patterns
+- CI release-drafter pinned to SHA and aligned setup action versions
+
+### Documentation
+
+- TUI user guide, architecture, and troubleshooting documentation
+- Landing page README with deployment guide and project structure
+- Fixed agent count mismatch across documentation (#421)
+- MCP_SSE_TOKEN environment variable documentation (#416)
+- JSON-LD implementation plan (#424)
+
+### Tests
+
+- Context-document handler tests (#417)
+- TUI EventBus-UI, App root, and transport integration tests
+- TUI performance and stability verification tests
+- Landing page root layout and CSP headers tests
+- Landing page async server component tests
+
+---
+
 ## [4.0.1] - 2026-02-04
 
 ### Added

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Multi-AI Rules MCP Server - One source of truth for AI coding rules across all AI assistants",
   "author": "JeremyDev87",
   "license": "MIT",

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "PLAN/ACT/EVAL workflow with auto-detection, specialist agents, and reusable skills for systematic TDD development",
   "author": {
     "name": "JeremyDev87",

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -1,6 +1,6 @@
 # CodingBuddy Claude Code Plugin
 
-> Version 4.0.1
+> Version 4.1.0
 
 Multi-AI Rules for consistent coding practices - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic development.
 

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-claude-plugin",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Claude Code Plugin for CodingBuddy - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills",
   "author": "JeremyDev87",
   "license": "MIT",
@@ -46,7 +46,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "codingbuddy": "^4.0.0"
+    "codingbuddy": "^4.1.0"
   },
   "peerDependenciesMeta": {
     "codingbuddy": {

--- a/packages/rules/.ai-rules/CHANGELOG.md
+++ b/packages/rules/.ai-rules/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to the Multi-AI Coding Assistant Common Rules System will be
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-02-17
+
+### Added
+
+- **TUI Dashboard System**
+  - Ink-based terminal UI with Header, AgentCard, AgentTree, AgentGrid, StatusBar, ProgressBar
+  - EventEmitter2-based EventBus with `useEventBus` and `useAgentState` React hooks
+  - Unix Domain Socket IPC for standalone TUI process
+  - Compact single-line design for 24-line terminals
+  - TuiInterceptor MCP tool dispatch layer
+  - Agent Metadata Lookup Service
+
+- **Landing Page**
+  - Next.js 16 multilingual (5 languages) landing page
+  - Widget Slot architecture (AgentsShowcase, CodeExample, QuickStart)
+  - shadcn/ui, self-hosted fonts, next-intl i18n
+  - Vercel deployment with analytics, JSON-LD structured data
+
+- **MCP Server Enhancements**
+  - Bearer token authentication for SSE endpoints (#416)
+  - `dispatch_agents` tool and auto-dispatch in `parse_mode`
+  - `recommendedActAgent` support in EVAL mode (#361)
+  - `frontend-developer` and `devops-engineer` intent patterns
+
+- **Skills**
+  - `widget-slot-architecture` skill for Next.js App Router
+
+### Changed
+
+- Prettier `printWidth: 100` applied to entire codebase (#423)
+- MCP Server: extracted shared `rules-core` and `keyword-core` modules (#415)
+
+### Fixed
+
+- Plugin `isPathSafe()` path normalization and case-insensitive matching (#419)
+- MCP Server `appendContext` `findLastIndex` merge logic (#410)
+- MCP Server unsafe type assertion runtime validation (#411)
+- `validate-rules.sh` `.ai-rules` path reference (#422)
+- Agent count mismatch across documentation (#421)
+
+---
+
 ## [3.1.0] - 2026-01-22
 
 ### Added

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-rules",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "AI coding rules for consistent practices across AI assistants",
   "main": "index.js",
   "types": "index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6309,7 +6309,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:4.0.17"
   peerDependencies:
-    codingbuddy: ^4.0.0
+    codingbuddy: ^4.1.0
   peerDependenciesMeta:
     codingbuddy:
       optional: true


### PR DESCRIPTION
## Summary

- Bump all 3 package versions from `4.0.1` to `4.1.0` (codingbuddy, codingbuddy-rules, codingbuddy-claude-plugin)
- Update CHANGELOGs in 4 languages (EN, KO, JA, ES) with v4.1.0 release notes
- Update `.ai-rules/CHANGELOG.md` with v4.1.0 section
- Run `sync-version` to align plugin peerDependencies and plugin.json

## Changes

### Version Bump
- `apps/mcp-server/package.json`: 4.0.1 → 4.1.0
- `packages/rules/package.json`: 4.0.1 → 4.1.0
- `packages/claude-code-plugin/package.json`: 4.0.1 → 4.1.0
- `packages/claude-code-plugin/.claude-plugin/plugin.json`: synced to 4.1.0
- `packages/claude-code-plugin/README.md`: version reference updated

### CHANGELOGs (v4.1.0 - 148 commits since v4.0.1)

**Key highlights:**

- **TUI Dashboard**: Ink-based terminal UI with Header, AgentCard, AgentTree, AgentGrid, StatusBar, ProgressBar, EventBus, IPC, compact design (38 feat commits)
- **Landing Page**: Next.js 16 multilingual (5 languages) landing page with Widget Slot architecture, shadcn/ui, i18n, Vercel deployment, JSON-LD (18 feat commits)
- **MCP Server**: SSE Bearer token authentication, shared module extraction (rules-core, keyword-core)
- **Agent System**: `dispatch_agents` tool, auto-dispatch in `parse_mode`, EVAL mode `recommendedActAgent`
- **Code Quality**: Prettier `printWidth: 100` codebase-wide reformat, multiple bug fixes and test additions

## Verification

- [x] `yarn workspace codingbuddy build` — passed
- [x] `yarn workspace codingbuddy-claude-plugin build` — passed
- [x] `yarn workspace codingbuddy test` — 3,446 tests passed
- [x] `yarn workspace codingbuddy-claude-plugin test` — 71 tests passed
- [x] `./scripts/verify-release-versions.sh v4.1.0` — all 3 packages match

## Post-merge

After merging to master, create a GitHub Release with tag `v4.1.0` to trigger the automated npm publish workflow.