### PR TITLE
feat(tui): pre-register specialists on PARALLEL_STARTED event

### DIFF
--- a/apps/mcp-server/src/tui/eventbus-ui.integration.spec.tsx
+++ b/apps/mcp-server/src/tui/eventbus-ui.integration.spec.tsx
@@ -220,13 +220,13 @@ describe('EventBus ↔ UI Integration', () => {
       });
 
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
-        agentId: 'sec-1',
+        agentId: 'specialist:security-specialist',
         name: 'security-specialist',
         role: 'specialist',
         isPrimary: false,
       });
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
-        agentId: 'test-1',
+        agentId: 'specialist:test-strategy-specialist',
         name: 'test-strategy-specialist',
         role: 'specialist',
         isPrimary: false,
@@ -255,13 +255,13 @@ describe('EventBus ↔ UI Integration', () => {
         mode: 'PLAN',
       });
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
-        agentId: 'sec-1',
+        agentId: 'specialist:security-specialist',
         name: 'security-specialist',
         role: 'specialist',
         isPrimary: false,
       });
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
-        agentId: 'test-1',
+        agentId: 'specialist:test-strategy-specialist',
         name: 'test-strategy-specialist',
         role: 'specialist',
         isPrimary: false,
@@ -270,12 +270,12 @@ describe('EventBus ↔ UI Integration', () => {
       expect(lastFrame()).toContain('RUNNING');
 
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
-        agentId: 'sec-1',
+        agentId: 'specialist:security-specialist',
         reason: 'completed',
         durationMs: 800,
       });
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
-        agentId: 'test-1',
+        agentId: 'specialist:test-strategy-specialist',
         reason: 'completed',
         durationMs: 1200,
       });
@@ -313,19 +313,19 @@ describe('EventBus ↔ UI Integration', () => {
         mode: 'PLAN',
       });
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
-        agentId: 'sec-1',
+        agentId: 'specialist:security-specialist',
         name: 'security-specialist',
         role: 'specialist',
         isPrimary: false,
       });
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
-        agentId: 'acc-1',
+        agentId: 'specialist:accessibility-specialist',
         name: 'accessibility-specialist',
         role: 'specialist',
         isPrimary: false,
       });
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
-        agentId: 'perf-1',
+        agentId: 'specialist:performance-specialist',
         name: 'performance-specialist',
         role: 'specialist',
         isPrimary: false,
@@ -334,17 +334,17 @@ describe('EventBus ↔ UI Integration', () => {
       expect(lastFrame()).toContain('RUNNING');
 
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
-        agentId: 'sec-1',
+        agentId: 'specialist:security-specialist',
         reason: 'completed',
         durationMs: 500,
       });
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
-        agentId: 'acc-1',
+        agentId: 'specialist:accessibility-specialist',
         reason: 'completed',
         durationMs: 700,
       });
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
-        agentId: 'perf-1',
+        agentId: 'specialist:performance-specialist',
         reason: 'completed',
         durationMs: 900,
       });
@@ -474,13 +474,13 @@ describe('EventBus ↔ UI Integration', () => {
         mode: 'PLAN',
       });
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
-        agentId: 'sec-1',
+        agentId: 'specialist:security-specialist',
         name: 'security-specialist',
         role: 'specialist',
         isPrimary: false,
       });
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
-        agentId: 'test-1',
+        agentId: 'specialist:test-strategy-specialist',
         name: 'test-strategy-specialist',
         role: 'specialist',
         isPrimary: false,
@@ -490,12 +490,12 @@ describe('EventBus ↔ UI Integration', () => {
 
       // 4. Specialists complete
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
-        agentId: 'sec-1',
+        agentId: 'specialist:security-specialist',
         reason: 'completed',
         durationMs: 600,
       });
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
-        agentId: 'test-1',
+        agentId: 'specialist:test-strategy-specialist',
         reason: 'completed',
         durationMs: 800,
       });

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -234,12 +234,53 @@ describe('dashboardReducer', () => {
     expect(state.activeSkills).toEqual([]);
   });
 
-  it('handles PARALLEL_STARTED as no-op', () => {
+  it('should pre-register specialists as idle agents on PARALLEL_STARTED', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'MODE_CHANGED',
+      payload: { from: null, to: 'EVAL' },
+    });
+    state = dashboardReducer(state, {
+      type: 'PARALLEL_STARTED',
+      payload: { specialists: ['security-specialist', 'perf-specialist'], mode: 'EVAL' },
+    });
+    expect(state.agents.size).toBe(2);
+
+    const sec = state.agents.get('specialist:security-specialist');
+    expect(sec).toBeDefined();
+    expect(sec!.status).toBe('idle');
+    expect(sec!.isPrimary).toBe(false);
+    expect(sec!.stage).toBe('EVAL');
+
+    const perf = state.agents.get('specialist:perf-specialist');
+    expect(perf).toBeDefined();
+    expect(perf!.status).toBe('idle');
+  });
+
+  it('should not overwrite already running specialist on PARALLEL_STARTED', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: {
+        agentId: 'specialist:security-specialist',
+        name: 'security-specialist',
+        role: 'specialist',
+        isPrimary: false,
+      },
+    });
+    state = dashboardReducer(state, {
+      type: 'PARALLEL_STARTED',
+      payload: { specialists: ['security-specialist'], mode: 'EVAL' },
+    });
+    expect(state.agents.get('specialist:security-specialist')!.status).toBe('running');
+  });
+
+  it('should handle empty specialists array as no-op on PARALLEL_STARTED', () => {
     const state = dashboardReducer(initialDashboardState, {
       type: 'PARALLEL_STARTED',
-      payload: { specialists: ['sec'], mode: 'EVAL' },
+      payload: { specialists: [], mode: 'EVAL' },
     });
-    expect(state).toEqual(initialDashboardState);
+    expect(state.agents.size).toBe(0);
   });
 
   it('handles PARALLEL_COMPLETED as no-op', () => {

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -171,8 +171,25 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
       return { ...state, activeSkills: [...state.activeSkills, skillName] };
     }
 
-    case 'PARALLEL_STARTED':
-    // falls through — Reserved: no emitter currently produces PARALLEL_COMPLETED. Subscription kept for forward compatibility.
+    case 'PARALLEL_STARTED': {
+      const { specialists, mode } = action.payload;
+      const agents = cloneAgents(state.agents);
+      for (const name of specialists) {
+        const id = `specialist:${name}`;
+        if (agents.has(id)) continue;
+        agents.set(id, {
+          id,
+          name,
+          stage: mode,
+          status: 'idle',
+          isPrimary: false,
+          progress: 0,
+        });
+      }
+      return { ...state, agents };
+    }
+
+    // Reserved: no emitter currently produces PARALLEL_COMPLETED. Subscription kept for forward compatibility.
     case 'PARALLEL_COMPLETED':
     case 'AGENTS_LOADED':
       return state;


### PR DESCRIPTION
## Summary

Closes #475

- Pre-register specialist agents as `idle` nodes in the dashboard agents Map when `PARALLEL_STARTED` event is received, so they appear in FlowMap early before individual `AGENT_ACTIVATED` events arrive
- Guard against overwriting already-active agents (idempotency via `agents.has(id)` check)
- Align integration test agentIds to use `specialist:${name}` convention, consistent with `response-event-extractor.ts` and ensuring proper idle→running state transitions

## Changes

| File | Change |
|------|--------|
| `use-dashboard-state.ts` | Replace `PARALLEL_STARTED` no-op with pre-registration logic (+15 lines) |
| `use-dashboard-state.spec.ts` | Replace no-op test with 3 tests: pre-register, idempotency, empty array edge case |
| `eventbus-ui.integration.spec.tsx` | Align specialist agentIds to `specialist:${name}` format |

## Design Decisions

- **ID format**: `specialist:${name}` to avoid collision with general agent IDs and stay consistent with `AGENT_RELATIONSHIP` events
- **Idempotency**: Skip pre-registration if agent already exists (preserves running/done status)
- **Stage source**: Uses event payload `mode` for `stage` field (not `state.currentMode`)

## Test Plan

- [x] Unit: pre-register specialists as idle agents on PARALLEL_STARTED
- [x] Unit: do not overwrite already running specialist
- [x] Unit: handle empty specialists array as no-op
- [x] Integration: FlowMap renders specialists after PARALLEL_STARTED + AGENT_ACTIVATED
- [x] Integration: globalState transitions (RUNNING → IDLE) with specialist lifecycle
- [x] Full suite: 159 files, 3689 tests passed