### PR TITLE
replace hardcoded tokenCount with live tool invocation count

### DIFF
--- a/apps/mcp-server/src/tui/components/StageHealthBar.spec.tsx
+++ b/apps/mcp-server/src/tui/components/StageHealthBar.spec.tsx
@@ -16,12 +16,7 @@ function makeHealth() {
 describe('tui/components/StageHealthBar', () => {
   it('should render stage names with colors', () => {
     const { lastFrame } = render(
-      <StageHealthBar
-        stageHealth={makeHealth()}
-        bottlenecks={[]}
-        tokenCount={128000}
-        width={120}
-      />,
+      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} toolCount={128000} width={120} />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('PLAN:');
@@ -31,16 +26,16 @@ describe('tui/components/StageHealthBar', () => {
 
   it('should render running/done/error stats', () => {
     const { lastFrame } = render(
-      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} tokenCount={0} width={120} />,
+      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} toolCount={0} width={120} />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('running');
     expect(frame).toContain('err');
   });
 
-  it('should render token count', () => {
+  it('should render tool count', () => {
     const { lastFrame } = render(
-      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} tokenCount={64000} width={120} />,
+      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} toolCount={64000} width={120} />,
     );
     expect(lastFrame()).toContain('64k');
   });
@@ -50,7 +45,7 @@ describe('tui/components/StageHealthBar', () => {
       <StageHealthBar
         stageHealth={makeHealth()}
         bottlenecks={['tests failing(3)', 'lint errors']}
-        tokenCount={0}
+        toolCount={0}
         width={120}
       />,
     );
@@ -64,7 +59,7 @@ describe('tui/components/StageHealthBar', () => {
       <StageHealthBar
         stageHealth={makeHealth()}
         bottlenecks={['long bottleneck description']}
-        tokenCount={50000}
+        toolCount={50000}
         width={60}
       />,
     );
@@ -79,7 +74,7 @@ describe('tui/components/StageHealthBar', () => {
       AUTO: createEmptyStageStats(),
     };
     const { lastFrame } = render(
-      <StageHealthBar stageHealth={empty} bottlenecks={[]} tokenCount={0} width={120} />,
+      <StageHealthBar stageHealth={empty} bottlenecks={[]} toolCount={0} width={120} />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('PLAN:');
@@ -88,7 +83,7 @@ describe('tui/components/StageHealthBar', () => {
 
   it('should render double border', () => {
     const { lastFrame } = render(
-      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} tokenCount={0} width={120} />,
+      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} toolCount={0} width={120} />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('╔');

--- a/apps/mcp-server/src/tui/components/StageHealthBar.tsx
+++ b/apps/mcp-server/src/tui/components/StageHealthBar.tsx
@@ -7,7 +7,7 @@ import { getModeColor } from '../utils/theme';
 export interface StageHealthBarProps {
   stageHealth: Record<Mode, StageStats>;
   bottlenecks: string[];
-  tokenCount: number;
+  toolCount: number;
   width: number;
 }
 
@@ -79,10 +79,10 @@ function StageStatDisplay({
 export function StageHealthBar({
   stageHealth,
   bottlenecks,
-  tokenCount,
+  toolCount,
   width,
 }: StageHealthBarProps): React.ReactElement {
-  const tokenStr = tokenCount >= 1000 ? `${Math.round(tokenCount / 1000)}k` : String(tokenCount);
+  const countStr = toolCount >= 1000 ? `${Math.round(toolCount / 1000)}k` : String(toolCount);
 
   return (
     <Box borderStyle="double" borderColor="cyan" width={width} flexDirection="column">
@@ -99,7 +99,7 @@ export function StageHealthBar({
               ⚡ Bottlenecks: {bottlenecks.join(' / ')}
             </Text>
           )}
-          <Text dimColor>tokens: {tokenStr}</Text>
+          <Text dimColor>tools: {countStr}</Text>
         </Box>
       </Box>
     </Box>

--- a/apps/mcp-server/src/tui/components/stage-health.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/stage-health.pure.spec.ts
@@ -139,12 +139,12 @@ describe('tui/components/stage-health.pure', () => {
       expect(result).toContain('15k');
     });
 
-    it('should show token count', () => {
+    it('should show tool count', () => {
       const result = formatStageHealthBar(emptyHealth, [], 500, 120, 'wide');
       expect(result).toContain('500');
     });
 
-    it('should format token count as Nk for thousands', () => {
+    it('should format tool count as Nk for thousands', () => {
       const result = formatStageHealthBar(emptyHealth, [], 2500, 120, 'wide');
       expect(result).toContain('3k');
     });

--- a/apps/mcp-server/src/tui/components/stage-health.pure.ts
+++ b/apps/mcp-server/src/tui/components/stage-health.pure.ts
@@ -73,16 +73,16 @@ export function detectBottlenecks(eventLog: EventLogEntry[]): string[] {
 }
 
 /**
- * Format stage health bar with stats, bottlenecks, and token count.
+ * Format stage health bar with stats, bottlenecks, and tool count.
  */
 export function formatStageHealthBar(
   health: Record<Mode, StageStats>,
   bottlenecks: string[],
-  tokenCount: number,
+  toolCount: number,
   width: number,
   layoutMode: LayoutMode,
 ): string {
-  const tokenStr = tokenCount >= 1000 ? `${Math.round(tokenCount / 1000)}k` : String(tokenCount);
+  const countStr = toolCount >= 1000 ? `${Math.round(toolCount / 1000)}k` : String(toolCount);
 
   const formatStats = (mode: Mode, stats: StageStats): string => {
     if (layoutMode === 'narrow') {
@@ -111,11 +111,11 @@ export function formatStageHealthBar(
 
   if (layoutMode === 'narrow') {
     const line1 = stages;
-    const line2Parts = [bottleneckStr, tokenStr].filter(Boolean);
+    const line2Parts = [bottleneckStr, countStr].filter(Boolean);
     return [line1, line2Parts.join('  ')].filter(Boolean).join('\n');
   }
 
-  const spacer = ' '.repeat(Math.max(1, width - stages.length - tokenStr.length - 2));
-  const line1 = `${stages}${spacer}${tokenStr}`;
+  const spacer = ' '.repeat(Math.max(1, width - stages.length - countStr.length - 2));
+  const line1 = `${stages}${spacer}${countStr}`;
   return bottleneckStr ? `${line1}\n${bottleneckStr}` : line1;
 }

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -108,7 +108,7 @@ export function DashboardApp({ eventBus, externalState }: DashboardAppProps): Re
       <StageHealthBar
         stageHealth={stageHealth}
         bottlenecks={bottlenecks}
-        tokenCount={state.tokenUsage}
+        toolCount={state.toolInvokeCount}
         width={grid.stageHealth.width}
       />
     </Box>

--- a/apps/mcp-server/src/tui/dashboard-types.spec.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.spec.ts
@@ -152,7 +152,7 @@ describe('tui/dashboard-types', () => {
       expect(region.height).toBe(3);
     });
 
-    it('DashboardState includes tokenUsage and outputStats fields', () => {
+    it('DashboardState includes toolInvokeCount and outputStats fields', () => {
       const state: DashboardState = {
         workspace: '/tmp',
         sessionId: 'test',
@@ -166,10 +166,10 @@ describe('tui/dashboard-types', () => {
         objectives: [],
         activeSkills: [],
         toolCalls: [],
-        tokenUsage: 0,
+        toolInvokeCount: 0,
         outputStats: { files: 0, commits: 0 },
       };
-      expect(state.tokenUsage).toBe(0);
+      expect(state.toolInvokeCount).toBe(0);
       expect(state.outputStats).toEqual({ files: 0, commits: 0 });
     });
 

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -155,7 +155,7 @@ export interface DashboardState {
   toolCalls: ToolCallRecord[];
   objectives: string[];
   activeSkills: string[];
-  tokenUsage: number;
+  toolInvokeCount: number;
   outputStats: { files: number; commits: number };
 }
 

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -8,9 +8,9 @@ import {
 describe('dashboardReducer', () => {
   const initialDashboardState = createInitialDashboardState();
 
-  it('initializes tokenUsage to 0 and outputStats to zero counts', () => {
+  it('initializes toolInvokeCount to 0 and outputStats to zero counts', () => {
     const state = createInitialDashboardState();
-    expect(state.tokenUsage).toBe(0);
+    expect(state.toolInvokeCount).toBe(0);
     expect(state.outputStats).toEqual({ files: 0, commits: 0 });
   });
 
@@ -190,6 +190,20 @@ describe('dashboardReducer', () => {
       payload: { toolName: 'search', agentId: null, timestamp: Date.now() },
     });
     expect(state.eventLog[0].message).toBe('search');
+  });
+
+  it('increments toolInvokeCount on TOOL_INVOKED', () => {
+    const s1 = dashboardReducer(createInitialDashboardState(), {
+      type: 'TOOL_INVOKED',
+      payload: { toolName: 'search_rules', timestamp: Date.now(), agentId: null },
+    });
+    expect(s1.toolInvokeCount).toBe(1);
+
+    const s2 = dashboardReducer(s1, {
+      type: 'TOOL_INVOKED',
+      payload: { toolName: 'get_agent_details', timestamp: Date.now(), agentId: null },
+    });
+    expect(s2.toolInvokeCount).toBe(2);
   });
 
   it('limits eventLog to ring buffer size (100)', () => {

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -46,7 +46,7 @@ export function createInitialDashboardState(): DashboardState {
     toolCalls: [],
     objectives: [],
     activeSkills: [],
-    tokenUsage: 0,
+    toolInvokeCount: 0,
     outputStats: { files: 0, commits: 0 },
   };
 }
@@ -202,6 +202,7 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
         agents,
         eventLog: [...base, entry],
         toolCalls: [...toolCallsBase, toolCall],
+        toolInvokeCount: state.toolInvokeCount + 1,
       };
     }
 


### PR DESCRIPTION
## Summary

Closes #490

The `StageHealthBar` footer was hardcoded to always display `tokens: 0`, which is meaningless because the MCP server acts only as a tool provider and cannot access LLM API token usage metadata.

This PR replaces the token count display with the actual number of tool invocations, accumulated via the existing `TOOL_INVOKED` event stream.

## Changes

### New behavior
- Footer now displays `tools: <count>` instead of `tokens: 0`
- Count increments by 1 on every `TOOL_INVOKED` event
- Values ≥ 1,000 are abbreviated as `1k`, `2k`, etc. (existing logic retained)

### Renamed symbols

| Before | After | Location |
|--------|-------|----------|
| `DashboardState.tokenUsage` | `toolInvokeCount` | `dashboard-types.ts` |
| `StageHealthBarProps.tokenCount` | `toolCount` | `StageHealthBar.tsx` |
| `formatStageHealthBar` param `tokenCount` | `toolCount` | `stage-health.pure.ts` |
| Internal variable `tokenStr` | `countStr` | `StageHealthBar.tsx`, `stage-health.pure.ts` |
| Label `tokens:` | `tools:` | `StageHealthBar.tsx` |

### Implementation
- Added `toolInvokeCount: number` field to `DashboardState` interface
- Initialized to `0` in `createInitialDashboardState()`
- Incremented by 1 in the `TOOL_INVOKED` reducer case
- Passed as `toolCount` prop from `DashboardApp` to `StageHealthBar`

## Test Plan

- [x] New reducer test: `toolInvokeCount` increments from 0 → 1 → 2 on consecutive `TOOL_INVOKED` dispatches
- [x] All existing `StageHealthBar`, `stage-health.pure`, `use-dashboard-state`, and `dashboard-types` tests updated and passing
- [x] No residual references to `tokenCount`, `tokenUsage`, or `tokenStr` in the TUI source tree
- [x] 164 test files, 3,783 tests pass
- [x] TypeScript build succeeds