### PR TITLE
remove extra leading space in skills section list items

### DIFF
--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
@@ -125,7 +125,7 @@ export function FocusedAgentPanel({
       {/* Skills Section */}
       <SectionDivider title="Skills" />
       {activeSkills.length > 0 ? (
-        activeSkills.map((s, i) => <Text key={i}>  {s}</Text>)
+        activeSkills.map((s, i) => <Text key={i}> {s}</Text>)
       ) : (
         <Text dimColor>No skills</Text>
       )}


### PR DESCRIPTION
## Summary

- Fix inconsistent indentation in the FocusedAgentPanel skills section by removing an extra leading space from skill list items

## Changes

- `apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx`: Changed double-space indent (`  {s}`) to single-space indent (` {s}`) in the active skills mapping to maintain consistent text alignment

## Test plan

- [ ] Verify the skills section in FocusedAgentPanel renders with consistent single-space indentation
- [ ] Confirm no visual regression in the TUI dashboard