### PR TITLE
resolve progress bar stuck at 0% due to agentId mismatch (#503)

### DIFF
--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -515,4 +515,74 @@ describe('dashboardReducer', () => {
     });
     expect(state.objectives).toEqual(['second task']);
   });
+
+  it('should increment focused primary agent progress on TOOL_INVOKED with non-matching agentId (fallback)', () => {
+    // Primary agent registered as "primary:arch" — but TOOL_INVOKED has agentId "search_rules"
+    let state = dashboardReducer(initialDashboardState, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'primary:arch', name: 'arch', role: 'primary', isPrimary: true },
+    });
+    expect(state.focusedAgentId).toBe('primary:arch');
+    expect(state.agents.get('primary:arch')?.progress).toBe(0);
+
+    state = dashboardReducer(state, {
+      type: 'TOOL_INVOKED',
+      payload: { toolName: 'search_rules', agentId: 'search_rules', timestamp: Date.now() },
+    });
+    // Should fall back to focused agent and increment progress
+    expect(state.agents.get('primary:arch')?.progress).toBe(5);
+  });
+
+  it('should not crash on TOOL_INVOKED with non-matching agentId when focusedAgentId is null', () => {
+    // No agents activated — focusedAgentId is null
+    const state = dashboardReducer(initialDashboardState, {
+      type: 'TOOL_INVOKED',
+      payload: { toolName: 'search_rules', agentId: 'search_rules', timestamp: Date.now() },
+    });
+    // Should not crash, agents map unchanged
+    expect(state.agents.size).toBe(0);
+  });
+
+  it('should not increment progress via fallback when focused agent is not running', () => {
+    let state = dashboardReducer(initialDashboardState, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'primary:arch', name: 'arch', role: 'primary', isPrimary: true },
+    });
+    // Deactivate the primary agent
+    state = dashboardReducer(state, {
+      type: 'AGENT_DEACTIVATED',
+      payload: { agentId: 'primary:arch', reason: 'completed', durationMs: 1000 },
+    });
+    expect(state.agents.get('primary:arch')?.status).toBe('done');
+    expect(state.agents.get('primary:arch')?.progress).toBe(100);
+
+    state = dashboardReducer(state, {
+      type: 'TOOL_INVOKED',
+      payload: { toolName: 'search_rules', agentId: 'search_rules', timestamp: Date.now() },
+    });
+    // Progress should remain 100 (not incremented because agent is 'done', not 'running')
+    expect(state.agents.get('primary:arch')?.progress).toBe(100);
+  });
+
+  it('should prefer exact agentId match over focusedAgentId fallback', () => {
+    // Register primary agent AND a specialist with the same ID as the tool event
+    let state = dashboardReducer(initialDashboardState, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'primary:arch', name: 'arch', role: 'primary', isPrimary: true },
+    });
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'search_rules', name: 'search_rules', role: 'query', isPrimary: false },
+    });
+
+    state = dashboardReducer(state, {
+      type: 'TOOL_INVOKED',
+      payload: { toolName: 'search_rules', agentId: 'search_rules', timestamp: Date.now() },
+    });
+
+    // Exact match agent should be incremented
+    expect(state.agents.get('search_rules')?.progress).toBe(5);
+    // Focused primary agent should NOT be incremented (exact match took priority)
+    expect(state.agents.get('primary:arch')?.progress).toBe(0);
+  });
 });

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -168,18 +168,24 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
       const base =
         state.eventLog.length >= EVENT_LOG_MAX ? state.eventLog.slice(1) : state.eventLog;
 
-      // Progress increment for matched agent
+      // Progress increment with focusedAgentId fallback
       const invokedAgentId = action.payload.agentId;
       let agents = state.agents;
-      if (invokedAgentId) {
-        const agent = state.agents.get(invokedAgentId);
-        if (agent && agent.status === 'running') {
-          agents = cloneAgents(state.agents);
-          agents.set(invokedAgentId, {
-            ...agent,
-            progress: Math.min(95, agent.progress + 5),
-          });
-        }
+
+      // 1st: Try exact agentId match
+      let targetAgent = invokedAgentId ? (state.agents.get(invokedAgentId) ?? null) : null;
+
+      // 2nd: Fallback to focused agent when agentId exists but no exact match found
+      if (invokedAgentId && !targetAgent && state.focusedAgentId) {
+        targetAgent = state.agents.get(state.focusedAgentId) ?? null;
+      }
+
+      if (targetAgent && targetAgent.status === 'running') {
+        agents = cloneAgents(state.agents);
+        agents.set(targetAgent.id, {
+          ...targetAgent,
+          progress: Math.min(95, targetAgent.progress + 5),
+        });
       }
 
       const toolCall: ToolCallRecord = {


### PR DESCRIPTION
## Summary

Fixes #503 — FocusedAgent panel progress bar never advances from 0%.

**Root Cause:** The `TOOL_INVOKED` handler in `dashboardReducer` looks up agents by the exact `agentId` from the tool event (e.g., `"search_rules"`). However, the primary agent is registered with a `"primary:"` prefix (e.g., `"primary:solution-architect"`), so the lookup always fails and progress never increments.

**Fix:** Add a `focusedAgentId` fallback in the `TOOL_INVOKED` case — when the exact `agentId` lookup fails, fall back to `state.focusedAgentId` (which always points to the running primary agent via `selectFocusedAgent()`).

### Key behaviors
- Exact `agentId` match takes priority over fallback
- Fallback only activates when `agentId` is present but unmatched
- `agentId: null` still results in no progress change (existing behavior preserved)
- Non-running focused agents are not incremented (`status === 'running'` guard)

### Changes
- `use-dashboard-state.ts`: Replace single exact-match lookup with 2-step resolution (exact → fallback)
- `use-dashboard-state.spec.ts`: Add 4 tests covering fallback, null safety, done-agent guard, and exact-match priority

## Test plan
- [x] New test: fallback increments focused primary agent progress on non-matching agentId
- [x] New test: no crash when focusedAgentId is null
- [x] New test: no increment via fallback when focused agent is not running
- [x] New test: exact agentId match takes priority over fallback
- [x] All existing tests pass (3782 tests, 164 files, 0 failures)