### PR TITLE
split ChecklistPanel from FocusedAgentPanel (#548)

### DIFF
--- a/apps/mcp-server/src/tui/components/ChecklistPanel.spec.tsx
+++ b/apps/mcp-server/src/tui/components/ChecklistPanel.spec.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { ChecklistPanel } from './ChecklistPanel';
+
+describe('tui/components/ChecklistPanel', () => {
+  it('tasks가 있을 때 체크리스트를 렌더링한다', () => {
+    const { lastFrame } = render(
+      <ChecklistPanel
+        tasks={[
+          { id: '1', subject: 'routes added', completed: true },
+          { id: '2', subject: 'tests updated', completed: false },
+        ]}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('✔ routes added');
+    expect(frame).toContain('◻ tests updated');
+  });
+
+  it('tasks가 비어있고 contextDecisions가 있으면 fallback을 렌더링한다', () => {
+    const { lastFrame } = render(
+      <ChecklistPanel tasks={[]} contextDecisions={['Use JWT for auth']} contextNotes={[]} />,
+    );
+    expect(lastFrame()).toContain('Use JWT for auth');
+  });
+
+  it('tasks가 비어있고 contextNotes만 있으면 note fallback을 렌더링한다', () => {
+    const { lastFrame } = render(
+      <ChecklistPanel
+        tasks={[]}
+        contextDecisions={[]}
+        contextNotes={['Review existing codebase']}
+      />,
+    );
+    expect(lastFrame()).toContain('Review existing codebase');
+  });
+
+  it('모두 비어있으면 기본 fallback을 렌더링한다', () => {
+    const { lastFrame } = render(
+      <ChecklistPanel tasks={[]} contextDecisions={[]} contextNotes={[]} />,
+    );
+    expect(lastFrame()).toContain('Review current task objectives');
+  });
+
+  it('패널이 비어있지 않다 - 항상 최소 1개 항목 표시', () => {
+    const { lastFrame } = render(<ChecklistPanel tasks={[]} />);
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Review current task objectives');
+  });
+
+  it('border와 Checklist 헤더를 렌더링한다', () => {
+    const { lastFrame } = render(
+      <ChecklistPanel tasks={[{ id: '1', subject: 'task', completed: false }]} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('┌');
+    expect(frame).toContain('Checklist');
+  });
+
+  it('width, height props를 수용한다', () => {
+    const { lastFrame } = render(
+      <ChecklistPanel
+        tasks={[{ id: '1', subject: 'task', completed: false }]}
+        width={60}
+        height={8}
+      />,
+    );
+    expect(lastFrame()).toContain('task');
+  });
+});

--- a/apps/mcp-server/src/tui/components/ChecklistPanel.tsx
+++ b/apps/mcp-server/src/tui/components/ChecklistPanel.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Box, Text } from 'ink';
+import { resolveChecklistTasks } from './checklist-panel.pure';
+import { formatEnhancedChecklist } from './focused-agent.pure';
+import { BORDER_COLORS } from '../utils/theme';
+import type { TaskItem } from '../dashboard-types';
+
+export interface ChecklistPanelProps {
+  tasks: TaskItem[];
+  contextDecisions?: string[];
+  contextNotes?: string[];
+  width?: number;
+  height?: number;
+}
+
+export function ChecklistPanel({
+  tasks,
+  contextDecisions = [],
+  contextNotes = [],
+  width,
+  height,
+}: ChecklistPanelProps): React.ReactElement {
+  const resolvedTasks = resolveChecklistTasks(tasks, contextDecisions, contextNotes);
+  const checklist = formatEnhancedChecklist(resolvedTasks);
+
+  return (
+    <Box
+      borderStyle="single"
+      borderColor={BORDER_COLORS.panel}
+      flexDirection="column"
+      width={width}
+      height={height}
+    >
+      <Text bold dimColor>
+        ─── Checklist
+      </Text>
+      {checklist.split('\n').map((line, i) => {
+        const isCompleted = line.includes('✔');
+        return (
+          <Text key={i} color={isCompleted ? 'green' : undefined}>
+            {line}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+}

--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
@@ -20,7 +20,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={['Add /users endpoints']}
-        tasks={[{ id: '1', subject: 'routes added', completed: true }]}
         tools={['file_edit']}
         inputs={['spec.md']}
         outputs={{ files: 3 }}
@@ -40,7 +39,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -60,7 +58,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={['Design auth']}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -70,7 +67,6 @@ describe('tui/components/FocusedAgentPanel', () => {
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('─── Objective');
-    expect(frame).toContain('─── Checklist');
     expect(frame).toContain('─── Activity');
     expect(frame).toContain('─── Tools / IO');
     expect(frame).toContain('─── Event Log');
@@ -82,7 +78,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={['Add /users endpoints', 'Update DTO']}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -93,35 +88,12 @@ describe('tui/components/FocusedAgentPanel', () => {
     expect(lastFrame()).toContain('Add /users endpoints');
   });
 
-  it('should render checklist with ✔/◻ icons', () => {
-    const { lastFrame } = render(
-      <FocusedAgentPanel
-        agent={mockAgent}
-        activeSkills={[]}
-        objectives={[]}
-        tasks={[
-          { id: '1', subject: 'routes added', completed: true },
-          { id: '2', subject: 'tests updated', completed: false },
-        ]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
-        eventLog={[]}
-        toolCalls={[]}
-      />,
-    );
-    const frame = lastFrame() ?? '';
-    expect(frame).toContain('✔ routes added');
-    expect(frame).toContain('◻ tests updated');
-  });
-
   it('should render tool/IO section', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={['file_edit', 'test_run']}
         inputs={['spec.md']}
         outputs={{ files: 12, commits: 3 }}
@@ -140,7 +112,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -160,7 +131,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={null}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -177,7 +147,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -196,7 +165,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={null}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -215,7 +183,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -234,7 +201,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={['tdd', 'debugging']}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -254,7 +220,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -271,7 +236,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -289,7 +253,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -315,7 +278,6 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tasks={[]}
         tools={[]}
         inputs={[]}
         outputs={{}}
@@ -333,7 +295,6 @@ describe('tui/components/FocusedAgentPanel', () => {
           agent={mockAgent}
           activeSkills={[]}
           objectives={[]}
-          tasks={[]}
           tools={[]}
           inputs={[]}
           outputs={{}}
@@ -355,7 +316,6 @@ describe('tui/components/FocusedAgentPanel', () => {
           agent={mockAgent}
           activeSkills={[]}
           objectives={[]}
-          tasks={[]}
           tools={[]}
           inputs={[]}
           outputs={{}}
@@ -376,7 +336,6 @@ describe('tui/components/FocusedAgentPanel', () => {
           agent={mockAgent}
           activeSkills={[]}
           objectives={[]}
-          tasks={[]}
           tools={[]}
           inputs={[]}
           outputs={{}}
@@ -396,7 +355,6 @@ describe('tui/components/FocusedAgentPanel', () => {
           agent={mockAgent}
           activeSkills={[]}
           objectives={[]}
-          tasks={[]}
           tools={[]}
           inputs={[]}
           outputs={{}}

--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import type { DashboardNode, TaskItem, EventLogEntry, ToolCallRecord } from '../dashboard-types';
+import type { DashboardNode, EventLogEntry, ToolCallRecord } from '../dashboard-types';
 import { STATUS_ICONS, getNodeStatusColor, BORDER_COLORS, getAgentAvatar } from '../utils/theme';
 import {
   formatObjective,
-  formatEnhancedChecklist,
   formatToolIO,
   formatLogTail,
   formatSectionDivider,
@@ -18,7 +17,6 @@ export interface FocusedAgentPanelProps {
   agent: DashboardNode | null;
   objectives: string[];
   activeSkills: string[];
-  tasks: TaskItem[];
   tools: string[];
   inputs: string[];
   outputs: ToolIOData;
@@ -67,7 +65,6 @@ export function FocusedAgentPanel({
   agent,
   objectives,
   activeSkills,
-  tasks,
   tools,
   inputs,
   outputs,
@@ -98,7 +95,6 @@ export function FocusedAgentPanel({
   const statusLabel = agent.status.toUpperCase();
   const progressBar = formatEnhancedProgressBar(agent.progress);
   const objective = formatObjective(objectives);
-  const checklist = formatEnhancedChecklist(tasks);
   const toolIO = formatToolIO(tools, inputs, outputs);
   const logs = formatLogTail(eventLog);
   const agentToolCalls = toolCalls.filter(tc => tc.agentId === agent.id);
@@ -139,21 +135,6 @@ export function FocusedAgentPanel({
         activeSkills.map((s, i) => <Text key={i}> {s}</Text>)
       ) : (
         <Text dimColor>No skills</Text>
-      )}
-
-      {/* Checklist Section */}
-      <SectionDivider title="Checklist" />
-      {checklist ? (
-        checklist.split('\n').map((line, i) => {
-          const isCompleted = line.includes('✔');
-          return (
-            <Text key={i} color={isCompleted ? 'green' : undefined}>
-              {line}
-            </Text>
-          );
-        })
-      ) : (
-        <Text dimColor>No tasks</Text>
       )}
 
       {/* Activity Sparkline */}

--- a/apps/mcp-server/src/tui/components/checklist-panel.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/checklist-panel.pure.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { resolveChecklistTasks } from './checklist-panel.pure';
+import type { TaskItem } from '../dashboard-types';
+
+describe('resolveChecklistTasks', () => {
+  it('tasks가 있을 때 그대로 반환한다', () => {
+    const tasks: TaskItem[] = [
+      { id: '1', subject: 'routes added', completed: true },
+      { id: '2', subject: 'tests updated', completed: false },
+    ];
+    const result = resolveChecklistTasks(tasks, [], []);
+    expect(result).toEqual(tasks);
+  });
+
+  it('tasks가 비어있고 contextDecisions가 있으면 첫 번째 decision에서 도출한다', () => {
+    const result = resolveChecklistTasks(
+      [],
+      ['Use JWT for auth', 'Add rate limiting'],
+      ['Review codebase'],
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].subject).toContain('Use JWT for auth');
+    expect(result[0].completed).toBe(false);
+  });
+
+  it('tasks가 비어있고 contextDecisions가 없으면 contextNotes[0]에서 도출한다', () => {
+    const result = resolveChecklistTasks([], [], ['Review existing codebase']);
+    expect(result).toHaveLength(1);
+    expect(result[0].subject).toContain('Review existing codebase');
+    expect(result[0].completed).toBe(false);
+  });
+
+  it('tasks, contextDecisions, contextNotes 모두 비어있으면 기본 fallback을 반환한다', () => {
+    const result = resolveChecklistTasks([], [], []);
+    expect(result).toHaveLength(1);
+    expect(result[0].subject).toBe('Review current task objectives');
+    expect(result[0].completed).toBe(false);
+  });
+});

--- a/apps/mcp-server/src/tui/components/checklist-panel.pure.ts
+++ b/apps/mcp-server/src/tui/components/checklist-panel.pure.ts
@@ -1,0 +1,23 @@
+import type { TaskItem } from '../dashboard-types';
+
+export function resolveChecklistTasks(
+  tasks: TaskItem[],
+  contextDecisions: string[],
+  contextNotes: string[],
+): TaskItem[] {
+  if (tasks.length > 0) {
+    return tasks;
+  }
+
+  if (contextDecisions.length > 0) {
+    return [
+      { id: 'fallback-decision', subject: `Review: ${contextDecisions[0]}`, completed: false },
+    ];
+  }
+
+  if (contextNotes.length > 0) {
+    return [{ id: 'fallback-note', subject: `Check: ${contextNotes[0]}`, completed: false }];
+  }
+
+  return [{ id: 'fallback-default', subject: 'Review current task objectives', completed: false }];
+}

--- a/apps/mcp-server/src/tui/components/grid-layout.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/grid-layout.pure.spec.ts
@@ -15,6 +15,8 @@ function regionArea(r: GridRegion): number {
 describe('computeGridLayout', () => {
   describe('wide layout (120x40)', () => {
     const grid = computeGridLayout(120, 40, 'wide');
+    const mainHeight = 40 - 3 - 3; // 34
+    const checklistHeight = Math.max(6, Math.min(10, Math.ceil(mainHeight * 0.3))); // 10
 
     it('header spans full width at row 0 with height 3', () => {
       expect(grid.header).toEqual({ x: 0, y: 0, width: 120, height: 3 });
@@ -40,7 +42,6 @@ describe('computeGridLayout', () => {
     });
 
     it('flowMap and monitorPanel split the left column height evenly', () => {
-      const mainHeight = 40 - 3 - 3; // 34
       const flowMapHeight = Math.ceil(mainHeight / 2); // 17
       const monitorHeight = mainHeight - flowMapHeight; // 17
       expect(grid.flowMap.height).toBe(flowMapHeight);
@@ -53,9 +54,8 @@ describe('computeGridLayout', () => {
       expect(grid.monitorPanel.width).toBe(grid.flowMap.width);
     });
 
-    it('focusedAgent spans full main height', () => {
-      const mainHeight = 40 - 3 - 3;
-      expect(grid.focusedAgent.height).toBe(mainHeight);
+    it('focusedAgent spans mainHeight minus checklistPanel height', () => {
+      expect(grid.focusedAgent.height).toBe(mainHeight - checklistHeight);
     });
 
     it('flowMap starts at column 0, focusedAgent starts after flowMap', () => {
@@ -63,9 +63,19 @@ describe('computeGridLayout', () => {
       expect(grid.focusedAgent.x).toBe(grid.flowMap.width);
     });
 
-    it('both panels start at row 3 (after header)', () => {
+    it('flowMap starts at row 3 (after header)', () => {
       expect(grid.flowMap.y).toBe(3);
-      expect(grid.focusedAgent.y).toBe(3);
+    });
+
+    it('focusedAgent starts below checklistPanel', () => {
+      expect(grid.focusedAgent.y).toBe(grid.checklistPanel.y + grid.checklistPanel.height);
+    });
+
+    it('checklistPanel sits at the top of the focused-agent column', () => {
+      expect(grid.checklistPanel.x).toBe(grid.focusedAgent.x);
+      expect(grid.checklistPanel.width).toBe(grid.focusedAgent.width);
+      expect(grid.checklistPanel.y).toBe(3);
+      expect(grid.checklistPanel.height).toBe(checklistHeight);
     });
 
     it('total dimensions match input', () => {
@@ -75,6 +85,8 @@ describe('computeGridLayout', () => {
 
   describe('medium layout (100x30)', () => {
     const grid = computeGridLayout(100, 30, 'medium');
+    const mainHeight = 30 - 3 - 3; // 24
+    const checklistHeight = Math.max(6, Math.min(10, Math.ceil(mainHeight * 0.3))); // 8
 
     it('focusedAgent has fixed width 58 in medium mode', () => {
       expect(grid.focusedAgent.width).toBe(58);
@@ -88,13 +100,11 @@ describe('computeGridLayout', () => {
       expect(grid.focusedAgent.x + grid.focusedAgent.width).toBe(100);
     });
 
-    it('main area height is total - header(3) - stageHealth(3)', () => {
-      const mainHeight = 30 - 3 - 3;
-      expect(grid.focusedAgent.height).toBe(mainHeight);
+    it('main area height: focusedAgent height equals mainHeight minus checklistPanel height', () => {
+      expect(grid.focusedAgent.height).toBe(mainHeight - checklistHeight);
     });
 
     it('flowMap and monitorPanel split the left column height', () => {
-      const mainHeight = 30 - 3 - 3; // 24
       const flowMapHeight = Math.ceil(mainHeight / 2); // 12
       const monitorHeight = mainHeight - flowMapHeight; // 12
       expect(grid.flowMap.height).toBe(flowMapHeight);
@@ -106,14 +116,25 @@ describe('computeGridLayout', () => {
       expect(grid.monitorPanel.width).toBe(grid.flowMap.width);
     });
 
-    it('focusedAgent spans full main height', () => {
-      const mainHeight = 30 - 3 - 3;
-      expect(grid.focusedAgent.height).toBe(mainHeight);
+    it('focusedAgent starts below checklistPanel', () => {
+      expect(grid.focusedAgent.y).toBe(grid.checklistPanel.y + grid.checklistPanel.height);
+    });
+
+    it('checklistPanel sits at the top of the focused-agent column', () => {
+      expect(grid.checklistPanel.x).toBe(grid.focusedAgent.x);
+      expect(grid.checklistPanel.width).toBe(grid.focusedAgent.width);
+      expect(grid.checklistPanel.y).toBe(3);
+      expect(grid.checklistPanel.height).toBe(checklistHeight);
     });
   });
 
   describe('narrow layout (60x20)', () => {
     const grid = computeGridLayout(60, 20, 'narrow');
+    const mainHeight = 20 - 3 - 3; // 14
+    const flowMapHeight = Math.min(5, mainHeight - 1); // 5
+    const availableForChecklist = mainHeight - flowMapHeight; // 9
+    const rawChecklistHeight = Math.max(6, Math.min(10, Math.ceil(mainHeight * 0.3))); // 6
+    const checklistHeight = Math.min(rawChecklistHeight, Math.max(0, availableForChecklist - 1)); // 6
 
     it('all regions span full width', () => {
       expect(grid.header.width).toBe(60);
@@ -128,6 +149,7 @@ describe('computeGridLayout', () => {
 
     it('stageHealth is at bottom with height 3', () => {
       expect(grid.stageHealth.height).toBe(3);
+      expect(grid.stageHealth.height).toBe(3);
       expect(grid.stageHealth.y + grid.stageHealth.height).toBe(20);
     });
 
@@ -136,13 +158,21 @@ describe('computeGridLayout', () => {
       expect(grid.flowMap.y + grid.flowMap.height).toBe(grid.stageHealth.y);
     });
 
-    it('focusedAgent fills remaining space between header and flowMap', () => {
-      expect(grid.focusedAgent.y).toBe(3);
+    it('checklistPanel is at top in narrow mode', () => {
+      expect(grid.checklistPanel.x).toBe(0);
+      expect(grid.checklistPanel.width).toBe(60);
+      expect(grid.checklistPanel.y).toBe(3);
+      expect(grid.checklistPanel.height).toBe(checklistHeight);
+    });
+
+    it('focusedAgent fills remaining space between checklistPanel and flowMap', () => {
+      expect(grid.focusedAgent.y).toBe(grid.checklistPanel.y + grid.checklistPanel.height);
       expect(grid.focusedAgent.y + grid.focusedAgent.height).toBe(grid.flowMap.y);
     });
 
-    it('vertical stack order: header, focusedAgent, flowMap, stageHealth', () => {
-      expect(grid.header.y).toBeLessThan(grid.focusedAgent.y);
+    it('vertical stack order: header, checklistPanel, focusedAgent, flowMap, stageHealth', () => {
+      expect(grid.header.y).toBeLessThan(grid.checklistPanel.y);
+      expect(grid.checklistPanel.y).toBeLessThan(grid.focusedAgent.y);
       expect(grid.focusedAgent.y).toBeLessThan(grid.flowMap.y);
       expect(grid.flowMap.y).toBeLessThan(grid.stageHealth.y);
     });
@@ -160,7 +190,9 @@ describe('computeGridLayout', () => {
       expect(grid.flowMap.height).toBe(3);
     });
 
-    it('focusedAgent gets remaining 1 row', () => {
+    it('focusedAgent gets remaining row after checklist (checklist=0 when no space)', () => {
+      // availableForChecklist = 4-3 = 1, checklistHeight = min(6, max(0,1-1)) = 0
+      // focusedHeight = 1 - 0 = 1
       expect(grid.focusedAgent.height).toBe(1);
     });
 
@@ -177,9 +209,9 @@ describe('computeGridLayout', () => {
       expect(grid.flowMap.x + grid.flowMap.width).toBe(grid.focusedAgent.x);
     });
 
-    it('both panels start at row 3 (after header)', () => {
+    it('flowMap and checklistPanel start at row 3 (after header)', () => {
       expect(grid.flowMap.y).toBe(3);
-      expect(grid.focusedAgent.y).toBe(3);
+      expect(grid.checklistPanel.y).toBe(3);
     });
 
     it('header and stageHealth span full width', () => {
@@ -216,9 +248,17 @@ describe('computeGridLayout', () => {
           grid.focusedAgent,
           grid.stageHealth,
           grid.monitorPanel,
+          grid.checklistPanel,
         ];
-        const allNames = ['header', 'flowMap', 'focusedAgent', 'stageHealth', 'monitorPanel'];
-        // narrow 모드에서는 monitorPanel이 0x0이므로 필터링
+        const allNames = [
+          'header',
+          'flowMap',
+          'focusedAgent',
+          'stageHealth',
+          'monitorPanel',
+          'checklistPanel',
+        ];
+        // narrow 모드에서는 monitorPanel이 0x0이므로 필터링, checklistPanel도 공간 부족 시 0
         const regions = allRegions.filter(r => r.width > 0 && r.height > 0);
         const regionNames = allNames.filter(
           (_, i) => allRegions[i].width > 0 && allRegions[i].height > 0,
@@ -296,6 +336,7 @@ describe('computeGridLayout', () => {
         grid.focusedAgent,
         grid.stageHealth,
         grid.monitorPanel,
+        grid.checklistPanel,
       ];
       const regions = allRegions.filter(r => r.width > 0 && r.height > 0);
 

--- a/apps/mcp-server/src/tui/components/grid-layout.pure.ts
+++ b/apps/mcp-server/src/tui/components/grid-layout.pure.ts
@@ -11,11 +11,23 @@ const NARROW_FLOW_MAP_HEIGHT = 5;
 const MIN_ROWS = HEADER_HEIGHT + STAGE_HEALTH_HEIGHT + 2;
 const MIN_COLUMNS = 20;
 
+/** Checklist panel height bounds. */
+const CHECKLIST_HEIGHT_MIN = 6;
+const CHECKLIST_HEIGHT_MAX = 10;
+
 /** Fixed width for focusedAgent panel per layout mode (content-first right panel). */
 const FOCUSED_AGENT_WIDTH: Record<Exclude<LayoutMode, 'narrow'>, number> = {
   wide: 63, // was 70 → -10% (FlowMap/Activity gains +7 cols)
   medium: 58, // was 64 → -9.4% (FlowMap/Activity gains +6 cols)
 };
+
+/** Compute checklist panel height using 30% of mainHeight, clamped to [min, max]. */
+function computeChecklistHeight(mainHeight: number): number {
+  return Math.max(
+    CHECKLIST_HEIGHT_MIN,
+    Math.min(CHECKLIST_HEIGHT_MAX, Math.ceil(mainHeight * 0.3)),
+  );
+}
 
 /**
  * Compute deterministic grid layout for all dashboard sections.
@@ -47,12 +59,22 @@ export function computeGridLayout(
 
   if (layoutMode === 'narrow') {
     const flowMapHeight = Math.min(NARROW_FLOW_MAP_HEIGHT, mainHeight - 1);
-    const focusedHeight = mainHeight - flowMapHeight;
+    const availableForChecklist = mainHeight - flowMapHeight;
+    const rawChecklistHeight = computeChecklistHeight(mainHeight);
+    // Clamp so focusedAgent always gets at least 1 row
+    const checklistHeight = Math.min(rawChecklistHeight, Math.max(0, availableForChecklist - 1));
+    const focusedHeight = availableForChecklist - checklistHeight;
 
     return {
       header,
-      focusedAgent: { x: 0, y: mainY, width: cols, height: focusedHeight },
-      flowMap: { x: 0, y: mainY + focusedHeight, width: cols, height: flowMapHeight },
+      checklistPanel: { x: 0, y: mainY, width: cols, height: checklistHeight },
+      focusedAgent: { x: 0, y: mainY + checklistHeight, width: cols, height: focusedHeight },
+      flowMap: {
+        x: 0,
+        y: mainY + checklistHeight + focusedHeight,
+        width: cols,
+        height: flowMapHeight,
+      },
       monitorPanel: { x: 0, y: 0, width: 0, height: 0 },
       stageHealth,
       total: { width: cols, height: r },
@@ -63,12 +85,20 @@ export function computeGridLayout(
   const flowMapWidth = cols - focusedWidth;
   const flowMapHeight = Math.ceil(mainHeight / 2);
   const monitorHeight = mainHeight - flowMapHeight;
+  const checklistHeight = computeChecklistHeight(mainHeight);
+  const focusedAgentHeight = mainHeight - checklistHeight;
 
   return {
     header,
+    checklistPanel: { x: flowMapWidth, y: mainY, width: focusedWidth, height: checklistHeight },
     flowMap: { x: 0, y: mainY, width: flowMapWidth, height: flowMapHeight },
     monitorPanel: { x: 0, y: mainY + flowMapHeight, width: flowMapWidth, height: monitorHeight },
-    focusedAgent: { x: flowMapWidth, y: mainY, width: focusedWidth, height: mainHeight },
+    focusedAgent: {
+      x: flowMapWidth,
+      y: mainY + checklistHeight,
+      width: focusedWidth,
+      height: focusedAgentHeight,
+    },
     stageHealth,
     total: { width: cols, height: r },
   };

--- a/apps/mcp-server/src/tui/components/index.ts
+++ b/apps/mcp-server/src/tui/components/index.ts
@@ -8,6 +8,8 @@ export {
   layoutAgentNodes,
 } from './flow-map.pure';
 export { FocusedAgentPanel, type FocusedAgentPanelProps } from './FocusedAgentPanel';
+export { ChecklistPanel, type ChecklistPanelProps } from './ChecklistPanel';
+export { resolveChecklistTasks } from './checklist-panel.pure';
 export {
   formatObjective,
   formatChecklist,

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -7,6 +7,7 @@ import { useDashboardState } from './hooks/use-dashboard-state';
 import { HeaderBar } from './components/HeaderBar';
 import { FlowMap } from './components/FlowMap';
 import { FocusedAgentPanel } from './components/FocusedAgentPanel';
+import { ChecklistPanel } from './components/ChecklistPanel';
 import { StageHealthBar } from './components/StageHealthBar';
 import { ActivityVisualizer } from './components/ActivityVisualizer';
 import { computeStageHealth, detectBottlenecks } from './components/stage-health.pure';
@@ -58,11 +59,19 @@ export function DashboardApp({
       />
       {layoutMode === 'narrow' ? (
         <Box flexDirection="column">
+          {grid.checklistPanel.height > 0 && (
+            <ChecklistPanel
+              tasks={state.tasks}
+              contextDecisions={state.contextDecisions}
+              contextNotes={state.contextNotes}
+              width={grid.checklistPanel.width}
+              height={grid.checklistPanel.height}
+            />
+          )}
           <FocusedAgentPanel
             agent={focusedAgent}
             objectives={state.objectives}
             activeSkills={state.activeSkills}
-            tasks={state.tasks}
             tools={tools}
             inputs={tools}
             outputs={state.outputStats}
@@ -82,7 +91,11 @@ export function DashboardApp({
           />
         </Box>
       ) : (
-        <Box flexDirection="row" width={grid.total.width} height={grid.focusedAgent.height}>
+        <Box
+          flexDirection="row"
+          width={grid.total.width}
+          height={grid.checklistPanel.height + grid.focusedAgent.height}
+        >
           <Box flexDirection="column" width={grid.flowMap.width}>
             <FlowMap
               agents={state.agents}
@@ -98,21 +111,29 @@ export function DashboardApp({
               height={grid.monitorPanel.height}
             />
           </Box>
-          <FocusedAgentPanel
-            agent={focusedAgent}
-            objectives={state.objectives}
-            activeSkills={state.activeSkills}
-            tasks={state.tasks}
-            tools={tools}
-            inputs={tools}
-            outputs={state.outputStats}
-            eventLog={state.eventLog}
-            toolCalls={state.toolCalls}
-            contextDecisions={state.contextDecisions}
-            contextNotes={state.contextNotes}
-            width={grid.focusedAgent.width}
-            height={grid.focusedAgent.height}
-          />
+          <Box flexDirection="column" width={grid.checklistPanel.width}>
+            <ChecklistPanel
+              tasks={state.tasks}
+              contextDecisions={state.contextDecisions}
+              contextNotes={state.contextNotes}
+              width={grid.checklistPanel.width}
+              height={grid.checklistPanel.height}
+            />
+            <FocusedAgentPanel
+              agent={focusedAgent}
+              objectives={state.objectives}
+              activeSkills={state.activeSkills}
+              tools={tools}
+              inputs={tools}
+              outputs={state.outputStats}
+              eventLog={state.eventLog}
+              toolCalls={state.toolCalls}
+              contextDecisions={state.contextDecisions}
+              contextNotes={state.contextNotes}
+              width={grid.focusedAgent.width}
+              height={grid.focusedAgent.height}
+            />
+          </Box>
         </Box>
       )}
       <StageHealthBar

--- a/apps/mcp-server/src/tui/dashboard-types.spec.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.spec.ts
@@ -182,13 +182,15 @@ describe('tui/dashboard-types', () => {
         header: { x: 0, y: 0, width: 120, height: 3 },
         flowMap: { x: 0, y: 3, width: 54, height: 17 },
         monitorPanel: { x: 0, y: 20, width: 54, height: 17 },
-        focusedAgent: { x: 54, y: 3, width: 66, height: 34 },
+        checklistPanel: { x: 54, y: 3, width: 66, height: 7 },
+        focusedAgent: { x: 54, y: 10, width: 66, height: 27 },
         stageHealth: { x: 0, y: 37, width: 120, height: 3 },
         total: { width: 120, height: 40 },
       };
       expect(grid.header).toBeDefined();
       expect(grid.flowMap).toBeDefined();
       expect(grid.monitorPanel).toBeDefined();
+      expect(grid.checklistPanel).toBeDefined();
       expect(grid.focusedAgent).toBeDefined();
       expect(grid.stageHealth).toBeDefined();
       expect(grid.total).toBeDefined();

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -180,6 +180,7 @@ export interface GridRegion {
  */
 export interface DashboardGrid {
   header: GridRegion;
+  checklistPanel: GridRegion;
   flowMap: GridRegion;
   monitorPanel: GridRegion;
   focusedAgent: GridRegion;


### PR DESCRIPTION
## Summary

Extracts the Checklist section from `FocusedAgentPanel` into a dedicated `ChecklistPanel` component, placed at the **top** of the focused-agent column across all layout modes.

Closes #548

## Changes

### New Files
| File | Purpose |
|------|---------|
| `ChecklistPanel.tsx` | New panel component with border and title header |
| `ChecklistPanel.spec.tsx` | Component rendering tests |
| `checklist-panel.pure.ts` | `resolveChecklistTasks` — pure fallback logic |
| `checklist-panel.pure.spec.ts` | TDD tests (4 cases) for `resolveChecklistTasks` |

### Modified Files
| File | Change |
|------|--------|
| `dashboard-types.ts` | Add `checklistPanel: GridRegion` to `DashboardGrid` |
| `grid-layout.pure.ts` | Compute `checklistPanel` region; adjust `focusedAgent` height |
| `grid-layout.pure.spec.ts` | Assert `checklistPanel` dimensions for all layout modes |
| `FocusedAgentPanel.tsx` | Remove `tasks` prop and Checklist section |
| `FocusedAgentPanel.spec.tsx` | Remove checklist-related tests |
| `components/index.ts` | Export `ChecklistPanel` and `resolveChecklistTasks` |
| `dashboard-app.tsx` | Render `ChecklistPanel` above `FocusedAgentPanel` in all modes |

## Layout After Change

**Wide / Medium mode:**
```
┌──────────────┬──────────────────────┐
│  FlowMap     │  ChecklistPanel      │  ← NEW (top, 30% height)
│              │                      │
├──────────────┼──────────────────────┤
│ ActivityViz  │  FocusedAgentPanel   │  ← checklist removed
│              │                      │
└──────────────┴──────────────────────┘
```

**Narrow mode:**
```
┌──────────────────────┐
│  ChecklistPanel      │  ← NEW (top)
├──────────────────────┤
│  FocusedAgentPanel   │
├──────────────────────┤
│  FlowMap             │
└──────────────────────┘
```

## Key Implementation Details

- **Height formula**: `max(6, min(10, ceil(mainHeight * 0.3)))`
- **Fallback logic** (never blank): `contextDecisions[0]` → `contextNotes[0]` → `"Review current task objectives"`
- `formatEnhancedChecklist` reused from `focused-agent.pure.ts` — no duplication

## Test Coverage

- `resolveChecklistTasks`: 4 cases (tasks present / empty+decisions / empty+notes / empty+no context)
- `ChecklistPanel`: rendering with tasks, fallback from decisions, fallback from notes, default fallback
- `grid-layout.pure`: `checklistPanel` dimensions asserted for wide, medium, and narrow modes

## Acceptance Criteria

- [x] `ChecklistPanel` renders at the top of the focused-agent column in wide/medium/narrow modes
- [x] `ChecklistPanel` is never blank — always shows at least 1 TODO item
- [x] Fallback TODO derived from `contextDecisions` → `contextNotes` → default message
- [x] `FocusedAgentPanel` no longer contains a Checklist section
- [x] `DashboardGrid` includes `checklistPanel: GridRegion`
- [x] All existing tests pass
- [x] New tests cover `resolveChecklistTasks` (4 cases) and `ChecklistPanel` rendering