### PR TITLE
integrate context:updated event and display decisions/notes in FocusedAgentPanel

### DIFF
--- a/apps/mcp-server/src/tui/components/ContextSection.tsx
+++ b/apps/mcp-server/src/tui/components/ContextSection.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { formatContextDecisions, formatContextNotes } from './context-section.pure';
+
+export interface ContextSectionProps {
+  decisions: string[];
+  notes: string[];
+  width?: number;
+}
+
+export function ContextSection({
+  decisions,
+  notes,
+}: ContextSectionProps): React.ReactElement | null {
+  const hasDecisions = decisions.length > 0;
+  const hasNotes = notes.length > 0;
+
+  if (!hasDecisions && !hasNotes) return null;
+
+  return (
+    <Box flexDirection="column">
+      {hasDecisions && (
+        <Box flexDirection="column">
+          <Text dimColor bold>
+            Decisions
+          </Text>
+          {formatContextDecisions(decisions)
+            ?.split('\n')
+            .map((line, i) => (
+              <Text key={i} color="cyan">
+                {line}
+              </Text>
+            ))}
+        </Box>
+      )}
+      {hasNotes && (
+        <Box flexDirection="column">
+          <Text dimColor bold>
+            Notes
+          </Text>
+          {formatContextNotes(notes)
+            ?.split('\n')
+            .map((line, i) => (
+              <Text key={i} dimColor>
+                {line}
+              </Text>
+            ))}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
@@ -325,4 +325,87 @@ describe('tui/components/FocusedAgentPanel', () => {
     );
     expect(lastFrame()).toContain('─── Activity');
   });
+
+  describe('Context section', () => {
+    it('renders context decisions when provided', () => {
+      const { lastFrame } = render(
+        <FocusedAgentPanel
+          agent={mockAgent}
+          activeSkills={[]}
+          objectives={[]}
+          tasks={[]}
+          tools={[]}
+          inputs={[]}
+          outputs={{}}
+          eventLog={[]}
+          toolCalls={[]}
+          contextDecisions={['Use JWT for auth', 'Add rate limiting']}
+          contextNotes={[]}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('Use JWT for auth');
+      expect(frame).toContain('Add rate limiting');
+      expect(frame).toContain('─── Context');
+    });
+
+    it('renders context notes when provided', () => {
+      const { lastFrame } = render(
+        <FocusedAgentPanel
+          agent={mockAgent}
+          activeSkills={[]}
+          objectives={[]}
+          tasks={[]}
+          tools={[]}
+          inputs={[]}
+          outputs={{}}
+          eventLog={[]}
+          toolCalls={[]}
+          contextDecisions={[]}
+          contextNotes={['Review existing codebase']}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('Review existing codebase');
+      expect(frame).toContain('─── Context');
+    });
+
+    it('renders No context when both empty', () => {
+      const { lastFrame } = render(
+        <FocusedAgentPanel
+          agent={mockAgent}
+          activeSkills={[]}
+          objectives={[]}
+          tasks={[]}
+          tools={[]}
+          inputs={[]}
+          outputs={{}}
+          eventLog={[]}
+          toolCalls={[]}
+          contextDecisions={[]}
+          contextNotes={[]}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('No context');
+    });
+
+    it('renders No context when props omitted', () => {
+      const { lastFrame } = render(
+        <FocusedAgentPanel
+          agent={mockAgent}
+          activeSkills={[]}
+          objectives={[]}
+          tasks={[]}
+          tools={[]}
+          inputs={[]}
+          outputs={{}}
+          eventLog={[]}
+          toolCalls={[]}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('No context');
+    });
+  });
 });

--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
@@ -12,6 +12,7 @@ import {
   formatActivitySparkline,
   type ToolIOData,
 } from './focused-agent.pure';
+import { ContextSection } from './ContextSection';
 
 export interface FocusedAgentPanelProps {
   agent: DashboardNode | null;
@@ -23,6 +24,8 @@ export interface FocusedAgentPanelProps {
   outputs: ToolIOData;
   eventLog: EventLogEntry[];
   toolCalls: ToolCallRecord[];
+  contextDecisions?: string[];
+  contextNotes?: string[];
   width?: number;
   height?: number;
 }
@@ -70,6 +73,8 @@ export function FocusedAgentPanel({
   outputs,
   eventLog,
   toolCalls,
+  contextDecisions = [],
+  contextNotes = [],
   width,
   height,
 }: FocusedAgentPanelProps): React.ReactElement {
@@ -158,6 +163,14 @@ export function FocusedAgentPanel({
       {/* Tools / IO Section */}
       <SectionDivider title="Tools / IO" />
       <Text>{toolIO}</Text>
+
+      {/* Context Section */}
+      <SectionDivider title="Context" />
+      {contextDecisions.length > 0 || contextNotes.length > 0 ? (
+        <ContextSection decisions={contextDecisions} notes={contextNotes} width={width} />
+      ) : (
+        <Text dimColor>No context</Text>
+      )}
 
       {/* Event Log Section */}
       <SectionDivider title="Event Log" />

--- a/apps/mcp-server/src/tui/components/context-section.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/context-section.pure.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatContextDecisions,
+  formatContextNotes,
+  formatContextSection,
+} from './context-section.pure';
+
+describe('context-section.pure', () => {
+  describe('formatContextDecisions', () => {
+    it('formats decisions as numbered list', () => {
+      const result = formatContextDecisions(['Use JWT', 'Add rate limiting']);
+      expect(result).toBe('  1. Use JWT\n  2. Add rate limiting');
+    });
+
+    it('returns null for empty decisions', () => {
+      expect(formatContextDecisions([])).toBeNull();
+    });
+
+    it('truncates at maxItems with overflow indicator', () => {
+      const decisions = ['A', 'B', 'C', 'D', 'E', 'F'];
+      const result = formatContextDecisions(decisions, 3);
+      expect(result).toBe('  1. A\n  2. B\n  3. C\n  ⋯ (+3 more)');
+    });
+
+    it('shows all items when count equals maxItems', () => {
+      const result = formatContextDecisions(['A', 'B', 'C'], 3);
+      expect(result).toBe('  1. A\n  2. B\n  3. C');
+    });
+
+    it('formats single decision', () => {
+      expect(formatContextDecisions(['Only one'])).toBe('  1. Only one');
+    });
+  });
+
+  describe('formatContextNotes', () => {
+    it('formats notes with bullet prefix', () => {
+      const result = formatContextNotes(['Review codebase', 'Check deps']);
+      expect(result).toBe('  › Review codebase\n  › Check deps');
+    });
+
+    it('returns null for empty notes', () => {
+      expect(formatContextNotes([])).toBeNull();
+    });
+
+    it('truncates at maxItems', () => {
+      const notes = ['A', 'B', 'C', 'D'];
+      const result = formatContextNotes(notes, 2);
+      expect(result).toBe('  › A\n  › B\n  ⋯ (+2 more)');
+    });
+
+    it('shows all items when count equals maxItems', () => {
+      const result = formatContextNotes(['A', 'B'], 2);
+      expect(result).toBe('  › A\n  › B');
+    });
+
+    it('formats single note', () => {
+      expect(formatContextNotes(['Just one note'])).toBe('  › Just one note');
+    });
+  });
+
+  describe('formatContextSection', () => {
+    it('returns null when both decisions and notes are empty', () => {
+      expect(formatContextSection([], [])).toBeNull();
+    });
+
+    it('returns formatted string with decisions only', () => {
+      const result = formatContextSection(['Use JWT'], []);
+      expect(result).not.toBeNull();
+      expect(result).toContain('1. Use JWT');
+    });
+
+    it('returns formatted string with notes only', () => {
+      const result = formatContextSection([], ['Consider caching']);
+      expect(result).not.toBeNull();
+      expect(result).toContain('› Consider caching');
+    });
+
+    it('returns formatted string with both decisions and notes', () => {
+      const result = formatContextSection(['Decision A'], ['Note B']);
+      expect(result).not.toBeNull();
+      expect(result).toContain('Decision A');
+      expect(result).toContain('Note B');
+    });
+
+    it('separates decisions and notes with newline', () => {
+      const result = formatContextSection(['D1'], ['N1']);
+      expect(result).toBe('  1. D1\n  › N1');
+    });
+  });
+});

--- a/apps/mcp-server/src/tui/components/context-section.pure.ts
+++ b/apps/mcp-server/src/tui/components/context-section.pure.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure rendering functions for the ContextSection component.
+ * Displays decisions[] and notes[] from update_context responses.
+ */
+
+/**
+ * Format decisions as a numbered list.
+ * Returns null when decisions is empty.
+ */
+export function formatContextDecisions(decisions: string[], maxItems = 5): string | null {
+  if (decisions.length === 0) return null;
+  const visible = decisions.slice(0, maxItems);
+  const lines = visible.map((d, i) => `  ${i + 1}. ${d}`);
+  if (decisions.length > maxItems) {
+    lines.push(`  ⋯ (+${decisions.length - maxItems} more)`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format notes with a bullet prefix.
+ * Returns null when notes is empty.
+ */
+export function formatContextNotes(notes: string[], maxItems = 5): string | null {
+  if (notes.length === 0) return null;
+  const visible = notes.slice(0, maxItems);
+  const lines = visible.map(n => `  › ${n}`);
+  if (notes.length > maxItems) {
+    lines.push(`  ⋯ (+${notes.length - maxItems} more)`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format the combined context section (decisions + notes).
+ * Returns null when both are empty.
+ */
+export function formatContextSection(decisions: string[], notes: string[]): string | null {
+  const decStr = formatContextDecisions(decisions);
+  const noteStr = formatContextNotes(notes);
+  if (!decStr && !noteStr) return null;
+  const parts: string[] = [];
+  if (decStr) parts.push(decStr);
+  if (noteStr) parts.push(noteStr);
+  return parts.join('\n');
+}

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -64,6 +64,8 @@ export function DashboardApp({ eventBus, externalState }: DashboardAppProps): Re
             outputs={state.outputStats}
             eventLog={state.eventLog}
             toolCalls={state.toolCalls}
+            contextDecisions={state.contextDecisions}
+            contextNotes={state.contextNotes}
             width={grid.focusedAgent.width}
             height={grid.focusedAgent.height}
           />
@@ -102,6 +104,8 @@ export function DashboardApp({ eventBus, externalState }: DashboardAppProps): Re
             outputs={state.outputStats}
             eventLog={state.eventLog}
             toolCalls={state.toolCalls}
+            contextDecisions={state.contextDecisions}
+            contextNotes={state.contextNotes}
             width={grid.focusedAgent.width}
             height={grid.focusedAgent.height}
           />

--- a/apps/mcp-server/src/tui/dashboard-types.spec.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.spec.ts
@@ -168,6 +168,10 @@ describe('tui/dashboard-types', () => {
         toolCalls: [],
         toolInvokeCount: 0,
         outputStats: { files: 0, commits: 0 },
+        contextDecisions: [],
+        contextNotes: [],
+        contextMode: null,
+        contextStatus: null,
       };
       expect(state.toolInvokeCount).toBe(0);
       expect(state.outputStats).toEqual({ files: 0, commits: 0 });

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -157,6 +157,10 @@ export interface DashboardState {
   activeSkills: string[];
   toolInvokeCount: number;
   outputStats: { files: number; commits: number };
+  contextDecisions: string[];
+  contextNotes: string[];
+  contextMode: string | null;
+  contextStatus: string | null;
 }
 
 /**

--- a/apps/mcp-server/src/tui/eventbus-ui.integration.spec.tsx
+++ b/apps/mcp-server/src/tui/eventbus-ui.integration.spec.tsx
@@ -397,6 +397,7 @@ describe('EventBus ↔ UI Integration', () => {
         reason: 'bug detected',
       });
       await tick();
+      await tick();
 
       const frame = lastFrame() ?? '';
       expect(frame).toContain('RUNNING');

--- a/apps/mcp-server/src/tui/events/index.ts
+++ b/apps/mcp-server/src/tui/events/index.ts
@@ -19,6 +19,7 @@ export {
   type ToolInvokedEvent,
   type ObjectiveSetEvent,
   type SessionResetEvent,
+  type ContextUpdatedEvent,
 } from './types';
 export {
   type AgentMetadata,

--- a/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
@@ -705,9 +705,10 @@ describe('extractEventsFromResponse', () => {
           },
         }),
       );
-      expect(result).toHaveLength(1);
-      expect(result[0].event).toBe(TUI_EVENTS.TASK_SYNCED);
-      expect(result[0].payload).toEqual({
+      // decisions also emit context:updated, so total is 2 events
+      const taskSynced = result.find(e => e.event === TUI_EVENTS.TASK_SYNCED);
+      expect(taskSynced).toBeDefined();
+      expect(taskSynced!.payload).toEqual({
         agentId: 'technical-planner',
         tasks: [
           { id: 'ctx-d-0', subject: 'Use JWT for auth', completed: true },
@@ -759,8 +760,10 @@ describe('extractEventsFromResponse', () => {
           },
         }),
       );
-      expect(result).toHaveLength(1);
-      expect(result[0].payload).toEqual({
+      // notes also emit context:updated, so total is 2 events
+      const taskSynced = result.find(e => e.event === TUI_EVENTS.TASK_SYNCED);
+      expect(taskSynced).toBeDefined();
+      expect(taskSynced!.payload).toEqual({
         agentId: 'planner',
         tasks: [
           { id: 'ctx-n-0', subject: 'Reviewed existing codebase', completed: false },
@@ -918,6 +921,160 @@ describe('extractEventsFromResponse', () => {
           { id: 'ctx-f-0', subject: 'No XSS', completed: true },
           { id: 'ctx-n-0', subject: 'Consider caching', completed: false },
         ]);
+      });
+    });
+  });
+
+  describe('update_context → context:updated', () => {
+    it('should emit context:updated with decisions and notes', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({
+          document: {
+            sections: [
+              {
+                mode: 'PLAN',
+                primaryAgent: 'technical-planner',
+                status: 'in_progress',
+                decisions: ['Use JWT for auth', 'Add rate limiting'],
+                notes: ['Review existing codebase first'],
+              },
+            ],
+          },
+        }),
+      );
+      const contextEvent = result.find(e => e.event === TUI_EVENTS.CONTEXT_UPDATED);
+      expect(contextEvent).toBeDefined();
+      expect(contextEvent!.payload).toEqual({
+        decisions: ['Use JWT for auth', 'Add rate limiting'],
+        notes: ['Review existing codebase first'],
+        mode: 'PLAN',
+        status: 'in_progress',
+      });
+    });
+
+    it('should not emit context:updated when both decisions and notes are empty', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({
+          document: {
+            sections: [
+              { mode: 'ACT', primaryAgent: 'dev', status: 'in_progress', progress: ['done'] },
+            ],
+          },
+        }),
+      );
+      const contextEvents = result.filter(e => e.event === TUI_EVENTS.CONTEXT_UPDATED);
+      expect(contextEvents).toHaveLength(0);
+    });
+
+    it('should emit context:updated with only decisions when notes absent', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({
+          document: {
+            sections: [
+              {
+                mode: 'ACT',
+                primaryAgent: 'dev',
+                status: 'completed',
+                decisions: ['Use X pattern'],
+              },
+            ],
+          },
+        }),
+      );
+      const contextEvent = result.find(e => e.event === TUI_EVENTS.CONTEXT_UPDATED);
+      expect(contextEvent).toBeDefined();
+      expect(contextEvent!.payload).toEqual({
+        decisions: ['Use X pattern'],
+        notes: [],
+        mode: 'ACT',
+        status: 'completed',
+      });
+    });
+
+    it('should emit context:updated with only notes when decisions absent', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({
+          document: {
+            sections: [
+              {
+                mode: 'EVAL',
+                primaryAgent: 'reviewer',
+                status: 'in_progress',
+                notes: ['Consider caching'],
+              },
+            ],
+          },
+        }),
+      );
+      const contextEvent = result.find(e => e.event === TUI_EVENTS.CONTEXT_UPDATED);
+      expect(contextEvent).toBeDefined();
+      expect(contextEvent!.payload).toEqual({
+        decisions: [],
+        notes: ['Consider caching'],
+        mode: 'EVAL',
+        status: 'in_progress',
+      });
+    });
+
+    it('should not emit context:updated when document is missing', () => {
+      const result = extractEventsFromResponse('update_context', makeResponse({ success: true }));
+      const contextEvents = result.filter(e => e.event === TUI_EVENTS.CONTEXT_UPDATED);
+      expect(contextEvents).toHaveLength(0);
+    });
+
+    it('should not emit context:updated when sections is empty', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({ document: { sections: [] } }),
+      );
+      const contextEvents = result.filter(e => e.event === TUI_EVENTS.CONTEXT_UPDATED);
+      expect(contextEvents).toHaveLength(0);
+    });
+
+    it('should use null for mode and status when absent', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({
+          document: {
+            sections: [{ primaryAgent: 'dev', decisions: ['Use X'] }],
+          },
+        }),
+      );
+      const contextEvent = result.find(e => e.event === TUI_EVENTS.CONTEXT_UPDATED);
+      expect(contextEvent!.payload).toEqual({
+        decisions: ['Use X'],
+        notes: [],
+        mode: null,
+        status: null,
+      });
+    });
+
+    it('should filter out non-string decisions and notes', () => {
+      const result = extractEventsFromResponse(
+        'update_context',
+        makeResponse({
+          document: {
+            sections: [
+              {
+                mode: 'PLAN',
+                primaryAgent: 'dev',
+                decisions: ['Valid decision', 123, null, 'Another decision'],
+                notes: [42, 'Valid note'],
+              },
+            ],
+          },
+        }),
+      );
+      const contextEvent = result.find(e => e.event === TUI_EVENTS.CONTEXT_UPDATED);
+      expect(contextEvent!.payload).toEqual({
+        decisions: ['Valid decision', 'Another decision'],
+        notes: ['Valid note'],
+        mode: 'PLAN',
+        status: null,
       });
     });
   });

--- a/apps/mcp-server/src/tui/events/response-event-extractor.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.ts
@@ -14,6 +14,7 @@ import {
   type AgentRelationshipEvent,
   type TaskSyncedEvent,
   type ObjectiveSetEvent,
+  type ContextUpdatedEvent,
 } from './types';
 import { parseToolResponseJson } from './parse-tool-response';
 import type { Mode } from '../types';
@@ -46,6 +47,10 @@ export type ExtractedEvent =
   | {
       event: typeof TUI_EVENTS.OBJECTIVE_SET;
       payload: ObjectiveSetEvent;
+    }
+  | {
+      event: typeof TUI_EVENTS.CONTEXT_UPDATED;
+      payload: ContextUpdatedEvent;
     };
 
 /**
@@ -282,7 +287,7 @@ function buildTasksFromSection(
 }
 
 /**
- * Extract task sync events from update_context response.
+ * Extract task sync events and context updated events from update_context response.
  */
 function extractFromUpdateContext(json: Record<string, unknown>): ExtractedEvent[] {
   const doc = json.document;
@@ -293,11 +298,35 @@ function extractFromUpdateContext(json: Record<string, unknown>): ExtractedEvent
   if (!Array.isArray(sections) || sections.length === 0) return [];
 
   const lastSection = sections[sections.length - 1] as Record<string, unknown>;
+  const events: ExtractedEvent[] = [];
+
+  // task:synced — existing behavior
   const tasks = buildTasksFromSection(lastSection);
-  if (tasks.length === 0) return [];
+  if (tasks.length > 0) {
+    const agentId =
+      typeof lastSection.primaryAgent === 'string' ? lastSection.primaryAgent : UNKNOWN_AGENT_ID;
+    events.push({ event: TUI_EVENTS.TASK_SYNCED, payload: { agentId, tasks } });
+  }
 
-  const agentId =
-    typeof lastSection.primaryAgent === 'string' ? lastSection.primaryAgent : UNKNOWN_AGENT_ID;
+  // context:updated — emit when decisions or notes present
+  const decisions = Array.isArray(lastSection.decisions)
+    ? lastSection.decisions.filter((d): d is string => typeof d === 'string')
+    : [];
+  const notes = Array.isArray(lastSection.notes)
+    ? lastSection.notes.filter((n): n is string => typeof n === 'string')
+    : [];
 
-  return [{ event: TUI_EVENTS.TASK_SYNCED, payload: { agentId, tasks } }];
+  if (decisions.length > 0 || notes.length > 0) {
+    events.push({
+      event: TUI_EVENTS.CONTEXT_UPDATED,
+      payload: {
+        decisions,
+        notes,
+        mode: typeof lastSection.mode === 'string' ? lastSection.mode : null,
+        status: typeof lastSection.status === 'string' ? lastSection.status : null,
+      },
+    });
+  }
+
+  return events;
 }

--- a/apps/mcp-server/src/tui/events/tui-interceptor.ts
+++ b/apps/mcp-server/src/tui/events/tui-interceptor.ts
@@ -162,6 +162,9 @@ export class TuiInterceptor {
       case TUI_EVENTS.OBJECTIVE_SET:
         this.eventBus.emit(TUI_EVENTS.OBJECTIVE_SET, evt.payload);
         break;
+      case TUI_EVENTS.CONTEXT_UPDATED:
+        this.eventBus.emit(TUI_EVENTS.CONTEXT_UPDATED, evt.payload);
+        break;
       default: {
         const _exhaustive: never = evt;
         this.logger.warn(`Unhandled semantic event: ${(_exhaustive as { event: string }).event}`);

--- a/apps/mcp-server/src/tui/events/types.spec.ts
+++ b/apps/mcp-server/src/tui/events/types.spec.ts
@@ -18,7 +18,7 @@ import {
 
 describe('tui/events/types', () => {
   describe('TUI_EVENTS', () => {
-    it('should define all 12 event names', () => {
+    it('should define all 13 event names', () => {
       expect(TUI_EVENTS).toEqual({
         AGENT_ACTIVATED: 'agent:activated',
         AGENT_DEACTIVATED: 'agent:deactivated',
@@ -32,6 +32,7 @@ describe('tui/events/types', () => {
         TOOL_INVOKED: 'tool:invoked',
         OBJECTIVE_SET: 'objective:set',
         SESSION_RESET: 'session:reset',
+        CONTEXT_UPDATED: 'context:updated',
       });
     });
 
@@ -185,6 +186,7 @@ describe('tui/events/types', () => {
         'tool:invoked': { toolName: 'search_rules', agentId: null, timestamp: 0 },
         'objective:set': { objective: 'implement auth feature' },
         'session:reset': { reason: 'new-plan-session' },
+        'context:updated': { decisions: ['Use JWT'], notes: [], mode: null, status: null },
       };
       expect(map['agent:activated'].agentId).toBe('a1');
     });

--- a/apps/mcp-server/src/tui/events/types.ts
+++ b/apps/mcp-server/src/tui/events/types.ts
@@ -25,6 +25,7 @@ export const TUI_EVENTS = Object.freeze({
   TOOL_INVOKED: 'tool:invoked',
   OBJECTIVE_SET: 'objective:set',
   SESSION_RESET: 'session:reset',
+  CONTEXT_UPDATED: 'context:updated',
 } as const);
 
 export type TuiEventName = (typeof TUI_EVENTS)[keyof typeof TUI_EVENTS];
@@ -104,6 +105,14 @@ export interface SessionResetEvent {
   reason: string;
 }
 
+/** Payload when context document is updated with decisions/notes */
+export interface ContextUpdatedEvent {
+  decisions: string[];
+  notes: string[];
+  mode: string | null;
+  status: string | null;
+}
+
 /**
  * Maps event names to their payload types for type-safe emit/subscribe.
  */
@@ -120,4 +129,5 @@ export interface TuiEventMap {
   [TUI_EVENTS.TOOL_INVOKED]: ToolInvokedEvent;
   [TUI_EVENTS.OBJECTIVE_SET]: ObjectiveSetEvent;
   [TUI_EVENTS.SESSION_RESET]: SessionResetEvent;
+  [TUI_EVENTS.CONTEXT_UPDATED]: ContextUpdatedEvent;
 }

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -643,4 +643,64 @@ describe('dashboardReducer', () => {
       expect(typeof result.sessionId).toBe('string');
     });
   });
+
+  describe('CONTEXT_UPDATED', () => {
+    it('initializes contextDecisions and contextNotes as empty arrays', () => {
+      const state = createInitialDashboardState();
+      expect(state.contextDecisions).toEqual([]);
+      expect(state.contextNotes).toEqual([]);
+      expect(state.contextMode).toBeNull();
+      expect(state.contextStatus).toBeNull();
+    });
+
+    it('handles CONTEXT_UPDATED with decisions and notes', () => {
+      const action: DashboardAction = {
+        type: 'CONTEXT_UPDATED',
+        payload: {
+          decisions: ['Use JWT', 'Add rate limiting'],
+          notes: ['Review codebase first'],
+          mode: 'PLAN',
+          status: 'in_progress',
+        },
+      };
+      const state = dashboardReducer(initialDashboardState, action);
+      expect(state.contextDecisions).toEqual(['Use JWT', 'Add rate limiting']);
+      expect(state.contextNotes).toEqual(['Review codebase first']);
+      expect(state.contextMode).toBe('PLAN');
+      expect(state.contextStatus).toBe('in_progress');
+    });
+
+    it('handles CONTEXT_UPDATED with only decisions', () => {
+      const state = dashboardReducer(initialDashboardState, {
+        type: 'CONTEXT_UPDATED',
+        payload: { decisions: ['Use X pattern'], notes: [], mode: 'ACT', status: 'completed' },
+      });
+      expect(state.contextDecisions).toEqual(['Use X pattern']);
+      expect(state.contextNotes).toEqual([]);
+    });
+
+    it('handles CONTEXT_UPDATED with null mode and status', () => {
+      const state = dashboardReducer(initialDashboardState, {
+        type: 'CONTEXT_UPDATED',
+        payload: { decisions: ['decision'], notes: [], mode: null, status: null },
+      });
+      expect(state.contextMode).toBeNull();
+      expect(state.contextStatus).toBeNull();
+    });
+
+    it('SESSION_RESET clears context fields', () => {
+      const withContext = dashboardReducer(initialDashboardState, {
+        type: 'CONTEXT_UPDATED',
+        payload: { decisions: ['decision'], notes: ['note'], mode: 'PLAN', status: 'completed' },
+      });
+      const reset = dashboardReducer(withContext, {
+        type: 'SESSION_RESET',
+        payload: { reason: 'clear' },
+      });
+      expect(reset.contextDecisions).toEqual([]);
+      expect(reset.contextNotes).toEqual([]);
+      expect(reset.contextMode).toBeNull();
+      expect(reset.contextStatus).toBeNull();
+    });
+  });
 });

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -22,6 +22,7 @@ import {
   type ToolInvokedEvent,
   type ObjectiveSetEvent,
   type SessionResetEvent,
+  type ContextUpdatedEvent,
 } from '../events';
 import { selectFocusedAgent } from './use-focus-agent';
 
@@ -49,6 +50,10 @@ export function createInitialDashboardState(): DashboardState {
     activeSkills: [],
     toolInvokeCount: 0,
     outputStats: { files: 0, commits: 0 },
+    contextDecisions: [],
+    contextNotes: [],
+    contextMode: null,
+    contextStatus: null,
   };
 }
 
@@ -64,7 +69,8 @@ export type DashboardAction =
   | { type: 'TASK_SYNCED'; payload: TaskSyncedEvent }
   | { type: 'TOOL_INVOKED'; payload: ToolInvokedEvent }
   | { type: 'OBJECTIVE_SET'; payload: ObjectiveSetEvent }
-  | { type: 'SESSION_RESET'; payload: SessionResetEvent };
+  | { type: 'SESSION_RESET'; payload: SessionResetEvent }
+  | { type: 'CONTEXT_UPDATED'; payload: ContextUpdatedEvent };
 
 function cloneAgents(agents: Map<string, DashboardNode>): Map<string, DashboardNode> {
   return new Map(agents);
@@ -235,6 +241,17 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
       return { ...state, agents };
     }
 
+    case 'CONTEXT_UPDATED': {
+      const { decisions, notes, mode, status } = action.payload;
+      return {
+        ...state,
+        contextDecisions: decisions,
+        contextNotes: notes,
+        contextMode: mode,
+        contextStatus: status,
+      };
+    }
+
     case 'SESSION_RESET':
       return createInitialDashboardState();
 
@@ -280,6 +297,8 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
       dispatch({ type: 'OBJECTIVE_SET', payload: p });
     const onSessionReset = (p: SessionResetEvent) =>
       dispatch({ type: 'SESSION_RESET', payload: p });
+    const onContextUpdated = (p: ContextUpdatedEvent) =>
+      dispatch({ type: 'CONTEXT_UPDATED', payload: p });
 
     eventBus.on(TUI_EVENTS.AGENT_ACTIVATED, onActivated);
     eventBus.on(TUI_EVENTS.AGENT_DEACTIVATED, onDeactivated);
@@ -293,6 +312,7 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
     eventBus.on(TUI_EVENTS.TOOL_INVOKED, onToolInvoked);
     eventBus.on(TUI_EVENTS.OBJECTIVE_SET, onObjectiveSet);
     eventBus.on(TUI_EVENTS.SESSION_RESET, onSessionReset);
+    eventBus.on(TUI_EVENTS.CONTEXT_UPDATED, onContextUpdated);
 
     return () => {
       eventBus.off(TUI_EVENTS.AGENT_ACTIVATED, onActivated);
@@ -307,6 +327,7 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
       eventBus.off(TUI_EVENTS.TOOL_INVOKED, onToolInvoked);
       eventBus.off(TUI_EVENTS.OBJECTIVE_SET, onObjectiveSet);
       eventBus.off(TUI_EVENTS.SESSION_RESET, onSessionReset);
+      eventBus.off(TUI_EVENTS.CONTEXT_UPDATED, onContextUpdated);
     };
   }, [eventBus]);
 


### PR DESCRIPTION
## Summary

Closes #515

Integrates the `update_context` MCP tool response into the TUI dashboard by emitting a `context:updated` event and displaying accumulated `decisions[]` and `notes[]` in the FocusedAgentPanel.

## Changes

### Event Layer
- Add `context:updated` to `TUI_EVENTS` constant and `TuiEventMap` interface
- Add `ContextUpdatedEvent` payload type (`decisions`, `notes`, `mode`, `status`)
- Extend `extractFromUpdateContext()` to emit `context:updated` alongside `task:synced` when decisions or notes are present

### State Layer
- Add `contextDecisions`, `contextNotes`, `contextMode`, `contextStatus` fields to `DashboardState`
- Add `CONTEXT_UPDATED` reducer case in `dashboardReducer`
- Subscribe to `context:updated` EventBus event in `use-dashboard-state` hook

### UI Layer
- Create `context-section.pure.ts` with `formatContextDecisions`, `formatContextNotes`, `formatContextSection` pure functions (numbered list / bullet prefix, max 5 items with overflow indicator)
- Create `ContextSection.tsx` Ink component rendering decisions (cyan) and notes (dimColor)
- Integrate `ContextSection` into `FocusedAgentPanel` below the Tools/IO section
- Pass `contextDecisions` and `contextNotes` props down from `dashboard-app.tsx`

## Test Plan

- [x] `context-section.pure.spec.ts` — pure rendering functions (empty, single, overflow, combined)
- [x] `response-event-extractor.spec.ts` — `context:updated` emitted with decisions/notes; not emitted when both empty; `task:synced` still emitted alongside
- [x] `use-dashboard-state.spec.ts` — `CONTEXT_UPDATED` reducer updates state correctly
- [x] `FocusedAgentPanel.spec.tsx` — renders ContextSection with props; shows "No context" fallback
- [x] `dashboard-types.spec.ts` — `createInitialDashboardState` includes new fields
- [x] `types.spec.ts` — `CONTEXT_UPDATED` constant and event map coverage