### PR TITLE
implement TUI restart capability via MCP tool and CLI flag

### DIFF
--- a/apps/mcp-server/src/cli/cli.spec.ts
+++ b/apps/mcp-server/src/cli/cli.spec.ts
@@ -24,6 +24,20 @@ describe('cli', () => {
       expect(result.command).toBe('mcp');
     });
 
+    it('should parse tui command with restart=false by default', () => {
+      const result = parseArgs(['tui']);
+
+      expect(result.command).toBe('tui');
+      expect(result.options.restart).toBe(false);
+    });
+
+    it('should parse tui --restart flag', () => {
+      const result = parseArgs(['tui', '--restart']);
+
+      expect(result.command).toBe('tui');
+      expect(result.options.restart).toBe(true);
+    });
+
     it('should parse init with --force flag', () => {
       const result = parseArgs(['init', '--force']);
 

--- a/apps/mcp-server/src/cli/cli.ts
+++ b/apps/mcp-server/src/cli/cli.ts
@@ -8,14 +8,14 @@
 import { runInit } from './init';
 import { bootstrap } from '../main';
 import { getPackageVersion } from '../shared/version.utils';
-import type { InitOptions } from './cli.types';
+import type { InitOptions, TuiOptions } from './cli.types';
 
 /**
  * Parsed command line arguments
  */
 export interface ParsedArgs {
   command: 'init' | 'mcp' | 'tui' | 'help' | 'version';
-  options: Partial<InitOptions>;
+  options: Partial<InitOptions> & Partial<TuiOptions>;
 }
 
 /**
@@ -45,7 +45,8 @@ export function parseArgs(args: string[]): ParsedArgs {
   }
 
   if (command === 'tui') {
-    return { command: 'tui', options };
+    const restart = args.includes('--restart');
+    return { command: 'tui', options: { ...options, restart } };
   }
 
   if (command !== 'init') {
@@ -82,6 +83,7 @@ Usage:
   codingbuddy init [path] [options]    Initialize configuration
   codingbuddy mcp                      Start MCP server (stdio mode)
   codingbuddy tui                      Monitor agent execution in real-time
+  codingbuddy tui --restart            Restart TUI client (fixes blank screen)
   codingbuddy --help                   Show this help
   codingbuddy --version                Show version
 
@@ -157,7 +159,7 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<void
 
     case 'tui': {
       const { runTui } = await import('./run-tui');
-      await runTui();
+      await runTui({ restart: options.restart ?? false });
       break;
     }
 

--- a/apps/mcp-server/src/cli/cli.types.ts
+++ b/apps/mcp-server/src/cli/cli.types.ts
@@ -40,6 +40,14 @@ export interface InitResult {
 }
 
 /**
+ * Tui command options
+ */
+export interface TuiOptions {
+  /** Restart the TUI client (terminate existing and spawn fresh) */
+  restart: boolean;
+}
+
+/**
  * Console output levels
  */
 export type LogLevel = 'info' | 'success' | 'warn' | 'error';

--- a/apps/mcp-server/src/cli/restart-tui.spec.ts
+++ b/apps/mcp-server/src/cli/restart-tui.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPrune = vi.fn().mockReturnValue(0);
+const mockList = vi.fn();
+
+vi.mock('../tui/ipc/instance-registry', () => ({
+  InstanceRegistry: class {
+    prune = mockPrune;
+    list = mockList;
+  },
+}));
+
+const mockLaunch = vi.fn();
+vi.mock('../tui/ipc/tui-auto-launcher', () => ({
+  TuiAutoLauncher: class {
+    constructor(_opts: unknown) {}
+    launch = mockLaunch;
+  },
+}));
+
+const mockSpawnSync = vi.fn().mockReturnValue({ status: 0 });
+vi.mock('child_process', () => ({
+  spawnSync: mockSpawnSync,
+}));
+
+vi.mock('../tui/ipc/ipc.types', () => ({
+  getInstancesFilePath: vi.fn().mockReturnValue('/fake/.codingbuddy/instances.json'),
+}));
+
+const fakeInstance = {
+  pid: 1234,
+  socketPath: '/tmp/codingbuddy-1234.sock',
+  projectRoot: '/project',
+  startedAt: '2026-01-01T00:00:00Z',
+};
+
+describe('restartTui', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockList.mockReturnValue([]);
+  });
+
+  it('should return error when no MCP server instances found', async () => {
+    mockList.mockReturnValue([]);
+    const { restartTui } = await import('./restart-tui');
+    const result = await restartTui();
+    expect(result.success).toBe(false);
+    expect(result.reason).toMatch(/No running MCP server/);
+  });
+
+  it('should kill existing TUI client before checking instances', async () => {
+    mockList.mockReturnValue([fakeInstance]);
+    mockLaunch.mockResolvedValue({ launched: true, reason: 'spawned', pid: 9999 });
+
+    const { restartTui } = await import('./restart-tui');
+    await restartTui();
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'pkill',
+      expect.arrayContaining(['-f']),
+      expect.any(Object),
+    );
+  });
+
+  it('should prune registry before relaunching', async () => {
+    mockList.mockReturnValue([fakeInstance]);
+    mockLaunch.mockResolvedValue({ launched: true, reason: 'spawned', pid: 9999 });
+
+    const { restartTui } = await import('./restart-tui');
+    await restartTui();
+
+    expect(mockPrune).toHaveBeenCalled();
+  });
+
+  it('should return success with pid when spawn succeeds', async () => {
+    mockList.mockReturnValue([fakeInstance]);
+    mockLaunch.mockResolvedValue({ launched: true, reason: 'spawned', pid: 9999 });
+
+    const { restartTui } = await import('./restart-tui');
+    const result = await restartTui();
+
+    expect(result.success).toBe(true);
+    expect(result.pid).toBe(9999);
+  });
+
+  it('should return failure when TuiAutoLauncher spawn fails', async () => {
+    mockList.mockReturnValue([fakeInstance]);
+    mockLaunch.mockResolvedValue({ launched: false, reason: 'spawn-failed' });
+
+    const { restartTui } = await import('./restart-tui');
+    const result = await restartTui();
+
+    expect(result.success).toBe(false);
+    expect(result.reason).toContain('spawn-failed');
+  });
+
+  it('should call TuiAutoLauncher with clientCount returning 0 to force spawn', async () => {
+    mockList.mockReturnValue([fakeInstance]);
+    mockLaunch.mockResolvedValue({ launched: true, reason: 'spawned', pid: 8888 });
+
+    const { restartTui } = await import('./restart-tui');
+    await restartTui();
+
+    // launch should be called with a stub that always returns 0
+    expect(mockLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({ clientCount: expect.any(Function) }),
+    );
+    const stub = mockLaunch.mock.calls[0][0] as { clientCount: () => number };
+    expect(stub.clientCount()).toBe(0);
+  });
+
+  it('should accept custom codingbuddyBin option', async () => {
+    mockList.mockReturnValue([fakeInstance]);
+    mockLaunch.mockResolvedValue({ launched: true, reason: 'spawned', pid: 7777 });
+
+    const { restartTui } = await import('./restart-tui');
+    const result = await restartTui({ codingbuddyBin: '/custom/bin/codingbuddy' });
+
+    expect(result.success).toBe(true);
+    expect(mockLaunch).toHaveBeenCalled();
+  });
+});

--- a/apps/mcp-server/src/cli/restart-tui.ts
+++ b/apps/mcp-server/src/cli/restart-tui.ts
@@ -1,0 +1,58 @@
+import { spawnSync } from 'child_process';
+import { getInstancesFilePath } from '../tui/ipc/ipc.types';
+import { InstanceRegistry } from '../tui/ipc/instance-registry';
+import { TuiAutoLauncher } from '../tui/ipc/tui-auto-launcher';
+
+export interface RestartResult {
+  success: boolean;
+  reason: string;
+  pid?: number;
+}
+
+export interface RestartOptions {
+  codingbuddyBin?: string;
+}
+
+/**
+ * Shared TUI restart logic used by both the MCP tool and CLI --restart flag.
+ *
+ * Algorithm:
+ * 1. Kill existing TUI client process (SIGTERM via pkill)
+ * 2. Prune stale MCP server entries from instance registry
+ * 3. Validate at least one live MCP server instance exists
+ * 4. Spawn fresh TUI client in new terminal window
+ */
+export async function restartTui(options: RestartOptions = {}): Promise<RestartResult> {
+  // Step 1: Kill existing TUI client (ignore failures — process may not exist)
+  spawnSync('pkill', ['-f', 'codingbuddy.*tui$'], { stdio: 'ignore' });
+
+  // Step 2: Prune stale registry entries
+  const registry = new InstanceRegistry(getInstancesFilePath());
+  registry.prune();
+
+  // Step 3: Validate live instances exist
+  const instances = registry.list();
+  if (instances.length === 0) {
+    return {
+      success: false,
+      reason: 'No running MCP server found. Start your AI tool (Claude Code, Cursor, etc.) first.',
+    };
+  }
+
+  // Step 4: Spawn fresh TUI client
+  // Pass clientCount: () => 0 to bypass the "already connected" guard in TuiAutoLauncher,
+  // ensuring a new terminal is always opened regardless of previous state.
+  const launcher = new TuiAutoLauncher({
+    enabled: true,
+    delayMs: 0,
+    codingbuddyBin: options.codingbuddyBin ?? 'codingbuddy',
+  });
+
+  const result = await launcher.launch({ clientCount: () => 0 });
+
+  if (!result.launched) {
+    return { success: false, reason: result.reason };
+  }
+
+  return { success: true, reason: result.reason, pid: result.pid };
+}

--- a/apps/mcp-server/src/cli/run-tui.spec.ts
+++ b/apps/mcp-server/src/cli/run-tui.spec.ts
@@ -3,6 +3,11 @@ import type { IpcInstance } from '../tui/ipc/ipc.types';
 
 // --- runTui integration tests with module mocks ---
 
+const mockRestartTui = vi.fn();
+vi.mock('./restart-tui', () => ({
+  restartTui: mockRestartTui,
+}));
+
 const mockPrune = vi.fn().mockReturnValue(0);
 const mockList = vi.fn<() => IpcInstance[]>().mockReturnValue([]);
 
@@ -182,5 +187,55 @@ describe('runTui', () => {
 
     vi.doUnmock('../shared/esm-import');
     vi.doUnmock('../shared/tui-bundle-path');
+  });
+});
+
+describe('runTui with restart=true', () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  let savedExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+    stderrSpy.mockRestore();
+  });
+
+  it('should call restartTui and print success message', async () => {
+    mockRestartTui.mockResolvedValue({ success: true, reason: 'spawned', pid: 9999 });
+
+    const { runTui } = await import('./run-tui');
+    await runTui({ restart: true });
+
+    expect(mockRestartTui).toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('TUI restarted'));
+  });
+
+  it('should print error and set exitCode=1 when restart fails', async () => {
+    mockRestartTui.mockResolvedValue({
+      success: false,
+      reason: 'No running MCP server found.',
+    });
+
+    const { runTui } = await import('./run-tui');
+    await runTui({ restart: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('No running MCP server found'));
+  });
+
+  it('should not proceed to normal TUI flow when restart=true', async () => {
+    mockRestartTui.mockResolvedValue({ success: true, reason: 'spawned', pid: 1 });
+
+    const { runTui } = await import('./run-tui');
+    await runTui({ restart: true });
+
+    // Normal flow would call mockConnectAll — it should NOT be called
+    expect(mockConnectAll).not.toHaveBeenCalled();
   });
 });

--- a/apps/mcp-server/src/cli/run-tui.ts
+++ b/apps/mcp-server/src/cli/run-tui.ts
@@ -1,5 +1,6 @@
 import { getInstancesFilePath } from '../tui/ipc/ipc.types';
 import { InstanceRegistry } from '../tui/ipc/instance-registry';
+import { restartTui } from './restart-tui';
 
 /** Forced-exit timeout for client-side shutdown (ms) */
 const CLIENT_SHUTDOWN_TIMEOUT_MS = 3000;
@@ -7,8 +8,21 @@ const CLIENT_SHUTDOWN_TIMEOUT_MS = 3000;
 /**
  * Run standalone TUI client that connects to running MCP server instances.
  * Uses MultiSessionManager to handle multiple concurrent sessions.
+ *
+ * @param options.restart - When true, kill existing TUI and spawn a fresh one instead of connecting
  */
-export async function runTui(): Promise<void> {
+export async function runTui(options: { restart?: boolean } = {}): Promise<void> {
+  if (options.restart) {
+    const result = await restartTui();
+    if (result.success) {
+      process.stderr.write(`TUI restarted successfully (pid: ${result.pid ?? 'unknown'}).\n`);
+    } else {
+      process.stderr.write(`Failed to restart TUI: ${result.reason}\n`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   const registry = new InstanceRegistry(getInstancesFilePath());
   registry.prune();
   const instances = registry.list();

--- a/apps/mcp-server/src/mcp/handlers/index.ts
+++ b/apps/mcp-server/src/mcp/handlers/index.ts
@@ -85,6 +85,12 @@ export { ConventionsHandler } from './conventions.handler';
 export { ContextDocumentHandler } from './context-document.handler';
 
 /**
+ * Handler for TUI tools (restart_tui)
+ * @see {@link TuiHandler}
+ */
+export { TuiHandler } from './tui.handler';
+
+/**
  * Injection token for the array of all tool handlers.
  *
  * Use this token to inject all handlers into a service that needs to

--- a/apps/mcp-server/src/mcp/handlers/tui.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/tui.handler.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/security.utils', () => ({
+  sanitizeHandlerArgs: vi.fn(() => ({ safe: true })),
+  assertPathSafe: vi.fn((p: string) => p),
+}));
+
+const mockRestartTui = vi.fn();
+vi.mock('../../cli/restart-tui', () => ({
+  restartTui: mockRestartTui,
+}));
+
+describe('TuiHandler', () => {
+  let handler: import('./tui.handler').TuiHandler;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { TuiHandler } = await import('./tui.handler');
+    handler = new TuiHandler();
+  });
+
+  describe('handle', () => {
+    it('should return null for unhandled tools', async () => {
+      const result = await handler.handle('unknown_tool', {});
+      expect(result).toBeNull();
+    });
+
+    it('should handle restart_tui tool successfully', async () => {
+      mockRestartTui.mockResolvedValue({ success: true, reason: 'spawned', pid: 9999 });
+      const result = await handler.handle('restart_tui', {});
+      expect(result?.isError).toBeFalsy();
+    });
+
+    it('should return JSON with success and pid in content', async () => {
+      mockRestartTui.mockResolvedValue({ success: true, reason: 'spawned', pid: 9999 });
+      const result = await handler.handle('restart_tui', {});
+      const content = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(content.success).toBe(true);
+      expect(content.pid).toBe(9999);
+    });
+
+    it('should return error response when restart fails', async () => {
+      mockRestartTui.mockResolvedValue({
+        success: false,
+        reason: 'No running MCP server found.',
+      });
+      const result = await handler.handle('restart_tui', {});
+      expect(result?.isError).toBe(true);
+      expect((result?.content[0] as { text: string }).text).toContain('No running MCP server');
+    });
+
+    it('should return error response when restartTui throws', async () => {
+      mockRestartTui.mockRejectedValue(new Error('unexpected pkill error'));
+      const result = await handler.handle('restart_tui', {});
+      expect(result?.isError).toBe(true);
+      expect((result?.content[0] as { text: string }).text).toContain('unexpected pkill error');
+    });
+
+    it('should call restartTui with no args', async () => {
+      mockRestartTui.mockResolvedValue({ success: true, reason: 'spawned', pid: 1 });
+      await handler.handle('restart_tui', {});
+      expect(mockRestartTui).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getToolDefinitions', () => {
+    it('should return exactly one tool definition', () => {
+      const defs = handler.getToolDefinitions();
+      expect(defs).toHaveLength(1);
+    });
+
+    it('should define restart_tui tool', () => {
+      const defs = handler.getToolDefinitions();
+      expect(defs[0].name).toBe('restart_tui');
+    });
+
+    it('should have no required parameters', () => {
+      const defs = handler.getToolDefinitions();
+      expect(defs[0].inputSchema.required).toEqual([]);
+    });
+
+    it('should have a meaningful description', () => {
+      const defs = handler.getToolDefinitions();
+      expect(defs[0].description.length).toBeGreaterThan(10);
+    });
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/tui.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/tui.handler.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import type { ToolDefinition } from './base.handler';
+import type { ToolResponse } from '../response.utils';
+import { AbstractHandler } from './abstract-handler';
+import { createJsonResponse, createErrorResponse } from '../response.utils';
+import { restartTui } from '../../cli/restart-tui';
+
+/**
+ * Handler for TUI-related tools.
+ * - restart_tui: Restart the TUI client when it becomes unresponsive or blank
+ */
+@Injectable()
+export class TuiHandler extends AbstractHandler {
+  protected getHandledTools(): string[] {
+    return ['restart_tui'];
+  }
+
+  protected async handleTool(
+    _toolName: string,
+    _args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    try {
+      const result = await restartTui();
+      if (!result.success) {
+        return createErrorResponse(result.reason);
+      }
+      return createJsonResponse(result);
+    } catch (error) {
+      return createErrorResponse(
+        `Failed to restart TUI: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'restart_tui',
+        description:
+          'Restart the TUI client when it becomes unresponsive or shows a blank screen. ' +
+          'Terminates any existing TUI client and spawns a fresh one in a new terminal window. ' +
+          'Returns { success, reason, pid? }.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+          required: [],
+        },
+      },
+    ];
+  }
+}

--- a/apps/mcp-server/src/mcp/mcp.module.ts
+++ b/apps/mcp-server/src/mcp/mcp.module.ts
@@ -26,6 +26,7 @@ import {
   ChecklistContextHandler,
   ConventionsHandler,
   ContextDocumentHandler,
+  TuiHandler,
 } from './handlers';
 
 const handlers = [
@@ -37,6 +38,7 @@ const handlers = [
   ChecklistContextHandler,
   ConventionsHandler,
   ContextDocumentHandler,
+  TuiHandler,
 ];
 
 @Module({


### PR DESCRIPTION
## Summary

Closes #545

Adds TUI restart capability through two entry points that share a single restart function:

- **`restart_tui` MCP tool** — AI agents can call this tool when the TUI becomes unresponsive or shows a blank screen
- **`codingbuddy tui --restart` CLI flag** — users can restart the TUI directly from the terminal

## Changes

### New Files
- `cli/restart-tui.ts` — shared restart logic: kills existing TUI client via `pkill`, prunes stale registry entries, validates a live MCP server instance exists, then spawns a fresh TUI client
- `cli/restart-tui.spec.ts` — unit tests for `restartTui()`
- `mcp/handlers/tui.handler.ts` — `TuiHandler` implementing `restart_tui` MCP tool using `AbstractHandler` pattern
- `mcp/handlers/tui.handler.spec.ts` — unit tests for `TuiHandler`

### Modified Files
- `mcp/handlers/index.ts` — export `TuiHandler`
- `mcp/mcp.module.ts` — register `TuiHandler` as NestJS provider
- `cli/cli.types.ts` — add `TuiOptions` interface with `restart: boolean`
- `cli/cli.ts` — parse `--restart` flag in `tui` command, pass to `runTui()`
- `cli/run-tui.ts` — handle `restart` option: call `restartTui()` and print success/failure to stderr
- `cli/cli.spec.ts` — tests for `tui` and `tui --restart` flag parsing
- `cli/run-tui.spec.ts` — tests for restart flow in `runTui()`

## Test Plan

- [x] All 167 test files pass (3,859 tests)
- [x] `restartTui()` returns error when no MCP server instances found
- [x] `restartTui()` kills existing TUI client via `pkill` before relaunching
- [x] `restartTui()` prunes registry before relaunching
- [x] `restart_tui` MCP tool returns `{ success, reason, pid }` on success
- [x] `restart_tui` MCP tool returns `isError: true` when restart fails or throws
- [x] `codingbuddy tui --restart` calls `restartTui()` and prints result to stderr
- [x] `codingbuddy tui` (without `--restart`) behavior unchanged
- [x] `restart_tui` appears in `list_tools` output