### PR TITLE
reduce FocusedAgent panel width by ~10% and expand Activity/FlowMap panels

### DIFF
--- a/apps/mcp-server/src/tui/components/activity-visualizer.pure.ts
+++ b/apps/mcp-server/src/tui/components/activity-visualizer.pure.ts
@@ -45,7 +45,7 @@ export function aggregateToolCalls(
   return { agents, tools, matrix };
 }
 
-const AGENT_NAME_WIDTH = 10;
+const AGENT_NAME_WIDTH = 15; // was 10 → agent names visible up to 15 chars
 
 export function getDensityChar(count: number): string {
   if (count <= 0) return '··';

--- a/apps/mcp-server/src/tui/components/grid-layout.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/grid-layout.pure.spec.ts
@@ -27,12 +27,12 @@ describe('computeGridLayout', () => {
       expect(grid.stageHealth.y + grid.stageHealth.height).toBe(40);
     });
 
-    it('focusedAgent has fixed width 70 in wide mode', () => {
-      expect(grid.focusedAgent.width).toBe(70);
+    it('focusedAgent has fixed width 63 in wide mode', () => {
+      expect(grid.focusedAgent.width).toBe(63);
     });
 
     it('flowMap takes all remaining width after focusedAgent', () => {
-      expect(grid.flowMap.width).toBe(120 - 70);
+      expect(grid.flowMap.width).toBe(120 - 63);
     });
 
     it('focusedAgent is right-aligned', () => {
@@ -76,12 +76,12 @@ describe('computeGridLayout', () => {
   describe('medium layout (100x30)', () => {
     const grid = computeGridLayout(100, 30, 'medium');
 
-    it('focusedAgent has fixed width 64 in medium mode', () => {
-      expect(grid.focusedAgent.width).toBe(64);
+    it('focusedAgent has fixed width 58 in medium mode', () => {
+      expect(grid.focusedAgent.width).toBe(58);
     });
 
     it('flowMap takes all remaining width after focusedAgent', () => {
-      expect(grid.flowMap.width).toBe(100 - 64);
+      expect(grid.flowMap.width).toBe(100 - 58);
     });
 
     it('focusedAgent is right-aligned', () => {
@@ -340,13 +340,13 @@ describe('computeGridLayout', () => {
       const grid150 = computeGridLayout(150, 40, 'wide');
       const grid200 = computeGridLayout(200, 40, 'wide');
 
-      // focusedAgent stays at 70 in both
-      expect(grid150.focusedAgent.width).toBe(70);
-      expect(grid200.focusedAgent.width).toBe(70);
+      // focusedAgent stays at 63 in both
+      expect(grid150.focusedAgent.width).toBe(63);
+      expect(grid200.focusedAgent.width).toBe(63);
 
       // flowMap grows with terminal width
-      expect(grid150.flowMap.width).toBe(80);
-      expect(grid200.flowMap.width).toBe(130);
+      expect(grid150.flowMap.width).toBe(87);
+      expect(grid200.flowMap.width).toBe(137);
     });
   });
 

--- a/apps/mcp-server/src/tui/components/grid-layout.pure.ts
+++ b/apps/mcp-server/src/tui/components/grid-layout.pure.ts
@@ -13,8 +13,8 @@ const MIN_COLUMNS = 20;
 
 /** Fixed width for focusedAgent panel per layout mode (content-first right panel). */
 const FOCUSED_AGENT_WIDTH: Record<Exclude<LayoutMode, 'narrow'>, number> = {
-  wide: 70,
-  medium: 64,
+  wide: 63, // was 70 → -10% (FlowMap/Activity gains +7 cols)
+  medium: 58, // was 64 → -9.4% (FlowMap/Activity gains +6 cols)
 };
 
 /**


### PR DESCRIPTION
## Summary

Closes #501

- Reduce `FOCUSED_AGENT_WIDTH`: wide `70→63`, medium `64→58` (~10% reduction)
- FlowMap and ActivityVisualizer automatically gain the freed horizontal space (`cols - focusedWidth`)
- Increase `AGENT_NAME_WIDTH` from `10→15` so agent names in the heatmap are no longer truncated
- Update `grid-layout.pure.spec.ts` width assertions to reflect new values

## Changes

| File | Change |
|------|--------|
| `grid-layout.pure.ts` | Reduce `FOCUSED_AGENT_WIDTH` (wide: 70→63, medium: 64→58) |
| `grid-layout.pure.spec.ts` | Update width assertions to match new values |
| `activity-visualizer.pure.ts` | Increase `AGENT_NAME_WIDTH` from 10→15 |

## Test Plan

- [ ] `computeGridLayout('wide')` returns `focusedAgent.width = 63`
- [ ] `computeGridLayout('medium')` returns `focusedAgent.width = 58`
- [ ] `flowMap.width + focusedAgent.width = total terminal width`
- [ ] Agent names in heatmap display up to 15 characters without truncation
- [ ] Narrow mode unchanged
- [ ] All tests pass: `yarn workspace codingbuddy test -- --testPathPattern="grid-layout|activity-visualizer"`