### PR TITLE
fix header bar overflow, workspace path, and remove sess: prefix

### DIFF
--- a/apps/mcp-server/src/tui/components/HeaderBar.spec.tsx
+++ b/apps/mcp-server/src/tui/components/HeaderBar.spec.tsx
@@ -8,7 +8,6 @@ describe('tui/components/HeaderBar', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo/myapp"
-        sessionId="2026-01-01_14-30-00"
         currentMode="PLAN"
         globalState="RUNNING"
         layoutMode="wide"
@@ -22,7 +21,6 @@ describe('tui/components/HeaderBar', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo/myapp"
-        sessionId="sess-1"
         currentMode="ACT"
         globalState="RUNNING"
         layoutMode="wide"
@@ -39,7 +37,6 @@ describe('tui/components/HeaderBar', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo"
-        sessionId="s"
         currentMode={null}
         globalState="IDLE"
         layoutMode="wide"
@@ -55,7 +52,6 @@ describe('tui/components/HeaderBar', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo"
-        sessionId="s"
         currentMode="PLAN"
         globalState="RUNNING"
         layoutMode="wide"
@@ -71,7 +67,6 @@ describe('tui/components/HeaderBar', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo"
-        sessionId="s"
         currentMode="PLAN"
         globalState="ERROR"
         layoutMode="wide"
@@ -87,7 +82,6 @@ describe('tui/components/HeaderBar', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/very/long/workspace/path"
-        sessionId="long-session-id"
         currentMode="PLAN"
         globalState="RUNNING"
         layoutMode="narrow"
@@ -98,11 +92,10 @@ describe('tui/components/HeaderBar', () => {
     expect(frame).toContain('CODINGBUDDY');
   });
 
-  it('should render workspace and session in wide mode', () => {
+  it('should render workspace path without sess: prefix in wide mode', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo/myapp"
-        sessionId="abc123def"
         currentMode="PLAN"
         globalState="RUNNING"
         layoutMode="wide"
@@ -111,14 +104,13 @@ describe('tui/components/HeaderBar', () => {
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('/repo/myapp');
-    expect(frame).toContain('sess:');
+    expect(frame).not.toContain('sess:');
   });
 
   it('should render with null mode', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo"
-        sessionId="s"
         currentMode={null}
         globalState="IDLE"
         layoutMode="medium"
@@ -134,7 +126,6 @@ describe('tui/components/HeaderBar', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo"
-        sessionId="s"
         currentMode="PLAN"
         globalState="RUNNING"
         layoutMode="wide"
@@ -152,7 +143,6 @@ describe('tui/components/HeaderBar', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo"
-        sessionId="s"
         currentMode="AUTO"
         globalState="RUNNING"
         layoutMode="wide"
@@ -172,7 +162,6 @@ describe('tui/components/HeaderBar', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo"
-        sessionId="s"
         currentMode="PLAN"
         globalState="RUNNING"
         layoutMode="wide"

--- a/apps/mcp-server/src/tui/components/HeaderBar.tsx
+++ b/apps/mcp-server/src/tui/components/HeaderBar.tsx
@@ -11,7 +11,6 @@ import {
 
 export interface HeaderBarProps {
   workspace: string;
-  sessionId: string;
   currentMode: Mode | null;
   globalState: GlobalRunState;
   layoutMode: LayoutMode;
@@ -64,7 +63,6 @@ function StateIndicator({ globalState }: { globalState: GlobalRunState }): React
 
 export function HeaderBar({
   workspace,
-  sessionId,
   currentMode,
   globalState,
   layoutMode,
@@ -90,8 +88,6 @@ export function HeaderBar({
     );
   }
 
-  const sessDisplay = sessionId.length > 8 ? sessionId.slice(0, 8) : sessionId;
-
   return (
     <Box
       borderStyle="double"
@@ -100,7 +96,11 @@ export function HeaderBar({
       overflowX="hidden"
       flexDirection="row"
     >
-      <Box gap={2} flexShrink={0}>
+      {/* flexShrink={1} prevents left content from overflowing the double-border in
+          narrow terminals. Note: this visual overflow only occurs in real terminals —
+          ink-testing-library clips content at the specified width, making unit test
+          reproduction impossible. */}
+      <Box gap={2} flexShrink={1} minWidth={0}>
         <Text color="cyan" bold>
           ⟨⟩ CODINGBUDDY AGENT DASHBOARD
         </Text>
@@ -110,7 +110,7 @@ export function HeaderBar({
       <Box flexGrow={1} />
       <Box flexShrink={1} overflowX="hidden">
         <Text dimColor wrap="truncate">
-          {workspace} sess:{sessDisplay}
+          {workspace}
         </Text>
       </Box>
     </Box>

--- a/apps/mcp-server/src/tui/dashboard-app.spec.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.spec.tsx
@@ -145,6 +145,16 @@ describe('DashboardApp', () => {
     expect(frame).toContain('Objective');
   });
 
+  it('should use workspace prop over state.workspace when provided', () => {
+    const mockState = createInitialDashboardState();
+    mockState.workspace = '/from-state';
+
+    const { lastFrame } = render(<DashboardApp externalState={mockState} workspace="/from-prop" />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('/from-prop');
+    expect(frame).not.toContain('/from-state');
+  });
+
   it('should use externalState when provided (multi-session mode)', () => {
     const mockState = createInitialDashboardState();
     // Modify some fields to verify they propagate

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -15,9 +15,14 @@ import { computeGridLayout } from './components/grid-layout.pure';
 export interface DashboardAppProps {
   eventBus?: TuiEventBus;
   externalState?: DashboardState;
+  workspace?: string;
 }
 
-export function DashboardApp({ eventBus, externalState }: DashboardAppProps): React.ReactElement {
+export function DashboardApp({
+  eventBus,
+  externalState,
+  workspace: workspaceProp,
+}: DashboardAppProps): React.ReactElement {
   const { columns, rows, layoutMode } = useTerminalSize();
   const internalState = useDashboardState(externalState ? undefined : eventBus);
   const state = externalState ?? internalState;
@@ -45,8 +50,7 @@ export function DashboardApp({ eventBus, externalState }: DashboardAppProps): Re
   return (
     <Box flexDirection="column" width={grid.total.width} height={grid.total.height}>
       <HeaderBar
-        workspace={state.workspace}
-        sessionId={state.sessionId}
+        workspace={workspaceProp ?? state.workspace}
         currentMode={state.currentMode}
         globalState={state.globalState}
         layoutMode={layoutMode}

--- a/apps/mcp-server/src/tui/multi-session-app.tsx
+++ b/apps/mcp-server/src/tui/multi-session-app.tsx
@@ -41,6 +41,11 @@ export function MultiSessionApp({ manager }: MultiSessionAppProps): React.ReactE
     return found?.eventBus;
   }, [manager, activeSessionPid]);
 
+  const activeProjectRoot = useMemo(() => {
+    if (activeSessionPid === null) return undefined;
+    return sessions.get(activeSessionPid)?.projectRoot;
+  }, [sessions, activeSessionPid]);
+
   const handleInput = useCallback(
     (input: string, key: KeyInput) => {
       if (key.rightArrow) {
@@ -68,7 +73,11 @@ export function MultiSessionApp({ manager }: MultiSessionAppProps): React.ReactE
       {/* key={pid} forces remount on session switch — intentional tradeoff:
           per-session widget state (scroll, focus) resets, but ensures clean isolation
           between sessions without cross-contamination of stale React state. */}
-      <DashboardApp key={activeSessionPid ?? 'none'} eventBus={activeEventBus} />
+      <DashboardApp
+        key={activeSessionPid ?? 'none'}
+        eventBus={activeEventBus}
+        workspace={activeProjectRoot}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
Fixes #547

## Summary

Three bugs in the TUI header bar (`HeaderBar.tsx`) are fixed in this PR:

- **Overflow**: Left-side content overflowed the double-border in narrow terminals due to `flexShrink={0}`
- **Wrong workspace path**: Header displayed `process.cwd()` (TUI process home dir) instead of the active session's project root
- **Visual noise**: `sess:` prefix with truncated session ID was shown alongside the workspace path

## Changes

### Bug 1 — Left content overflow fix (`HeaderBar.tsx`)

Changed `flexShrink={0}` to `flexShrink={1} minWidth={0}` on the left `<Box>` so it can shrink when terminal width is insufficient, preventing content from escaping the double-border boundary.

```tsx
// Before
<Box gap={2} flexShrink={0}>

// After
<Box gap={2} flexShrink={1} minWidth={0}>
```

> Note: this visual overflow only occurs in real terminals — `ink-testing-library` clips content at the specified width, so it cannot be reproduced in unit tests.

### Bug 2 — Correct workspace path (`dashboard-app.tsx`, `multi-session-app.tsx`)

The `projectRoot` from `SessionState` was never passed to `DashboardApp`, causing `createInitialDashboardState()` to fall back to `process.cwd()` (the TUI process home directory).

**Fix:** Added an optional `workspace` prop to `DashboardApp` that overrides `state.workspace`, and extracted `activeProjectRoot` in `MultiSessionApp` to pass it down.

```tsx
// multi-session-app.tsx
const activeProjectRoot = useMemo(() => {
  if (activeSessionPid === null) return undefined;
  return sessions.get(activeSessionPid)?.projectRoot;
}, [sessions, activeSessionPid]);

<DashboardApp workspace={activeProjectRoot} ... />

// dashboard-app.tsx
<HeaderBar workspace={workspaceProp ?? state.workspace} ... />
```

### Bug 3 — Remove `sess:` prefix (`HeaderBar.tsx`)

Removed the `sessionId` prop from `HeaderBar` entirely and eliminated the `sess:{truncatedId}` display. Only the workspace path is now shown on the right side.

## Test Plan

- [x] Updated `HeaderBar.spec.tsx` — removed `sessionId` from all test cases, updated assertion to verify `sess:` is not present
- [x] Added `dashboard-app.spec.tsx` test — verifies `workspace` prop overrides `state.workspace`
- [ ] Run `yarn workspace codingbuddy test` to confirm all tests pass
- [ ] Run `yarn workspace codingbuddy build` to confirm compilation succeeds
- [ ] Manual verification: launch TUI and confirm header shows correct project root path