### PR TITLE
feat(tui): wire up objectives from parse_mode response

### DIFF
--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -11,7 +11,6 @@ import { MonitorPanel } from './components/MonitorPanel';
 import { computeStageHealth, detectBottlenecks } from './components/stage-health.pure';
 import { computeGridLayout } from './components/grid-layout.pure';
 
-const EMPTY_OBJECTIVES: string[] = [];
 const EMPTY_INPUTS: string[] = [];
 const EMPTY_OUTPUTS = { files: 0, commits: 0 } as const;
 
@@ -57,7 +56,7 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
         <Box flexDirection="column">
           <FocusedAgentPanel
             agent={focusedAgent}
-            objectives={EMPTY_OBJECTIVES}
+            objectives={state.objectives}
             tasks={state.tasks}
             tools={tools}
             inputs={EMPTY_INPUTS}
@@ -94,7 +93,7 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
           </Box>
           <FocusedAgentPanel
             agent={focusedAgent}
-            objectives={EMPTY_OBJECTIVES}
+            objectives={state.objectives}
             tasks={state.tasks}
             tools={tools}
             inputs={EMPTY_INPUTS}

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -135,6 +135,7 @@ export interface DashboardState {
   focusedAgentId: string | null;
   tasks: TaskItem[];
   eventLog: EventLogEntry[];
+  objectives: string[];
 }
 
 /**

--- a/apps/mcp-server/src/tui/events/index.ts
+++ b/apps/mcp-server/src/tui/events/index.ts
@@ -17,6 +17,7 @@ export {
   type AgentRelationshipEvent,
   type TaskSyncedEvent,
   type ToolInvokedEvent,
+  type ObjectiveSetEvent,
 } from './types';
 export {
   type AgentMetadata,

--- a/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
@@ -189,6 +189,47 @@ describe('extractEventsFromResponse', () => {
     });
   });
 
+  describe('parse_mode → objective:set', () => {
+    it('should extract OBJECTIVE_SET from parse_mode with originalPrompt', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'PLAN',
+          originalPrompt: 'implement auth feature',
+          delegates_to: 'technical-planner',
+        }),
+      );
+      const objectiveEvent = events.find(e => e.event === TUI_EVENTS.OBJECTIVE_SET);
+      expect(objectiveEvent).toBeDefined();
+      expect(objectiveEvent!.payload).toEqual({ objective: 'implement auth feature' });
+    });
+
+    it('should not extract OBJECTIVE_SET when originalPrompt is missing', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'PLAN',
+          delegates_to: 'technical-planner',
+        }),
+      );
+      const objectiveEvent = events.find(e => e.event === TUI_EVENTS.OBJECTIVE_SET);
+      expect(objectiveEvent).toBeUndefined();
+    });
+
+    it('should not extract OBJECTIVE_SET when originalPrompt is empty string', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'PLAN',
+          originalPrompt: '   ',
+          delegates_to: 'technical-planner',
+        }),
+      );
+      const objectiveEvent = events.find(e => e.event === TUI_EVENTS.OBJECTIVE_SET);
+      expect(objectiveEvent).toBeUndefined();
+    });
+  });
+
   describe('prepare_parallel_agents → parallel:started', () => {
     it('should extract parallel:started from prepare_parallel_agents response', () => {
       const result = extractEventsFromResponse(

--- a/apps/mcp-server/src/tui/events/response-event-extractor.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.ts
@@ -13,6 +13,7 @@ import {
   type AgentActivatedEvent,
   type AgentRelationshipEvent,
   type TaskSyncedEvent,
+  type ObjectiveSetEvent,
 } from './types';
 import { parseToolResponseJson } from './parse-tool-response';
 import type { Mode } from '../types';
@@ -41,6 +42,10 @@ export type ExtractedEvent =
   | {
       event: typeof TUI_EVENTS.TASK_SYNCED;
       payload: TaskSyncedEvent;
+    }
+  | {
+      event: typeof TUI_EVENTS.OBJECTIVE_SET;
+      payload: ObjectiveSetEvent;
     };
 
 /**
@@ -110,6 +115,14 @@ function extractFromParseMode(json: Record<string, unknown>): ExtractedEvent[] {
         role: 'primary',
         isPrimary: true,
       },
+    });
+  }
+
+  // objective:set
+  if (typeof json.originalPrompt === 'string' && json.originalPrompt.trim()) {
+    events.push({
+      event: TUI_EVENTS.OBJECTIVE_SET,
+      payload: { objective: json.originalPrompt.trim() },
     });
   }
 

--- a/apps/mcp-server/src/tui/events/tui-interceptor.ts
+++ b/apps/mcp-server/src/tui/events/tui-interceptor.ts
@@ -145,6 +145,9 @@ export class TuiInterceptor {
       case TUI_EVENTS.TASK_SYNCED:
         this.eventBus.emit(TUI_EVENTS.TASK_SYNCED, evt.payload);
         break;
+      case TUI_EVENTS.OBJECTIVE_SET:
+        this.eventBus.emit(TUI_EVENTS.OBJECTIVE_SET, evt.payload);
+        break;
       default: {
         const _exhaustive: never = evt;
         this.logger.warn(`Unhandled semantic event: ${(_exhaustive as { event: string }).event}`);

--- a/apps/mcp-server/src/tui/events/types.spec.ts
+++ b/apps/mcp-server/src/tui/events/types.spec.ts
@@ -11,12 +11,13 @@ import {
   type AgentRelationshipEvent,
   type TaskSyncedEvent,
   type ToolInvokedEvent,
+  type ObjectiveSetEvent,
   type TuiEventMap,
 } from './types';
 
 describe('tui/events/types', () => {
   describe('TUI_EVENTS', () => {
-    it('should define all 10 event names', () => {
+    it('should define all 11 event names', () => {
       expect(TUI_EVENTS).toEqual({
         AGENT_ACTIVATED: 'agent:activated',
         AGENT_DEACTIVATED: 'agent:deactivated',
@@ -28,6 +29,7 @@ describe('tui/events/types', () => {
         AGENT_RELATIONSHIP: 'agent:relationship',
         TASK_SYNCED: 'task:synced',
         TOOL_INVOKED: 'tool:invoked',
+        OBJECTIVE_SET: 'objective:set',
       });
     });
 
@@ -175,8 +177,16 @@ describe('tui/events/types', () => {
         },
         'task:synced': { agentId: 'a1', tasks: [] },
         'tool:invoked': { toolName: 'search_rules', agentId: null, timestamp: 0 },
+        'objective:set': { objective: 'implement auth feature' },
       };
       expect(map['agent:activated'].agentId).toBe('a1');
+    });
+  });
+
+  describe('ObjectiveSetEvent', () => {
+    it('should have correct shape', () => {
+      const event: ObjectiveSetEvent = { objective: 'implement auth feature' };
+      expect(event.objective).toBe('implement auth feature');
     });
   });
 });

--- a/apps/mcp-server/src/tui/events/types.ts
+++ b/apps/mcp-server/src/tui/events/types.ts
@@ -21,6 +21,7 @@ export const TUI_EVENTS = Object.freeze({
   AGENT_RELATIONSHIP: 'agent:relationship',
   TASK_SYNCED: 'task:synced',
   TOOL_INVOKED: 'tool:invoked',
+  OBJECTIVE_SET: 'objective:set',
 } as const);
 
 export type TuiEventName = (typeof TUI_EVENTS)[keyof typeof TUI_EVENTS];
@@ -90,6 +91,11 @@ export interface ToolInvokedEvent {
   timestamp: number;
 }
 
+/** Payload when an objective is set from parse_mode originalPrompt */
+export interface ObjectiveSetEvent {
+  objective: string;
+}
+
 /**
  * Maps event names to their payload types for type-safe emit/subscribe.
  */
@@ -104,4 +110,5 @@ export interface TuiEventMap {
   [TUI_EVENTS.AGENT_RELATIONSHIP]: AgentRelationshipEvent;
   [TUI_EVENTS.TASK_SYNCED]: TaskSyncedEvent;
   [TUI_EVENTS.TOOL_INVOKED]: ToolInvokedEvent;
+  [TUI_EVENTS.OBJECTIVE_SET]: ObjectiveSetEvent;
 }

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -319,4 +319,26 @@ describe('dashboardReducer', () => {
     expect(state.eventLog[0].timestamp).toHaveLength(8);
     expect(state.eventLog[0].timestamp).toMatch(/^\d{2}:\d{2}:\d{2}$/);
   });
+
+  it('should set objectives on OBJECTIVE_SET', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'OBJECTIVE_SET',
+      payload: { objective: 'implement auth feature' },
+    });
+    expect(state.objectives).toEqual(['implement auth feature']);
+  });
+
+  it('should replace objectives on new OBJECTIVE_SET (not accumulate)', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'OBJECTIVE_SET',
+      payload: { objective: 'first task' },
+    });
+    state = dashboardReducer(state, {
+      type: 'OBJECTIVE_SET',
+      payload: { objective: 'second task' },
+    });
+    expect(state.objectives).toEqual(['second task']);
+  });
 });

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -19,6 +19,7 @@ import {
   type AgentRelationshipEvent,
   type TaskSyncedEvent,
   type ToolInvokedEvent,
+  type ObjectiveSetEvent,
 } from '../events';
 import { selectFocusedAgent } from './use-focus-agent';
 
@@ -40,6 +41,7 @@ export function createInitialDashboardState(): DashboardState {
     focusedAgentId: null,
     tasks: [],
     eventLog: [],
+    objectives: [],
   };
 }
 
@@ -53,7 +55,8 @@ export type DashboardAction =
   | { type: 'AGENTS_LOADED'; payload: AgentsLoadedEvent }
   | { type: 'AGENT_RELATIONSHIP'; payload: AgentRelationshipEvent }
   | { type: 'TASK_SYNCED'; payload: TaskSyncedEvent }
-  | { type: 'TOOL_INVOKED'; payload: ToolInvokedEvent };
+  | { type: 'TOOL_INVOKED'; payload: ToolInvokedEvent }
+  | { type: 'OBJECTIVE_SET'; payload: ObjectiveSetEvent };
 
 function cloneAgents(agents: Map<string, DashboardNode>): Map<string, DashboardNode> {
   return new Map(agents);
@@ -158,6 +161,9 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
       return { ...state, agents, eventLog: [...base, entry] };
     }
 
+    case 'OBJECTIVE_SET':
+      return { ...state, objectives: [action.payload.objective] };
+
     case 'SKILL_RECOMMENDED':
     case 'PARALLEL_STARTED':
     // falls through — Reserved: no emitter currently produces PARALLEL_COMPLETED. Subscription kept for forward compatibility.
@@ -198,6 +204,8 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
       dispatch({ type: 'AGENT_RELATIONSHIP', payload: p });
     const onTaskSynced = (p: TaskSyncedEvent) => dispatch({ type: 'TASK_SYNCED', payload: p });
     const onToolInvoked = (p: ToolInvokedEvent) => dispatch({ type: 'TOOL_INVOKED', payload: p });
+    const onObjectiveSet = (p: ObjectiveSetEvent) =>
+      dispatch({ type: 'OBJECTIVE_SET', payload: p });
 
     eventBus.on(TUI_EVENTS.AGENT_ACTIVATED, onActivated);
     eventBus.on(TUI_EVENTS.AGENT_DEACTIVATED, onDeactivated);
@@ -209,6 +217,7 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
     eventBus.on(TUI_EVENTS.AGENT_RELATIONSHIP, onRelationship);
     eventBus.on(TUI_EVENTS.TASK_SYNCED, onTaskSynced);
     eventBus.on(TUI_EVENTS.TOOL_INVOKED, onToolInvoked);
+    eventBus.on(TUI_EVENTS.OBJECTIVE_SET, onObjectiveSet);
 
     return () => {
       eventBus.off(TUI_EVENTS.AGENT_ACTIVATED, onActivated);
@@ -221,6 +230,7 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
       eventBus.off(TUI_EVENTS.AGENT_RELATIONSHIP, onRelationship);
       eventBus.off(TUI_EVENTS.TASK_SYNCED, onTaskSynced);
       eventBus.off(TUI_EVENTS.TOOL_INVOKED, onToolInvoked);
+      eventBus.off(TUI_EVENTS.OBJECTIVE_SET, onObjectiveSet);
     };
   }, [eventBus]);
 

--- a/docs/plans/2026-02-17-wire-objectives-from-parse-mode.md
+++ b/docs/plans/2026-02-17-wire-objectives-from-parse-mode.md
@@ -1,0 +1,323 @@
+# [TUI] Wire Up Objectives from parse_mode Response - Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** `FocusedAgentPanel`에 항상 빈 배열로 전달되는 `objectives`를 `parse_mode` 응답의 `originalPrompt`에서 추출하여 실제 데이터로 연결한다.
+
+**Architecture:** 기존 이벤트 기반 아키텍처(EventBus → Extractor → Reducer → React)를 그대로 따른다. 새 이벤트 `OBJECTIVE_SET`을 정의하고, `extractFromParseMode()`에서 추출, reducer에서 상태 반영, `DashboardApp`에서 `state.objectives`를 전달하는 흐름.
+
+**Tech Stack:** TypeScript, Vitest, React (Ink)
+
+**Issue:** https://github.com/JeremyDev87/codingbuddy/issues/473
+
+---
+
+## Task 1: 이벤트 타입 정의 (`ObjectiveSetEvent` + `TUI_EVENTS.OBJECTIVE_SET`)
+
+**Files:**
+- Modify: `apps/mcp-server/src/tui/events/types.ts`
+
+### Step 1: `ObjectiveSetEvent` 인터페이스 추가
+
+`types.ts` 파일에 새 이벤트 인터페이스를 추가한다:
+
+```typescript
+export interface ObjectiveSetEvent {
+  objective: string;
+}
+```
+
+### Step 2: `TUI_EVENTS`에 `OBJECTIVE_SET` 추가
+
+```typescript
+export const TUI_EVENTS = Object.freeze({
+  // ... existing
+  OBJECTIVE_SET: 'objective:set',
+} as const);
+```
+
+### Step 3: `TuiEventMap`에 매핑 추가
+
+```typescript
+export interface TuiEventMap {
+  // ... existing
+  [TUI_EVENTS.OBJECTIVE_SET]: ObjectiveSetEvent;
+}
+```
+
+### Step 4: 빌드 확인
+
+Run: `yarn workspace codingbuddy exec tsc --noEmit --project tsconfig.json 2>&1 | head -20`
+Expected: 타입 에러 없음 (또는 아직 사용하지 않는 타입이므로 기존 에러만)
+
+### Step 5: Commit
+
+```bash
+git add apps/mcp-server/src/tui/events/types.ts
+git commit -m "feat(tui): add ObjectiveSetEvent type and OBJECTIVE_SET to TUI_EVENTS"
+```
+
+---
+
+## Task 2: Extractor 테스트 작성 (RED)
+
+**Files:**
+- Modify: `apps/mcp-server/src/tui/events/response-event-extractor.spec.ts`
+
+### Step 1: `OBJECTIVE_SET` 추출 테스트 추가
+
+`describe('parse_mode → ...')` 섹션 내에 새 describe 블록을 추가:
+
+```typescript
+describe('parse_mode → objective:set', () => {
+  it('should extract OBJECTIVE_SET from parse_mode with originalPrompt', () => {
+    const events = extractEventsFromResponse(
+      makeResponse('parse_mode', {
+        mode: 'PLAN',
+        originalPrompt: 'implement auth feature',
+        delegates_to: 'technical-planner',
+      }),
+    );
+    const objectiveEvent = events.find(e => e.event === TUI_EVENTS.OBJECTIVE_SET);
+    expect(objectiveEvent).toBeDefined();
+    expect(objectiveEvent!.payload).toEqual({ objective: 'implement auth feature' });
+  });
+
+  it('should not extract OBJECTIVE_SET when originalPrompt is missing', () => {
+    const events = extractEventsFromResponse(
+      makeResponse('parse_mode', {
+        mode: 'PLAN',
+        delegates_to: 'technical-planner',
+      }),
+    );
+    const objectiveEvent = events.find(e => e.event === TUI_EVENTS.OBJECTIVE_SET);
+    expect(objectiveEvent).toBeUndefined();
+  });
+
+  it('should not extract OBJECTIVE_SET when originalPrompt is empty string', () => {
+    const events = extractEventsFromResponse(
+      makeResponse('parse_mode', {
+        mode: 'PLAN',
+        originalPrompt: '   ',
+        delegates_to: 'technical-planner',
+      }),
+    );
+    const objectiveEvent = events.find(e => e.event === TUI_EVENTS.OBJECTIVE_SET);
+    expect(objectiveEvent).toBeUndefined();
+  });
+});
+```
+
+### Step 2: 테스트 실행하여 실패 확인
+
+Run: `yarn workspace codingbuddy test -- --run response-event-extractor.spec.ts`
+Expected: FAIL — `OBJECTIVE_SET`이 `TUI_EVENTS`에는 있지만 extractor가 아직 추출하지 않으므로 `objectiveEvent`가 `undefined`
+
+---
+
+## Task 3: Extractor 구현 (GREEN)
+
+**Files:**
+- Modify: `apps/mcp-server/src/tui/events/response-event-extractor.ts`
+
+### Step 1: `ExtractedEvent` 유니온에 `OBJECTIVE_SET` 변형 추가
+
+```typescript
+export type ExtractedEvent =
+  // ... existing variants
+  | {
+      event: typeof TUI_EVENTS.OBJECTIVE_SET;
+      payload: ObjectiveSetEvent;
+    };
+```
+
+import에 `ObjectiveSetEvent`도 추가.
+
+### Step 2: `extractFromParseMode()`에 추출 로직 추가
+
+`return events;` 직전에 추가:
+
+```typescript
+// objective:set
+if (typeof json.originalPrompt === 'string' && json.originalPrompt.trim()) {
+  events.push({
+    event: TUI_EVENTS.OBJECTIVE_SET,
+    payload: { objective: json.originalPrompt.trim() },
+  });
+}
+```
+
+### Step 3: 테스트 실행하여 통과 확인
+
+Run: `yarn workspace codingbuddy test -- --run response-event-extractor.spec.ts`
+Expected: PASS
+
+### Step 4: Commit
+
+```bash
+git add apps/mcp-server/src/tui/events/response-event-extractor.ts apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
+git commit -m "feat(tui): extract OBJECTIVE_SET from parse_mode originalPrompt"
+```
+
+---
+
+## Task 4: DashboardState에 `objectives` 필드 추가 + Reducer 테스트 작성 (RED)
+
+**Files:**
+- Modify: `apps/mcp-server/src/tui/dashboard-types.ts`
+- Modify: `apps/mcp-server/src/tui/hooks/use-dashboard-state.ts`
+- Modify: `apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts`
+
+### Step 1: `DashboardState`에 `objectives` 필드 추가
+
+`apps/mcp-server/src/tui/dashboard-types.ts`:
+
+```typescript
+export interface DashboardState {
+  // ... existing fields
+  objectives: string[];
+}
+```
+
+### Step 2: `createInitialDashboardState()`에 초기값 추가
+
+`apps/mcp-server/src/tui/hooks/use-dashboard-state.ts`:
+
+```typescript
+export function createInitialDashboardState(): DashboardState {
+  return {
+    // ... existing
+    objectives: [],
+  };
+}
+```
+
+### Step 3: Reducer 테스트 작성
+
+`apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts`에 추가:
+
+```typescript
+it('should set objectives on OBJECTIVE_SET', () => {
+  let state = createInitialDashboardState();
+  state = dashboardReducer(state, {
+    type: 'OBJECTIVE_SET',
+    payload: { objective: 'implement auth feature' },
+  });
+  expect(state.objectives).toEqual(['implement auth feature']);
+});
+
+it('should replace objectives on new OBJECTIVE_SET (not accumulate)', () => {
+  let state = createInitialDashboardState();
+  state = dashboardReducer(state, {
+    type: 'OBJECTIVE_SET',
+    payload: { objective: 'first task' },
+  });
+  state = dashboardReducer(state, {
+    type: 'OBJECTIVE_SET',
+    payload: { objective: 'second task' },
+  });
+  expect(state.objectives).toEqual(['second task']);
+});
+```
+
+### Step 4: 테스트 실행하여 실패 확인
+
+Run: `yarn workspace codingbuddy test -- --run use-dashboard-state.spec.ts`
+Expected: FAIL — `DashboardAction`에 `OBJECTIVE_SET` 타입이 없어서 컴파일 에러 또는 exhaustive check 실패
+
+---
+
+## Task 5: Reducer 구현 (GREEN)
+
+**Files:**
+- Modify: `apps/mcp-server/src/tui/hooks/use-dashboard-state.ts`
+
+### Step 1: `DashboardAction`에 `OBJECTIVE_SET` 추가
+
+```typescript
+export type DashboardAction =
+  // ... existing
+  | { type: 'OBJECTIVE_SET'; payload: ObjectiveSetEvent };
+```
+
+import에 `ObjectiveSetEvent`도 추가.
+
+### Step 2: Reducer에 케이스 추가
+
+`dashboardReducer`의 switch 문에 추가 (no-op 케이스들 위에):
+
+```typescript
+case 'OBJECTIVE_SET':
+  return { ...state, objectives: [action.payload.objective] };
+```
+
+### Step 3: 테스트 실행하여 통과 확인
+
+Run: `yarn workspace codingbuddy test -- --run use-dashboard-state.spec.ts`
+Expected: PASS
+
+### Step 4: Commit
+
+```bash
+git add apps/mcp-server/src/tui/dashboard-types.ts apps/mcp-server/src/tui/hooks/use-dashboard-state.ts apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+git commit -m "feat(tui): add objectives to DashboardState with OBJECTIVE_SET reducer"
+```
+
+---
+
+## Task 6: EventBus 구독 추가 + DashboardApp 연결
+
+**Files:**
+- Modify: `apps/mcp-server/src/tui/hooks/use-dashboard-state.ts`
+- Modify: `apps/mcp-server/src/tui/dashboard-app.tsx`
+
+### Step 1: `useDashboardState`에 `OBJECTIVE_SET` 구독 추가
+
+`apps/mcp-server/src/tui/hooks/use-dashboard-state.ts`의 `useDashboardState` 함수에 추가:
+
+```typescript
+const onObjectiveSet = (p: ObjectiveSetEvent) =>
+  dispatch({ type: 'OBJECTIVE_SET', payload: p });
+
+eventBus.on(TUI_EVENTS.OBJECTIVE_SET, onObjectiveSet);
+
+// cleanup에도 추가:
+eventBus.off(TUI_EVENTS.OBJECTIVE_SET, onObjectiveSet);
+```
+
+### Step 2: `DashboardApp`에서 `EMPTY_OBJECTIVES` 제거하고 `state.objectives` 사용
+
+`apps/mcp-server/src/tui/dashboard-app.tsx`:
+
+1. `const EMPTY_OBJECTIVES: string[] = [];` 상수 삭제
+2. narrow 레이아웃과 wide 레이아웃 모두에서 `objectives={EMPTY_OBJECTIVES}` → `objectives={state.objectives}`로 변경
+
+### Step 3: 전체 테스트 실행
+
+Run: `yarn workspace codingbuddy test`
+Expected: ALL PASS
+
+### Step 4: 빌드 확인
+
+Run: `yarn workspace codingbuddy exec tsc --noEmit --project tsconfig.json 2>&1 | head -20`
+Expected: 타입 에러 없음
+
+### Step 5: Commit
+
+```bash
+git add apps/mcp-server/src/tui/hooks/use-dashboard-state.ts apps/mcp-server/src/tui/dashboard-app.tsx
+git commit -m "feat(tui): wire objectives from parse_mode to FocusedAgentPanel (#473)"
+```
+
+---
+
+## Summary
+
+| Task | 파일 | 내용 |
+|------|------|------|
+| 1 | `events/types.ts` | `ObjectiveSetEvent` + `TUI_EVENTS.OBJECTIVE_SET` + `TuiEventMap` |
+| 2 | `response-event-extractor.spec.ts` | Extractor 테스트 3개 (RED) |
+| 3 | `response-event-extractor.ts` | `ExtractedEvent` 확장 + `extractFromParseMode()` 로직 (GREEN) |
+| 4 | `dashboard-types.ts`, `use-dashboard-state.ts/spec.ts` | State 타입 + 초기값 + Reducer 테스트 2개 (RED) |
+| 5 | `use-dashboard-state.ts` | `DashboardAction` + Reducer 케이스 (GREEN) |
+| 6 | `use-dashboard-state.ts`, `dashboard-app.tsx` | EventBus 구독 + `EMPTY_OBJECTIVES` 제거 |


### PR DESCRIPTION
## Summary

Closes #473

- Add `OBJECTIVE_SET` event to the TUI event system to extract `originalPrompt` from `parse_mode` response
- Wire the extracted objective through the full event pipeline: `extractFromParseMode()` → EventBus → reducer → `state.objectives`
- Replace hardcoded `EMPTY_OBJECTIVES` constant in `DashboardApp` with live `state.objectives` data passed to `FocusedAgentPanel`

## Changes

### Event Type Definition
- Add `ObjectiveSetEvent` interface and `OBJECTIVE_SET` to `TUI_EVENTS` constant
- Extend `TuiEventMap` with the new event mapping
- Export `ObjectiveSetEvent` from barrel `index.ts`

### Event Extraction
- Extend `ExtractedEvent` union type with `OBJECTIVE_SET` variant
- Add extraction logic in `extractFromParseMode()` for `originalPrompt` field
- Guard against missing/whitespace-only values with `trim()` check

### State Management
- Add `objectives: string[]` field to `DashboardState`
- Add `OBJECTIVE_SET` case to `DashboardAction` union and `dashboardReducer`
- Objectives are replaced (not accumulated) on each new `OBJECTIVE_SET` event
- Add EventBus subscription/cleanup in `useDashboardState` hook

### UI Integration
- Remove `EMPTY_OBJECTIVES` constant from `dashboard-app.tsx`
- Pass `state.objectives` to `FocusedAgentPanel` in both narrow and wide layouts

### Interceptor
- Add `OBJECTIVE_SET` case to `TuiInterceptor` exhaustive switch for event forwarding

## Test Plan

- [x] Extractor tests: valid `originalPrompt`, missing field, whitespace-only string (3 tests)
- [x] Reducer tests: objective set, objective replacement on subsequent events (2 tests)
- [x] Type tests: event count updated 10→11, `ObjectiveSetEvent` shape, `TuiEventMap` completeness (2 tests)
- [x] Full test suite: 159 files passed, 3683 tests passed, 0 type errors