### PR TITLE
add prettier and tsconfig ignore rules for landing-page

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,22 @@ dist/
 *.log
 *.md
 *.mdc
+
+# Build outputs
+.next/
+out/
+build/
+coverage/
+
+# Generated files
+*.tsbuildinfo
+next-env.d.ts
+
+# AI/Tool local state
+.omc/
+.serena/
+.codingbuddy/
+docs/codingbuddy/
+.mcp.json
+codingbuddy.config.js
+codingbuddy.config.json

--- a/apps/landing-page/.prettierignore
+++ b/apps/landing-page/.prettierignore
@@ -1,0 +1,8 @@
+node_modules/
+.next/
+out/
+build/
+coverage/
+*.tsbuildinfo
+next-env.d.ts
+.omc/

--- a/apps/landing-page/tsconfig.json
+++ b/apps/landing-page/tsconfig.json
@@ -36,5 +36,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "coverage"]
 }


### PR DESCRIPTION
## Summary

Closes #496

- Add build outputs (`.next/`, `out/`, `build/`, `coverage/`), generated files (`*.tsbuildinfo`, `next-env.d.ts`), and AI/tool local state (`.omc/`, `.serena/`, `.codingbuddy/`, `docs/codingbuddy/`, `.mcp.json`, `codingbuddy.config.*`) to root `.prettierignore`
- Add `coverage` directory to `apps/landing-page/tsconfig.json` exclude list to prevent TypeScript from processing test coverage output
- Add `apps/landing-page/.prettierignore` with project-specific ignore patterns for Next.js build artifacts

## Test plan

- [ ] Run `prettier --check .` from root and verify no false positives on ignored paths
- [ ] Run `tsc --noEmit` inside `apps/landing-page` and verify `coverage/` is excluded
- [ ] Confirm `apps/landing-page/.prettierignore` entries are respected by Prettier