### PR TITLE
show tasks panel data in PLAN and EVAL modes (#492)

### DIFF
--- a/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
@@ -583,12 +583,21 @@ describe('extractEventsFromResponse', () => {
       expect(result).toHaveLength(0);
     });
 
-    it('should return empty if progress is empty', () => {
+    it('should return empty if all task source fields are empty or missing', () => {
       const result = extractEventsFromResponse(
         'update_context',
         makeResponse({
           document: {
-            sections: [{ mode: 'ACT', primaryAgent: 'dev', progress: [] }],
+            sections: [
+              {
+                mode: 'ACT',
+                primaryAgent: 'dev',
+                progress: [],
+                decisions: [],
+                findings: [],
+                notes: [],
+              },
+            ],
           },
         }),
       );
@@ -620,6 +629,109 @@ describe('extractEventsFromResponse', () => {
         }),
       );
       expect(result[0].payload).toEqual(expect.objectContaining({ agentId: 'new' }));
+    });
+
+    it('should extract task:synced from PLAN mode decisions', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({
+          document: {
+            sections: [
+              {
+                mode: 'PLAN',
+                primaryAgent: 'technical-planner',
+                status: 'in_progress',
+                decisions: ['Use JWT for auth', 'Add rate limiting'],
+              },
+            ],
+          },
+        }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].event).toBe(TUI_EVENTS.TASK_SYNCED);
+      expect(result[0].payload).toEqual({
+        agentId: 'technical-planner',
+        tasks: [
+          { id: 'ctx-0', subject: 'Use JWT for auth', completed: false },
+          { id: 'ctx-1', subject: 'Add rate limiting', completed: false },
+        ],
+      });
+    });
+
+    it('should extract task:synced from EVAL mode findings', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({
+          document: {
+            sections: [
+              {
+                mode: 'EVAL',
+                primaryAgent: 'code-reviewer',
+                status: 'in_progress',
+                findings: ['Missing error handling in auth', 'No input validation'],
+              },
+            ],
+          },
+        }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].event).toBe(TUI_EVENTS.TASK_SYNCED);
+      expect(result[0].payload).toEqual({
+        agentId: 'code-reviewer',
+        tasks: [
+          { id: 'ctx-0', subject: 'Missing error handling in auth', completed: false },
+          { id: 'ctx-1', subject: 'No input validation', completed: false },
+        ],
+      });
+    });
+
+    it('should fall back to notes when no primary field is present', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({
+          document: {
+            sections: [
+              {
+                mode: 'PLAN',
+                primaryAgent: 'planner',
+                status: 'in_progress',
+                notes: ['Reviewed existing codebase', 'Identified dependencies'],
+              },
+            ],
+          },
+        }),
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].payload).toEqual({
+        agentId: 'planner',
+        tasks: [
+          { id: 'ctx-0', subject: 'Reviewed existing codebase', completed: false },
+          { id: 'ctx-1', subject: 'Identified dependencies', completed: false },
+        ],
+      });
+    });
+
+    it('should prioritize progress over decisions when both exist', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({
+          document: {
+            sections: [
+              {
+                mode: 'ACT',
+                primaryAgent: 'dev',
+                status: 'in_progress',
+                progress: ['Implemented feature'],
+                decisions: ['Use pattern X'],
+              },
+            ],
+          },
+        }),
+      );
+      expect(result[0].payload).toEqual({
+        agentId: 'dev',
+        tasks: [{ id: 'ctx-0', subject: 'Implemented feature', completed: false }],
+      });
     });
   });
 

--- a/apps/mcp-server/src/tui/events/response-event-extractor.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.ts
@@ -231,6 +231,21 @@ function extractFromDispatchAgents(json: Record<string, unknown>): ExtractedEven
 }
 
 /**
+ * Pick the first non-empty string array from the section's task-related fields.
+ * Priority: progress (ACT) > decisions (PLAN) > findings (EVAL) > notes (fallback).
+ */
+function pickTaskSource(section: Record<string, unknown>): string[] | null {
+  for (const field of ['progress', 'decisions', 'findings', 'notes']) {
+    const value = section[field];
+    if (Array.isArray(value) && value.length > 0) {
+      const strings = value.filter((v): v is string => typeof v === 'string');
+      if (strings.length > 0) return strings;
+    }
+  }
+  return null;
+}
+
+/**
  * Extract task sync events from update_context response.
  */
 function extractFromUpdateContext(json: Record<string, unknown>): ExtractedEvent[] {
@@ -241,22 +256,17 @@ function extractFromUpdateContext(json: Record<string, unknown>): ExtractedEvent
   const sections = document.sections;
   if (!Array.isArray(sections) || sections.length === 0) return [];
 
-  // Get the most recent section's progress items
   const lastSection = sections[sections.length - 1] as Record<string, unknown>;
-  const progress = lastSection?.progress;
-  if (!Array.isArray(progress) || progress.length === 0) return [];
+  const items = pickTaskSource(lastSection);
+  if (!items || items.length === 0) return [];
 
   const sectionCompleted = lastSection?.status === 'completed';
-  const tasks = progress
-    .filter((p): p is string => typeof p === 'string')
-    .map((p, idx) => ({
-      // Positional IDs are intentionally ephemeral; each TASK_SYNCED replaces all tasks.
-      id: `ctx-${idx}`,
-      subject: p,
-      completed: sectionCompleted,
-    }));
-
-  if (tasks.length === 0) return [];
+  const tasks = items.map((item, idx) => ({
+    // Positional IDs are intentionally ephemeral; each TASK_SYNCED replaces all tasks.
+    id: `ctx-${idx}`,
+    subject: item,
+    completed: sectionCompleted,
+  }));
 
   const agentId =
     typeof lastSection.primaryAgent === 'string' ? lastSection.primaryAgent : UNKNOWN_AGENT_ID;


### PR DESCRIPTION
## Summary

- Add `pickTaskSource` helper with fallback chain: `progress` > `decisions` > `findings` > `notes`
- Update `extractFromUpdateContext` to use the helper instead of reading only `progress`
- Tasks panel now displays relevant items in **all** workflow modes (PLAN, ACT, EVAL)

## Root Cause

`extractFromUpdateContext()` only read the `progress` field from the last context section. Since PLAN mode uses `decisions` and EVAL mode uses `findings`, the Tasks panel was always empty outside ACT mode.

## Changes

**`response-event-extractor.ts`**
- New `pickTaskSource(section)` function that tries each field in priority order and returns the first non-empty string array
- `extractFromUpdateContext` delegates source selection to `pickTaskSource`

**`response-event-extractor.spec.ts`**
- Add test: PLAN mode `decisions` emit `TASK_SYNCED`
- Add test: EVAL mode `findings` emit `TASK_SYNCED`
- Add test: `notes` fallback when no primary field present
- Add test: `progress` takes priority when multiple fields coexist
- Update existing empty-check test to cover all fields

## Test plan

- [x] New tests cover PLAN decisions, EVAL findings, notes fallback, and priority scenarios
- [x] All existing `update_context → task:synced` tests pass unchanged
- [x] Full test suite passes (3776 tests, 0 failures)

```bash
yarn workspace codingbuddy test -- --testPathPattern="response-event-extractor" --no-coverage
```

Closes #492