### PR TITLE
sync running agent stage on MODE_CHANGED

### DIFF
--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -299,6 +299,71 @@ describe('dashboardReducer', () => {
     expect(state).toEqual(initialDashboardState);
   });
 
+  it('should update running agents stage on MODE_CHANGED', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'MODE_CHANGED',
+      payload: { from: null, to: 'PLAN' },
+    });
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'a1', name: 'planner', role: 'primary', isPrimary: true },
+    });
+    expect(state.agents.get('a1')!.stage).toBe('PLAN');
+
+    state = dashboardReducer(state, {
+      type: 'MODE_CHANGED',
+      payload: { from: 'PLAN', to: 'ACT' },
+    });
+    expect(state.agents.get('a1')!.stage).toBe('ACT');
+  });
+
+  it('should only update running agents stage, preserving done/error/idle on MODE_CHANGED', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'MODE_CHANGED',
+      payload: { from: null, to: 'PLAN' },
+    });
+    // running agent
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'r1', name: 'runner', role: 'primary', isPrimary: true },
+    });
+    // done agent
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'd1', name: 'done-agent', role: 'specialist', isPrimary: false },
+    });
+    state = dashboardReducer(state, {
+      type: 'AGENT_DEACTIVATED',
+      payload: { agentId: 'd1', reason: 'completed', durationMs: 100 },
+    });
+    // error agent
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'e1', name: 'error-agent', role: 'specialist', isPrimary: false },
+    });
+    state = dashboardReducer(state, {
+      type: 'AGENT_DEACTIVATED',
+      payload: { agentId: 'e1', reason: 'error', durationMs: 50 },
+    });
+    // idle agent (pre-registered specialist)
+    state = dashboardReducer(state, {
+      type: 'PARALLEL_STARTED',
+      payload: { specialists: ['idle-spec'], mode: 'PLAN' },
+    });
+
+    state = dashboardReducer(state, {
+      type: 'MODE_CHANGED',
+      payload: { from: 'PLAN', to: 'ACT' },
+    });
+
+    expect(state.agents.get('r1')!.stage).toBe('ACT');
+    expect(state.agents.get('d1')!.stage).toBe('PLAN');
+    expect(state.agents.get('e1')!.stage).toBe('PLAN');
+    expect(state.agents.get('specialist:idle-spec')!.stage).toBe('PLAN');
+  });
+
   it('does not mutate original agents map', () => {
     const originalAgents = initialDashboardState.agents;
     dashboardReducer(initialDashboardState, {

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -109,8 +109,26 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
       return { ...state, agents, globalState, focusedAgentId };
     }
 
-    case 'MODE_CHANGED':
-      return { ...state, currentMode: action.payload.to, activeSkills: [] };
+    case 'MODE_CHANGED': {
+      const newMode = action.payload.to;
+      let agents = state.agents;
+      let needsClone = false;
+      for (const a of state.agents.values()) {
+        if (a.status === 'running') {
+          needsClone = true;
+          break;
+        }
+      }
+      if (needsClone) {
+        agents = cloneAgents(state.agents);
+        for (const [id, a] of agents) {
+          if (a.status === 'running') {
+            agents.set(id, { ...a, stage: newMode });
+          }
+        }
+      }
+      return { ...state, currentMode: newMode, agents, activeSkills: [] };
+    }
 
     case 'AGENT_RELATIONSHIP': {
       const edge: Edge = {


### PR DESCRIPTION
## Summary

Closes #476

- Update `MODE_CHANGED` reducer case to sync the `stage` field of all `running` agents to the new mode
- Agents with `done`, `error`, or `idle` status retain their original stage, preserving the mode context in which they operated
- Uses `needsClone` optimization to skip Map cloning when no running agents exist

## Changes

| File | Change |
|------|--------|
| `apps/mcp-server/src/tui/hooks/use-dashboard-state.ts` | Update `MODE_CHANGED` case to iterate agents and set `stage` for `running` status |
| `apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts` | Add 2 tests: running agent stage sync + mixed status preservation (done/error/idle) |

## Test plan

- [x] New test: `should update running agents stage on MODE_CHANGED` — verifies running agent stage changes from PLAN to ACT
- [x] New test: `should only update running agents stage, preserving done/error/idle on MODE_CHANGED` — verifies done, error, and idle agents retain original stage
- [x] Full test suite: 159 files, 3691 tests passing