### PR TITLE
derive FocusedAgentPanel inputs from tool invocations

### DIFF
--- a/apps/mcp-server/src/tui/dashboard-app.spec.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.spec.tsx
@@ -99,6 +99,32 @@ describe('DashboardApp', () => {
     expect(frame).toContain('security-');
   });
 
+  it('passes tool names as inputs to FocusedAgentPanel', async () => {
+    const eventBus = new TuiEventBus();
+    const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
+    await tick();
+
+    eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
+      agentId: 'a1',
+      name: 'test-agent',
+      role: 'primary',
+      isPrimary: true,
+    });
+    await tick();
+
+    eventBus.emit(TUI_EVENTS.TOOL_INVOKED, {
+      toolName: 'file_edit',
+      agentId: 'a1',
+      timestamp: Date.now(),
+    });
+    await tick();
+
+    const frame = lastFrame() ?? '';
+    // IN line should show tool name, not "none"
+    expect(frame).toContain('IN :');
+    expect(frame).not.toMatch(/IN\s*:\s*none/);
+  });
+
   it('focuses on primary running agent', async () => {
     const eventBus = new TuiEventBus();
     const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -11,7 +11,6 @@ import { MonitorPanel } from './components/MonitorPanel';
 import { computeStageHealth, detectBottlenecks } from './components/stage-health.pure';
 import { computeGridLayout } from './components/grid-layout.pure';
 
-const EMPTY_INPUTS: string[] = [];
 const EMPTY_OUTPUTS = { files: 0, commits: 0 } as const;
 
 export interface DashboardAppProps {
@@ -60,7 +59,7 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
             activeSkills={state.activeSkills}
             tasks={state.tasks}
             tools={tools}
-            inputs={EMPTY_INPUTS}
+            inputs={tools}
             outputs={EMPTY_OUTPUTS}
             eventLog={state.eventLog}
             width={grid.focusedAgent.width}
@@ -98,7 +97,7 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
             activeSkills={state.activeSkills}
             tasks={state.tasks}
             tools={tools}
-            inputs={EMPTY_INPUTS}
+            inputs={tools}
             outputs={EMPTY_OUTPUTS}
             eventLog={state.eventLog}
             width={grid.focusedAgent.width}


### PR DESCRIPTION
## Summary

Closes #478

- Replace hardcoded `EMPTY_INPUTS` (always empty array) with the already-computed `tools` array derived from `state.eventLog`
- Remove unused `EMPTY_INPUTS` constant
- The `IN:` line in FocusedAgentPanel now displays actual tool names instead of always showing `none`

## Changes

| File | Change |
|------|--------|
| `dashboard-app.tsx` | Remove `EMPTY_INPUTS` constant, pass `tools` to `inputs` prop (2 locations) |
| `dashboard-app.spec.tsx` | Add test verifying `IN:` line shows tool names after `TOOL_INVOKED` event |

## Test plan

- [x] New test: `passes tool names as inputs to FocusedAgentPanel` — verifies `IN:` line is not `none` when tool invocations exist
- [x] Full test suite: 159 files, 3701 tests passed, 0 failed