### PR TITLE
double focusedAgent panel width (wide: 35→70, medium: 32→64)

### DIFF
--- a/apps/mcp-server/src/tui/components/grid-layout.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/grid-layout.pure.spec.ts
@@ -27,12 +27,12 @@ describe('computeGridLayout', () => {
       expect(grid.stageHealth.y + grid.stageHealth.height).toBe(40);
     });
 
-    it('focusedAgent has fixed width 35 in wide mode', () => {
-      expect(grid.focusedAgent.width).toBe(35);
+    it('focusedAgent has fixed width 70 in wide mode', () => {
+      expect(grid.focusedAgent.width).toBe(70);
     });
 
     it('flowMap takes all remaining width after focusedAgent', () => {
-      expect(grid.flowMap.width).toBe(120 - 35);
+      expect(grid.flowMap.width).toBe(120 - 70);
     });
 
     it('focusedAgent is right-aligned', () => {
@@ -63,12 +63,12 @@ describe('computeGridLayout', () => {
   describe('medium layout (100x30)', () => {
     const grid = computeGridLayout(100, 30, 'medium');
 
-    it('focusedAgent has fixed width 32 in medium mode', () => {
-      expect(grid.focusedAgent.width).toBe(32);
+    it('focusedAgent has fixed width 64 in medium mode', () => {
+      expect(grid.focusedAgent.width).toBe(64);
     });
 
     it('flowMap takes all remaining width after focusedAgent', () => {
-      expect(grid.flowMap.width).toBe(100 - 32);
+      expect(grid.flowMap.width).toBe(100 - 64);
     });
 
     it('focusedAgent is right-aligned', () => {
@@ -266,7 +266,7 @@ describe('computeGridLayout', () => {
   });
 
   describe('edge case: terminal narrower than focused width + MIN_COLUMNS', () => {
-    // medium mode but only 60 columns (< 45 + 20 = 65, but clamp ensures flowMap >= MIN_COLUMNS)
+    // medium mode but only 60 columns (< 64 + 20 = 84, but clamp ensures flowMap >= MIN_COLUMNS)
     const grid = computeGridLayout(60, 30, 'medium');
 
     it('focusedAgent width is clamped so flowMap gets at least MIN_COLUMNS', () => {
@@ -288,13 +288,13 @@ describe('computeGridLayout', () => {
       const grid150 = computeGridLayout(150, 40, 'wide');
       const grid200 = computeGridLayout(200, 40, 'wide');
 
-      // focusedAgent stays at 35 in both
-      expect(grid150.focusedAgent.width).toBe(35);
-      expect(grid200.focusedAgent.width).toBe(35);
+      // focusedAgent stays at 70 in both
+      expect(grid150.focusedAgent.width).toBe(70);
+      expect(grid200.focusedAgent.width).toBe(70);
 
       // flowMap grows with terminal width
-      expect(grid150.flowMap.width).toBe(115);
-      expect(grid200.flowMap.width).toBe(165);
+      expect(grid150.flowMap.width).toBe(80);
+      expect(grid200.flowMap.width).toBe(130);
     });
   });
 

--- a/apps/mcp-server/src/tui/components/grid-layout.pure.ts
+++ b/apps/mcp-server/src/tui/components/grid-layout.pure.ts
@@ -13,8 +13,8 @@ const MIN_COLUMNS = 20;
 
 /** Fixed width for focusedAgent panel per layout mode (content-first right panel). */
 const FOCUSED_AGENT_WIDTH: Record<Exclude<LayoutMode, 'narrow'>, number> = {
-  wide: 35,
-  medium: 32,
+  wide: 70,
+  medium: 64,
 };
 
 /**


### PR DESCRIPTION
## Summary

- Double `FOCUSED_AGENT_WIDTH` constants to provide more content display space in the focusedAgent panel
  - `wide`: 35 → **70**
  - `medium`: 32 → **64**
- Update 8 test assertions to match new width values
- Update 3 stale test descriptions and comments to reflect new values

Closes #466

## Changes

### `grid-layout.pure.ts`
- `FOCUSED_AGENT_WIDTH.wide`: 35 → 70
- `FOCUSED_AGENT_WIDTH.medium`: 32 → 64

### `grid-layout.pure.spec.ts`
- Updated 8 assertion values across wide/medium/scaling test cases
- Fixed 2 test description strings (`width 35` → `width 70`, `width 32` → `width 64`)
- Fixed 1 comment (`45 + 20 = 65` → `64 + 20 = 84`)

## Clamping Safety

| Scenario | focusedAgent | flowMap | Status |
|---|---|---|---|
| wide 120cols | `min(70, 100) = 70` | 50 | OK |
| medium 100cols | `min(64, 80) = 64` | 36 | OK |
| medium 80cols | `min(64, 60) = 60` | 20 | OK (clamped) |
| narrow | full width | full width | No change |

No layout logic changes required — existing clamping (`Math.min`) handles all edge cases.

## Test plan

- [x] All 61 grid-layout tests pass
- [x] Full test suite: 157 files, 3638 tests passed, 0 failures
- [x] Invariant tests (no overlap, no gap, bounds) pass without modification
- [x] Clamping edge cases (narrow terminal) pass