### PR TITLE
update yarn.lock peerDependency codingbuddy from ^4.1.0 to ^4.2.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5411,7 +5411,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:4.0.17"
   peerDependencies:
-    codingbuddy: ^4.1.0
+    codingbuddy: ^4.2.0
   peerDependenciesMeta:
     codingbuddy:
       optional: true


### PR DESCRIPTION
## Summary

- The `yarn install --immutable` step in the publish CI was failing because `yarn.lock` still referenced `codingbuddy: ^4.1.0` as a peer dependency for `codingbuddy-claude-plugin`
- The `package.json` was already updated to `^4.2.0` in the v4.2.0 release bump, but the lockfile was not updated accordingly
- This PR updates the single affected line in `yarn.lock` to `^4.2.0` so the lockfile is consistent with the declared peer dependency

## Root Cause

The release commit (`cf2f27b`) bumped `packages/claude-code-plugin/package.json` to require `codingbuddy: ^4.2.0` but omitted the corresponding `yarn.lock` update, causing the immutable install check to fail in CI.

## Test Plan

- [x] Verified `yarn install --immutable` passes locally after the fix