### PR TITLE
add session:reset event and auto-reset on new PLAN/AUTO session

### DIFF
--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -164,6 +164,7 @@ async function initIpc(app: INestApplicationContext): Promise<InitIpcResult> {
     (p: unknown) => (p as { agentId: string }).agentId,
   );
   stateCache.trackToggle(TUI_EVENTS.PARALLEL_STARTED, TUI_EVENTS.PARALLEL_COMPLETED);
+  stateCache.trackReset(TUI_EVENTS.SESSION_RESET);
 
   // Provide initial state snapshot for late-connecting TUI clients
   const ipcServer = new TuiIpcServer(socketPath, {

--- a/apps/mcp-server/src/tui/events/index.ts
+++ b/apps/mcp-server/src/tui/events/index.ts
@@ -18,6 +18,7 @@ export {
   type TaskSyncedEvent,
   type ToolInvokedEvent,
   type ObjectiveSetEvent,
+  type SessionResetEvent,
 } from './types';
 export {
   type AgentMetadata,

--- a/apps/mcp-server/src/tui/events/tui-interceptor.spec.ts
+++ b/apps/mcp-server/src/tui/events/tui-interceptor.spec.ts
@@ -433,6 +433,157 @@ describe('TuiInterceptor', () => {
     });
   });
 
+  describe('resetSession()', () => {
+    beforeEach(() => {
+      interceptor.enable();
+    });
+
+    it('should emit session:reset event with given reason', async () => {
+      const resetHandler = vi.fn();
+      eventBus.on(TUI_EVENTS.SESSION_RESET, resetHandler);
+
+      interceptor.resetSession('manual');
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(resetHandler).toHaveBeenCalledWith({ reason: 'manual' });
+    });
+
+    it('should emit session:reset only once per call', async () => {
+      const resetHandler = vi.fn();
+      eventBus.on(TUI_EVENTS.SESSION_RESET, resetHandler);
+
+      interceptor.resetSession('test');
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(resetHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('MODE_CHANGED auto-reset', () => {
+    beforeEach(() => {
+      interceptor.enable();
+    });
+
+    it('should NOT emit SESSION_RESET on first PLAN when currentMode is null', async () => {
+      const resetHandler = vi.fn();
+      eventBus.on(TUI_EVENTS.SESSION_RESET, resetHandler);
+
+      await interceptor.intercept('parse_mode', { prompt: 'PLAN first session' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'PLAN' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(resetHandler).not.toHaveBeenCalled();
+    });
+
+    it('should emit SESSION_RESET on second PLAN when previous session exists', async () => {
+      const resetHandler = vi.fn();
+      eventBus.on(TUI_EVENTS.SESSION_RESET, resetHandler);
+
+      // 첫 번째 PLAN: currentMode null → PLAN (reset 없음)
+      await interceptor.intercept('parse_mode', { prompt: 'PLAN first' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'PLAN' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+      expect(resetHandler).not.toHaveBeenCalled();
+
+      // 두 번째 PLAN: currentMode PLAN → reset 발생
+      await interceptor.intercept('parse_mode', { prompt: 'PLAN second' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'PLAN' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(resetHandler).toHaveBeenCalledWith({ reason: 'new-plan-session' });
+      expect(resetHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should emit SESSION_RESET on AUTO when previous session exists', async () => {
+      const resetHandler = vi.fn();
+      eventBus.on(TUI_EVENTS.SESSION_RESET, resetHandler);
+
+      // 첫 번째 PLAN
+      await interceptor.intercept('parse_mode', { prompt: 'PLAN setup' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'PLAN' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+
+      // AUTO: currentMode PLAN → reset 발생
+      await interceptor.intercept('parse_mode', { prompt: 'AUTO build feature' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'AUTO' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(resetHandler).toHaveBeenCalledWith({ reason: 'new-plan-session' });
+    });
+
+    it('should NOT emit SESSION_RESET on ACT even with previous session', async () => {
+      const resetHandler = vi.fn();
+      eventBus.on(TUI_EVENTS.SESSION_RESET, resetHandler);
+
+      // PLAN 먼저
+      await interceptor.intercept('parse_mode', { prompt: 'PLAN setup' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'PLAN' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+      resetHandler.mockClear();
+
+      // ACT: reset 없어야 함
+      await interceptor.intercept('parse_mode', { prompt: 'ACT implement' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'ACT' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(resetHandler).not.toHaveBeenCalled();
+    });
+
+    it('should NOT emit SESSION_RESET on EVAL even with previous session', async () => {
+      const resetHandler = vi.fn();
+      eventBus.on(TUI_EVENTS.SESSION_RESET, resetHandler);
+
+      // PLAN → ACT 먼저
+      await interceptor.intercept('parse_mode', { prompt: 'PLAN setup' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'PLAN' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+      await interceptor.intercept('parse_mode', { prompt: 'ACT impl' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'ACT' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+      resetHandler.mockClear();
+
+      // EVAL: reset 없어야 함
+      await interceptor.intercept('parse_mode', { prompt: 'EVAL review' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'EVAL' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(resetHandler).not.toHaveBeenCalled();
+    });
+
+    it('MODE_CHANGED should still be emitted after SESSION_RESET', async () => {
+      const modeHandler = vi.fn();
+      const resetHandler = vi.fn();
+      eventBus.on(TUI_EVENTS.MODE_CHANGED, modeHandler);
+      eventBus.on(TUI_EVENTS.SESSION_RESET, resetHandler);
+
+      // 첫 PLAN
+      await interceptor.intercept('parse_mode', { prompt: 'PLAN first' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'PLAN' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+      modeHandler.mockClear();
+
+      // 두 번째 PLAN: reset 후 mode:changed도 발생해야 함
+      await interceptor.intercept('parse_mode', { prompt: 'PLAN second' }, async () => ({
+        content: [{ type: 'text', text: JSON.stringify({ mode: 'PLAN' }) }],
+      }));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(resetHandler).toHaveBeenCalledTimes(1);
+      expect(modeHandler).toHaveBeenCalledWith({ from: null, to: 'PLAN' });
+    });
+  });
+
   describe('enable/disable', () => {
     it('should be disabled by default', () => {
       expect(interceptor.isEnabled()).toBe(false);

--- a/apps/mcp-server/src/tui/events/tui-interceptor.ts
+++ b/apps/mcp-server/src/tui/events/tui-interceptor.ts
@@ -112,9 +112,23 @@ export class TuiInterceptor {
     }
   }
 
+  /**
+   * Emits SESSION_RESET and clears internal session state.
+   * Public for testability — prefer auto-trigger via emitSemanticEvent().
+   */
+  resetSession(reason: string): void {
+    this.eventBus.emit(TUI_EVENTS.SESSION_RESET, { reason });
+    this.currentMode = null;
+    this.currentPrimaryAgentId = null;
+  }
+
   private emitSemanticEvent(evt: ExtractedEvent): void {
     switch (evt.event) {
       case TUI_EVENTS.MODE_CHANGED: {
+        const targetMode = evt.payload.to;
+        if ((targetMode === 'PLAN' || targetMode === 'AUTO') && this.currentMode !== null) {
+          this.resetSession('new-plan-session');
+        }
         const payload = { ...evt.payload, from: this.currentMode };
         this.currentMode = evt.payload.to;
         this.eventBus.emit(TUI_EVENTS.MODE_CHANGED, payload);

--- a/apps/mcp-server/src/tui/events/types.spec.ts
+++ b/apps/mcp-server/src/tui/events/types.spec.ts
@@ -12,12 +12,13 @@ import {
   type TaskSyncedEvent,
   type ToolInvokedEvent,
   type ObjectiveSetEvent,
+  type SessionResetEvent,
   type TuiEventMap,
 } from './types';
 
 describe('tui/events/types', () => {
   describe('TUI_EVENTS', () => {
-    it('should define all 11 event names', () => {
+    it('should define all 12 event names', () => {
       expect(TUI_EVENTS).toEqual({
         AGENT_ACTIVATED: 'agent:activated',
         AGENT_DEACTIVATED: 'agent:deactivated',
@@ -30,7 +31,12 @@ describe('tui/events/types', () => {
         TASK_SYNCED: 'task:synced',
         TOOL_INVOKED: 'tool:invoked',
         OBJECTIVE_SET: 'objective:set',
+        SESSION_RESET: 'session:reset',
       });
+    });
+
+    it('should include SESSION_RESET event', () => {
+      expect(TUI_EVENTS.SESSION_RESET).toBe('session:reset');
     });
 
     it('should include AGENTS_LOADED event', () => {
@@ -178,6 +184,7 @@ describe('tui/events/types', () => {
         'task:synced': { agentId: 'a1', tasks: [] },
         'tool:invoked': { toolName: 'search_rules', agentId: null, timestamp: 0 },
         'objective:set': { objective: 'implement auth feature' },
+        'session:reset': { reason: 'new-plan-session' },
       };
       expect(map['agent:activated'].agentId).toBe('a1');
     });
@@ -187,6 +194,18 @@ describe('tui/events/types', () => {
     it('should have correct shape', () => {
       const event: ObjectiveSetEvent = { objective: 'implement auth feature' };
       expect(event.objective).toBe('implement auth feature');
+    });
+  });
+
+  describe('SessionResetEvent', () => {
+    it('should have reason field', () => {
+      const event: SessionResetEvent = { reason: 'new-plan-session' };
+      expect(event.reason).toBe('new-plan-session');
+    });
+
+    it('should accept manual reason', () => {
+      const event: SessionResetEvent = { reason: 'manual' };
+      expect(event.reason).toBe('manual');
     });
   });
 });

--- a/apps/mcp-server/src/tui/events/types.ts
+++ b/apps/mcp-server/src/tui/events/types.ts
@@ -9,7 +9,8 @@ import type { EdgeType } from '../dashboard-types';
 import type { AgentMetadata } from './agent-metadata.types';
 
 /**
- * Event name constants for the TUI EventBus
+ * Event name constants for the TUI EventBus.
+ * Defines the 12 core events for the TUI Agent Monitor event system.
  */
 export const TUI_EVENTS = Object.freeze({
   AGENT_ACTIVATED: 'agent:activated',
@@ -23,6 +24,7 @@ export const TUI_EVENTS = Object.freeze({
   TASK_SYNCED: 'task:synced',
   TOOL_INVOKED: 'tool:invoked',
   OBJECTIVE_SET: 'objective:set',
+  SESSION_RESET: 'session:reset',
 } as const);
 
 export type TuiEventName = (typeof TUI_EVENTS)[keyof typeof TUI_EVENTS];
@@ -97,6 +99,11 @@ export interface ObjectiveSetEvent {
   objective: string;
 }
 
+/** Payload when the session is reset (e.g. after /clear command) */
+export interface SessionResetEvent {
+  reason: string;
+}
+
 /**
  * Maps event names to their payload types for type-safe emit/subscribe.
  */
@@ -112,4 +119,5 @@ export interface TuiEventMap {
   [TUI_EVENTS.TASK_SYNCED]: TaskSyncedEvent;
   [TUI_EVENTS.TOOL_INVOKED]: ToolInvokedEvent;
   [TUI_EVENTS.OBJECTIVE_SET]: ObjectiveSetEvent;
+  [TUI_EVENTS.SESSION_RESET]: SessionResetEvent;
 }

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -599,4 +599,48 @@ describe('dashboardReducer', () => {
     // Focused primary agent should NOT be incremented (exact match took priority)
     expect(state.agents.get('primary:arch')?.progress).toBe(0);
   });
+
+  describe('SESSION_RESET', () => {
+    it('should clear agents, edges, eventLog, tasks, objectives on SESSION_RESET', () => {
+      let state = dashboardReducer(initialDashboardState, {
+        type: 'AGENT_ACTIVATED',
+        payload: { agentId: 'a1', name: 'Architect', role: 'architect', isPrimary: true },
+      });
+      state = dashboardReducer(state, {
+        type: 'MODE_CHANGED',
+        payload: { from: null, to: 'PLAN' },
+      });
+      state = dashboardReducer(state, {
+        type: 'TOOL_INVOKED',
+        payload: { toolName: 'search_rules', agentId: 'a1', timestamp: Date.now() },
+      });
+      state = dashboardReducer(state, {
+        type: 'OBJECTIVE_SET',
+        payload: { objective: 'build auth feature' },
+      });
+
+      const result = dashboardReducer(state, {
+        type: 'SESSION_RESET',
+        payload: { reason: 'new-plan-session' },
+      });
+
+      expect(result.agents.size).toBe(0);
+      expect(result.edges).toEqual([]);
+      expect(result.eventLog).toEqual([]);
+      expect(result.tasks).toEqual([]);
+      expect(result.objectives).toEqual([]);
+      expect(result.currentMode).toBeNull();
+      expect(result.globalState).toBe('IDLE');
+      expect(result.toolInvokeCount).toBe(0);
+    });
+
+    it('should generate a new sessionId on SESSION_RESET', () => {
+      const result = dashboardReducer(initialDashboardState, {
+        type: 'SESSION_RESET',
+        payload: { reason: 'new-plan-session' },
+      });
+      expect(result.sessionId).toBeDefined();
+      expect(typeof result.sessionId).toBe('string');
+    });
+  });
 });

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -21,6 +21,7 @@ import {
   type TaskSyncedEvent,
   type ToolInvokedEvent,
   type ObjectiveSetEvent,
+  type SessionResetEvent,
 } from '../events';
 import { selectFocusedAgent } from './use-focus-agent';
 
@@ -62,7 +63,8 @@ export type DashboardAction =
   | { type: 'AGENT_RELATIONSHIP'; payload: AgentRelationshipEvent }
   | { type: 'TASK_SYNCED'; payload: TaskSyncedEvent }
   | { type: 'TOOL_INVOKED'; payload: ToolInvokedEvent }
-  | { type: 'OBJECTIVE_SET'; payload: ObjectiveSetEvent };
+  | { type: 'OBJECTIVE_SET'; payload: ObjectiveSetEvent }
+  | { type: 'SESSION_RESET'; payload: SessionResetEvent };
 
 function cloneAgents(agents: Map<string, DashboardNode>): Map<string, DashboardNode> {
   return new Map(agents);
@@ -233,6 +235,9 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
       return { ...state, agents };
     }
 
+    case 'SESSION_RESET':
+      return createInitialDashboardState();
+
     // Reserved: no emitter currently produces PARALLEL_COMPLETED. Subscription kept for forward compatibility.
     case 'PARALLEL_COMPLETED':
     case 'AGENTS_LOADED':
@@ -273,6 +278,8 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
     const onToolInvoked = (p: ToolInvokedEvent) => dispatch({ type: 'TOOL_INVOKED', payload: p });
     const onObjectiveSet = (p: ObjectiveSetEvent) =>
       dispatch({ type: 'OBJECTIVE_SET', payload: p });
+    const onSessionReset = (p: SessionResetEvent) =>
+      dispatch({ type: 'SESSION_RESET', payload: p });
 
     eventBus.on(TUI_EVENTS.AGENT_ACTIVATED, onActivated);
     eventBus.on(TUI_EVENTS.AGENT_DEACTIVATED, onDeactivated);
@@ -285,6 +292,7 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
     eventBus.on(TUI_EVENTS.TASK_SYNCED, onTaskSynced);
     eventBus.on(TUI_EVENTS.TOOL_INVOKED, onToolInvoked);
     eventBus.on(TUI_EVENTS.OBJECTIVE_SET, onObjectiveSet);
+    eventBus.on(TUI_EVENTS.SESSION_RESET, onSessionReset);
 
     return () => {
       eventBus.off(TUI_EVENTS.AGENT_ACTIVATED, onActivated);
@@ -298,6 +306,7 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
       eventBus.off(TUI_EVENTS.TASK_SYNCED, onTaskSynced);
       eventBus.off(TUI_EVENTS.TOOL_INVOKED, onToolInvoked);
       eventBus.off(TUI_EVENTS.OBJECTIVE_SET, onObjectiveSet);
+      eventBus.off(TUI_EVENTS.SESSION_RESET, onSessionReset);
     };
   }, [eventBus]);
 

--- a/apps/mcp-server/src/tui/ipc/ipc-state-cache.spec.ts
+++ b/apps/mcp-server/src/tui/ipc/ipc-state-cache.spec.ts
@@ -143,6 +143,42 @@ describe('IpcStateCache', () => {
     });
   });
 
+  describe('trackReset', () => {
+    it('should clear all cached state when reset event fires', () => {
+      cache.trackSimple('mode:changed');
+      cache.trackSimple('agents:loaded');
+      bus.emit('mode:changed', { from: null, to: 'PLAN' });
+      bus.emit('agents:loaded', { agents: [] });
+
+      expect(cache.getSnapshot()).toHaveLength(2);
+
+      cache.trackReset('session:reset');
+      bus.emit('session:reset', { reason: 'new-plan-session' });
+
+      expect(cache.getSnapshot()).toHaveLength(0);
+    });
+
+    it('should not affect cache before reset event fires', () => {
+      cache.trackSimple('mode:changed');
+      bus.emit('mode:changed', { from: null, to: 'PLAN' });
+
+      cache.trackReset('session:reset');
+
+      // reset 이벤트가 아직 발생 전이므로 캐시는 유지됨
+      expect(cache.getSnapshot()).toHaveLength(1);
+    });
+
+    it('should register cleanup for reset handler on destroy', () => {
+      const offSpy = vi.spyOn(bus, 'off');
+      cache.trackReset('session:reset');
+
+      cache.destroy();
+
+      // trackReset이 등록한 리스너 1개가 정리되어야 함
+      expect(offSpy).toHaveBeenCalledWith('session:reset', expect.any(Function));
+    });
+  });
+
   describe('destroy', () => {
     it('should remove all listeners and clear cache', () => {
       const offSpy = vi.spyOn(bus, 'off');

--- a/apps/mcp-server/src/tui/ipc/ipc-state-cache.ts
+++ b/apps/mcp-server/src/tui/ipc/ipc-state-cache.ts
@@ -88,6 +88,15 @@ export class IpcStateCache {
     this.removers.push(() => this.eventBus.off(endEvent, endHandler));
   }
 
+  /** Clear all cached state when the given reset event fires (e.g. session:reset) */
+  trackReset(resetEvent: string): void {
+    const handler = (): void => {
+      this.latestState.clear();
+    };
+    this.eventBus.on(resetEvent, handler);
+    this.removers.push(() => this.eventBus.off(resetEvent, handler));
+  }
+
   /** Return snapshot of all cached state for late-connecting clients */
   getSnapshot(): IpcMessage[] {
     return [...this.latestState.values()];


### PR DESCRIPTION
## Summary

Closes #499

Adds a `session:reset` event to the TUI event system so that the dashboard and IPC state cache are fully cleared whenever a new PLAN or AUTO session begins, preventing stale agent/task data from a previous session bleeding into the new one.

## Changes

### New event: `session:reset`
- Added `SESSION_RESET` constant to `TUI_EVENTS` and `SessionResetEvent` interface to `TuiEventMap`

### `TuiInterceptor`
- Added `resetSession(reason)` — emits `session:reset` and clears `currentMode` / `currentPrimaryAgentId`
- Auto-triggers on `MODE_CHANGED` when the incoming mode is `PLAN` or `AUTO` and a prior session already exists (`currentMode !== null`)

### `dashboardReducer` / `useDashboardState`
- Added `SESSION_RESET` action that returns `createInitialDashboardState()`, wiping agents, edges, event log, tasks, and objectives
- `useDashboardState` subscribes/unsubscribes to `session:reset` for reactive UI reset

### `IpcStateCache`
- Added `trackReset(resetEvent)` — clears the internal `latestState` map when the reset event fires, so late-connecting TUI clients receive a clean snapshot

### `main.ts`
- Wires `stateCache.trackReset(TUI_EVENTS.SESSION_RESET)` at startup

## Test coverage

- `resetSession()` emits the correct payload and fires exactly once
- Auto-reset fires on second PLAN / first AUTO, but not on ACT or EVAL
- `MODE_CHANGED` is still emitted after the reset
- `dashboardReducer` returns initial state on `SESSION_RESET`
- `IpcStateCache.trackReset()` clears cached messages on event

## Test plan

- [ ] Start TUI, run a PLAN session, verify agents/tasks appear
- [ ] Issue a second PLAN — dashboard should clear and repopulate fresh
- [ ] Issue AUTO — same reset behavior confirmed
- [ ] Issue ACT / EVAL after PLAN — no reset, prior state preserved
- [ ] Run unit tests: `yarn workspace codingbuddy test`