### PR TITLE
resolve absolute binary path for TuiAutoLauncher

### DIFF
--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import * as path from 'path';
 import { NestFactory } from '@nestjs/core';
 import type { INestApplicationContext } from '@nestjs/common';
 import { AppModule } from './app.module';
@@ -109,8 +110,10 @@ async function initTui(
  */
 async function launchAutoTui(ipcServer: { clientCount(): number }): Promise<void> {
   const { TuiAutoLauncher } = await import('./tui/ipc');
+  const codingbuddyBin = path.resolve(process.argv[1]);
   const launcher = new TuiAutoLauncher({
     enabled: process.env.CODINGBUDDY_AUTO_TUI === '1',
+    codingbuddyBin,
   });
   const result = await launcher.launch(ipcServer);
   debugLog(`TUI auto-launch: ${result.reason}${result.pid ? ` (PID: ${result.pid})` : ''}`);

--- a/apps/mcp-server/src/tui/ipc/tui-auto-launcher.spec.ts
+++ b/apps/mcp-server/src/tui/ipc/tui-auto-launcher.spec.ts
@@ -169,6 +169,31 @@ describe('TuiAutoLauncher', () => {
         { detached: true, stdio: 'ignore' },
       );
     });
+
+    it('should use npx-style absolute path in spawn args', async () => {
+      process.env.TERM_PROGRAM = 'iTerm.app';
+      createMockChildProcess(7777);
+
+      const npxPath = '/Users/x/.npm/_npx/abc123/node_modules/.bin/codingbuddy';
+      const launcher = new TuiAutoLauncher({
+        enabled: true,
+        delayMs: 0,
+        codingbuddyBin: npxPath,
+      });
+      const ipcServer = createMockIpcServer(0);
+
+      const result = await launcher.launch(ipcServer);
+
+      expect(result.launched).toBe(true);
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'osascript',
+        [
+          '-e',
+          `tell application "iTerm2" to create window with default profile command "${npxPath} tui"`,
+        ],
+        { detached: true, stdio: 'ignore' },
+      );
+    });
   });
 
   describe('Linux', () => {


### PR DESCRIPTION
## Summary

Fixes #519

- Resolve `process.argv[1]` to an absolute path via `path.resolve()` and pass it as `codingbuddyBin` to `TuiAutoLauncher`
- Add regression test for npx-cache-style absolute paths (e.g. `~/.npm/_npx/<hash>/node_modules/.bin/codingbuddy`)

## Problem

When codingbuddy is installed via `npx` (the default/recommended setup), the binary lives in an npx cache directory and is **not** in the global `$PATH`. The `TuiAutoLauncher` defaults `codingbuddyBin` to `'codingbuddy'`, causing the auto-launched terminal window to open and immediately close because the shell cannot find the command.

## Solution

In `main.ts`'s `launchAutoTui()`, resolve the current binary's absolute path from `process.argv[1]` and pass it to `TuiAutoLauncher`:

```typescript
const codingbuddyBin = path.resolve(process.argv[1]);
```

This works because:
- `process.argv[1]` contains the actual script path (e.g. `/Users/x/.npm/_npx/<hash>/node_modules/.bin/codingbuddy`)
- `path.resolve()` converts relative paths to absolute; already-absolute paths are returned as-is
- `SAFE_PATH_PATTERN` (`/^[a-zA-Z0-9._\-/]+$/`) allows all characters in npx cache paths
- No changes to `TuiAutoLauncher` itself — it already supports the `codingbuddyBin` option

## Files Changed

| File | Change |
|------|--------|
| `apps/mcp-server/src/main.ts` | Add `path` import; resolve `process.argv[1]` and pass as `codingbuddyBin` |
| `apps/mcp-server/src/tui/ipc/tui-auto-launcher.spec.ts` | Add regression test for npx-style absolute path |

## Test Plan

- [x] New test: npx-cache-style absolute path is correctly passed through to spawn args
- [x] All existing tests pass (3821 passed)
- [x] TypeScript build succeeds