### PR TITLE
reflect SKILL_RECOMMENDED event in dashboard state (#474)

### DIFF
--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
@@ -18,6 +18,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
+        activeSkills={[]}
         objectives={['Add /users endpoints']}
         tasks={[{ id: '1', subject: 'routes added', completed: true }]}
         tools={['file_edit']}
@@ -36,6 +37,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
+        activeSkills={[]}
         objectives={[]}
         tasks={[]}
         tools={[]}
@@ -54,6 +56,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
+        activeSkills={[]}
         objectives={['Design auth']}
         tasks={[]}
         tools={[]}
@@ -73,6 +76,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
+        activeSkills={[]}
         objectives={['Add /users endpoints', 'Update DTO']}
         tasks={[]}
         tools={[]}
@@ -88,6 +92,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
+        activeSkills={[]}
         objectives={[]}
         tasks={[
           { id: '1', subject: 'routes added', completed: true },
@@ -108,6 +113,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
+        activeSkills={[]}
         objectives={[]}
         tasks={[]}
         tools={['file_edit', 'test_run']}
@@ -125,6 +131,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
+        activeSkills={[]}
         objectives={[]}
         tasks={[]}
         tools={[]}
@@ -143,6 +150,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={null}
+        activeSkills={[]}
         objectives={[]}
         tasks={[]}
         tools={[]}
@@ -158,6 +166,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
+        activeSkills={[]}
         objectives={[]}
         tasks={[]}
         tools={[]}
@@ -175,6 +184,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={null}
+        activeSkills={[]}
         objectives={[]}
         tasks={[]}
         tools={[]}
@@ -192,6 +202,7 @@ describe('tui/components/FocusedAgentPanel', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
+        activeSkills={[]}
         objectives={[]}
         tasks={[]}
         tools={[]}
@@ -204,5 +215,40 @@ describe('tui/components/FocusedAgentPanel', () => {
     // Single border uses ┌ ┐ └ ┘
     expect(frame).toContain('┌');
     expect(frame).toContain('┘');
+  });
+
+  it('should render Skills section with active skills', () => {
+    const { lastFrame } = render(
+      <FocusedAgentPanel
+        agent={mockAgent}
+        activeSkills={['tdd', 'debugging']}
+        objectives={[]}
+        tasks={[]}
+        tools={[]}
+        inputs={[]}
+        outputs={{}}
+        eventLog={[]}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('─── Skills');
+    expect(frame).toContain('tdd');
+    expect(frame).toContain('debugging');
+  });
+
+  it('should render "No skills" when activeSkills is empty', () => {
+    const { lastFrame } = render(
+      <FocusedAgentPanel
+        agent={mockAgent}
+        activeSkills={[]}
+        objectives={[]}
+        tasks={[]}
+        tools={[]}
+        inputs={[]}
+        outputs={{}}
+        eventLog={[]}
+      />,
+    );
+    expect(lastFrame()).toContain('No skills');
   });
 });

--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
@@ -15,6 +15,7 @@ import {
 export interface FocusedAgentPanelProps {
   agent: DashboardNode | null;
   objectives: string[];
+  activeSkills: string[];
   tasks: TaskItem[];
   tools: string[];
   inputs: string[];
@@ -60,6 +61,7 @@ function LogSection({
 export function FocusedAgentPanel({
   agent,
   objectives,
+  activeSkills,
   tasks,
   tools,
   inputs,
@@ -119,6 +121,14 @@ export function FocusedAgentPanel({
       {/* Objective Section */}
       <SectionDivider title="Objective" />
       {objective ? <Text>{objective}</Text> : <Text dimColor>No objectives</Text>}
+
+      {/* Skills Section */}
+      <SectionDivider title="Skills" />
+      {activeSkills.length > 0 ? (
+        activeSkills.map((s, i) => <Text key={i}>  {s}</Text>)
+      ) : (
+        <Text dimColor>No skills</Text>
+      )}
 
       {/* Checklist Section */}
       <SectionDivider title="Checklist" />

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -57,6 +57,7 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
           <FocusedAgentPanel
             agent={focusedAgent}
             objectives={state.objectives}
+            activeSkills={state.activeSkills}
             tasks={state.tasks}
             tools={tools}
             inputs={EMPTY_INPUTS}
@@ -94,6 +95,7 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
           <FocusedAgentPanel
             agent={focusedAgent}
             objectives={state.objectives}
+            activeSkills={state.activeSkills}
             tasks={state.tasks}
             tools={tools}
             inputs={EMPTY_INPUTS}

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -136,6 +136,7 @@ export interface DashboardState {
   tasks: TaskItem[];
   eventLog: EventLogEntry[];
   objectives: string[];
+  activeSkills: string[];
 }
 
 /**

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -199,12 +199,39 @@ describe('dashboardReducer', () => {
     expect(state.eventLog[state.eventLog.length - 1].message).toBe('tool_149');
   });
 
-  it('handles SKILL_RECOMMENDED as no-op', () => {
-    const state = dashboardReducer(initialDashboardState, {
+  it('should accumulate activeSkills on SKILL_RECOMMENDED', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
       type: 'SKILL_RECOMMENDED',
-      payload: { skillName: 'test', reason: 'reason' },
+      payload: { skillName: 'tdd', reason: 'matched' },
     });
-    expect(state).toEqual(initialDashboardState);
+    expect(state.activeSkills).toEqual(['tdd']);
+  });
+
+  it('should deduplicate activeSkills', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'SKILL_RECOMMENDED',
+      payload: { skillName: 'tdd', reason: 'matched' },
+    });
+    state = dashboardReducer(state, {
+      type: 'SKILL_RECOMMENDED',
+      payload: { skillName: 'tdd', reason: 'matched again' },
+    });
+    expect(state.activeSkills).toEqual(['tdd']);
+  });
+
+  it('should reset activeSkills on MODE_CHANGED', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'SKILL_RECOMMENDED',
+      payload: { skillName: 'tdd', reason: 'matched' },
+    });
+    state = dashboardReducer(state, {
+      type: 'MODE_CHANGED',
+      payload: { from: 'PLAN', to: 'ACT' },
+    });
+    expect(state.activeSkills).toEqual([]);
   });
 
   it('handles PARALLEL_STARTED as no-op', () => {

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -42,6 +42,7 @@ export function createInitialDashboardState(): DashboardState {
     tasks: [],
     eventLog: [],
     objectives: [],
+    activeSkills: [],
   };
 }
 
@@ -109,7 +110,7 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
     }
 
     case 'MODE_CHANGED':
-      return { ...state, currentMode: action.payload.to };
+      return { ...state, currentMode: action.payload.to, activeSkills: [] };
 
     case 'AGENT_RELATIONSHIP': {
       const edge: Edge = {
@@ -164,7 +165,12 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
     case 'OBJECTIVE_SET':
       return { ...state, objectives: [action.payload.objective] };
 
-    case 'SKILL_RECOMMENDED':
+    case 'SKILL_RECOMMENDED': {
+      const { skillName } = action.payload;
+      if (state.activeSkills.includes(skillName)) return state;
+      return { ...state, activeSkills: [...state.activeSkills, skillName] };
+    }
+
     case 'PARALLEL_STARTED':
     // falls through — Reserved: no emitter currently produces PARALLEL_COMPLETED. Subscription kept for forward compatibility.
     case 'PARALLEL_COMPLETED':


### PR DESCRIPTION
## Summary

- Add `activeSkills: string[]` field to `DashboardState` and handle `SKILL_RECOMMENDED` event in the reducer with deduplication
- Reset `activeSkills` on `MODE_CHANGED` to clear stale skills when switching modes
- Display active skills list in `FocusedAgentPanel` between Objective and Checklist sections

Closes #474

## Changes

| File | Change |
|------|--------|
| `dashboard-types.ts` | Add `activeSkills: string[]` to `DashboardState` |
| `use-dashboard-state.ts` | Initial state, `SKILL_RECOMMENDED` handler (deduplicated accumulation), `MODE_CHANGED` reset |
| `use-dashboard-state.spec.ts` | Replace no-op test with 3 behavior tests (accumulate, deduplicate, reset on mode change) |
| `FocusedAgentPanel.tsx` | Add `activeSkills` prop, render Skills section |
| `FocusedAgentPanel.spec.tsx` | Add `activeSkills` prop to existing tests, add 2 new tests for Skills section |
| `dashboard-app.tsx` | Pass `activeSkills` prop to `FocusedAgentPanel` (narrow + wide layouts) |

## Test plan

- [x] Reducer: `SKILL_RECOMMENDED` accumulates `activeSkills` array
- [x] Reducer: duplicate skill names are ignored
- [x] Reducer: `MODE_CHANGED` resets `activeSkills` to empty
- [x] UI: Skills section renders skill names when present
- [x] UI: "No skills" placeholder when `activeSkills` is empty
- [x] Full test suite: 3687 tests passing
- [x] TypeScript: `tsc --noEmit` clean