### PR TITLE
replace Activity heatmap with horizontal bar chart

### DIFF
--- a/apps/mcp-server/src/tui/components/ActivityVisualizer.spec.tsx
+++ b/apps/mcp-server/src/tui/components/ActivityVisualizer.spec.tsx
@@ -37,7 +37,7 @@ describe('tui/components/ActivityVisualizer', () => {
     ).not.toThrow();
   });
 
-  it('contains heatmap content when calls exist', () => {
+  it('contains bar chart content when calls exist', () => {
     const { lastFrame } = render(
       <ActivityVisualizer toolCalls={makeCalls()} currentMode={null} width={80} height={10} />,
     );

--- a/apps/mcp-server/src/tui/components/ActivityVisualizer.tsx
+++ b/apps/mcp-server/src/tui/components/ActivityVisualizer.tsx
@@ -2,7 +2,11 @@ import React, { useMemo } from 'react';
 import { Box, Text } from 'ink';
 import type { ToolCallRecord } from '../dashboard-types';
 import type { Mode } from '../types';
-import { aggregateToolCalls, renderHeatmap, renderLiveContext } from './activity-visualizer.pure';
+import {
+  aggregateForBarChart,
+  renderBarChart,
+  renderLiveContext,
+} from './activity-visualizer.pure';
 import { BORDER_COLORS } from '../utils/theme';
 
 export interface ActivityVisualizerProps {
@@ -22,14 +26,14 @@ export function ActivityVisualizer({
     return <Box />;
   }
 
-  const heatmapWidth = Math.floor(width * 0.6);
-  const livePanelWidth = width - heatmapWidth;
+  const barChartWidth = Math.floor(width * 0.6);
+  const livePanelWidth = width - barChartWidth;
   const contentHeight = Math.max(1, height - 2);
 
-  const heatmapData = useMemo(() => aggregateToolCalls(toolCalls), [toolCalls]);
-  const heatmapLines = useMemo(
-    () => renderHeatmap(heatmapData, Math.max(1, heatmapWidth - 2), contentHeight),
-    [heatmapData, heatmapWidth, contentHeight],
+  const barChartData = useMemo(() => aggregateForBarChart(toolCalls), [toolCalls]);
+  const barChartLines = useMemo(
+    () => renderBarChart(barChartData, Math.max(1, barChartWidth - 2), contentHeight),
+    [barChartData, barChartWidth, contentHeight],
   );
   const liveLines = useMemo(
     () => renderLiveContext(toolCalls, currentMode, Math.max(1, livePanelWidth - 2), contentHeight),
@@ -42,10 +46,10 @@ export function ActivityVisualizer({
         borderStyle="single"
         borderColor={BORDER_COLORS.panel}
         flexDirection="column"
-        width={heatmapWidth}
+        width={barChartWidth}
         height={height}
       >
-        {heatmapLines.map((line, i) => (
+        {barChartLines.map((line, i) => (
           <Text key={i}>{line}</Text>
         ))}
       </Box>

--- a/apps/mcp-server/src/tui/components/activity-visualizer.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/activity-visualizer.pure.spec.ts
@@ -1,196 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
-  aggregateToolCalls,
-  getDensityChar,
-  renderHeatmap,
   renderLiveContext,
-  type HeatmapData,
+  aggregateForBarChart,
+  renderBarChart,
+  type BarChartItem,
 } from './activity-visualizer.pure';
 import type { ToolCallRecord } from '../dashboard-types';
 import { estimateDisplayWidth } from '../utils/display-width';
-
-describe('aggregateToolCalls', () => {
-  it('returns empty arrays for empty input', () => {
-    const result = aggregateToolCalls([]);
-    expect(result).toEqual({ agents: [], tools: [], matrix: [] });
-  });
-
-  it('generates correct matrix for simple input', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: 1, status: 'completed' },
-      { agentId: 'a1', toolName: 'Read', timestamp: 2, status: 'completed' },
-      { agentId: 'a1', toolName: 'Bash', timestamp: 3, status: 'completed' },
-      { agentId: 'a2', toolName: 'Read', timestamp: 4, status: 'completed' },
-    ];
-    const result = aggregateToolCalls(calls);
-    expect(result.agents).toEqual(['a1', 'a2']);
-    expect(result.tools).toEqual(['Read', 'Bash']);
-    // a1: Read=2, Bash=1; a2: Read=1, Bash=0
-    expect(result.matrix).toEqual([
-      [2, 1],
-      [1, 0],
-    ]);
-  });
-
-  it('sorts agents by total calls descending', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'low', toolName: 'Read', timestamp: 1, status: 'completed' },
-      { agentId: 'high', toolName: 'Read', timestamp: 2, status: 'completed' },
-      { agentId: 'high', toolName: 'Read', timestamp: 3, status: 'completed' },
-      { agentId: 'high', toolName: 'Read', timestamp: 4, status: 'completed' },
-    ];
-    const result = aggregateToolCalls(calls);
-    expect(result.agents[0]).toBe('high');
-    expect(result.agents[1]).toBe('low');
-  });
-
-  it('sorts tools by total calls descending', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'rare', timestamp: 1, status: 'completed' },
-      { agentId: 'a1', toolName: 'common', timestamp: 2, status: 'completed' },
-      { agentId: 'a1', toolName: 'common', timestamp: 3, status: 'completed' },
-      { agentId: 'a1', toolName: 'common', timestamp: 4, status: 'completed' },
-    ];
-    const result = aggregateToolCalls(calls);
-    expect(result.tools[0]).toBe('common');
-    expect(result.tools[1]).toBe('rare');
-  });
-
-  it('limits agents to maxAgents (default 7)', () => {
-    const calls: ToolCallRecord[] = [];
-    for (let i = 0; i < 10; i++) {
-      calls.push({ agentId: `agent_${i}`, toolName: 'Read', timestamp: i, status: 'completed' });
-    }
-    const result = aggregateToolCalls(calls);
-    expect(result.agents).toHaveLength(7);
-    expect(result.matrix).toHaveLength(7);
-  });
-
-  it('limits tools to maxTools (default 8)', () => {
-    const calls: ToolCallRecord[] = [];
-    for (let i = 0; i < 12; i++) {
-      calls.push({ agentId: 'a1', toolName: `tool_${i}`, timestamp: i, status: 'completed' });
-    }
-    const result = aggregateToolCalls(calls);
-    expect(result.tools).toHaveLength(8);
-    expect(result.matrix[0]).toHaveLength(8);
-  });
-
-  it('respects custom maxAgents and maxTools', () => {
-    const calls: ToolCallRecord[] = [];
-    for (let i = 0; i < 5; i++) {
-      for (let j = 0; j < 5; j++) {
-        calls.push({
-          agentId: `a${i}`,
-          toolName: `t${j}`,
-          timestamp: i * 5 + j,
-          status: 'completed',
-        });
-      }
-    }
-    const result = aggregateToolCalls(calls, 3, 2);
-    expect(result.agents).toHaveLength(3);
-    expect(result.tools).toHaveLength(2);
-    expect(result.matrix).toHaveLength(3);
-    expect(result.matrix[0]).toHaveLength(2);
-  });
-});
-
-describe('getDensityChar', () => {
-  it('returns "··" for count 0', () => {
-    expect(getDensityChar(0)).toBe('··');
-  });
-
-  it('returns "··" for negative count', () => {
-    expect(getDensityChar(-1)).toBe('··');
-  });
-
-  it('returns "░░" for count 1-2', () => {
-    expect(getDensityChar(1)).toBe('░░');
-    expect(getDensityChar(2)).toBe('░░');
-  });
-
-  it('returns "▒▒" for count 3-5', () => {
-    expect(getDensityChar(3)).toBe('▒▒');
-    expect(getDensityChar(5)).toBe('▒▒');
-  });
-
-  it('returns "▓▓" for count 6-9', () => {
-    expect(getDensityChar(6)).toBe('▓▓');
-    expect(getDensityChar(9)).toBe('▓▓');
-  });
-
-  it('returns "██" for count >= 10', () => {
-    expect(getDensityChar(10)).toBe('██');
-    expect(getDensityChar(100)).toBe('██');
-  });
-});
-
-describe('renderHeatmap', () => {
-  const sampleData: HeatmapData = {
-    agents: ['agent-1', 'agent-2'],
-    tools: ['Read', 'Bash'],
-    matrix: [
-      [3, 1],
-      [0, 10],
-    ],
-  };
-
-  it('returns empty array for empty agents', () => {
-    expect(renderHeatmap({ agents: [], tools: [], matrix: [] }, 80, 10)).toEqual([]);
-  });
-
-  it('returns empty array for height <= 0', () => {
-    expect(renderHeatmap(sampleData, 80, 0)).toEqual([]);
-  });
-
-  it('returns empty array for width <= 0', () => {
-    expect(renderHeatmap(sampleData, 0, 10)).toEqual([]);
-    expect(renderHeatmap(sampleData, -1, 10)).toEqual([]);
-  });
-
-  it('includes Activity header as first line', () => {
-    const lines = renderHeatmap(sampleData, 80, 10);
-    expect(lines[0]).toContain('Activity');
-  });
-
-  it('includes tool names in header row', () => {
-    const lines = renderHeatmap(sampleData, 80, 10);
-    // Second line is the tool header row
-    expect(lines[1]).toContain('Read');
-    expect(lines[1]).toContain('Bash');
-  });
-
-  it('includes agent names in data rows', () => {
-    const lines = renderHeatmap(sampleData, 80, 10);
-    const content = lines.join('\n');
-    expect(content).toContain('agent-1');
-    expect(content).toContain('agent-2');
-  });
-
-  it('uses density chars in data rows', () => {
-    const lines = renderHeatmap(sampleData, 80, 10);
-    const content = lines.join('\n');
-    // agent-1: Read=3 -> ▒▒, Bash=1 -> ░░
-    expect(content).toContain('▒▒');
-    expect(content).toContain('░░');
-    // agent-2: Read=0 -> ··, Bash=10 -> ██
-    expect(content).toContain('··');
-    expect(content).toContain('██');
-  });
-
-  it('limits output to height lines', () => {
-    const lines = renderHeatmap(sampleData, 80, 3);
-    expect(lines.length).toBeLessThanOrEqual(3);
-  });
-
-  it('truncates lines to width', () => {
-    const lines = renderHeatmap(sampleData, 20, 10);
-    for (const line of lines) {
-      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(20);
-    }
-  });
-});
 
 describe('renderLiveContext', () => {
   const NOW = 100_000;
@@ -345,5 +161,147 @@ describe('renderLiveContext', () => {
     ];
     const lines = renderLiveContext(calls, null, 40, 5, NOW);
     expect(lines).toHaveLength(1);
+  });
+});
+
+describe('aggregateForBarChart', () => {
+  it('returns empty array for empty input', () => {
+    expect(aggregateForBarChart([])).toEqual([]);
+  });
+
+  it('counts calls per tool and sorts descending', () => {
+    const calls: ToolCallRecord[] = [
+      { agentId: 'a1', toolName: 'Read', timestamp: 1, status: 'completed' },
+      { agentId: 'a1', toolName: 'Read', timestamp: 2, status: 'completed' },
+      { agentId: 'a2', toolName: 'Bash', timestamp: 3, status: 'completed' },
+      { agentId: 'a1', toolName: 'Read', timestamp: 4, status: 'completed' },
+      { agentId: 'a2', toolName: 'Grep', timestamp: 5, status: 'completed' },
+      { agentId: 'a2', toolName: 'Grep', timestamp: 6, status: 'completed' },
+    ];
+    const result = aggregateForBarChart(calls);
+    expect(result).toEqual([
+      { tool: 'Read', count: 3 },
+      { tool: 'Grep', count: 2 },
+      { tool: 'Bash', count: 1 },
+    ]);
+  });
+
+  it('limits results to maxTools (default 10)', () => {
+    const calls: ToolCallRecord[] = [];
+    for (let i = 0; i < 15; i++) {
+      calls.push({ agentId: 'a1', toolName: `tool_${i}`, timestamp: i, status: 'completed' });
+    }
+    const result = aggregateForBarChart(calls);
+    expect(result).toHaveLength(10);
+  });
+
+  it('respects custom maxTools', () => {
+    const calls: ToolCallRecord[] = [
+      { agentId: 'a1', toolName: 'Read', timestamp: 1, status: 'completed' },
+      { agentId: 'a1', toolName: 'Bash', timestamp: 2, status: 'completed' },
+      { agentId: 'a1', toolName: 'Grep', timestamp: 3, status: 'completed' },
+    ];
+    const result = aggregateForBarChart(calls, 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns single tool correctly', () => {
+    const calls: ToolCallRecord[] = [
+      { agentId: 'a1', toolName: 'Read', timestamp: 1, status: 'completed' },
+    ];
+    expect(aggregateForBarChart(calls)).toEqual([{ tool: 'Read', count: 1 }]);
+  });
+});
+
+describe('renderBarChart', () => {
+  const sampleData: BarChartItem[] = [
+    { tool: 'Read', count: 10 },
+    { tool: 'Bash', count: 5 },
+    { tool: 'Grep', count: 2 },
+  ];
+
+  it('returns empty array for empty data', () => {
+    expect(renderBarChart([], 80, 10)).toEqual([]);
+  });
+
+  it('returns empty array for height <= 0', () => {
+    expect(renderBarChart(sampleData, 80, 0)).toEqual([]);
+  });
+
+  it('returns empty array for width <= 0', () => {
+    expect(renderBarChart(sampleData, 0, 10)).toEqual([]);
+    expect(renderBarChart(sampleData, -1, 10)).toEqual([]);
+  });
+
+  it('includes Activity header as first line', () => {
+    const lines = renderBarChart(sampleData, 80, 10);
+    expect(lines[0]).toContain('Activity');
+  });
+
+  it('includes tool names in output', () => {
+    const lines = renderBarChart(sampleData, 80, 10);
+    const content = lines.join('\n');
+    expect(content).toContain('Read');
+    expect(content).toContain('Bash');
+    expect(content).toContain('Grep');
+  });
+
+  it('includes counts in output', () => {
+    const lines = renderBarChart(sampleData, 80, 10);
+    const content = lines.join('\n');
+    expect(content).toContain('10');
+    expect(content).toContain('5');
+    expect(content).toContain('2');
+  });
+
+  it('includes bar characters', () => {
+    const lines = renderBarChart(sampleData, 80, 10);
+    const content = lines.join('\n');
+    expect(content).toContain('█');
+    expect(content).toContain('░');
+  });
+
+  it('limits output to height lines', () => {
+    const lines = renderBarChart(sampleData, 80, 3);
+    expect(lines.length).toBeLessThanOrEqual(3);
+  });
+
+  it('truncates lines to width', () => {
+    const lines = renderBarChart(sampleData, 30, 10);
+    for (const line of lines) {
+      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(30);
+    }
+  });
+
+  it('highest count tool has full bar (no empty chars)', () => {
+    const lines = renderBarChart(sampleData, 80, 10);
+    const readLine = lines.find(l => l.includes('Read'));
+    expect(readLine).toBeDefined();
+    expect(readLine).not.toContain('░');
+  });
+
+  it('renders single item correctly', () => {
+    const lines = renderBarChart([{ tool: 'Read', count: 5 }], 80, 5);
+    expect(lines).toHaveLength(2); // header + 1 row
+    expect(lines[1]).toContain('Read');
+    expect(lines[1]).toContain('5');
+  });
+
+  it('renders correctly with very narrow width (width < BAR_FIXED_OVERHEAD)', () => {
+    const lines = renderBarChart(sampleData, 15, 5);
+    // barWidth = max(1, 15-20) = 1, should still render without error
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(15);
+    }
+  });
+
+  it('renders safely when count is 0 (maxCount fallback to 1)', () => {
+    const data: BarChartItem[] = [{ tool: 'Read', count: 0 }];
+    const lines = renderBarChart(data, 80, 5);
+    expect(lines).toHaveLength(2);
+    // bar should be all empty (count=0, maxCount=1 → filled=0)
+    expect(lines[1]).toContain('░');
+    expect(lines[1]).not.toContain('█');
   });
 });

--- a/apps/mcp-server/src/tui/components/activity-visualizer.pure.ts
+++ b/apps/mcp-server/src/tui/components/activity-visualizer.pure.ts
@@ -2,85 +2,55 @@ import type { ToolCallRecord } from '../dashboard-types';
 import type { Mode } from '../types';
 import { truncateToDisplayWidth, padEndDisplayWidth } from '../utils/display-width';
 
-export interface HeatmapData {
-  agents: string[];
-  tools: string[];
-  matrix: number[][];
+export interface BarChartItem {
+  tool: string;
+  count: number;
 }
 
-export function aggregateToolCalls(
-  calls: ToolCallRecord[],
-  maxAgents = 7,
-  maxTools = 8,
-): HeatmapData {
-  if (calls.length === 0) return { agents: [], tools: [], matrix: [] };
+export function aggregateForBarChart(calls: ToolCallRecord[], maxTools = 10): BarChartItem[] {
+  if (calls.length === 0) return [];
 
-  const agentToolMap = new Map<string, Map<string, number>>();
-  const toolTotals = new Map<string, number>();
-  const agentTotals = new Map<string, number>();
-
+  const toolCounts = new Map<string, number>();
   for (const call of calls) {
-    const agentMap = agentToolMap.get(call.agentId) ?? new Map<string, number>();
-    agentMap.set(call.toolName, (agentMap.get(call.toolName) ?? 0) + 1);
-    agentToolMap.set(call.agentId, agentMap);
-    toolTotals.set(call.toolName, (toolTotals.get(call.toolName) ?? 0) + 1);
-    agentTotals.set(call.agentId, (agentTotals.get(call.agentId) ?? 0) + 1);
+    toolCounts.set(call.toolName, (toolCounts.get(call.toolName) ?? 0) + 1);
   }
 
-  const agents = [...agentTotals.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, maxAgents)
-    .map(e => e[0]);
-
-  const tools = [...toolTotals.entries()]
+  return [...toolCounts.entries()]
     .sort((a, b) => b[1] - a[1])
     .slice(0, maxTools)
-    .map(e => e[0]);
-
-  const matrix = agents.map(agent => {
-    const agentMap = agentToolMap.get(agent)!;
-    return tools.map(tool => agentMap.get(tool) ?? 0);
-  });
-
-  return { agents, tools, matrix };
+    .map(([tool, count]) => ({ tool, count }));
 }
 
-const AGENT_NAME_WIDTH = 15; // was 10 → agent names visible up to 15 chars
+const TOOL_NAME_WIDTH = 12;
+const BAR_FIXED_OVERHEAD = TOOL_NAME_WIDTH + 2 + 2 + 4; // "name [bar] cnt"
 
-export function getDensityChar(count: number): string {
-  if (count <= 0) return '··';
-  if (count <= 2) return '░░';
-  if (count <= 5) return '▒▒';
-  if (count <= 9) return '▓▓';
-  return '██';
-}
+export function renderBarChart(data: BarChartItem[], width: number, height: number): string[] {
+  if (data.length === 0 || height <= 0 || width <= 0) return [];
 
-export function renderHeatmap(data: HeatmapData, width: number, height: number): string[] {
-  if (data.agents.length === 0 || height <= 0 || width <= 0) return [];
+  const lines: string[] = [truncateToDisplayWidth('📊 Activity', width)];
 
-  const header = truncateToDisplayWidth('🔥 Activity', width);
-  const lines: string[] = [header];
+  const barWidth = Math.max(1, width - BAR_FIXED_OVERHEAD);
+  const maxCount = data[0]?.count || 1;
 
-  // Tool header row - fixed agent name col + tool columns
-  const nameCol = padEndDisplayWidth('', AGENT_NAME_WIDTH);
-  const toolHeaders = data.tools
-    .map(t => padEndDisplayWidth(truncateToDisplayWidth(t, 6), 6))
-    .join(' ');
-  lines.push(truncateToDisplayWidth(`${nameCol} ${toolHeaders}`, width));
-
-  for (const [i, agent] of data.agents.entries()) {
+  for (const item of data) {
     if (lines.length >= height) break;
+
     const name = padEndDisplayWidth(
-      truncateToDisplayWidth(agent, AGENT_NAME_WIDTH),
-      AGENT_NAME_WIDTH,
+      truncateToDisplayWidth(item.tool, TOOL_NAME_WIDTH),
+      TOOL_NAME_WIDTH,
     );
-    const cells = data.matrix[i].map(c => getDensityChar(c)).join(' ');
-    lines.push(truncateToDisplayWidth(`${name} ${cells}`, width));
+    const filled = Math.round((item.count / maxCount) * barWidth);
+    const empty = barWidth - filled;
+    const bar = '█'.repeat(filled) + '░'.repeat(empty);
+    const countStr = String(item.count).padStart(4);
+
+    lines.push(truncateToDisplayWidth(`${name} [${bar}] ${countStr}`, width));
   }
 
   return lines.slice(0, height);
 }
 
+const LIVE_AGENT_NAME_WIDTH = 15;
 const LIVE_HOT_WINDOW_MS = 5_000;
 const LIVE_RECENT_WINDOW_MS = 30_000;
 const LIVE_HOT_SEC = LIVE_HOT_WINDOW_MS / 1000;
@@ -115,7 +85,7 @@ export function renderLiveContext(
     const ageIndicator = ageSec < LIVE_HOT_SEC ? '◉' : ageSec < LIVE_RECENT_SEC ? '○' : '·';
     const agent =
       call.agentId !== 'unknown'
-        ? truncateToDisplayWidth(call.agentId, AGENT_NAME_WIDTH) + ' '
+        ? truncateToDisplayWidth(call.agentId, LIVE_AGENT_NAME_WIDTH) + ' '
         : '';
     lines.push(truncateToDisplayWidth(`${ageIndicator} ${agent}${call.toolName}`, width));
   }

--- a/apps/mcp-server/src/tui/components/index.ts
+++ b/apps/mcp-server/src/tui/components/index.ts
@@ -28,11 +28,10 @@ export { computeStageHealth, detectBottlenecks } from './stage-health.pure';
 export { computeGridLayout } from './grid-layout.pure';
 export { ActivityVisualizer, type ActivityVisualizerProps } from './ActivityVisualizer';
 export {
-  aggregateToolCalls,
-  getDensityChar,
-  renderHeatmap,
+  aggregateForBarChart,
+  renderBarChart,
   renderLiveContext,
-  type HeatmapData,
+  type BarChartItem,
 } from './activity-visualizer.pure';
 export { SessionTabBar } from './SessionTabBar';
 export type { SessionTabBarProps } from './SessionTabBar';


### PR DESCRIPTION
## Summary

Fixes the broken heatmap grid in the Activity panel by replacing it with a horizontal bar chart.

The previous `renderHeatmap()` had a column alignment bug: tool header columns used 7 display-columns (6 chars + 1 space) while data cell columns used 3 display-columns (2-char density char + 1 space), making the output completely unreadable.

Closes #517

## Changes

### Pure Functions (`activity-visualizer.pure.ts`)
- **Add** `aggregateForBarChart(toolCalls, maxTools?)` — groups tool calls by tool name, returns `BarChartItem[]` sorted descending by count
- **Add** `renderBarChart(data, width, height)` — renders proportional horizontal bars using `█`/`░` block characters with tool name and count
- **Remove** `aggregateToolCalls()`, `getDensityChar()`, `renderHeatmap()`, `HeatmapData` type

### Component (`ActivityVisualizer.tsx`)
- Replace `aggregateToolCalls` + `renderHeatmap` with `aggregateForBarChart` + `renderBarChart`
- Rename internal variables from `heatmap*` to `barChart*` for clarity

### Exports (`index.ts`)
- Replace `aggregateToolCalls`, `getDensityChar`, `renderHeatmap`, `HeatmapData` with `aggregateForBarChart`, `renderBarChart`, `BarChartItem`

## Test Plan

- [x] `aggregateForBarChart` — empty input, count/sort, maxTools limit, custom maxTools, single item
- [x] `renderBarChart` — empty data, height/width bounds, header line, tool names, counts, bar characters, height limit, width truncation, full bar for max item, single item, narrow width edge case, zero count edge case
- [x] `ActivityVisualizer` — smoke render, bar chart content when calls exist