### PR TITLE
separate AUTO mode from process flow in HeaderBar

### DIFF
--- a/apps/mcp-server/src/tui/components/HeaderBar.spec.tsx
+++ b/apps/mcp-server/src/tui/components/HeaderBar.spec.tsx
@@ -128,6 +128,46 @@ describe('tui/components/HeaderBar', () => {
     expect(lastFrame()).toBeTruthy();
   });
 
+  // --- Bug #488: AUTO mode display fix ---
+
+  it('should not render AUTO in process flow arrows for non-AUTO modes', () => {
+    const { lastFrame } = render(
+      <HeaderBar
+        workspace="/repo"
+        sessionId="s"
+        currentMode="PLAN"
+        globalState="RUNNING"
+        layoutMode="wide"
+        width={120}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('PLAN');
+    expect(frame).toContain('ACT');
+    expect(frame).toContain('EVAL');
+    expect(frame).not.toMatch(/EVAL[^]*AUTO/);
+  });
+
+  it('should render AUTO as separate badge when AUTO mode is active', () => {
+    const { lastFrame } = render(
+      <HeaderBar
+        workspace="/repo"
+        sessionId="s"
+        currentMode="AUTO"
+        globalState="RUNNING"
+        layoutMode="wide"
+        width={120}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('AUTO');
+    expect(frame).toContain('PLAN');
+    expect(frame).toContain('ACT');
+    expect(frame).toContain('EVAL');
+    // AUTO should not be connected by arrow to EVAL
+    expect(frame).not.toMatch(/EVAL[^A]*→[^A]*AUTO/);
+  });
+
   it('should render double border (Ink box rendering)', () => {
     const { lastFrame } = render(
       <HeaderBar

--- a/apps/mcp-server/src/tui/components/HeaderBar.tsx
+++ b/apps/mcp-server/src/tui/components/HeaderBar.tsx
@@ -13,16 +13,22 @@ export interface HeaderBarProps {
   width: number;
 }
 
-const ALL_MODES: Mode[] = ['PLAN', 'ACT', 'EVAL', 'AUTO'];
-
-/** Characters reserved for border (4), title (~32), mode flow (~30), state (~8), gaps (~8). */
-const HEADER_RESERVED_CHARS = 82;
+const PROCESS_MODES: Mode[] = ['PLAN', 'ACT', 'EVAL'];
 
 function ModeFlow({ currentMode }: { currentMode: Mode | null }): React.ReactElement {
+  const isAutoMode = currentMode === 'AUTO';
   return (
     <Box>
-      {ALL_MODES.map((mode, i) => {
-        const isActive = mode === currentMode;
+      {isAutoMode && (
+        <>
+          <Text color={getModeColor('AUTO')} bold>
+            [AUTO]
+          </Text>
+          <Text dimColor> </Text>
+        </>
+      )}
+      {PROCESS_MODES.map((mode, i) => {
+        const isActive = !isAutoMode && mode === currentMode;
         const color = getModeColor(mode);
         return (
           <React.Fragment key={mode}>
@@ -51,15 +57,6 @@ function StateIndicator({ globalState }: { globalState: GlobalRunState }): React
   );
 }
 
-function truncateWorkspace(ws: string, maxLen: number): string {
-  if (ws.length <= maxLen) return ws;
-  const segments = ws.split('/').filter(Boolean);
-  if (segments.length <= 1) return '…' + ws.slice(-(maxLen - 1));
-  // Show last 2 path segments
-  const short = segments.slice(-2).join('/');
-  return short.length <= maxLen ? short : '…' + ws.slice(-(maxLen - 1));
-}
-
 export function HeaderBar({
   workspace,
   sessionId,
@@ -70,7 +67,13 @@ export function HeaderBar({
 }: HeaderBarProps): React.ReactElement {
   if (layoutMode === 'narrow') {
     return (
-      <Box borderStyle="double" borderColor="cyan" width={width} flexDirection="row">
+      <Box
+        borderStyle="double"
+        borderColor="cyan"
+        width={width}
+        overflowX="hidden"
+        flexDirection="row"
+      >
         <Text color="cyan" bold>
           ⟨⟩ CODINGBUDDY
         </Text>
@@ -82,14 +85,17 @@ export function HeaderBar({
     );
   }
 
-  const reservedChars = HEADER_RESERVED_CHARS;
-  const maxWsLen = Math.max(8, width - reservedChars - 16);
-  const displayWs = truncateWorkspace(workspace, maxWsLen);
   const sessDisplay = sessionId.length > 8 ? sessionId.slice(0, 8) : sessionId;
 
   return (
-    <Box borderStyle="double" borderColor="cyan" width={width} flexDirection="row">
-      <Box gap={2}>
+    <Box
+      borderStyle="double"
+      borderColor="cyan"
+      width={width}
+      overflowX="hidden"
+      flexDirection="row"
+    >
+      <Box gap={2} flexShrink={0}>
         <Text color="cyan" bold>
           ⟨⟩ CODINGBUDDY AGENT DASHBOARD
         </Text>
@@ -97,9 +103,10 @@ export function HeaderBar({
         <StateIndicator globalState={globalState} />
       </Box>
       <Box flexGrow={1} />
-      <Box gap={2}>
-        <Text dimColor>{displayWs}</Text>
-        <Text dimColor>sess:{sessDisplay}</Text>
+      <Box flexShrink={1} overflowX="hidden">
+        <Text dimColor wrap="truncate">
+          {workspace} sess:{sessDisplay}
+        </Text>
       </Box>
     </Box>
   );

--- a/apps/mcp-server/src/tui/components/header-bar.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/header-bar.pure.spec.ts
@@ -112,5 +112,52 @@ describe('tui/components/header-bar.pure', () => {
       const result = formatHeaderBar(baseData, 40, 'narrow');
       expect(result.length).toBeLessThanOrEqual(40);
     });
+
+    // --- Bug #488: AUTO mode display fix ---
+
+    it('should not include AUTO in process flow arrows', () => {
+      const result = formatHeaderBar(baseData, 120, 'wide');
+      expect(result).toContain('[PLAN]');
+      expect(result).not.toMatch(/EVAL → AUTO/);
+    });
+
+    it('should show AUTO mode as separate indicator when active', () => {
+      const autoData: HeaderBarData = { ...baseData, currentMode: 'AUTO' };
+      const result = formatHeaderBar(autoData, 120, 'wide');
+      expect(result).toContain('[AUTO]');
+      expect(result).not.toMatch(/EVAL → AUTO/);
+      expect(result).not.toMatch(/→ \[AUTO\]/);
+    });
+
+    it('should show process flow without highlighting when AUTO is active', () => {
+      const autoData: HeaderBarData = { ...baseData, currentMode: 'AUTO' };
+      const result = formatHeaderBar(autoData, 120, 'wide');
+      expect(result).toMatch(/PLAN → ACT → EVAL/);
+    });
+
+    // --- Bug #488: Overflow fix ---
+
+    it('should never produce line2 exceeding width in wide mode', () => {
+      const longData: HeaderBarData = {
+        ...baseData,
+        workspace: '/very/long/path/to/some/deeply/nested/workspace/directory/that/goes/on',
+        sessionId: 'sess-very-long-session-id-that-is-quite-lengthy',
+      };
+      const result = formatHeaderBar(longData, 80, 'wide');
+      const lines = result.split('\n');
+      for (const line of lines) {
+        expect(line.length).toBeLessThanOrEqual(80);
+      }
+    });
+
+    it('should never produce output exceeding width in narrow mode', () => {
+      const longData: HeaderBarData = {
+        ...baseData,
+        workspace: '/very/long/workspace',
+        sessionId: 'very-long-session-id',
+      };
+      const result = formatHeaderBar(longData, 50, 'narrow');
+      expect(result.length).toBeLessThanOrEqual(50);
+    });
   });
 });

--- a/apps/mcp-server/src/tui/components/header-bar.pure.ts
+++ b/apps/mcp-server/src/tui/components/header-bar.pure.ts
@@ -36,10 +36,13 @@ export function formatHeaderBar(
   layoutMode: LayoutMode,
 ): string {
   const title = 'Codingbuddy TUI / Agent Dashboard';
-  const ALL_MODES: Mode[] = ['PLAN', 'ACT', 'EVAL', 'AUTO'];
-  const modeStr = data.currentMode
-    ? ALL_MODES.map(m => (m === data.currentMode ? `[${m}]` : m)).join(' → ')
-    : ALL_MODES.slice(0, 3).join(' → ');
+  const PROCESS_MODES: Mode[] = ['PLAN', 'ACT', 'EVAL'];
+  const isAutoMode = data.currentMode === 'AUTO';
+
+  const processFlow = PROCESS_MODES.map(m =>
+    !isAutoMode && m === data.currentMode ? `[${m}]` : m,
+  ).join(' → ');
+  const modeStr = isAutoMode ? `${processFlow} [AUTO]` : processFlow;
   const stateStr = `${data.globalState} ${STATE_ICONS[data.globalState]}`;
 
   if (layoutMode === 'narrow') {
@@ -51,25 +54,34 @@ export function formatHeaderBar(
   // Wide/Medium: two lines
   const line1 = title;
 
-  const workspacePart = `Workspace: ${data.workspace}`;
   const sessionPart = `Session: ${data.sessionId}`;
   const modePart = `Mode: ${modeStr}`;
   const statePart = `State: ${stateStr}`;
 
-  let line2 = `${workspacePart}   ${sessionPart}   ${modePart}   ${statePart}`;
+  const separator = '   ';
+  const fixedParts = `${sessionPart}${separator}${modePart}${separator}${statePart}`;
+  const wsPrefix = 'Workspace: ';
+  const fullLine2 = `${wsPrefix}${data.workspace}${separator}${fixedParts}`;
 
-  // Truncate workspace if line2 exceeds width
-  if (line2.length > width) {
-    const maxWorkspace = width - sessionPart.length - modePart.length - statePart.length - 15;
-    if (maxWorkspace > 10) {
+  let line2: string;
+  if (fullLine2.length <= width) {
+    line2 = fullLine2;
+  } else {
+    const maxWsLen = width - wsPrefix.length - separator.length - fixedParts.length;
+    if (maxWsLen > 10) {
       const truncatedWs =
-        data.workspace.length > maxWorkspace
-          ? data.workspace.slice(0, maxWorkspace - 3) + '...'
+        data.workspace.length > maxWsLen
+          ? data.workspace.slice(0, maxWsLen - 3) + '...'
           : data.workspace;
-      line2 = `Workspace: ${truncatedWs}   ${sessionPart}   ${modePart}   ${statePart}`;
+      line2 = `${wsPrefix}${truncatedWs}${separator}${fixedParts}`;
     } else {
-      line2 = `${modePart}   ${statePart}`;
+      line2 = `${modePart}${separator}${statePart}`;
     }
+  }
+
+  // Final safety: hard truncate
+  if (line2.length > width) {
+    line2 = line2.slice(0, width);
   }
 
   return `${line1}\n${line2}`;

--- a/apps/mcp-server/src/tui/utils/theme.ts
+++ b/apps/mcp-server/src/tui/utils/theme.ts
@@ -39,7 +39,7 @@ export const STATUS_STYLES: Readonly<Record<DashboardNodeStatus, CellStyle>> = O
 });
 
 /**
- * Styles for mode labels in header pipeline (PLAN → ACT → EVAL → AUTO).
+ * Styles for mode labels in header pipeline (PLAN → ACT → EVAL, AUTO separate).
  */
 export const MODE_LABEL_STYLES: Readonly<Record<Mode, CellStyle>> = Object.freeze({
   PLAN: { fg: 'cyan', bold: true },


### PR DESCRIPTION
## Summary

Fixes #488 — Two bugs in the TUI HeaderBar component:

- **AUTO mode display error**: AUTO was rendered as `PLAN → ACT → EVAL → AUTO`, making it appear as a sequential step. AUTO is actually an independent mode that cycles through PLAN→ACT→EVAL autonomously. Now rendered as a separate `[AUTO]` badge.
- **Right-side content overflow**: Workspace/session text could extend beyond the terminal boundary. Fixed with `overflowX="hidden"`, `flexShrink` constraints, and dynamic width calculation with safety truncate.

## Changes

| File | Change |
|------|--------|
| `header-bar.pure.ts` | `ALL_MODES` → `PROCESS_MODES` (exclude AUTO), AUTO as separate badge, dynamic overflow calculation + safety truncate |
| `header-bar.pure.spec.ts` | +5 tests (AUTO separation ×3, overflow ×2) |
| `HeaderBar.tsx` | `ModeFlow` refactored for AUTO badge, removed `truncateWorkspace`/`HEADER_RESERVED_CHARS`, added `overflowX="hidden"` + `flexShrink` |
| `HeaderBar.spec.tsx` | +2 tests (AUTO separation) |
| `theme.ts` | Updated stale comment |

**Before:** `PLAN → ACT → EVAL → AUTO`
**After (non-AUTO):** `[PLAN] → ACT → EVAL`
**After (AUTO active):** `[AUTO] PLAN → ACT → EVAL`

## Test plan

- [x] 946 TUI tests passing (58 test files)
- [x] 7 new tests added covering both bugs
- [x] Build compiles without errors
- [x] No dangling references to removed symbols (`ALL_MODES`, `HEADER_RESERVED_CHARS`, `truncateWorkspace`)