### PR TITLE
feat(mcp-server): add TDD execution continuity rules to prevent RED phase halt

### DIFF
--- a/.claude/rules/custom-instructions.md
+++ b/.claude/rules/custom-instructions.md
@@ -53,6 +53,35 @@ Follow the common rules defined in `packages/rules/.ai-rules/` for consistency a
 
 See [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md) for details.
 
+## 🔴 MANDATORY: TDD Execution Continuity
+
+<TDD_CONTINUITY_RULE>
+
+**TDD RED phase test failures are expected results and are NOT a reason to halt implementation.**
+
+### Test Failure Classification
+
+| Type | Description | Action |
+|------|-------------|--------|
+| **Expected RED** | Intentional test failure in TDD RED phase | Proceed to GREEN phase immediately |
+| **Unexpected Failure** | Test that should pass but doesn't | Stop and analyze root cause |
+
+### RED-GREEN-REFACTOR is an Atomic Operation
+
+1. **RED**: Write failing test -> Run to confirm failure -> **DO NOT STOP**
+2. **GREEN**: Write minimal implementation -> Run to confirm pass
+3. **REFACTOR**: Refactor -> Confirm tests still pass
+
+**Do not wait for user input until all three phases are complete.**
+
+### TDD Step Handling During Plan Execution
+
+Even if plan separates TDD into individual steps (e.g., Step 1: Write test, Step 2: Verify fails, Step 3: Implement):
+- When a step containing **"Expected: FAIL" or "verify it fails"** results in test failure -> Proceed to next step immediately
+- This **takes precedence** over the executing-plans skill's "STOP on test fail" rule
+
+</TDD_CONTINUITY_RULE>
+
 ## 🔴 MANDATORY: Keyword Mode Detection
 
 <CODINGBUDDY_CRITICAL_RULE>

--- a/apps/mcp-server/src/keyword/keyword.service.spec.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.spec.ts
@@ -1169,6 +1169,20 @@ describe('KeywordService', () => {
       // activation_message.formatted에 포함된 agent 이름이 instructions에도 포함
       expect(result.instructions).toContain(result.activation_message!.formatted);
     });
+
+    it('ACT mode default instructions include TDD continuity rule', async () => {
+      // Use default config fallback (loadConfigFn fails → DEFAULT_CONFIG with enriched instructions)
+      const fallbackService = new KeywordService(
+        vi.fn().mockRejectedValue(new Error('Config not found')),
+        mockLoadRule,
+        mockLoadAgentInfo,
+      );
+      const result = await fallbackService.parseMode('ACT implement feature');
+
+      expect(result.instructions).toContain('RED phase test failures are EXPECTED');
+      expect(result.instructions).toContain('do NOT stop');
+      expect(result.instructions).toContain('atomic operation');
+    });
   });
 
   describe('recommendedActAgent parameter (ACT mode agent override)', () => {

--- a/apps/mcp-server/src/keyword/keyword.service.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.ts
@@ -150,7 +150,11 @@ const DEFAULT_CONFIG: KeywordModesConfig = {
       // Enriched instructions: context prefix + ACT-specific guidance + mandatory action suffix
       instructions:
         '🔴 CONTEXT: contextDocument contains PLAN decisions and recommendedActAgent. Use this context! ' +
-        'Follow Red-Green-Refactor cycle. Use recommended agent from PLAN. ' +
+        'Follow Red-Green-Refactor cycle. ' +
+        '⚠️ TDD CONTINUITY: RED phase test failures are EXPECTED — do NOT stop or wait for user input. ' +
+        'Proceed to GREEN phase immediately. Treat RED→GREEN→REFACTOR as ONE atomic operation. ' +
+        "Only stop on UNEXPECTED failures (tests that should pass but don't). " +
+        'Use recommended agent from PLAN. ' +
         '📝 MANDATORY BEFORE COMPLETION: Call update_context with mode=ACT, task (what was done), decisions, and notes. ' +
         'Decisions and notes will be APPENDED to existing content.',
       agent: MODE_AGENTS[1],

--- a/apps/mcp-server/src/shared/keyword-core.spec.ts
+++ b/apps/mcp-server/src/shared/keyword-core.spec.ts
@@ -357,6 +357,15 @@ describe('getDefaultModeConfig', () => {
       expect(config.modes[mode]).not.toHaveProperty('defaultSpecialists');
     }
   });
+
+  it('ACT mode instructions include TDD continuity guidance', () => {
+    const config = getDefaultModeConfig();
+    const actInstructions = config.modes.ACT.instructions;
+
+    expect(actInstructions).toContain('RED phase test failures are expected');
+    expect(actInstructions).toContain('do not stop');
+    expect(actInstructions).toContain('atomic operation');
+  });
 });
 
 // ============================================================================

--- a/apps/mcp-server/src/shared/keyword-core.ts
+++ b/apps/mcp-server/src/shared/keyword-core.ts
@@ -111,7 +111,9 @@ export function getDefaultModeConfig(): KeywordModesConfig {
       ACT: {
         description: 'Actual task execution phase',
         instructions:
-          'Follow Red-Green-Refactor cycle. Implement minimally then improve incrementally. Verify quality standards.',
+          'Follow Red-Green-Refactor cycle. RED phase test failures are expected — do not stop, proceed to GREEN immediately. ' +
+          'Treat RED→GREEN→REFACTOR as one atomic operation. ' +
+          'Implement minimally then improve incrementally. Verify quality standards.',
         rules: ['rules/core.md', 'rules/project.md', 'rules/augmented-coding.md'],
       },
       EVAL: {

--- a/packages/rules/.ai-rules/rules/core.md
+++ b/packages/rules/.ai-rules/rules/core.md
@@ -410,8 +410,12 @@ Execute implementation following TDD cycle, augmented coding principles, and qua
 1. **Execute TDD Cycle** (via Primary Developer Agent)
    - 🔴 For core logic: Red → Green → Refactor cycle
    - Write failing test first
+   - Run test to confirm it fails (this is **expected** — do NOT stop here)
    - Implement minimal code to pass
+   - Run test to confirm it passes
    - Refactor only after tests pass
+   - 🔴 **Required**: Treat RED→GREEN→REFACTOR as ONE atomic operation
+   - 🔴 **Required**: Only stop on UNEXPECTED test failures (GREEN phase failures)
    - 🔴 **Required**: Follow Primary Developer Agent's TDD cycle
 
 2. **Implement Components** (via Primary Developer Agent)


### PR DESCRIPTION
## Summary

Closes #463

Adds a 4-layer defense strategy to prevent AI agents from halting implementation when encountering expected RED phase test failures during TDD workflow. The RED→GREEN→REFACTOR cycle is now treated as one atomic operation across all instruction layers.

### Changes

- **`.claude/rules/custom-instructions.md`** — Add `TDD_CONTINUITY_RULE` project-level override with test failure classification table (Expected RED vs Unexpected Failure) and explicit plan execution step handling that overrides external skill's "STOP on test fail" rule
- **`apps/mcp-server/src/shared/keyword-core.ts`** — Add TDD continuity guidance to ACT base instructions (single source of truth for standalone/serverless consumers)
- **`apps/mcp-server/src/keyword/keyword.service.ts`** — Add TDD continuity rule with stronger emphasis to ACT enriched instructions in `DEFAULT_CONFIG` (used as fallback when config loading fails)
- **`packages/rules/.ai-rules/rules/core.md`** — Expand TDD cycle description with failure classification rules, shared across all AI assistants (Cursor, Claude Code, Codex, Q, Kiro, Antigravity)
- **`apps/mcp-server/src/shared/keyword-core.spec.ts`** — Add test verifying ACT base instructions contain TDD continuity keywords
- **`apps/mcp-server/src/keyword/keyword.service.spec.ts`** — Add test using fallback service (rejected `loadConfigFn`) to verify `DEFAULT_CONFIG` enriched instructions contain TDD continuity rule

### 4-Layer Defense Strategy

| Layer | File | Purpose |
|-------|------|---------|
| 1 | `.claude/rules/custom-instructions.md` | Project-level override for Claude Code (highest priority) |
| 2 | `keyword-core.ts` (base) | Standalone/serverless consumers |
| 3 | `keyword.service.ts` (enriched) | NestJS MCP server with stronger emphasis |
| 4 | `core.md` (shared rules) | Cross-tool consistency for all AI assistants |

## Test Plan

- [x] `keyword-core.spec.ts` — ACT base instructions contain `RED phase test failures are expected`, `do not stop`, `atomic operation`
- [x] `keyword.service.spec.ts` — ACT enriched instructions (via DEFAULT_CONFIG fallback) contain `RED phase test failures are EXPECTED`, `do NOT stop`, `atomic operation`
- [x] All 3,602 existing tests pass with no regressions
- [x] `tsc --noEmit` type check passes