### PR TITLE
feat(tui): add MonitorPanel with event log, timeline, and tasks

### DIFF
--- a/apps/mcp-server/src/tui/components/FlowMap.tsx
+++ b/apps/mcp-server/src/tui/components/FlowMap.tsx
@@ -66,6 +66,10 @@ export function FlowMap({
   height,
   activeStage = null,
 }: FlowMapProps): React.ReactElement {
+  // Border consumes 2 chars width + 2 lines height; header "FLOW MAP" takes 1 line
+  const contentWidth = Math.max(1, width - 2);
+  const contentHeight = Math.max(1, height - 3);
+
   const compactContent = useMemo(() => {
     if (layoutMode !== 'narrow') return null;
     return renderFlowMapCompact(agents);
@@ -75,14 +79,20 @@ export function FlowMap({
     if (layoutMode === 'narrow') return null;
     const buf =
       layoutMode === 'wide'
-        ? renderFlowMap(agents, edges, width, height, activeStage)
-        : renderFlowMapSimplified(agents, width, height);
+        ? renderFlowMap(agents, edges, contentWidth, contentHeight, activeStage)
+        : renderFlowMapSimplified(agents, contentWidth, contentHeight);
     return buf.toLinesDirect();
-  }, [agents, edges, width, height, layoutMode, activeStage]);
+  }, [agents, edges, contentWidth, contentHeight, layoutMode, activeStage]);
 
   if (layoutMode === 'narrow') {
     return (
-      <Box flexDirection="column">
+      <Box
+        borderStyle="single"
+        borderColor="gray"
+        flexDirection="column"
+        width={width}
+        height={height}
+      >
         <Text bold color="cyan">
           FLOW MAP
         </Text>
@@ -93,7 +103,13 @@ export function FlowMap({
 
   if (!lines) {
     return (
-      <Box flexDirection="column" width={width}>
+      <Box
+        borderStyle="single"
+        borderColor="gray"
+        flexDirection="column"
+        width={width}
+        height={height}
+      >
         <Text bold color="cyan">
           FLOW MAP
         </Text>
@@ -102,7 +118,13 @@ export function FlowMap({
   }
 
   return (
-    <Box flexDirection="column" width={width}>
+    <Box
+      borderStyle="single"
+      borderColor="gray"
+      flexDirection="column"
+      width={width}
+      height={height}
+    >
       <Text bold color="cyan">
         FLOW MAP
       </Text>

--- a/apps/mcp-server/src/tui/components/MonitorPanel.spec.tsx
+++ b/apps/mcp-server/src/tui/components/MonitorPanel.spec.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { MonitorPanel } from './MonitorPanel';
+import { createDefaultDashboardNode } from '../dashboard-types';
+import type { EventLogEntry, DashboardNode, TaskItem } from '../dashboard-types';
+
+function makeAgents(): Map<string, DashboardNode> {
+  const agents = new Map<string, DashboardNode>();
+  agents.set(
+    'a1',
+    createDefaultDashboardNode({
+      id: 'a1',
+      name: 'architect',
+      stage: 'PLAN',
+      status: 'running',
+      isPrimary: true,
+      progress: 75,
+    }),
+  );
+  agents.set(
+    'a2',
+    createDefaultDashboardNode({
+      id: 'a2',
+      name: 'tester',
+      stage: 'ACT',
+      status: 'idle',
+      progress: 30,
+    }),
+  );
+  return agents;
+}
+
+function makeEventLog(): EventLogEntry[] {
+  return [
+    { timestamp: '10:01', message: 'Agent started', level: 'info' },
+    { timestamp: '10:02', message: 'Tool called', level: 'info' },
+    { timestamp: '10:03', message: 'Error occurred', level: 'error' },
+  ];
+}
+
+function makeTasks(): TaskItem[] {
+  return [
+    { id: '1', subject: 'Write tests', completed: true },
+    { id: '2', subject: 'Implement feature', completed: false },
+    { id: '3', subject: 'Code review', completed: false },
+  ];
+}
+
+describe('tui/components/MonitorPanel', () => {
+  it('should render all three sub-panels with headers', () => {
+    const { lastFrame } = render(
+      <MonitorPanel
+        eventLog={makeEventLog()}
+        agents={makeAgents()}
+        tasks={makeTasks()}
+        width={90}
+        height={10}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Event Log');
+    expect(frame).toContain('Timeline');
+    expect(frame).toContain('Tasks');
+  });
+
+  it('should show empty-state messages when data is empty', () => {
+    const { lastFrame } = render(
+      <MonitorPanel eventLog={[]} agents={new Map()} tasks={[]} width={90} height={10} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('No events');
+    expect(frame).toContain('No agents');
+    expect(frame).toContain('No tasks');
+  });
+
+  it('should render event log entries and agent names when data is present', () => {
+    const { lastFrame } = render(
+      <MonitorPanel
+        eventLog={makeEventLog()}
+        agents={makeAgents()}
+        tasks={makeTasks()}
+        width={90}
+        height={10}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Agent started');
+    expect(frame).toContain('architect');
+    expect(frame).toContain('Write tests');
+  });
+
+  it('should render without crashing when width=0 or height=0', () => {
+    const renderZeroWidth = () =>
+      render(
+        <MonitorPanel
+          eventLog={makeEventLog()}
+          agents={makeAgents()}
+          tasks={makeTasks()}
+          width={0}
+          height={10}
+        />,
+      );
+    expect(renderZeroWidth).not.toThrow();
+
+    const renderZeroHeight = () =>
+      render(
+        <MonitorPanel
+          eventLog={makeEventLog()}
+          agents={makeAgents()}
+          tasks={makeTasks()}
+          width={90}
+          height={0}
+        />,
+      );
+    expect(renderZeroHeight).not.toThrow();
+  });
+});

--- a/apps/mcp-server/src/tui/components/MonitorPanel.tsx
+++ b/apps/mcp-server/src/tui/components/MonitorPanel.tsx
@@ -1,0 +1,93 @@
+import React, { useMemo } from 'react';
+import { Box, Text } from 'ink';
+import type { EventLogEntry, DashboardNode, TaskItem } from '../dashboard-types';
+import { renderEventLog, renderAgentTimeline, renderTaskProgress } from './monitor-panel.pure';
+
+/**
+ * Props for MonitorPanel component.
+ *
+ * Reference stability contract: `eventLog`, `agents`, and `tasks` must be
+ * stable references across renders (e.g. stored in useState/useRef) for
+ * useMemo to be effective. Passing new instances on every render defeats
+ * memoization.
+ */
+export interface MonitorPanelProps {
+  eventLog: EventLogEntry[];
+  agents: Map<string, DashboardNode>;
+  tasks: TaskItem[];
+  width: number;
+  height: number;
+}
+
+export function MonitorPanel({
+  eventLog,
+  agents,
+  tasks,
+  width,
+  height,
+}: MonitorPanelProps): React.ReactElement {
+  if (width <= 0 || height <= 0) {
+    return <Box />;
+  }
+
+  const logWidth = Math.floor(width / 3);
+  const timelineWidth = Math.floor(width / 3);
+  const taskWidth = width - logWidth - timelineWidth;
+
+  // Border consumes 2 chars width + 2 lines height per sub-panel
+  const logContentWidth = Math.max(1, logWidth - 2);
+  const timelineContentWidth = Math.max(1, timelineWidth - 2);
+  const taskContentWidth = Math.max(1, taskWidth - 2);
+  const contentHeight = Math.max(1, height - 2);
+
+  const logLines = useMemo(
+    () => renderEventLog(eventLog, logContentWidth, contentHeight),
+    [eventLog, logContentWidth, contentHeight],
+  );
+  const timelineLines = useMemo(
+    () => renderAgentTimeline(agents, timelineContentWidth, contentHeight),
+    [agents, timelineContentWidth, contentHeight],
+  );
+  const taskLines = useMemo(
+    () => renderTaskProgress(tasks, taskContentWidth, contentHeight),
+    [tasks, taskContentWidth, contentHeight],
+  );
+
+  return (
+    <Box flexDirection="row" width={width} height={height}>
+      <Box
+        borderStyle="single"
+        borderColor="gray"
+        flexDirection="column"
+        width={logWidth}
+        height={height}
+      >
+        {logLines.map((line, i) => (
+          <Text key={i}>{line}</Text>
+        ))}
+      </Box>
+      <Box
+        borderStyle="single"
+        borderColor="gray"
+        flexDirection="column"
+        width={timelineWidth}
+        height={height}
+      >
+        {timelineLines.map((line, i) => (
+          <Text key={i}>{line}</Text>
+        ))}
+      </Box>
+      <Box
+        borderStyle="single"
+        borderColor="gray"
+        flexDirection="column"
+        width={taskWidth}
+        height={height}
+      >
+        {taskLines.map((line, i) => (
+          <Text key={i}>{line}</Text>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/mcp-server/src/tui/components/grid-layout.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/grid-layout.pure.spec.ts
@@ -39,9 +39,22 @@ describe('computeGridLayout', () => {
       expect(grid.focusedAgent.x + grid.focusedAgent.width).toBe(120);
     });
 
-    it('flowMap and focusedAgent fill the main area height', () => {
+    it('flowMap and monitorPanel split the left column height evenly', () => {
+      const mainHeight = 40 - 3 - 3; // 34
+      const flowMapHeight = Math.ceil(mainHeight / 2); // 17
+      const monitorHeight = mainHeight - flowMapHeight; // 17
+      expect(grid.flowMap.height).toBe(flowMapHeight);
+      expect(grid.monitorPanel.height).toBe(monitorHeight);
+    });
+
+    it('monitorPanel sits below flowMap with same width', () => {
+      expect(grid.monitorPanel.x).toBe(0);
+      expect(grid.monitorPanel.y).toBe(grid.flowMap.y + grid.flowMap.height);
+      expect(grid.monitorPanel.width).toBe(grid.flowMap.width);
+    });
+
+    it('focusedAgent spans full main height', () => {
       const mainHeight = 40 - 3 - 3;
-      expect(grid.flowMap.height).toBe(mainHeight);
       expect(grid.focusedAgent.height).toBe(mainHeight);
     });
 
@@ -77,7 +90,24 @@ describe('computeGridLayout', () => {
 
     it('main area height is total - header(3) - stageHealth(3)', () => {
       const mainHeight = 30 - 3 - 3;
-      expect(grid.flowMap.height).toBe(mainHeight);
+      expect(grid.focusedAgent.height).toBe(mainHeight);
+    });
+
+    it('flowMap and monitorPanel split the left column height', () => {
+      const mainHeight = 30 - 3 - 3; // 24
+      const flowMapHeight = Math.ceil(mainHeight / 2); // 12
+      const monitorHeight = mainHeight - flowMapHeight; // 12
+      expect(grid.flowMap.height).toBe(flowMapHeight);
+      expect(grid.monitorPanel.height).toBe(monitorHeight);
+    });
+
+    it('monitorPanel sits below flowMap', () => {
+      expect(grid.monitorPanel.y).toBe(grid.flowMap.y + grid.flowMap.height);
+      expect(grid.monitorPanel.width).toBe(grid.flowMap.width);
+    });
+
+    it('focusedAgent spans full main height', () => {
+      const mainHeight = 30 - 3 - 3;
       expect(grid.focusedAgent.height).toBe(mainHeight);
     });
   });
@@ -115,6 +145,10 @@ describe('computeGridLayout', () => {
       expect(grid.header.y).toBeLessThan(grid.focusedAgent.y);
       expect(grid.focusedAgent.y).toBeLessThan(grid.flowMap.y);
       expect(grid.flowMap.y).toBeLessThan(grid.stageHealth.y);
+    });
+
+    it('monitorPanel is hidden in narrow mode', () => {
+      expect(grid.monitorPanel).toEqual({ x: 0, y: 0, width: 0, height: 0 });
     });
   });
 
@@ -176,8 +210,19 @@ describe('computeGridLayout', () => {
     for (const tc of testCases) {
       describe(tc.name, () => {
         const grid = computeGridLayout(tc.cols, tc.rows, tc.mode);
-        const regions = [grid.header, grid.flowMap, grid.focusedAgent, grid.stageHealth];
-        const regionNames = ['header', 'flowMap', 'focusedAgent', 'stageHealth'];
+        const allRegions = [
+          grid.header,
+          grid.flowMap,
+          grid.focusedAgent,
+          grid.stageHealth,
+          grid.monitorPanel,
+        ];
+        const allNames = ['header', 'flowMap', 'focusedAgent', 'stageHealth', 'monitorPanel'];
+        // narrow 모드에서는 monitorPanel이 0x0이므로 필터링
+        const regions = allRegions.filter(r => r.width > 0 && r.height > 0);
+        const regionNames = allNames.filter(
+          (_, i) => allRegions[i].width > 0 && allRegions[i].height > 0,
+        );
 
         it('no regions overlap', () => {
           for (let i = 0; i < regions.length; i++) {
@@ -245,7 +290,14 @@ describe('computeGridLayout', () => {
 
     it('clamped layout still satisfies all invariants', () => {
       const grid = computeGridLayout(5, 3, 'narrow');
-      const regions = [grid.header, grid.flowMap, grid.focusedAgent, grid.stageHealth];
+      const allRegions = [
+        grid.header,
+        grid.flowMap,
+        grid.focusedAgent,
+        grid.stageHealth,
+        grid.monitorPanel,
+      ];
+      const regions = allRegions.filter(r => r.width > 0 && r.height > 0);
 
       // No overlap
       for (let i = 0; i < regions.length; i++) {
@@ -316,6 +368,8 @@ describe('computeGridLayout', () => {
       expect(grid.focusedAgent.height - 2).toBeGreaterThanOrEqual(1);
       expect(grid.flowMap.width - 2).toBeGreaterThanOrEqual(1);
       expect(grid.flowMap.height - 2).toBeGreaterThanOrEqual(1);
+      expect(grid.monitorPanel.width - 2).toBeGreaterThanOrEqual(1);
+      expect(grid.monitorPanel.height - 2).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/apps/mcp-server/src/tui/components/grid-layout.pure.ts
+++ b/apps/mcp-server/src/tui/components/grid-layout.pure.ts
@@ -53,6 +53,7 @@ export function computeGridLayout(
       header,
       focusedAgent: { x: 0, y: mainY, width: cols, height: focusedHeight },
       flowMap: { x: 0, y: mainY + focusedHeight, width: cols, height: flowMapHeight },
+      monitorPanel: { x: 0, y: 0, width: 0, height: 0 },
       stageHealth,
       total: { width: cols, height: r },
     };
@@ -60,10 +61,13 @@ export function computeGridLayout(
 
   const focusedWidth = Math.min(FOCUSED_AGENT_WIDTH[layoutMode], cols - MIN_COLUMNS);
   const flowMapWidth = cols - focusedWidth;
+  const flowMapHeight = Math.ceil(mainHeight / 2);
+  const monitorHeight = mainHeight - flowMapHeight;
 
   return {
     header,
-    flowMap: { x: 0, y: mainY, width: flowMapWidth, height: mainHeight },
+    flowMap: { x: 0, y: mainY, width: flowMapWidth, height: flowMapHeight },
+    monitorPanel: { x: 0, y: mainY + flowMapHeight, width: flowMapWidth, height: monitorHeight },
     focusedAgent: { x: flowMapWidth, y: mainY, width: focusedWidth, height: mainHeight },
     stageHealth,
     total: { width: cols, height: r },

--- a/apps/mcp-server/src/tui/components/index.ts
+++ b/apps/mcp-server/src/tui/components/index.ts
@@ -26,3 +26,5 @@ export { StageHealthBar, type StageHealthBarProps } from './StageHealthBar';
 export { formatStageHealthBar } from './stage-health.pure';
 export { computeStageHealth, detectBottlenecks } from './stage-health.pure';
 export { computeGridLayout } from './grid-layout.pure';
+export { MonitorPanel, type MonitorPanelProps } from './MonitorPanel';
+export { renderEventLog, renderAgentTimeline, renderTaskProgress } from './monitor-panel.pure';

--- a/apps/mcp-server/src/tui/components/monitor-panel.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/monitor-panel.pure.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { renderEventLog, renderAgentTimeline, renderTaskProgress } from './monitor-panel.pure';
+import type { EventLogEntry, DashboardNode, TaskItem } from '../dashboard-types';
+
+describe('renderEventLog', () => {
+  const entries: EventLogEntry[] = [
+    { timestamp: '10:01', message: 'Agent started', level: 'info' },
+    { timestamp: '10:02', message: 'Tool called', level: 'info' },
+    { timestamp: '10:03', message: 'Error occurred', level: 'error' },
+  ];
+
+  it('returns header as first line', () => {
+    const lines = renderEventLog(entries, 30, 5);
+    expect(lines[0]).toContain('Event Log');
+  });
+
+  it('shows most recent entries last (chronological order)', () => {
+    const lines = renderEventLog(entries, 30, 5);
+    const content = lines.slice(1).join('\n');
+    expect(content).toContain('10:01');
+    expect(content).toContain('10:03');
+  });
+
+  it('limits output to height lines', () => {
+    const lines = renderEventLog(entries, 30, 3);
+    expect(lines.length).toBeLessThanOrEqual(3);
+  });
+
+  it('truncates long messages to width', () => {
+    const longEntries: EventLogEntry[] = [
+      { timestamp: '10:01', message: 'A'.repeat(100), level: 'info' },
+    ];
+    const lines = renderEventLog(longEntries, 20, 5);
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it('returns only header for empty entries', () => {
+    const lines = renderEventLog([], 30, 5);
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toContain('No events');
+  });
+
+  it('returns only header when height=1 and entries empty', () => {
+    const lines = renderEventLog([], 30, 1);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('Event Log');
+  });
+
+  it('returns empty array for height <= 0', () => {
+    expect(renderEventLog(entries, 30, 0)).toEqual([]);
+    expect(renderEventLog(entries, 30, -1)).toEqual([]);
+  });
+});
+
+describe('renderAgentTimeline', () => {
+  const agents = new Map<string, DashboardNode>([
+    [
+      'a1',
+      {
+        id: 'a1',
+        name: 'architect',
+        stage: 'PLAN',
+        status: 'running',
+        isPrimary: true,
+        progress: 75,
+      },
+    ],
+    [
+      'a2',
+      { id: 'a2', name: 'tester', stage: 'ACT', status: 'idle', isPrimary: false, progress: 30 },
+    ],
+  ]);
+
+  it('returns header as first line', () => {
+    const lines = renderAgentTimeline(agents, 30, 5);
+    expect(lines[0]).toContain('Timeline');
+  });
+
+  it('shows one line per agent with name and progress bar', () => {
+    const lines = renderAgentTimeline(agents, 30, 5);
+    const content = lines.slice(1).join('\n');
+    expect(content).toContain('architect');
+    expect(content).toContain('tester');
+  });
+
+  it('limits output to height lines', () => {
+    const lines = renderAgentTimeline(agents, 30, 3);
+    expect(lines.length).toBeLessThanOrEqual(3);
+  });
+
+  it('returns only header for empty agents', () => {
+    const lines = renderAgentTimeline(new Map(), 30, 5);
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toContain('No agents');
+  });
+
+  it('truncates agent names to fit width', () => {
+    const lines = renderAgentTimeline(agents, 15, 5);
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(15);
+    }
+  });
+
+  it('clamps progress > 100 without crashing', () => {
+    const overflowAgents = new Map<string, DashboardNode>([
+      [
+        'a1',
+        { id: 'a1', name: 'bot', stage: 'ACT', status: 'running', isPrimary: false, progress: 150 },
+      ],
+    ]);
+    const lines = renderAgentTimeline(overflowAgents, 30, 5);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    // Bar should be fully filled, not overflow
+    const barLine = lines[1];
+    expect(barLine).toBeDefined();
+    expect(barLine!.length).toBeLessThanOrEqual(30);
+  });
+
+  it('clamps negative progress without crashing', () => {
+    const negAgents = new Map<string, DashboardNode>([
+      [
+        'a1',
+        { id: 'a1', name: 'bot', stage: 'ACT', status: 'error', isPrimary: false, progress: -20 },
+      ],
+    ]);
+    const lines = renderAgentTimeline(negAgents, 30, 5);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    const barLine = lines[1];
+    expect(barLine).toBeDefined();
+    expect(barLine!.length).toBeLessThanOrEqual(30);
+  });
+
+  it('returns only header when height=1 and agents empty', () => {
+    const lines = renderAgentTimeline(new Map(), 30, 1);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('Timeline');
+  });
+
+  it('returns empty array for height <= 0', () => {
+    expect(renderAgentTimeline(agents, 30, 0)).toEqual([]);
+    expect(renderAgentTimeline(agents, 30, -1)).toEqual([]);
+  });
+});
+
+describe('renderTaskProgress', () => {
+  const tasks: TaskItem[] = [
+    { id: '1', subject: 'Write tests', completed: true },
+    { id: '2', subject: 'Implement feature', completed: false },
+    { id: '3', subject: 'Code review', completed: false },
+  ];
+
+  it('returns header as first line with completion summary', () => {
+    const lines = renderTaskProgress(tasks, 30, 6);
+    expect(lines[0]).toContain('Tasks');
+    expect(lines[0]).toContain('1/3');
+  });
+
+  it('shows completed tasks with checkmark', () => {
+    const lines = renderTaskProgress(tasks, 30, 6);
+    const content = lines.join('\n');
+    expect(content).toMatch(/\[x].*Write tests/);
+  });
+
+  it('shows incomplete tasks with empty checkbox', () => {
+    const lines = renderTaskProgress(tasks, 30, 6);
+    const content = lines.join('\n');
+    expect(content).toMatch(/\[ ].*Implement feature/);
+  });
+
+  it('limits output to height lines', () => {
+    const lines = renderTaskProgress(tasks, 30, 3);
+    expect(lines.length).toBeLessThanOrEqual(3);
+  });
+
+  it('returns only header for empty tasks', () => {
+    const lines = renderTaskProgress([], 30, 5);
+    expect(lines.length).toBe(2);
+    expect(lines[1]).toContain('No tasks');
+  });
+
+  it('returns only header when height=1 and tasks empty', () => {
+    const lines = renderTaskProgress([], 30, 1);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('Tasks');
+  });
+
+  it('returns empty array for height <= 0', () => {
+    expect(renderTaskProgress(tasks, 30, 0)).toEqual([]);
+    expect(renderTaskProgress(tasks, 30, -1)).toEqual([]);
+  });
+
+  it('truncates long subjects to width', () => {
+    const longTasks: TaskItem[] = [{ id: '1', subject: 'A'.repeat(100), completed: false }];
+    const lines = renderTaskProgress(longTasks, 20, 5);
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(20);
+    }
+  });
+});

--- a/apps/mcp-server/src/tui/components/monitor-panel.pure.ts
+++ b/apps/mcp-server/src/tui/components/monitor-panel.pure.ts
@@ -1,0 +1,79 @@
+import type { EventLogEntry, DashboardNode, TaskItem } from '../dashboard-types';
+import {
+  estimateDisplayWidth,
+  truncateToDisplayWidth,
+  padEndDisplayWidth,
+} from '../utils/display-width';
+
+function truncate(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return '';
+  if (estimateDisplayWidth(text) <= maxWidth) return text;
+  return truncateToDisplayWidth(text, maxWidth - 1) + '…';
+}
+
+export function renderEventLog(entries: EventLogEntry[], width: number, height: number): string[] {
+  if (height <= 0) return [];
+  const header = truncate('📋 Event Log', width);
+  if (entries.length === 0) {
+    return [header, truncate('  No events', width)].slice(0, height);
+  }
+
+  const maxLines = height - 1;
+  const tail = entries.slice(-maxLines);
+  const lines: string[] = [header];
+  for (const e of tail) {
+    lines.push(truncate(`${e.timestamp} ${e.message}`, width));
+  }
+  return lines.slice(0, height);
+}
+
+export function renderAgentTimeline(
+  agents: Map<string, DashboardNode>,
+  width: number,
+  height: number,
+): string[] {
+  if (height <= 0) return [];
+  const header = truncate('📊 Timeline', width);
+  if (agents.size === 0) {
+    return [header, truncate('  No agents', width)].slice(0, height);
+  }
+
+  // Determine name column width: longest agent name, capped to leave room for bar
+  const maxNameLen = Math.min(
+    Math.max(...[...agents.values()].map(a => estimateDisplayWidth(a.name))),
+    width - 4, // leave at least space for " " + minimal bar
+  );
+  const nameCol = Math.max(1, maxNameLen);
+  const barWidth = Math.max(1, width - nameCol - 2);
+  const lines: string[] = [header];
+
+  for (const agent of agents.values()) {
+    if (lines.length >= height) break;
+    const name = padEndDisplayWidth(truncateToDisplayWidth(agent.name, nameCol), nameCol);
+    const clamped = Math.max(0, Math.min(100, agent.progress));
+    const filled = Math.round((clamped / 100) * barWidth);
+    const bar = '█'.repeat(filled) + '░'.repeat(barWidth - filled);
+    lines.push(truncate(`${name} ${bar}`, width));
+  }
+
+  return lines.slice(0, height);
+}
+
+export function renderTaskProgress(tasks: TaskItem[], width: number, height: number): string[] {
+  if (height <= 0) return [];
+  const done = tasks.filter(t => t.completed).length;
+  const header = truncate(`✅ Tasks ${done}/${tasks.length}`, width);
+  if (tasks.length === 0) {
+    return [header, truncate('  No tasks', width)].slice(0, height);
+  }
+
+  const maxLines = height - 1;
+  const visible = tasks.slice(0, maxLines);
+  const lines: string[] = [header];
+  for (const t of visible) {
+    const mark = t.completed ? '[x]' : '[ ]';
+    lines.push(truncate(`${mark} ${t.subject}`, width));
+  }
+
+  return lines.slice(0, height);
+}

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -7,6 +7,7 @@ import { HeaderBar } from './components/HeaderBar';
 import { FlowMap } from './components/FlowMap';
 import { FocusedAgentPanel } from './components/FocusedAgentPanel';
 import { StageHealthBar } from './components/StageHealthBar';
+import { MonitorPanel } from './components/MonitorPanel';
 import { computeStageHealth, detectBottlenecks } from './components/stage-health.pure';
 import { computeGridLayout } from './components/grid-layout.pure';
 
@@ -74,14 +75,23 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
           />
         </Box>
       ) : (
-        <Box flexDirection="row" width={grid.total.width} height={grid.flowMap.height}>
-          <FlowMap
-            agents={state.agents}
-            edges={state.edges}
-            layoutMode={layoutMode}
-            width={grid.flowMap.width}
-            height={grid.flowMap.height}
-          />
+        <Box flexDirection="row" width={grid.total.width} height={grid.focusedAgent.height}>
+          <Box flexDirection="column" width={grid.flowMap.width}>
+            <FlowMap
+              agents={state.agents}
+              edges={state.edges}
+              layoutMode={layoutMode}
+              width={grid.flowMap.width}
+              height={grid.flowMap.height}
+            />
+            <MonitorPanel
+              eventLog={state.eventLog}
+              agents={state.agents}
+              tasks={state.tasks}
+              width={grid.monitorPanel.width}
+              height={grid.monitorPanel.height}
+            />
+          </Box>
           <FocusedAgentPanel
             agent={focusedAgent}
             objectives={EMPTY_OBJECTIVES}

--- a/apps/mcp-server/src/tui/dashboard-types.spec.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.spec.ts
@@ -132,13 +132,15 @@ describe('tui/dashboard-types', () => {
     it('DashboardGrid has all required sections', () => {
       const grid: DashboardGrid = {
         header: { x: 0, y: 0, width: 120, height: 3 },
-        flowMap: { x: 0, y: 3, width: 54, height: 34 },
+        flowMap: { x: 0, y: 3, width: 54, height: 17 },
+        monitorPanel: { x: 0, y: 20, width: 54, height: 17 },
         focusedAgent: { x: 54, y: 3, width: 66, height: 34 },
         stageHealth: { x: 0, y: 37, width: 120, height: 3 },
         total: { width: 120, height: 40 },
       };
       expect(grid.header).toBeDefined();
       expect(grid.flowMap).toBeDefined();
+      expect(grid.monitorPanel).toBeDefined();
       expect(grid.focusedAgent).toBeDefined();
       expect(grid.stageHealth).toBeDefined();
       expect(grid.total).toBeDefined();

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -155,6 +155,7 @@ export interface GridRegion {
 export interface DashboardGrid {
   header: GridRegion;
   flowMap: GridRegion;
+  monitorPanel: GridRegion;
   focusedAgent: GridRegion;
   stageHealth: GridRegion;
   total: Pick<GridRegion, 'width' | 'height'>;


### PR DESCRIPTION
## Summary

- Add **MonitorPanel** component that splits the left column of the TUI dashboard grid into FlowMap (top) and MonitorPanel (bottom)
- MonitorPanel displays three sub-panels: **Event Log**, **Agent Timeline** (with progress bars), and **Task Checklist**
- Use display-width-aware utilities (`estimateDisplayWidth`, `truncateToDisplayWidth`, `padEndDisplayWidth`) for correct emoji/CJK character rendering

## Changes

### New Files (4)
| File | Description |
|------|-------------|
| `MonitorPanel.tsx` | React/Ink component with 3-column sub-panel layout |
| `MonitorPanel.spec.tsx` | Component tests (headers, empty states, zero dimensions) |
| `monitor-panel.pure.ts` | Pure render functions: `renderEventLog`, `renderAgentTimeline`, `renderTaskProgress` |
| `monitor-panel.pure.spec.ts` | 24 tests covering edge cases (height=1, overflow progress, truncation) |

### Modified Files (7)
| File | Description |
|------|-------------|
| `grid-layout.pure.ts` | Split left column: flowMap gets `ceil(mainHeight/2)`, monitorPanel gets remainder |
| `grid-layout.pure.spec.ts` | Add monitorPanel to overlap/boundary invariant tests |
| `FlowMap.tsx` | Add border styling, content size calculation accounting for border/header |
| `dashboard-app.tsx` | Integrate MonitorPanel below FlowMap in left column |
| `dashboard-types.ts` | Add `monitorPanel: GridRegion` to `DashboardGrid` |
| `dashboard-types.spec.ts` | Update grid type tests |
| `index.ts` | Export MonitorPanel and pure render functions |

## Code Review Findings Addressed

| Severity | Issue | Fix |
|----------|-------|-----|
| HIGH | Empty-state paths exceeded height constraint | `.slice(0, height)` on all 3 empty-state returns |
| MEDIUM | Naive `truncate` used JS `.length` instead of display width | Replaced with `estimateDisplayWidth`/`truncateToDisplayWidth` |
| MEDIUM | Agent name padding ignored wide characters | Replaced with `padEndDisplayWidth` |
| LOW | No early return for zero/negative dimensions | Added `width <= 0 \|\| height <= 0` guard |
| LOW | Missing reference stability JSDoc | Added contract documentation to `MonitorPanelProps` |
| GAP-LOW | No test for height=1 + empty data | Added 3 tests (one per render function) |
| GAP-LOW | `maxNameLen` used `.length` not display width | Replaced with `estimateDisplayWidth(a.name)` |

## Test Plan

- [x] All 159 test files pass (3672 tests, +3 new)
- [x] MonitorPanel component renders headers, empty states, and data
- [x] Pure functions handle edge cases: height<=0, height=1, overflow progress, negative progress, truncation
- [x] Grid layout invariants hold: no overlap, regions within bounds, monitorPanel hidden in narrow mode
- [x] Zero-dimension rendering does not crash