### PR TITLE
feat(mcp-server): add precise grid layout system for TUI dashboard

### DIFF
--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
@@ -154,6 +154,40 @@ describe('tui/components/FocusedAgentPanel', () => {
     expect(lastFrame()).toContain('No agent focused');
   });
 
+  it('accepts and applies width and height props', () => {
+    const { lastFrame } = render(
+      <FocusedAgentPanel
+        agent={mockAgent}
+        objectives={[]}
+        tasks={[]}
+        tools={[]}
+        inputs={[]}
+        outputs={{}}
+        eventLog={[]}
+        width={60}
+        height={20}
+      />,
+    );
+    expect(lastFrame()).toContain('BackendDev');
+  });
+
+  it('accepts width and height props with no agent', () => {
+    const { lastFrame } = render(
+      <FocusedAgentPanel
+        agent={null}
+        objectives={[]}
+        tasks={[]}
+        tools={[]}
+        inputs={[]}
+        outputs={{}}
+        eventLog={[]}
+        width={60}
+        height={20}
+      />,
+    );
+    expect(lastFrame()).toContain('No agent focused');
+  });
+
   it('should render single border with cyan color', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel

--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
@@ -20,6 +20,8 @@ export interface FocusedAgentPanelProps {
   inputs: string[];
   outputs: ToolIOData;
   eventLog: EventLogEntry[];
+  width?: number;
+  height?: number;
 }
 
 function SectionDivider({ title }: { title: string }): React.ReactElement {
@@ -63,10 +65,18 @@ export function FocusedAgentPanel({
   inputs,
   outputs,
   eventLog,
+  width,
+  height,
 }: FocusedAgentPanelProps): React.ReactElement {
   if (!agent) {
     return (
-      <Box borderStyle="single" borderColor="cyan" flexDirection="column">
+      <Box
+        borderStyle="single"
+        borderColor="cyan"
+        flexDirection="column"
+        width={width}
+        height={height}
+      >
         <Text dimColor>No agent focused</Text>
       </Box>
     );
@@ -82,7 +92,13 @@ export function FocusedAgentPanel({
   const logs = formatLogTail(eventLog);
 
   return (
-    <Box borderStyle="single" borderColor="cyan" flexDirection="column">
+    <Box
+      borderStyle="single"
+      borderColor="cyan"
+      flexDirection="column"
+      width={width}
+      height={height}
+    >
       {/* Agent Header */}
       <Box gap={2}>
         <Text color={statusColor} bold>

--- a/apps/mcp-server/src/tui/components/HeaderBar.tsx
+++ b/apps/mcp-server/src/tui/components/HeaderBar.tsx
@@ -15,6 +15,9 @@ export interface HeaderBarProps {
 
 const ALL_MODES: Mode[] = ['PLAN', 'ACT', 'EVAL', 'AUTO'];
 
+/** Characters reserved for border (4), title (~32), mode flow (~30), state (~8), gaps (~8). */
+const HEADER_RESERVED_CHARS = 82;
+
 function ModeFlow({ currentMode }: { currentMode: Mode | null }): React.ReactElement {
   return (
     <Box>
@@ -67,36 +70,25 @@ export function HeaderBar({
 }: HeaderBarProps): React.ReactElement {
   if (layoutMode === 'narrow') {
     return (
-      <Box
-        borderStyle="double"
-        borderColor="cyan"
-        width={width}
-        flexDirection="row"
-        justifyContent="space-between"
-      >
+      <Box borderStyle="double" borderColor="cyan" width={width} flexDirection="row">
         <Text color="cyan" bold>
           ⟨⟩ CODINGBUDDY
         </Text>
+        <Box flexGrow={1} />
         <ModeFlow currentMode={currentMode} />
+        <Box flexGrow={1} />
         <StateIndicator globalState={globalState} />
       </Box>
     );
   }
 
-  // Reserve space for border (4), title (~32), mode flow (~30), state (~8), gaps (~8)
-  const reservedChars = 82;
+  const reservedChars = HEADER_RESERVED_CHARS;
   const maxWsLen = Math.max(8, width - reservedChars - 16);
   const displayWs = truncateWorkspace(workspace, maxWsLen);
   const sessDisplay = sessionId.length > 8 ? sessionId.slice(0, 8) : sessionId;
 
   return (
-    <Box
-      borderStyle="double"
-      borderColor="cyan"
-      width={width}
-      flexDirection="row"
-      justifyContent="space-between"
-    >
+    <Box borderStyle="double" borderColor="cyan" width={width} flexDirection="row">
       <Box gap={2}>
         <Text color="cyan" bold>
           ⟨⟩ CODINGBUDDY AGENT DASHBOARD
@@ -104,6 +96,7 @@ export function HeaderBar({
         <ModeFlow currentMode={currentMode} />
         <StateIndicator globalState={globalState} />
       </Box>
+      <Box flexGrow={1} />
       <Box gap={2}>
         <Text dimColor>{displayWs}</Text>
         <Text dimColor>sess:{sessDisplay}</Text>

--- a/apps/mcp-server/src/tui/components/StageHealthBar.tsx
+++ b/apps/mcp-server/src/tui/components/StageHealthBar.tsx
@@ -86,12 +86,13 @@ export function StageHealthBar({
 
   return (
     <Box borderStyle="double" borderColor="cyan" width={width} flexDirection="column">
-      <Box justifyContent="space-between">
+      <Box>
         <Box gap={2}>
           {(['PLAN', 'ACT', 'EVAL'] as const).map(mode => (
             <StageStatDisplay key={mode} mode={mode} stats={stageHealth[mode]} />
           ))}
         </Box>
+        <Box flexGrow={1} />
         <Box gap={2}>
           {bottlenecks.length > 0 && (
             <Text color="red" bold>

--- a/apps/mcp-server/src/tui/components/grid-layout.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/grid-layout.pure.spec.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from 'vitest';
+import { computeGridLayout } from './grid-layout.pure';
+import type { GridRegion } from '../dashboard-types';
+
+/** Helper: check two regions don't overlap */
+function regionsOverlap(a: GridRegion, b: GridRegion): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+}
+
+/** Helper: compute area of a region */
+function regionArea(r: GridRegion): number {
+  return r.width * r.height;
+}
+
+describe('computeGridLayout', () => {
+  describe('wide layout (120x40)', () => {
+    const grid = computeGridLayout(120, 40, 'wide');
+
+    it('header spans full width at row 0 with height 3', () => {
+      expect(grid.header).toEqual({ x: 0, y: 0, width: 120, height: 3 });
+    });
+
+    it('stageHealth spans full width at bottom with height 3', () => {
+      expect(grid.stageHealth.x).toBe(0);
+      expect(grid.stageHealth.width).toBe(120);
+      expect(grid.stageHealth.height).toBe(3);
+      expect(grid.stageHealth.y + grid.stageHealth.height).toBe(40);
+    });
+
+    it('flowMap takes 45% of columns in wide mode', () => {
+      expect(grid.flowMap.width).toBe(Math.floor(120 * 0.45));
+    });
+
+    it('focusedAgent takes remaining columns', () => {
+      expect(grid.focusedAgent.width).toBe(120 - Math.floor(120 * 0.45));
+    });
+
+    it('flowMap and focusedAgent fill the main area height', () => {
+      const mainHeight = 40 - 3 - 3;
+      expect(grid.flowMap.height).toBe(mainHeight);
+      expect(grid.focusedAgent.height).toBe(mainHeight);
+    });
+
+    it('flowMap starts at column 0, focusedAgent starts after flowMap', () => {
+      expect(grid.flowMap.x).toBe(0);
+      expect(grid.focusedAgent.x).toBe(grid.flowMap.width);
+    });
+
+    it('both panels start at row 3 (after header)', () => {
+      expect(grid.flowMap.y).toBe(3);
+      expect(grid.focusedAgent.y).toBe(3);
+    });
+
+    it('total dimensions match input', () => {
+      expect(grid.total).toEqual({ width: 120, height: 40 });
+    });
+  });
+
+  describe('medium layout (100x30)', () => {
+    const grid = computeGridLayout(100, 30, 'medium');
+
+    it('flowMap takes 40% of columns in medium mode', () => {
+      expect(grid.flowMap.width).toBe(Math.floor(100 * 0.4));
+    });
+
+    it('focusedAgent takes remaining columns', () => {
+      expect(grid.focusedAgent.width).toBe(100 - Math.floor(100 * 0.4));
+    });
+
+    it('main area height is total - header(3) - stageHealth(3)', () => {
+      const mainHeight = 30 - 3 - 3;
+      expect(grid.flowMap.height).toBe(mainHeight);
+      expect(grid.focusedAgent.height).toBe(mainHeight);
+    });
+  });
+
+  describe('narrow layout (60x20)', () => {
+    const grid = computeGridLayout(60, 20, 'narrow');
+
+    it('all regions span full width', () => {
+      expect(grid.header.width).toBe(60);
+      expect(grid.flowMap.width).toBe(60);
+      expect(grid.focusedAgent.width).toBe(60);
+      expect(grid.stageHealth.width).toBe(60);
+    });
+
+    it('header is at top with height 3', () => {
+      expect(grid.header).toEqual({ x: 0, y: 0, width: 60, height: 3 });
+    });
+
+    it('stageHealth is at bottom with height 3', () => {
+      expect(grid.stageHealth.height).toBe(3);
+      expect(grid.stageHealth.y + grid.stageHealth.height).toBe(20);
+    });
+
+    it('flowMap has fixed height 5 above stageHealth', () => {
+      expect(grid.flowMap.height).toBe(5);
+      expect(grid.flowMap.y + grid.flowMap.height).toBe(grid.stageHealth.y);
+    });
+
+    it('focusedAgent fills remaining space between header and flowMap', () => {
+      expect(grid.focusedAgent.y).toBe(3);
+      expect(grid.focusedAgent.y + grid.focusedAgent.height).toBe(grid.flowMap.y);
+    });
+
+    it('vertical stack order: header, focusedAgent, flowMap, stageHealth', () => {
+      expect(grid.header.y).toBeLessThan(grid.focusedAgent.y);
+      expect(grid.focusedAgent.y).toBeLessThan(grid.flowMap.y);
+      expect(grid.flowMap.y).toBeLessThan(grid.stageHealth.y);
+    });
+  });
+
+  describe('narrow clamp at minimum height (40x10)', () => {
+    const grid = computeGridLayout(40, 10, 'narrow');
+
+    it('clamps flowMap height to mainHeight-1 when mainHeight < NARROW_FLOW_MAP_HEIGHT', () => {
+      // mainHeight = 10 - 3 - 3 = 4, flowMapHeight = min(5, 4-1) = 3
+      expect(grid.flowMap.height).toBe(3);
+    });
+
+    it('focusedAgent gets remaining 1 row', () => {
+      expect(grid.focusedAgent.height).toBe(1);
+    });
+
+    it('regions still tile correctly', () => {
+      expect(grid.focusedAgent.y + grid.focusedAgent.height).toBe(grid.flowMap.y);
+      expect(grid.flowMap.y + grid.flowMap.height).toBe(grid.stageHealth.y);
+    });
+  });
+
+  describe('medium layout additional assertions (100x30)', () => {
+    const grid = computeGridLayout(100, 30, 'medium');
+
+    it('flowMap and focusedAgent are side by side, not overlapping', () => {
+      expect(grid.flowMap.x + grid.flowMap.width).toBe(grid.focusedAgent.x);
+    });
+
+    it('both panels start at row 3 (after header)', () => {
+      expect(grid.flowMap.y).toBe(3);
+      expect(grid.focusedAgent.y).toBe(3);
+    });
+
+    it('header and stageHealth span full width', () => {
+      expect(grid.header.width).toBe(100);
+      expect(grid.stageHealth.width).toBe(100);
+    });
+
+    it('total dimensions match input', () => {
+      expect(grid.total).toEqual({ width: 100, height: 30 });
+    });
+  });
+
+  describe('no overlap / no gap invariants', () => {
+    const testCases: Array<{
+      name: string;
+      cols: number;
+      rows: number;
+      mode: 'wide' | 'medium' | 'narrow';
+    }> = [
+      { name: 'wide 120x40', cols: 120, rows: 40, mode: 'wide' },
+      { name: 'medium 100x30', cols: 100, rows: 30, mode: 'medium' },
+      { name: 'narrow 60x20', cols: 60, rows: 20, mode: 'narrow' },
+      { name: 'minimum 40x10', cols: 40, rows: 10, mode: 'narrow' },
+    ];
+
+    for (const tc of testCases) {
+      describe(tc.name, () => {
+        const grid = computeGridLayout(tc.cols, tc.rows, tc.mode);
+        const regions = [grid.header, grid.flowMap, grid.focusedAgent, grid.stageHealth];
+        const regionNames = ['header', 'flowMap', 'focusedAgent', 'stageHealth'];
+
+        it('no regions overlap', () => {
+          for (let i = 0; i < regions.length; i++) {
+            for (let j = i + 1; j < regions.length; j++) {
+              expect(
+                regionsOverlap(regions[i], regions[j]),
+                `${regionNames[i]} overlaps ${regionNames[j]}`,
+              ).toBe(false);
+            }
+          }
+        });
+
+        it('total area equals sum of region areas', () => {
+          const totalArea = tc.cols * tc.rows;
+          const sumArea = regions.reduce((s, r) => s + regionArea(r), 0);
+          expect(sumArea).toBe(totalArea);
+        });
+
+        it('all regions have positive dimensions', () => {
+          for (const region of regions) {
+            expect(region.width).toBeGreaterThan(0);
+            expect(region.height).toBeGreaterThan(0);
+          }
+        });
+
+        it('no region extends beyond terminal bounds', () => {
+          for (const region of regions) {
+            expect(region.x + region.width).toBeLessThanOrEqual(tc.cols);
+            expect(region.y + region.height).toBeLessThanOrEqual(tc.rows);
+            expect(region.x).toBeGreaterThanOrEqual(0);
+            expect(region.y).toBeGreaterThanOrEqual(0);
+          }
+        });
+      });
+    }
+  });
+
+  describe('degenerate size clamping', () => {
+    it('clamps rows below minimum (rows=5) to MIN_ROWS=8', () => {
+      const grid = computeGridLayout(60, 5, 'narrow');
+      // Should clamp to 8 rows: header(3) + main(2) + stageHealth(3)
+      expect(grid.total.height).toBe(8);
+      expect(grid.header.height).toBe(3);
+      expect(grid.stageHealth.height).toBe(3);
+      expect(grid.focusedAgent.height).toBeGreaterThan(0);
+      expect(grid.flowMap.height).toBeGreaterThan(0);
+    });
+
+    it('clamps columns below minimum (columns=10) to MIN_COLUMNS=20', () => {
+      const grid = computeGridLayout(10, 30, 'medium');
+      expect(grid.total.width).toBe(20);
+      expect(grid.header.width).toBe(20);
+    });
+
+    it('clamps both dimensions simultaneously', () => {
+      const grid = computeGridLayout(5, 3, 'narrow');
+      expect(grid.total.width).toBe(20);
+      expect(grid.total.height).toBe(8);
+    });
+
+    it('does not clamp valid dimensions', () => {
+      const grid = computeGridLayout(120, 40, 'wide');
+      expect(grid.total).toEqual({ width: 120, height: 40 });
+    });
+
+    it('clamped layout still satisfies all invariants', () => {
+      const grid = computeGridLayout(5, 3, 'narrow');
+      const regions = [grid.header, grid.flowMap, grid.focusedAgent, grid.stageHealth];
+
+      // No overlap
+      for (let i = 0; i < regions.length; i++) {
+        for (let j = i + 1; j < regions.length; j++) {
+          expect(regionsOverlap(regions[i], regions[j])).toBe(false);
+        }
+      }
+      // Positive dimensions
+      for (const region of regions) {
+        expect(region.width).toBeGreaterThan(0);
+        expect(region.height).toBeGreaterThan(0);
+      }
+      // Total area
+      const totalArea = grid.total.width * grid.total.height;
+      const sumArea = regions.reduce((s, r) => s + regionArea(r), 0);
+      expect(sumArea).toBe(totalArea);
+    });
+  });
+
+  describe('border-aware content dimensions at clamped minimum', () => {
+    it('all bordered regions have at least 1 content row/column at minimum size', () => {
+      const grid = computeGridLayout(5, 3, 'narrow');
+      // After clamping to 20x8, all regions should have content space
+      expect(grid.header.width - 2).toBeGreaterThanOrEqual(1);
+      expect(grid.header.height - 2).toBeGreaterThanOrEqual(1);
+      expect(grid.stageHealth.width - 2).toBeGreaterThanOrEqual(1);
+      expect(grid.stageHealth.height - 2).toBeGreaterThanOrEqual(1);
+      expect(grid.focusedAgent.width - 2).toBeGreaterThanOrEqual(1);
+      // focusedAgent at minimum clamped size: height=1, no border subtraction guarantee
+    });
+
+    it('wide layout at standard size has ample content space', () => {
+      const grid = computeGridLayout(120, 40, 'wide');
+      expect(grid.focusedAgent.width - 2).toBeGreaterThanOrEqual(1);
+      expect(grid.focusedAgent.height - 2).toBeGreaterThanOrEqual(1);
+      expect(grid.flowMap.width - 2).toBeGreaterThanOrEqual(1);
+      expect(grid.flowMap.height - 2).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/apps/mcp-server/src/tui/components/grid-layout.pure.ts
+++ b/apps/mcp-server/src/tui/components/grid-layout.pure.ts
@@ -1,0 +1,71 @@
+import type { LayoutMode, DashboardGrid } from '../dashboard-types';
+
+/** Fixed heights for header and stageHealth sections (including borders). */
+const HEADER_HEIGHT = 3;
+const STAGE_HEALTH_HEIGHT = 3;
+
+/** Fixed height for flowMap in narrow mode. */
+const NARROW_FLOW_MAP_HEIGHT = 5;
+
+/** Minimum terminal dimensions to prevent zero/negative regions. */
+const MIN_ROWS = HEADER_HEIGHT + STAGE_HEALTH_HEIGHT + 2;
+const MIN_COLUMNS = 20;
+
+/** FlowMap width ratio per layout mode. */
+const FLOW_MAP_WIDTH_RATIO: Record<Exclude<LayoutMode, 'narrow'>, number> = {
+  wide: 0.45,
+  medium: 0.4,
+};
+
+/**
+ * Compute deterministic grid layout for all dashboard sections.
+ *
+ * Returns exact (x, y, width, height) for every section so that:
+ * - No regions overlap
+ * - No gaps (total area = sum of region areas)
+ * - All regions have positive dimensions
+ * - All regions fit within (columns x rows) bounds
+ */
+export function computeGridLayout(
+  columns: number,
+  rows: number,
+  layoutMode: LayoutMode,
+): DashboardGrid {
+  const cols = Math.max(MIN_COLUMNS, columns);
+  const r = Math.max(MIN_ROWS, rows);
+
+  const header = { x: 0, y: 0, width: cols, height: HEADER_HEIGHT };
+  const stageHealth = {
+    x: 0,
+    y: r - STAGE_HEALTH_HEIGHT,
+    width: cols,
+    height: STAGE_HEALTH_HEIGHT,
+  };
+
+  const mainY = HEADER_HEIGHT;
+  const mainHeight = r - HEADER_HEIGHT - STAGE_HEALTH_HEIGHT;
+
+  if (layoutMode === 'narrow') {
+    const flowMapHeight = Math.min(NARROW_FLOW_MAP_HEIGHT, mainHeight - 1);
+    const focusedHeight = mainHeight - flowMapHeight;
+
+    return {
+      header,
+      focusedAgent: { x: 0, y: mainY, width: cols, height: focusedHeight },
+      flowMap: { x: 0, y: mainY + focusedHeight, width: cols, height: flowMapHeight },
+      stageHealth,
+      total: { width: cols, height: r },
+    };
+  }
+
+  const flowMapWidth = Math.floor(cols * FLOW_MAP_WIDTH_RATIO[layoutMode]);
+  const focusedWidth = cols - flowMapWidth;
+
+  return {
+    header,
+    flowMap: { x: 0, y: mainY, width: flowMapWidth, height: mainHeight },
+    focusedAgent: { x: flowMapWidth, y: mainY, width: focusedWidth, height: mainHeight },
+    stageHealth,
+    total: { width: cols, height: r },
+  };
+}

--- a/apps/mcp-server/src/tui/components/index.ts
+++ b/apps/mcp-server/src/tui/components/index.ts
@@ -25,3 +25,4 @@ export { StageHealthBar, type StageHealthBarProps } from './StageHealthBar';
 /** @deprecated formatStageHealthBar is no longer used by StageHealthBar (now Ink-native). Kept for backward compatibility. */
 export { formatStageHealthBar } from './stage-health.pure';
 export { computeStageHealth, detectBottlenecks } from './stage-health.pure';
+export { computeGridLayout } from './grid-layout.pure';

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -8,6 +8,11 @@ import { FlowMap } from './components/FlowMap';
 import { FocusedAgentPanel } from './components/FocusedAgentPanel';
 import { StageHealthBar } from './components/StageHealthBar';
 import { computeStageHealth, detectBottlenecks } from './components/stage-health.pure';
+import { computeGridLayout } from './components/grid-layout.pure';
+
+const EMPTY_OBJECTIVES: string[] = [];
+const EMPTY_INPUTS: string[] = [];
+const EMPTY_OUTPUTS = { files: 0, commits: 0 } as const;
 
 export interface DashboardAppProps {
   eventBus?: TuiEventBus;
@@ -32,66 +37,69 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
 
   const bottlenecks = useMemo(() => detectBottlenecks(state.eventLog), [state.eventLog]);
 
-  const mainHeight = Math.max(rows - 6, 10);
-  const flowMapWidth =
-    layoutMode === 'wide'
-      ? Math.floor(columns * 0.45)
-      : layoutMode === 'medium'
-        ? Math.floor(columns * 0.4)
-        : columns;
-
-  const focusedAgentPanel = (
-    <FocusedAgentPanel
-      agent={focusedAgent}
-      objectives={[]}
-      tasks={state.tasks}
-      tools={tools}
-      inputs={[]}
-      outputs={{ files: 0, commits: 0 }}
-      eventLog={state.eventLog}
-    />
+  const grid = useMemo(
+    () => computeGridLayout(columns, rows, layoutMode),
+    [columns, rows, layoutMode],
   );
 
   return (
-    <Box flexDirection="column" width={columns}>
+    <Box flexDirection="column" width={grid.total.width} height={grid.total.height}>
       <HeaderBar
         workspace={state.workspace}
         sessionId={state.sessionId}
         currentMode={state.currentMode}
         globalState={state.globalState}
         layoutMode={layoutMode}
-        width={columns}
+        width={grid.header.width}
       />
       {layoutMode === 'narrow' ? (
         <Box flexDirection="column">
-          {focusedAgentPanel}
+          <FocusedAgentPanel
+            agent={focusedAgent}
+            objectives={EMPTY_OBJECTIVES}
+            tasks={state.tasks}
+            tools={tools}
+            inputs={EMPTY_INPUTS}
+            outputs={EMPTY_OUTPUTS}
+            eventLog={state.eventLog}
+            width={grid.focusedAgent.width}
+            height={grid.focusedAgent.height}
+          />
           <FlowMap
             agents={state.agents}
             edges={state.edges}
             layoutMode={layoutMode}
-            width={columns}
-            height={5}
+            width={grid.flowMap.width}
+            height={grid.flowMap.height}
           />
         </Box>
       ) : (
-        <Box flexDirection="row" height={mainHeight}>
-          <Box width={flowMapWidth}>
-            <FlowMap
-              agents={state.agents}
-              edges={state.edges}
-              layoutMode={layoutMode}
-              width={flowMapWidth}
-              height={mainHeight}
-            />
-          </Box>
-          <Box flexGrow={1}>{focusedAgentPanel}</Box>
+        <Box flexDirection="row" width={grid.total.width} height={grid.flowMap.height}>
+          <FlowMap
+            agents={state.agents}
+            edges={state.edges}
+            layoutMode={layoutMode}
+            width={grid.flowMap.width}
+            height={grid.flowMap.height}
+          />
+          <FocusedAgentPanel
+            agent={focusedAgent}
+            objectives={EMPTY_OBJECTIVES}
+            tasks={state.tasks}
+            tools={tools}
+            inputs={EMPTY_INPUTS}
+            outputs={EMPTY_OUTPUTS}
+            eventLog={state.eventLog}
+            width={grid.focusedAgent.width}
+            height={grid.focusedAgent.height}
+          />
         </Box>
       )}
       <StageHealthBar
         stageHealth={stageHealth}
         bottlenecks={bottlenecks}
         tokenCount={0}
-        width={columns}
+        width={grid.stageHealth.width}
       />
     </Box>
   );

--- a/apps/mcp-server/src/tui/dashboard-types.spec.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.spec.ts
@@ -6,6 +6,8 @@ import {
   getLayoutMode,
   type DashboardNode,
   type StageStats,
+  type GridRegion,
+  type DashboardGrid,
 } from './dashboard-types';
 
 describe('tui/dashboard-types', () => {
@@ -115,6 +117,31 @@ describe('tui/dashboard-types', () => {
 
       expect(stats1).not.toBe(stats2);
       expect(stats1).toEqual(stats2);
+    });
+  });
+
+  describe('GridRegion / DashboardGrid types', () => {
+    it('GridRegion has required fields', () => {
+      const region: GridRegion = { x: 0, y: 0, width: 120, height: 3 };
+      expect(region.x).toBe(0);
+      expect(region.y).toBe(0);
+      expect(region.width).toBe(120);
+      expect(region.height).toBe(3);
+    });
+
+    it('DashboardGrid has all required sections', () => {
+      const grid: DashboardGrid = {
+        header: { x: 0, y: 0, width: 120, height: 3 },
+        flowMap: { x: 0, y: 3, width: 54, height: 34 },
+        focusedAgent: { x: 54, y: 3, width: 66, height: 34 },
+        stageHealth: { x: 0, y: 37, width: 120, height: 3 },
+        total: { width: 120, height: 40 },
+      };
+      expect(grid.header).toBeDefined();
+      expect(grid.flowMap).toBeDefined();
+      expect(grid.focusedAgent).toBeDefined();
+      expect(grid.stageHealth).toBeDefined();
+      expect(grid.total).toBeDefined();
     });
   });
 });

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -136,3 +136,26 @@ export interface DashboardState {
   tasks: TaskItem[];
   eventLog: EventLogEntry[];
 }
+
+/**
+ * A rectangular region in the terminal grid.
+ * All values are in character units (columns/rows), 0-based.
+ */
+export interface GridRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Pre-computed layout for all dashboard sections.
+ * Every section has deterministic (x, y, width, height).
+ */
+export interface DashboardGrid {
+  header: GridRegion;
+  flowMap: GridRegion;
+  focusedAgent: GridRegion;
+  stageHealth: GridRegion;
+  total: Pick<GridRegion, 'width' | 'height'>;
+}


### PR DESCRIPTION
## Summary

Closes #458

Replace ad-hoc flexbox layout with a deterministic grid layout system that pre-computes exact `(x, y, width, height)` for every dashboard section. This eliminates layout drift across terminal sizes and ensures pixel-perfect tiling.

### Key Changes

- **`grid-layout.pure.ts`** — Pure function `computeGridLayout(columns, rows, layoutMode)` returns a `DashboardGrid` with deterministic regions for header, flowMap, focusedAgent, and stageHealth
- **`dashboard-types.ts`** — Added `GridRegion` and `DashboardGrid` types; `DashboardGrid.total` uses `Pick<GridRegion, 'width' | 'height'>` for type precision
- **`dashboard-app.tsx`** — Integrated grid layout via `useMemo`; hoisted inline literals (`EMPTY_OBJECTIVES`, `EMPTY_INPUTS`, `EMPTY_OUTPUTS`) to module-scope constants; removed unnecessary double `<Box>` wrapping
- **`FocusedAgentPanel.tsx`** — Added optional `width`/`height` props for grid-driven sizing
- **`HeaderBar.tsx`** — Extracted magic number to `HEADER_RESERVED_CHARS` constant; replaced `justifyContent="space-between"` with `flexGrow` spacers
- **`StageHealthBar.tsx`** — Replaced `justifyContent="space-between"` with `flexGrow` spacer for consistent Ink layout

### Layout Modes

| Mode | Terminal Width | Strategy |
|------|---------------|----------|
| `wide` | >= 120 cols | 45% flowMap / 55% focusedAgent side-by-side |
| `medium` | 80-119 cols | 40% / 60% side-by-side |
| `narrow` | < 80 cols | Vertical stack (focusedAgent → flowMap) |

### Invariants Guaranteed

- No regions overlap
- No gaps (total area = sum of region areas)
- All regions have positive dimensions
- All regions fit within terminal bounds
- Degenerate sizes clamped to MIN_ROWS=8, MIN_COLUMNS=20

## Test plan

- [x] 47 grid-layout tests covering wide, medium, narrow modes
- [x] Overlap detection, area conservation, positive dimension checks
- [x] Boundary clamping for degenerate terminal sizes (rows=5, cols=10, both)
- [x] Border-aware content dimension checks at minimum and standard sizes
- [x] FocusedAgentPanel width/height prop tests (with agent and null agent)
- [x] GridRegion/DashboardGrid type validation tests
- [x] Full test suite: 157 files, 3586 tests passed