### PR TITLE
refactor(tui): consolidate task:synced into single pass and fix event ordering

### DIFF
--- a/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
@@ -185,9 +185,9 @@ describe('extractEventsFromResponse', () => {
       );
       expect(result[0].event).toBe(TUI_EVENTS.MODE_CHANGED);
       expect(result[1].event).toBe(TUI_EVENTS.SKILL_RECOMMENDED);
-      expect(result[2].event).toBe(TUI_EVENTS.AGENT_ACTIVATED);
-      // TASK_SYNCED is also emitted for included_skills (initial checklist)
-      expect(result.some(e => e.event === TUI_EVENTS.TASK_SYNCED)).toBe(true);
+      // TASK_SYNCED follows immediately after skill:recommended (same included_skills pass)
+      expect(result[2].event).toBe(TUI_EVENTS.TASK_SYNCED);
+      expect(result[3].event).toBe(TUI_EVENTS.AGENT_ACTIVATED);
     });
   });
 
@@ -839,9 +839,7 @@ describe('extractEventsFromResponse', () => {
           'update_context',
           makeResponse({
             document: {
-              sections: [
-                { primaryAgent: 'agent-1', status: 'completed', progress: ['Impl auth'] },
-              ],
+              sections: [{ primaryAgent: 'agent-1', status: 'completed', progress: ['Impl auth'] }],
             },
           }),
         );

--- a/apps/mcp-server/src/tui/events/response-event-extractor.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.ts
@@ -79,6 +79,7 @@ export function extractEventsFromResponse(toolName: string, result: unknown): Ex
 
 function extractFromParseMode(json: Record<string, unknown>): ExtractedEvent[] {
   const events: ExtractedEvent[] = [];
+  const delegateName = typeof json.delegates_to === 'string' ? json.delegates_to : null;
 
   // mode:changed (validate against known Mode values)
   if (typeof json.mode === 'string' && VALID_MODES.has(json.mode)) {
@@ -88,9 +89,10 @@ function extractFromParseMode(json: Record<string, unknown>): ExtractedEvent[] {
     });
   }
 
-  // skill:recommended
+  // skill:recommended + task:synced initial checklist (single pass over included_skills)
   if (Array.isArray(json.included_skills)) {
-    for (const skill of json.included_skills) {
+    const initialTasks: Array<{ id: string; subject: string; completed: boolean }> = [];
+    for (const [i, skill] of json.included_skills.entries()) {
       if (!skill || typeof skill !== 'object') continue;
       const s = skill as Record<string, unknown>;
       if (typeof s.name !== 'string') continue;
@@ -101,11 +103,15 @@ function extractFromParseMode(json: Record<string, unknown>): ExtractedEvent[] {
           reason: typeof s.reason === 'string' ? s.reason : '',
         },
       });
+      initialTasks.push({ id: `skill-${i}`, subject: `Apply ${s.name}`, completed: false });
+    }
+    if (initialTasks.length > 0) {
+      const agentId = delegateName ? `primary:${delegateName}` : UNKNOWN_AGENT_ID;
+      events.push({ event: TUI_EVENTS.TASK_SYNCED, payload: { agentId, tasks: initialTasks } });
     }
   }
 
   // agent:activated (primary agent from delegates_to)
-  const delegateName = typeof json.delegates_to === 'string' ? json.delegates_to : null;
   if (delegateName) {
     events.push({
       event: TUI_EVENTS.AGENT_ACTIVATED,
@@ -162,21 +168,6 @@ function extractFromParseMode(json: Record<string, unknown>): ExtractedEvent[] {
       event: TUI_EVENTS.OBJECTIVE_SET,
       payload: { objective: json.originalPrompt.trim() },
     });
-  }
-
-  // task:synced (initial checklist from included_skills)
-  if (Array.isArray(json.included_skills)) {
-    const initialTasks: Array<{ id: string; subject: string; completed: boolean }> = [];
-    for (const [i, skill] of json.included_skills.entries()) {
-      if (!skill || typeof skill !== 'object') continue;
-      const s = skill as Record<string, unknown>;
-      if (typeof s.name !== 'string') continue;
-      initialTasks.push({ id: `skill-${i}`, subject: `Apply ${s.name}`, completed: false });
-    }
-    if (initialTasks.length > 0) {
-      const agentId = delegateName ? `primary:${delegateName}` : UNKNOWN_AGENT_ID;
-      events.push({ event: TUI_EVENTS.TASK_SYNCED, payload: { agentId, tasks: initialTasks } });
-    }
   }
 
   return events;
@@ -246,8 +237,11 @@ function extractFromDispatchAgents(json: Record<string, unknown>): ExtractedEven
 }
 
 /**
- * Pick the first non-empty string array from the section's task-related fields.
- * Priority: progress (ACT) > decisions (PLAN) > findings (EVAL) > notes (fallback).
+ * Build task list from all section fields with source-aware completion status.
+ * - decisions: always completed (decided = done)
+ * - progress: completed based on section status
+ * - findings: always completed (observed = done)
+ * - notes: always incomplete (informational)
  */
 function buildTasksFromSection(
   section: Record<string, unknown>,


### PR DESCRIPTION
## Summary

Follow-up refactor for #504 — consolidates the `task:synced` event emission and fixes the event ordering in `extractFromParseMode`.

- **Move `delegateName` to top**: extracted once at the start of `extractFromParseMode` so it is available for both `task:synced` and `agent:activated` without duplication
- **Single-pass `included_skills` loop**: merges `skill:recommended` and `task:synced` initial checklist construction into one iteration, eliminating a redundant second loop
- **Fix event order**: `TASK_SYNCED` now emits immediately after `SKILL_RECOMMENDED` (within the same `included_skills` pass), before `AGENT_ACTIVATED` — reflecting the logical dependency (tasks must be seeded before the agent is considered active)
- **Update tests**: assertions updated to match the corrected event sequence (`TASK_SYNCED` at index 2, `AGENT_ACTIVATED` at index 3)

## Changes

| File | Change |
|------|--------|
| `response-event-extractor.ts` | Consolidate loops, hoist `delegateName`, remove duplicate `task:synced` block |
| `response-event-extractor.spec.ts` | Update event order assertions |

## Test Plan

- [ ] Confirm `extractEventsFromResponse` test suite passes with updated event order assertions
- [ ] Verify `TASK_SYNCED` emits before `AGENT_ACTIVATED` in parse_mode responses that include `included_skills`
- [ ] Verify no regression in cases where `included_skills` is absent or `delegates_to` is unset