### PR TITLE
prepare tokenCount and outputs for future extension

### DIFF
--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -11,8 +11,6 @@ import { MonitorPanel } from './components/MonitorPanel';
 import { computeStageHealth, detectBottlenecks } from './components/stage-health.pure';
 import { computeGridLayout } from './components/grid-layout.pure';
 
-const EMPTY_OUTPUTS = { files: 0, commits: 0 } as const;
-
 export interface DashboardAppProps {
   eventBus?: TuiEventBus;
 }
@@ -60,7 +58,7 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
             tasks={state.tasks}
             tools={tools}
             inputs={tools}
-            outputs={EMPTY_OUTPUTS}
+            outputs={state.outputStats}
             eventLog={state.eventLog}
             width={grid.focusedAgent.width}
             height={grid.focusedAgent.height}
@@ -98,7 +96,7 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
             tasks={state.tasks}
             tools={tools}
             inputs={tools}
-            outputs={EMPTY_OUTPUTS}
+            outputs={state.outputStats}
             eventLog={state.eventLog}
             width={grid.focusedAgent.width}
             height={grid.focusedAgent.height}
@@ -108,7 +106,7 @@ export function DashboardApp({ eventBus }: DashboardAppProps): React.ReactElemen
       <StageHealthBar
         stageHealth={stageHealth}
         bottlenecks={bottlenecks}
-        tokenCount={0}
+        tokenCount={state.tokenUsage}
         width={grid.stageHealth.width}
       />
     </Box>

--- a/apps/mcp-server/src/tui/dashboard-types.spec.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.spec.ts
@@ -5,6 +5,7 @@ import {
   createEmptyStageStats,
   getLayoutMode,
   type DashboardNode,
+  type DashboardState,
   type StageStats,
   type GridRegion,
   type DashboardGrid,
@@ -127,6 +128,26 @@ describe('tui/dashboard-types', () => {
       expect(region.y).toBe(0);
       expect(region.width).toBe(120);
       expect(region.height).toBe(3);
+    });
+
+    it('DashboardState includes tokenUsage and outputStats fields', () => {
+      const state: DashboardState = {
+        workspace: '/tmp',
+        sessionId: 'test',
+        currentMode: null,
+        globalState: 'IDLE',
+        agents: new Map(),
+        edges: [],
+        focusedAgentId: null,
+        tasks: [],
+        eventLog: [],
+        objectives: [],
+        activeSkills: [],
+        tokenUsage: 0,
+        outputStats: { files: 0, commits: 0 },
+      };
+      expect(state.tokenUsage).toBe(0);
+      expect(state.outputStats).toEqual({ files: 0, commits: 0 });
     });
 
     it('DashboardGrid has all required sections', () => {

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -137,6 +137,8 @@ export interface DashboardState {
   eventLog: EventLogEntry[];
   objectives: string[];
   activeSkills: string[];
+  tokenUsage: number;
+  outputStats: { files: number; commits: number };
 }
 
 /**

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -8,6 +8,12 @@ import {
 describe('dashboardReducer', () => {
   const initialDashboardState = createInitialDashboardState();
 
+  it('initializes tokenUsage to 0 and outputStats to zero counts', () => {
+    const state = createInitialDashboardState();
+    expect(state.tokenUsage).toBe(0);
+    expect(state.outputStats).toEqual({ files: 0, commits: 0 });
+  });
+
   it('handles AGENT_ACTIVATED by adding node', () => {
     const action: DashboardAction = {
       type: 'AGENT_ACTIVATED',

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -43,6 +43,8 @@ export function createInitialDashboardState(): DashboardState {
     eventLog: [],
     objectives: [],
     activeSkills: [],
+    tokenUsage: 0,
+    outputStats: { files: 0, commits: 0 },
   };
 }
 


### PR DESCRIPTION
## Summary

- Add `tokenUsage` and `outputStats` fields to `DashboardState` interface for future data source integration
- Set zero-valued defaults in `createInitialDashboardState()` so no type changes are needed when real data becomes available
- Replace hardcoded `EMPTY_OUTPUTS` constant and `tokenCount={0}` in `DashboardApp` with state-driven values

## Changes

| File | Change |
|------|--------|
| `dashboard-types.ts` | Add `tokenUsage: number` and `outputStats: { files: number; commits: number }` to `DashboardState` |
| `dashboard-types.spec.ts` | Add type compatibility test for new fields |
| `use-dashboard-state.ts` | Set initial values (`0`) in `createInitialDashboardState()` |
| `use-dashboard-state.spec.ts` | Add initial value verification test |
| `dashboard-app.tsx` | Remove `EMPTY_OUTPUTS` constant, wire `state.tokenUsage` and `state.outputStats` |

## Test plan

- [x] TypeScript compile check (`tsc --noEmit`) passes with zero errors
- [x] All 3703 existing tests pass (no regressions)
- [x] New type compatibility test verifies `DashboardState` accepts `tokenUsage` and `outputStats`
- [x] New initial value test verifies `createInitialDashboardState()` returns zero defaults
- [x] Runtime behavior unchanged (default values are identical to previous hardcoded values)

Closes #479