### PR TITLE
extract additional data from parse_mode response

### DIFF
--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -64,7 +64,7 @@ export function createDefaultDashboardNode(
 /**
  * Relationship type between two agent nodes.
  */
-export type EdgeType = 'delegation' | 'output' | 'dependency';
+export type EdgeType = 'delegation' | 'output' | 'dependency' | 'recommendation';
 
 /**
  * Represents a directed edge between two agent nodes.

--- a/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
@@ -189,6 +189,138 @@ describe('extractEventsFromResponse', () => {
     });
   });
 
+  describe('parse_mode → agent:relationship (recommended_act_agent)', () => {
+    it('should extract AGENT_RELATIONSHIP from recommended_act_agent', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'PLAN',
+          delegates_to: 'technical-planner',
+          recommended_act_agent: { agentName: 'frontend-developer', confidence: 0.9 },
+        }),
+      );
+      const rel = events.find(e => e.event === TUI_EVENTS.AGENT_RELATIONSHIP);
+      expect(rel).toBeDefined();
+      expect(rel!.payload).toEqual({
+        from: 'primary:technical-planner',
+        to: 'recommended:frontend-developer',
+        label: 'recommends',
+        type: 'recommendation',
+      });
+    });
+
+    it('should not extract AGENT_RELATIONSHIP without delegates_to', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'PLAN',
+          recommended_act_agent: { agentName: 'frontend-developer', confidence: 0.9 },
+        }),
+      );
+      const rel = events.find(e => e.event === TUI_EVENTS.AGENT_RELATIONSHIP);
+      expect(rel).toBeUndefined();
+    });
+
+    it('should not extract AGENT_RELATIONSHIP if agentName is not a string', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'PLAN',
+          delegates_to: 'technical-planner',
+          recommended_act_agent: { agentName: 123 },
+        }),
+      );
+      const rel = events.find(e => e.event === TUI_EVENTS.AGENT_RELATIONSHIP);
+      expect(rel).toBeUndefined();
+    });
+
+    it('should not extract AGENT_RELATIONSHIP if recommended_act_agent is missing', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'PLAN',
+          delegates_to: 'technical-planner',
+        }),
+      );
+      const rel = events.find(e => e.event === TUI_EVENTS.AGENT_RELATIONSHIP);
+      expect(rel).toBeUndefined();
+    });
+  });
+
+  describe('parse_mode → parallel:started (parallelAgentsRecommendation)', () => {
+    it('should extract PARALLEL_STARTED from parallelAgentsRecommendation', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'EVAL',
+          delegates_to: 'evaluator',
+          parallelAgentsRecommendation: {
+            specialists: ['security-specialist', 'performance-specialist'],
+          },
+        }),
+      );
+      const ps = events.find(e => e.event === TUI_EVENTS.PARALLEL_STARTED);
+      expect(ps).toBeDefined();
+      expect(ps!.payload).toEqual({
+        specialists: ['security-specialist', 'performance-specialist'],
+        mode: 'EVAL',
+      });
+    });
+
+    it('should default mode to PLAN if mode is missing in json', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          parallelAgentsRecommendation: {
+            specialists: ['arch-specialist'],
+          },
+        }),
+      );
+      const ps = events.find(e => e.event === TUI_EVENTS.PARALLEL_STARTED);
+      expect(ps).toBeDefined();
+      expect(ps!.payload).toEqual({
+        specialists: ['arch-specialist'],
+        mode: 'PLAN',
+      });
+    });
+
+    it('should filter out non-string specialists', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'ACT',
+          parallelAgentsRecommendation: {
+            specialists: ['valid', 123, null, 'also-valid'],
+          },
+        }),
+      );
+      const ps = events.find(e => e.event === TUI_EVENTS.PARALLEL_STARTED);
+      expect(ps).toBeDefined();
+      expect(ps!.payload).toEqual({
+        specialists: ['valid', 'also-valid'],
+        mode: 'ACT',
+      });
+    });
+
+    it('should not extract PARALLEL_STARTED if specialists is empty', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'PLAN',
+          parallelAgentsRecommendation: { specialists: [] },
+        }),
+      );
+      const ps = events.find(e => e.event === TUI_EVENTS.PARALLEL_STARTED);
+      expect(ps).toBeUndefined();
+    });
+
+    it('should not extract PARALLEL_STARTED if parallelAgentsRecommendation is missing', () => {
+      const events = extractEventsFromResponse('parse_mode', makeResponse({ mode: 'PLAN' }));
+      const ps = events.find(e => e.event === TUI_EVENTS.PARALLEL_STARTED);
+      expect(ps).toBeUndefined();
+    });
+  });
+
   describe('parse_mode → objective:set', () => {
     it('should extract OBJECTIVE_SET from parse_mode with originalPrompt', () => {
       const events = extractEventsFromResponse(

--- a/apps/mcp-server/src/tui/events/response-event-extractor.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.ts
@@ -118,6 +118,44 @@ function extractFromParseMode(json: Record<string, unknown>): ExtractedEvent[] {
     });
   }
 
+  // agent:relationship (recommended_act_agent → next-phase recommendation)
+  const recAgent = json.recommended_act_agent;
+  if (recAgent && typeof recAgent === 'object') {
+    const rec = recAgent as Record<string, unknown>;
+    if (typeof rec.agentName === 'string' && delegateName) {
+      events.push({
+        event: TUI_EVENTS.AGENT_RELATIONSHIP,
+        payload: {
+          from: `primary:${delegateName}`,
+          to: `recommended:${rec.agentName}`,
+          label: 'recommends',
+          type: 'recommendation',
+        },
+      });
+    }
+  }
+
+  // parallel:started (parallelAgentsRecommendation → pre-register specialists)
+  const parRec = json.parallelAgentsRecommendation;
+  if (parRec && typeof parRec === 'object') {
+    const par = parRec as Record<string, unknown>;
+    if (Array.isArray(par.specialists) && par.specialists.length > 0) {
+      const specialists = par.specialists.filter((s): s is string => typeof s === 'string');
+      if (specialists.length > 0) {
+        events.push({
+          event: TUI_EVENTS.PARALLEL_STARTED,
+          payload: {
+            specialists,
+            mode:
+              typeof json.mode === 'string' && VALID_MODES.has(json.mode)
+                ? (json.mode as Mode)
+                : 'PLAN',
+          },
+        });
+      }
+    }
+  }
+
   // objective:set
   if (typeof json.originalPrompt === 'string' && json.originalPrompt.trim()) {
     events.push({

--- a/apps/mcp-server/src/tui/events/types.ts
+++ b/apps/mcp-server/src/tui/events/types.ts
@@ -5,6 +5,7 @@
  * Each event has a typed payload interface for type-safe emit/subscribe.
  */
 import type { Mode } from '../types';
+import type { EdgeType } from '../dashboard-types';
 import type { AgentMetadata } from './agent-metadata.types';
 
 /**
@@ -75,7 +76,7 @@ export interface AgentRelationshipEvent {
   from: string;
   to: string;
   label: string;
-  type: 'delegation' | 'output' | 'dependency';
+  type: EdgeType;
 }
 
 /** Payload when tasks are synced for an agent */


### PR DESCRIPTION
## Summary

Closes #477 (Parent: #471 - TUI Data Integration Audit)

- Extract `recommended_act_agent` from `parse_mode` response as `AGENT_RELATIONSHIP` event with `type: 'recommendation'`
- Extract `parallelAgentsRecommendation.specialists` from `parse_mode` response as `PARALLEL_STARTED` event
- Add `'recommendation'` to `EdgeType` union in `dashboard-types.ts`
- Unify `AgentRelationshipEvent.type` to reference `EdgeType` directly (removes inline type duplication)
- Align `PARALLEL_STARTED` mode validation with `VALID_MODES` pattern used in `extractFromPrepareParallelAgents`

## Changed Files

| File | Change |
|------|--------|
| `dashboard-types.ts` | Add `'recommendation'` to `EdgeType` |
| `events/types.ts` | Import `EdgeType`, replace inline union |
| `response-event-extractor.ts` | Add 2 extraction blocks to `extractFromParseMode` |
| `response-event-extractor.spec.ts` | Add 9 tests (4 for AGENT_RELATIONSHIP, 5 for PARALLEL_STARTED) |

## Test plan

- [x] All 9 new tests pass (positive + edge cases)
- [x] Full test suite passes (159 files, 3700 tests, 0 failures)
- [ ] Verify TUI dashboard displays recommendation edges correctly
- [ ] Verify parallel specialists pre-register from parse_mode response