### PR TITLE
replace renderBubbles with renderLiveContext in Live panel

### DIFF
--- a/apps/mcp-server/src/tui/components/ActivityVisualizer.spec.tsx
+++ b/apps/mcp-server/src/tui/components/ActivityVisualizer.spec.tsx
@@ -6,45 +6,59 @@ import type { ToolCallRecord } from '../dashboard-types';
 
 function makeCalls(): ToolCallRecord[] {
   return [
-    { agentId: 'architect', toolName: 'Read', timestamp: Date.now(), status: 'active' },
+    { agentId: 'architect', toolName: 'Read', timestamp: Date.now(), status: 'completed' },
     { agentId: 'architect', toolName: 'Read', timestamp: Date.now(), status: 'completed' },
     { agentId: 'architect', toolName: 'Grep', timestamp: Date.now(), status: 'completed' },
-    { agentId: 'tester', toolName: 'Bash', timestamp: Date.now(), status: 'active' },
+    { agentId: 'tester', toolName: 'Bash', timestamp: Date.now(), status: 'completed' },
   ];
 }
 
 describe('tui/components/ActivityVisualizer', () => {
   it('renders without crashing with data', () => {
     const { lastFrame } = render(
-      <ActivityVisualizer toolCalls={makeCalls()} width={80} height={10} />,
+      <ActivityVisualizer toolCalls={makeCalls()} currentMode="PLAN" width={80} height={10} />,
     );
     expect(lastFrame()).toBeDefined();
   });
 
   it('renders without crashing with empty data', () => {
-    const { lastFrame } = render(<ActivityVisualizer toolCalls={[]} width={80} height={10} />);
+    const { lastFrame } = render(
+      <ActivityVisualizer toolCalls={[]} currentMode={null} width={80} height={10} />,
+    );
     expect(lastFrame()).toBeDefined();
   });
 
   it('renders without crashing when width=0 or height=0', () => {
-    expect(() => render(<ActivityVisualizer toolCalls={[]} width={0} height={10} />)).not.toThrow();
-    expect(() => render(<ActivityVisualizer toolCalls={[]} width={80} height={0} />)).not.toThrow();
+    expect(() =>
+      render(<ActivityVisualizer toolCalls={[]} currentMode={null} width={0} height={10} />),
+    ).not.toThrow();
+    expect(() =>
+      render(<ActivityVisualizer toolCalls={[]} currentMode={null} width={80} height={0} />),
+    ).not.toThrow();
   });
 
   it('contains heatmap content when calls exist', () => {
     const { lastFrame } = render(
-      <ActivityVisualizer toolCalls={makeCalls()} width={80} height={10} />,
+      <ActivityVisualizer toolCalls={makeCalls()} currentMode={null} width={80} height={10} />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('Activity');
   });
 
-  it('contains bubble header and indicators when active calls exist', () => {
+  it('contains Live header and tool names when calls exist', () => {
     const { lastFrame } = render(
-      <ActivityVisualizer toolCalls={makeCalls()} width={80} height={10} />,
+      <ActivityVisualizer toolCalls={makeCalls()} currentMode={null} width={80} height={10} />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('Live');
-    expect(frame).toContain('◉');
+  });
+
+  it('shows current mode in live panel', () => {
+    const { lastFrame } = render(
+      <ActivityVisualizer toolCalls={makeCalls()} currentMode="ACT" width={80} height={10} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Mode');
+    expect(frame).toContain('ACT');
   });
 });

--- a/apps/mcp-server/src/tui/components/ActivityVisualizer.tsx
+++ b/apps/mcp-server/src/tui/components/ActivityVisualizer.tsx
@@ -1,16 +1,19 @@
 import React, { useMemo } from 'react';
 import { Box, Text } from 'ink';
 import type { ToolCallRecord } from '../dashboard-types';
-import { aggregateToolCalls, renderHeatmap, renderBubbles } from './activity-visualizer.pure';
+import type { Mode } from '../types';
+import { aggregateToolCalls, renderHeatmap, renderLiveContext } from './activity-visualizer.pure';
 
 export interface ActivityVisualizerProps {
   toolCalls: ToolCallRecord[];
+  currentMode: Mode | null;
   width: number;
   height: number;
 }
 
 export function ActivityVisualizer({
   toolCalls,
+  currentMode,
   width,
   height,
 }: ActivityVisualizerProps): React.ReactElement {
@@ -19,7 +22,7 @@ export function ActivityVisualizer({
   }
 
   const heatmapWidth = Math.floor(width * 0.6);
-  const bubblesWidth = width - heatmapWidth;
+  const livePanelWidth = width - heatmapWidth;
   const contentHeight = Math.max(1, height - 2);
 
   const heatmapData = useMemo(() => aggregateToolCalls(toolCalls), [toolCalls]);
@@ -27,9 +30,9 @@ export function ActivityVisualizer({
     () => renderHeatmap(heatmapData, Math.max(1, heatmapWidth - 2), contentHeight),
     [heatmapData, heatmapWidth, contentHeight],
   );
-  const bubbleLines = useMemo(
-    () => renderBubbles(toolCalls, Math.max(1, bubblesWidth - 2), contentHeight),
-    [toolCalls, bubblesWidth, contentHeight],
+  const liveLines = useMemo(
+    () => renderLiveContext(toolCalls, currentMode, Math.max(1, livePanelWidth - 2), contentHeight),
+    [toolCalls, currentMode, livePanelWidth, contentHeight],
   );
 
   return (
@@ -49,10 +52,10 @@ export function ActivityVisualizer({
         borderStyle="single"
         borderColor="gray"
         flexDirection="column"
-        width={bubblesWidth}
+        width={livePanelWidth}
         height={height}
       >
-        {bubbleLines.map((line, i) => (
+        {liveLines.map((line, i) => (
           <Text key={i}>{line}</Text>
         ))}
       </Box>

--- a/apps/mcp-server/src/tui/components/activity-visualizer.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/activity-visualizer.pure.spec.ts
@@ -3,10 +3,11 @@ import {
   aggregateToolCalls,
   getDensityChar,
   renderHeatmap,
-  renderBubbles,
+  renderLiveContext,
   type HeatmapData,
 } from './activity-visualizer.pure';
 import type { ToolCallRecord } from '../dashboard-types';
+import { estimateDisplayWidth } from '../utils/display-width';
 
 describe('aggregateToolCalls', () => {
   it('returns empty arrays for empty input', () => {
@@ -186,164 +187,163 @@ describe('renderHeatmap', () => {
   it('truncates lines to width', () => {
     const lines = renderHeatmap(sampleData, 20, 10);
     for (const line of lines) {
-      // estimateDisplayWidth handles wide chars; length check is a reasonable proxy for ASCII
-      expect(line.length).toBeLessThanOrEqual(25); // tightened allowance for multi-byte
+      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(20);
     }
   });
 });
 
-describe('renderBubbles', () => {
+describe('renderLiveContext', () => {
   const NOW = 100_000;
 
   it('returns empty array for height <= 0', () => {
     const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'active' },
+      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'completed' },
     ];
-    expect(renderBubbles(calls, 40, 0, NOW)).toEqual([]);
+    expect(renderLiveContext(calls, null, 40, 0, NOW)).toEqual([]);
   });
 
   it('returns empty array for width <= 0', () => {
     const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'active' },
+      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'completed' },
     ];
-    expect(renderBubbles(calls, 0, 5, NOW)).toEqual([]);
-    expect(renderBubbles(calls, -1, 5, NOW)).toEqual([]);
+    expect(renderLiveContext(calls, null, 0, 5, NOW)).toEqual([]);
+    expect(renderLiveContext(calls, null, -1, 5, NOW)).toEqual([]);
   });
 
-  it('returns empty array when no active or recent calls', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: 1000, status: 'completed' },
-    ];
-    expect(renderBubbles(calls, 40, 5, NOW)).toEqual([]);
-  });
-
-  it('includes Live header when active calls exist', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'active' },
-    ];
-    const lines = renderBubbles(calls, 40, 5, NOW);
+  it('returns Live header only when no calls', () => {
+    const lines = renderLiveContext([], null, 40, 5, NOW);
+    expect(lines).toHaveLength(1);
     expect(lines[0]).toContain('Live');
   });
 
-  it('shows active tools with filled circles', () => {
+  it('always includes Live header', () => {
     const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'active' },
+      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'completed' },
     ];
-    const lines = renderBubbles(calls, 40, 5, NOW);
+    const lines = renderLiveContext(calls, null, 40, 5, NOW);
+    expect(lines[0]).toContain('Live');
+  });
+
+  it('shows current mode when provided', () => {
+    const lines = renderLiveContext([], 'PLAN', 40, 5, NOW);
     expect(lines).toHaveLength(2);
-    expect(lines[1]).toContain('◉');
-    expect(lines[1]).toContain('Read');
+    expect(lines[1]).toContain('Mode');
+    expect(lines[1]).toContain('PLAN');
   });
 
-  it('shows multiple active calls with multiple circles', () => {
+  it('omits mode line when currentMode is null', () => {
     const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'active' },
-      { agentId: 'a2', toolName: 'Read', timestamp: NOW, status: 'active' },
-      { agentId: 'a3', toolName: 'Read', timestamp: NOW, status: 'active' },
+      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'completed' },
     ];
-    const lines = renderBubbles(calls, 40, 5, NOW);
-    expect(lines[1]).toContain('◉◉◉');
+    const lines = renderLiveContext(calls, null, 40, 5, NOW);
+    const modeLines = lines.filter(l => l.includes('Mode'));
+    expect(modeLines).toHaveLength(0);
   });
 
-  it('caps bubbles at MAX_BUBBLES (5)', () => {
-    const calls: ToolCallRecord[] = Array.from({ length: 8 }, (_, i) => ({
-      agentId: `a${i}`,
-      toolName: 'Read',
-      timestamp: NOW,
-      status: 'active' as const,
-    }));
-    const lines = renderBubbles(calls, 40, 5, NOW);
-    expect(lines[1]).toContain('◉◉◉◉◉');
-    expect(lines[1]).not.toContain('◉◉◉◉◉◉');
-  });
-
-  it('treats completed calls within 5s as active (hot window)', () => {
+  it('shows unique tools newest first', () => {
     const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 3_000, status: 'completed' },
+      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 10_000, status: 'completed' },
+      { agentId: 'a1', toolName: 'Bash', timestamp: NOW - 5_000, status: 'completed' },
+      { agentId: 'a1', toolName: 'Grep', timestamp: NOW, status: 'completed' },
     ];
-    const lines = renderBubbles(calls, 40, 5, NOW);
-    expect(lines).toHaveLength(2);
-    expect(lines[1]).toContain('◉');
-    expect(lines[1]).toContain('Read');
-  });
-
-  it('shows recently completed tools (5-30s) with open circle', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Bash', timestamp: NOW - 10_000, status: 'completed' },
-    ];
-    const lines = renderBubbles(calls, 40, 5, NOW);
-    expect(lines).toHaveLength(2);
-    expect(lines[1]).toContain('○');
-    expect(lines[1]).toContain('Bash');
-  });
-
-  it('treats exactly 5000ms as recent (not hot)', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 5_000, status: 'completed' },
-    ];
-    const lines = renderBubbles(calls, 40, 5, NOW);
-    expect(lines).toHaveLength(2);
-    expect(lines[1]).toContain('○');
-  });
-
-  it('treats exactly 30000ms as excluded', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 30_000, status: 'completed' },
-    ];
-    const lines = renderBubbles(calls, 40, 5, NOW);
-    expect(lines).toEqual([]);
-  });
-
-  it('excludes completed calls older than 30s', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Bash', timestamp: NOW - 31_000, status: 'completed' },
-    ];
-    const lines = renderBubbles(calls, 40, 5, NOW);
-    expect(lines).toEqual([]);
-  });
-
-  it('sorts tools by active count descending', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Bash', timestamp: NOW, status: 'active' },
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'active' },
-      { agentId: 'a2', toolName: 'Read', timestamp: NOW, status: 'active' },
-    ];
-    const lines = renderBubbles(calls, 40, 5, NOW);
-    expect(lines[1]).toContain('Read');
+    const lines = renderLiveContext(calls, null, 40, 10, NOW);
+    expect(lines).toHaveLength(4);
+    expect(lines[1]).toContain('Grep');
     expect(lines[2]).toContain('Bash');
+    expect(lines[3]).toContain('Read');
   });
 
-  it('limits output to height lines', () => {
+  it('deduplicates tool names (keeps most recent)', () => {
     const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'tool1', timestamp: NOW, status: 'active' },
-      { agentId: 'a1', toolName: 'tool2', timestamp: NOW, status: 'active' },
-      { agentId: 'a1', toolName: 'tool3', timestamp: NOW, status: 'active' },
+      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 10_000, status: 'completed' },
+      { agentId: 'a2', toolName: 'Read', timestamp: NOW, status: 'completed' },
     ];
-    const lines = renderBubbles(calls, 40, 2, NOW);
-    expect(lines).toHaveLength(2);
+    const lines = renderLiveContext(calls, null, 40, 10, NOW);
+    const readLines = lines.filter(l => l.includes('Read'));
+    expect(readLines).toHaveLength(1);
+  });
+
+  it('shows hot indicator for calls < 5s old', () => {
+    const calls: ToolCallRecord[] = [
+      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 2_000, status: 'completed' },
+    ];
+    const lines = renderLiveContext(calls, null, 40, 5, NOW);
+    expect(lines[1]).toContain('◉');
+  });
+
+  it('shows recent indicator for calls 5-30s old', () => {
+    const calls: ToolCallRecord[] = [
+      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 10_000, status: 'completed' },
+    ];
+    const lines = renderLiveContext(calls, null, 40, 5, NOW);
+    expect(lines[1]).toContain('○');
+  });
+
+  it('shows older indicator for calls >= 30s old', () => {
+    const calls: ToolCallRecord[] = [
+      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 60_000, status: 'completed' },
+    ];
+    const lines = renderLiveContext(calls, null, 40, 5, NOW);
+    expect(lines[1]).toContain('·');
+  });
+
+  it('shows agent context when agentId is not unknown', () => {
+    const calls: ToolCallRecord[] = [
+      { agentId: 'architect', toolName: 'Read', timestamp: NOW, status: 'completed' },
+    ];
+    const lines = renderLiveContext(calls, null, 40, 5, NOW);
+    expect(lines[1]).toContain('architect');
+    expect(lines[1]).toContain('Read');
+  });
+
+  it('omits agent context when agentId is unknown', () => {
+    const calls: ToolCallRecord[] = [
+      { agentId: 'unknown', toolName: 'Read', timestamp: NOW, status: 'completed' },
+    ];
+    const lines = renderLiveContext(calls, null, 40, 5, NOW);
+    expect(lines[1]).not.toContain('unknown');
+    expect(lines[1]).toContain('Read');
+  });
+
+  it('respects height limit', () => {
+    const calls: ToolCallRecord[] = [
+      { agentId: 'a1', toolName: 'tool1', timestamp: NOW, status: 'completed' },
+      { agentId: 'a1', toolName: 'tool2', timestamp: NOW - 1_000, status: 'completed' },
+      { agentId: 'a1', toolName: 'tool3', timestamp: NOW - 2_000, status: 'completed' },
+    ];
+    const lines = renderLiveContext(calls, 'PLAN', 40, 3, NOW);
+    expect(lines).toHaveLength(3);
   });
 
   it('truncates lines to width', () => {
     const calls: ToolCallRecord[] = [
       {
-        agentId: 'a1',
+        agentId: 'very-long-agent-name',
         toolName: 'VeryLongToolNameThatExceedsWidth',
         timestamp: NOW,
-        status: 'active',
+        status: 'completed',
       },
     ];
-    const lines = renderBubbles(calls, 15, 5, NOW);
-    expect(lines).toHaveLength(2);
+    const lines = renderLiveContext(calls, null, 15, 5, NOW);
     for (const line of lines) {
-      expect(line.length).toBeLessThanOrEqual(15);
+      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(15);
     }
+  });
+
+  it('does not filter by time window — old calls still visible', () => {
+    const calls: ToolCallRecord[] = [
+      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 120_000, status: 'completed' },
+    ];
+    const lines = renderLiveContext(calls, null, 40, 5, NOW);
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('Read');
   });
 
   it('ignores error-status calls', () => {
     const calls: ToolCallRecord[] = [
       { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'error' },
     ];
-    const lines = renderBubbles(calls, 40, 5, NOW);
-    expect(lines).toEqual([]);
+    const lines = renderLiveContext(calls, null, 40, 5, NOW);
+    expect(lines).toHaveLength(1);
   });
 });

--- a/apps/mcp-server/src/tui/components/activity-visualizer.pure.ts
+++ b/apps/mcp-server/src/tui/components/activity-visualizer.pure.ts
@@ -1,4 +1,5 @@
 import type { ToolCallRecord } from '../dashboard-types';
+import type { Mode } from '../types';
 import { truncateToDisplayWidth, padEndDisplayWidth } from '../utils/display-width';
 
 export interface HeatmapData {
@@ -80,12 +81,14 @@ export function renderHeatmap(data: HeatmapData, width: number, height: number):
   return lines.slice(0, height);
 }
 
-const BUBBLE_ACTIVE_WINDOW_MS = 30_000;
-const BUBBLE_HOT_WINDOW_MS = 5_000;
-const MAX_BUBBLES = 5;
+const LIVE_HOT_WINDOW_MS = 5_000;
+const LIVE_RECENT_WINDOW_MS = 30_000;
+const LIVE_HOT_SEC = LIVE_HOT_WINDOW_MS / 1000;
+const LIVE_RECENT_SEC = LIVE_RECENT_WINDOW_MS / 1000;
 
-export function renderBubbles(
+export function renderLiveContext(
   calls: ToolCallRecord[],
+  currentMode: Mode | null,
   width: number,
   height: number,
   now?: number,
@@ -93,35 +96,28 @@ export function renderBubbles(
   const currentTime = now ?? Date.now();
   if (height <= 0 || width <= 0) return [];
 
-  const toolGroups = new Map<string, { active: number; recent: boolean }>();
-  for (const call of calls) {
-    const isActive = call.status === 'active';
-    // Treat recently completed calls (within 5s) as "hot" → shown like active
-    const isHot =
-      call.status === 'completed' && currentTime - call.timestamp < BUBBLE_HOT_WINDOW_MS;
-    const isRecent =
-      call.status === 'completed' &&
-      currentTime - call.timestamp >= BUBBLE_HOT_WINDOW_MS &&
-      currentTime - call.timestamp < BUBBLE_ACTIVE_WINDOW_MS;
-    if (!isActive && !isHot && !isRecent) continue;
+  const lines: string[] = [truncateToDisplayWidth('💬 Live', width)];
 
-    const existing = toolGroups.get(call.toolName) ?? { active: 0, recent: false };
-    if (isActive || isHot) existing.active++;
-    if (isRecent) existing.recent = true;
-    toolGroups.set(call.toolName, existing);
+  if (currentMode) {
+    lines.push(truncateToDisplayWidth(`⟫ Mode: ${currentMode}`, width));
   }
 
-  if (toolGroups.size === 0) return [];
+  const maxItems = height - lines.length;
+  const seen = new Set<string>();
 
-  const sorted = [...toolGroups.entries()].sort((a, b) => b[1].active - a[1].active);
+  for (let i = calls.length - 1; i >= 0 && seen.size < maxItems; i--) {
+    const call = calls[i];
+    if (call.status === 'error') continue;
+    if (seen.has(call.toolName)) continue;
+    seen.add(call.toolName);
 
-  const header = truncateToDisplayWidth('💬 Live', width);
-  const lines: string[] = [header];
-  for (const [toolName, info] of sorted) {
-    if (lines.length >= height) break;
-    const bubbleCount = Math.min(info.active, MAX_BUBBLES);
-    const indicator = bubbleCount > 0 ? '◉'.repeat(bubbleCount) : '○';
-    lines.push(truncateToDisplayWidth(`${indicator} ${toolName}`, width));
+    const ageSec = Math.floor((currentTime - call.timestamp) / 1000);
+    const ageIndicator = ageSec < LIVE_HOT_SEC ? '◉' : ageSec < LIVE_RECENT_SEC ? '○' : '·';
+    const agent =
+      call.agentId !== 'unknown'
+        ? truncateToDisplayWidth(call.agentId, AGENT_NAME_WIDTH) + ' '
+        : '';
+    lines.push(truncateToDisplayWidth(`${ageIndicator} ${agent}${call.toolName}`, width));
   }
 
   return lines.slice(0, height);

--- a/apps/mcp-server/src/tui/components/index.ts
+++ b/apps/mcp-server/src/tui/components/index.ts
@@ -31,7 +31,7 @@ export {
   aggregateToolCalls,
   getDensityChar,
   renderHeatmap,
-  renderBubbles,
+  renderLiveContext,
   type HeatmapData,
 } from './activity-visualizer.pure';
 export { SessionTabBar } from './SessionTabBar';

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -86,6 +86,7 @@ export function DashboardApp({ eventBus, externalState }: DashboardAppProps): Re
             />
             <ActivityVisualizer
               toolCalls={state.toolCalls}
+              currentMode={state.currentMode}
               width={grid.monitorPanel.width}
               height={grid.monitorPanel.height}
             />


### PR DESCRIPTION
## Summary

Closes #502

The TUI Live panel showed almost no data due to three root causes:
- `status: 'active'` was never produced by the event system, so `renderBubbles` found no active calls
- A 30-second time window was too restrictive, causing the panel to appear empty most of the time
- No contextual information (mode, agent names) was displayed

This PR replaces `renderBubbles` with `renderLiveContext` using a delete-insert pattern that:
- Always displays content regardless of call status or age
- Shows current workflow mode (PLAN/ACT/EVAL/AUTO)
- Displays agent context alongside tool names
- Uses age indicators: `◉` (hot <5s), `○` (recent <30s), `·` (older)
- Deduplicates tool names, showing the most recent occurrence
- Filters out error-status calls

## Changes

- **activity-visualizer.pure.ts**: Replace `renderBubbles` with `renderLiveContext`, add `Mode` type, use derived constants (`LIVE_HOT_SEC`, `LIVE_RECENT_SEC`)
- **ActivityVisualizer.tsx**: Add `currentMode` prop, rename `bubblesWidth` → `livePanelWidth`, wire `renderLiveContext`
- **dashboard-app.tsx**: Pass `state.currentMode` to `ActivityVisualizer`
- **index.ts**: Update re-export from `renderBubbles` to `renderLiveContext`
- **activity-visualizer.pure.spec.ts**: Replace `renderBubbles` test suite with 15 `renderLiveContext` tests, use `estimateDisplayWidth` for width assertions
- **ActivityVisualizer.spec.tsx**: Update all tests with `currentMode` prop, add mode display test

## Test plan

- [x] All 3778 tests pass (164 test files)
- [x] TypeScript build succeeds with zero errors
- [x] Live panel always shows content (no empty panel)
- [x] Mode display works when mode is set
- [x] Agent context shown for non-unknown agents
- [x] Age indicators render correctly based on call age
- [x] Width truncation uses `estimateDisplayWidth` for multi-byte correctness