### PR TITLE
unify panel border colors via BORDER_COLORS constant

### DIFF
--- a/apps/mcp-server/src/tui/components/ActivityVisualizer.tsx
+++ b/apps/mcp-server/src/tui/components/ActivityVisualizer.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from 'ink';
 import type { ToolCallRecord } from '../dashboard-types';
 import type { Mode } from '../types';
 import { aggregateToolCalls, renderHeatmap, renderLiveContext } from './activity-visualizer.pure';
+import { BORDER_COLORS } from '../utils/theme';
 
 export interface ActivityVisualizerProps {
   toolCalls: ToolCallRecord[];
@@ -39,7 +40,7 @@ export function ActivityVisualizer({
     <Box flexDirection="row" width={width} height={height}>
       <Box
         borderStyle="single"
-        borderColor="gray"
+        borderColor={BORDER_COLORS.panel}
         flexDirection="column"
         width={heatmapWidth}
         height={height}
@@ -50,7 +51,7 @@ export function ActivityVisualizer({
       </Box>
       <Box
         borderStyle="single"
-        borderColor="gray"
+        borderColor={BORDER_COLORS.panel}
         flexDirection="column"
         width={livePanelWidth}
         height={height}

--- a/apps/mcp-server/src/tui/components/FlowMap.tsx
+++ b/apps/mcp-server/src/tui/components/FlowMap.tsx
@@ -3,6 +3,7 @@ import { Box, Text } from 'ink';
 import type { LayoutMode, DashboardNode, Edge } from '../dashboard-types';
 import type { Mode } from '../types';
 import { groupByStyle, type ColorCell } from '../utils/color-buffer';
+import { BORDER_COLORS } from '../utils/theme';
 import { renderFlowMap, renderFlowMapSimplified, renderFlowMapCompact } from './flow-map.pure';
 
 /**
@@ -88,7 +89,7 @@ export function FlowMap({
     return (
       <Box
         borderStyle="single"
-        borderColor="gray"
+        borderColor={BORDER_COLORS.panel}
         flexDirection="column"
         width={width}
         height={height}
@@ -105,7 +106,7 @@ export function FlowMap({
     return (
       <Box
         borderStyle="single"
-        borderColor="gray"
+        borderColor={BORDER_COLORS.panel}
         flexDirection="column"
         width={width}
         height={height}
@@ -120,7 +121,7 @@ export function FlowMap({
   return (
     <Box
       borderStyle="single"
-      borderColor="gray"
+      borderColor={BORDER_COLORS.panel}
       flexDirection="column"
       width={width}
       height={height}

--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import type { DashboardNode, TaskItem, EventLogEntry } from '../dashboard-types';
-import { STATUS_ICONS, getNodeStatusColor } from '../utils/theme';
+import { STATUS_ICONS, getNodeStatusColor, BORDER_COLORS } from '../utils/theme';
 import {
   formatObjective,
   formatChecklist,
@@ -74,7 +74,7 @@ export function FocusedAgentPanel({
     return (
       <Box
         borderStyle="single"
-        borderColor="cyan"
+        borderColor={BORDER_COLORS.panel}
         flexDirection="column"
         width={width}
         height={height}
@@ -96,7 +96,7 @@ export function FocusedAgentPanel({
   return (
     <Box
       borderStyle="single"
-      borderColor="cyan"
+      borderColor={BORDER_COLORS.panel}
       flexDirection="column"
       width={width}
       height={height}

--- a/apps/mcp-server/src/tui/components/HeaderBar.tsx
+++ b/apps/mcp-server/src/tui/components/HeaderBar.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import type { LayoutMode, GlobalRunState } from '../dashboard-types';
 import type { Mode } from '../types';
-import { getModeColor, GLOBAL_STATE_ICONS, GLOBAL_STATE_COLORS } from '../utils/theme';
+import {
+  getModeColor,
+  GLOBAL_STATE_ICONS,
+  GLOBAL_STATE_COLORS,
+  BORDER_COLORS,
+} from '../utils/theme';
 
 export interface HeaderBarProps {
   workspace: string;
@@ -69,7 +74,7 @@ export function HeaderBar({
     return (
       <Box
         borderStyle="double"
-        borderColor="cyan"
+        borderColor={BORDER_COLORS.panel}
         width={width}
         overflowX="hidden"
         flexDirection="row"
@@ -90,7 +95,7 @@ export function HeaderBar({
   return (
     <Box
       borderStyle="double"
-      borderColor="cyan"
+      borderColor={BORDER_COLORS.panel}
       width={width}
       overflowX="hidden"
       flexDirection="row"

--- a/apps/mcp-server/src/tui/components/StageHealthBar.tsx
+++ b/apps/mcp-server/src/tui/components/StageHealthBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import type { StageStats } from '../dashboard-types';
 import type { Mode } from '../types';
-import { getModeColor } from '../utils/theme';
+import { getModeColor, BORDER_COLORS } from '../utils/theme';
 
 export interface StageHealthBarProps {
   stageHealth: Record<Mode, StageStats>;
@@ -85,7 +85,12 @@ export function StageHealthBar({
   const countStr = toolCount >= 1000 ? `${Math.round(toolCount / 1000)}k` : String(toolCount);
 
   return (
-    <Box borderStyle="double" borderColor="cyan" width={width} flexDirection="column">
+    <Box
+      borderStyle="double"
+      borderColor={BORDER_COLORS.panel}
+      width={width}
+      flexDirection="column"
+    >
       <Box>
         <Box gap={2}>
           {(['PLAN', 'ACT', 'EVAL'] as const).map(mode => (

--- a/apps/mcp-server/src/tui/utils/theme.spec.ts
+++ b/apps/mcp-server/src/tui/utils/theme.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   type CellStyle,
   NEON_COLORS,
+  BORDER_COLORS,
   STATUS_STYLES,
   STATUS_ICONS,
   MODE_LABEL_STYLES,
@@ -33,6 +34,16 @@ describe('theme', () => {
       expect(NEON_COLORS.done).toBe('green');
       expect(NEON_COLORS.inactive).toBe('gray');
       expect(NEON_COLORS.content).toBe('white');
+    });
+  });
+
+  describe('BORDER_COLORS', () => {
+    it('defines panel border color as primary (cyan)', () => {
+      expect(BORDER_COLORS.panel).toBe('cyan');
+    });
+
+    it('is frozen (immutable)', () => {
+      expect(Object.isFrozen(BORDER_COLORS)).toBe(true);
     });
   });
 

--- a/apps/mcp-server/src/tui/utils/theme.ts
+++ b/apps/mcp-server/src/tui/utils/theme.ts
@@ -28,6 +28,14 @@ export const NEON_COLORS = Object.freeze({
 } as const);
 
 /**
+ * Centralized border color constants for TUI panel components.
+ * Use BORDER_COLORS.panel instead of hardcoding 'cyan' or 'gray' in TSX components.
+ */
+export const BORDER_COLORS = Object.freeze({
+  panel: NEON_COLORS.primary, // 'cyan'
+} as const);
+
+/**
  * Styles for agent/node status indicators.
  */
 export const STATUS_STYLES: Readonly<Record<DashboardNodeStatus, CellStyle>> = Object.freeze({


### PR DESCRIPTION
## Summary

Closes #494

Replaces scattered hardcoded border color values (`'cyan'`, `'gray'`) across TUI panel components with a single centralized `BORDER_COLORS` constant exported from `theme.ts`.

- Add `BORDER_COLORS` constant to `theme.ts` referencing `NEON_COLORS.primary` (`'cyan'`)
- Replace all hardcoded `borderColor` values in 5 TUI components
- Add `theme.spec.ts` tests to verify value and immutability

## Changes

| File | Change |
|------|--------|
| `utils/theme.ts` | Add `BORDER_COLORS = { panel: NEON_COLORS.primary }` |
| `utils/theme.spec.ts` | Add tests for `BORDER_COLORS` value and `Object.freeze` |
| `components/ActivityVisualizer.tsx` | `'gray'` → `BORDER_COLORS.panel` (×2) |
| `components/FlowMap.tsx` | `'gray'` → `BORDER_COLORS.panel` (×3) |
| `components/FocusedAgentPanel.tsx` | `'cyan'` → `BORDER_COLORS.panel` (×2) |
| `components/HeaderBar.tsx` | `'cyan'` → `BORDER_COLORS.panel` (×2) |
| `components/StageHealthBar.tsx` | `'cyan'` → `BORDER_COLORS.panel` (×1) |

## Test Plan

- [ ] `yarn workspace codingbuddy test` passes with new `BORDER_COLORS` specs
- [ ] TUI renders with consistent border colors across all panels