### PR TITLE
replace tool-centric display with real agent visibility (#549)

### DIFF
--- a/apps/mcp-server/src/tui/components/ActivityVisualizer.spec.tsx
+++ b/apps/mcp-server/src/tui/components/ActivityVisualizer.spec.tsx
@@ -2,63 +2,113 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { ActivityVisualizer } from './ActivityVisualizer';
-import type { ToolCallRecord } from '../dashboard-types';
+import { createDefaultDashboardNode } from '../dashboard-types';
+import type { DashboardNode, EventLogEntry } from '../dashboard-types';
 
-function makeCalls(): ToolCallRecord[] {
-  return [
-    { agentId: 'architect', toolName: 'Read', timestamp: Date.now(), status: 'completed' },
-    { agentId: 'architect', toolName: 'Read', timestamp: Date.now(), status: 'completed' },
-    { agentId: 'architect', toolName: 'Grep', timestamp: Date.now(), status: 'completed' },
-    { agentId: 'tester', toolName: 'Bash', timestamp: Date.now(), status: 'completed' },
-  ];
+function makeAgents(): Map<string, DashboardNode> {
+  const agents = new Map<string, DashboardNode>();
+  agents.set(
+    'plan-mode',
+    createDefaultDashboardNode({
+      id: 'plan-mode',
+      name: 'plan-mode',
+      stage: 'PLAN',
+      status: 'running',
+      isPrimary: true,
+      progress: 50,
+    }),
+  );
+  agents.set(
+    'security',
+    createDefaultDashboardNode({
+      id: 'security',
+      name: 'security',
+      stage: 'EVAL',
+      status: 'idle',
+      isPrimary: false,
+      progress: 0,
+    }),
+  );
+  return agents;
 }
+
+const sampleEvents: EventLogEntry[] = [
+  { timestamp: '10:00:01', message: 'agent: plan-mode activated', level: 'info' },
+  { timestamp: '10:00:05', message: 'agent: security started', level: 'info' },
+];
 
 describe('tui/components/ActivityVisualizer', () => {
   it('renders without crashing with data', () => {
     const { lastFrame } = render(
-      <ActivityVisualizer toolCalls={makeCalls()} currentMode="PLAN" width={80} height={10} />,
+      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
     );
     expect(lastFrame()).toBeDefined();
   });
 
   it('renders without crashing with empty data', () => {
     const { lastFrame } = render(
-      <ActivityVisualizer toolCalls={[]} currentMode={null} width={80} height={10} />,
+      <ActivityVisualizer agents={new Map()} eventLog={[]} width={80} height={10} />,
     );
     expect(lastFrame()).toBeDefined();
   });
 
   it('renders without crashing when width=0 or height=0', () => {
     expect(() =>
-      render(<ActivityVisualizer toolCalls={[]} currentMode={null} width={0} height={10} />),
+      render(<ActivityVisualizer agents={new Map()} eventLog={[]} width={0} height={10} />),
     ).not.toThrow();
     expect(() =>
-      render(<ActivityVisualizer toolCalls={[]} currentMode={null} width={80} height={0} />),
+      render(<ActivityVisualizer agents={new Map()} eventLog={[]} width={80} height={0} />),
     ).not.toThrow();
   });
 
-  it('contains bar chart content when calls exist', () => {
+  it('contains Agents header in left panel', () => {
     const { lastFrame } = render(
-      <ActivityVisualizer toolCalls={makeCalls()} currentMode={null} width={80} height={10} />,
+      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
     );
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('Activity');
+    expect(frame).toContain('Agents');
   });
 
-  it('contains Live header and tool names when calls exist', () => {
+  it('contains Events header in right panel', () => {
     const { lastFrame } = render(
-      <ActivityVisualizer toolCalls={makeCalls()} currentMode={null} width={80} height={10} />,
+      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
     );
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('Live');
+    expect(frame).toContain('Events');
   });
 
-  it('shows current mode in live panel', () => {
+  it('shows agent names in roster', () => {
     const { lastFrame } = render(
-      <ActivityVisualizer toolCalls={makeCalls()} currentMode="ACT" width={80} height={10} />,
+      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
     );
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('Mode');
-    expect(frame).toContain('ACT');
+    expect(frame).toContain('plan-mode');
+  });
+
+  it('shows event messages', () => {
+    const shortEvents: EventLogEntry[] = [
+      { timestamp: '10:00:01', message: 'plan-mode ok', level: 'info' },
+    ];
+    const { lastFrame } = render(
+      <ActivityVisualizer agents={makeAgents()} eventLog={shortEvents} width={80} height={10} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('plan-mode ok');
+  });
+
+  it('does NOT contain old Activity bar chart header', () => {
+    const { lastFrame } = render(
+      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('📊 Activity');
+  });
+
+  it('does NOT contain old Live header', () => {
+    const { lastFrame } = render(
+      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).not.toContain('💬 Live');
   });
 });

--- a/apps/mcp-server/src/tui/components/ActivityVisualizer.tsx
+++ b/apps/mcp-server/src/tui/components/ActivityVisualizer.tsx
@@ -1,44 +1,38 @@
 import React, { useMemo } from 'react';
 import { Box, Text } from 'ink';
-import type { ToolCallRecord } from '../dashboard-types';
-import type { Mode } from '../types';
-import {
-  aggregateForBarChart,
-  renderBarChart,
-  renderLiveContext,
-} from './activity-visualizer.pure';
+import type { DashboardNode, EventLogEntry } from '../dashboard-types';
+import { renderAgentRoster, renderAgentEvents } from './activity-visualizer.pure';
 import { BORDER_COLORS } from '../utils/theme';
 
 export interface ActivityVisualizerProps {
-  toolCalls: ToolCallRecord[];
-  currentMode: Mode | null;
+  agents: Map<string, DashboardNode>;
+  eventLog: EventLogEntry[];
   width: number;
   height: number;
 }
 
 export function ActivityVisualizer({
-  toolCalls,
-  currentMode,
+  agents,
+  eventLog,
   width,
   height,
 }: ActivityVisualizerProps): React.ReactElement {
+  const rosterWidth = Math.floor(width * 0.6);
+  const eventsWidth = width - rosterWidth;
+  const contentHeight = Math.max(1, height - 2);
+
+  const rosterLines = useMemo(
+    () => renderAgentRoster(agents, Math.max(1, rosterWidth - 2), contentHeight),
+    [agents, rosterWidth, contentHeight],
+  );
+  const eventLines = useMemo(
+    () => renderAgentEvents(eventLog, Math.max(1, eventsWidth - 2), contentHeight),
+    [eventLog, eventsWidth, contentHeight],
+  );
+
   if (width <= 0 || height <= 0) {
     return <Box />;
   }
-
-  const barChartWidth = Math.floor(width * 0.6);
-  const livePanelWidth = width - barChartWidth;
-  const contentHeight = Math.max(1, height - 2);
-
-  const barChartData = useMemo(() => aggregateForBarChart(toolCalls), [toolCalls]);
-  const barChartLines = useMemo(
-    () => renderBarChart(barChartData, Math.max(1, barChartWidth - 2), contentHeight),
-    [barChartData, barChartWidth, contentHeight],
-  );
-  const liveLines = useMemo(
-    () => renderLiveContext(toolCalls, currentMode, Math.max(1, livePanelWidth - 2), contentHeight),
-    [toolCalls, currentMode, livePanelWidth, contentHeight],
-  );
 
   return (
     <Box flexDirection="row" width={width} height={height}>
@@ -46,10 +40,10 @@ export function ActivityVisualizer({
         borderStyle="single"
         borderColor={BORDER_COLORS.panel}
         flexDirection="column"
-        width={barChartWidth}
+        width={rosterWidth}
         height={height}
       >
-        {barChartLines.map((line, i) => (
+        {rosterLines.map((line, i) => (
           <Text key={i}>{line}</Text>
         ))}
       </Box>
@@ -57,10 +51,10 @@ export function ActivityVisualizer({
         borderStyle="single"
         borderColor={BORDER_COLORS.panel}
         flexDirection="column"
-        width={livePanelWidth}
+        width={eventsWidth}
         height={height}
       >
-        {liveLines.map((line, i) => (
+        {eventLines.map((line, i) => (
           <Text key={i}>{line}</Text>
         ))}
       </Box>

--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
@@ -20,11 +20,7 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={['Add /users endpoints']}
-        tools={['file_edit']}
-        inputs={['spec.md']}
-        outputs={{ files: 3 }}
         eventLog={[]}
-        toolCalls={[]}
       />,
     );
     const frame = lastFrame() ?? '';
@@ -35,16 +31,7 @@ describe('tui/components/FocusedAgentPanel', () => {
 
   it('should render progress bar with braille chars and label', () => {
     const { lastFrame } = render(
-      <FocusedAgentPanel
-        agent={mockAgent}
-        activeSkills={[]}
-        objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
-        eventLog={[]}
-        toolCalls={[]}
-      />,
+      <FocusedAgentPanel agent={mockAgent} activeSkills={[]} objectives={[]} eventLog={[]} />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('⣿');
@@ -52,23 +39,19 @@ describe('tui/components/FocusedAgentPanel', () => {
     expect(frame).toContain('50%');
   });
 
-  it('should render section dividers including Activity', () => {
+  it('should render section dividers without Activity or Tools/IO', () => {
     const { lastFrame } = render(
       <FocusedAgentPanel
         agent={mockAgent}
         activeSkills={[]}
         objectives={['Design auth']}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
         eventLog={[]}
-        toolCalls={[]}
       />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('─── Objective');
-    expect(frame).toContain('─── Activity');
-    expect(frame).toContain('─── Tools / IO');
+    expect(frame).not.toContain('─── Activity');
+    expect(frame).not.toContain('─── Tools / IO');
     expect(frame).toContain('─── Event Log');
   });
 
@@ -78,32 +61,10 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={['Add /users endpoints', 'Update DTO']}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
         eventLog={[]}
-        toolCalls={[]}
       />,
     );
     expect(lastFrame()).toContain('Add /users endpoints');
-  });
-
-  it('should render tool/IO section', () => {
-    const { lastFrame } = render(
-      <FocusedAgentPanel
-        agent={mockAgent}
-        activeSkills={[]}
-        objectives={[]}
-        tools={['file_edit', 'test_run']}
-        inputs={['spec.md']}
-        outputs={{ files: 12, commits: 3 }}
-        eventLog={[]}
-        toolCalls={[]}
-      />,
-    );
-    const frame = lastFrame() ?? '';
-    expect(frame).toContain('file_edit');
-    expect(frame).toContain('spec.md');
   });
 
   it('should render logs', () => {
@@ -112,14 +73,10 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
         eventLog={[
           { timestamp: '10:12:01', message: 'ACT start', level: 'info' },
           { timestamp: '10:12:09', message: 'edited: users.controller.ts', level: 'info' },
         ]}
-        toolCalls={[]}
       />,
     );
     expect(lastFrame()).toContain('ACT start');
@@ -127,16 +84,7 @@ describe('tui/components/FocusedAgentPanel', () => {
 
   it('should render placeholder when no agent focused', () => {
     const { lastFrame } = render(
-      <FocusedAgentPanel
-        agent={null}
-        activeSkills={[]}
-        objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
-        eventLog={[]}
-        toolCalls={[]}
-      />,
+      <FocusedAgentPanel agent={null} activeSkills={[]} objectives={[]} eventLog={[]} />,
     );
     expect(lastFrame()).toContain('No agent focused');
   });
@@ -147,11 +95,7 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={[]}
         objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
         eventLog={[]}
-        toolCalls={[]}
         width={60}
         height={20}
       />,
@@ -165,11 +109,7 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={null}
         activeSkills={[]}
         objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
         eventLog={[]}
-        toolCalls={[]}
         width={60}
         height={20}
       />,
@@ -179,16 +119,7 @@ describe('tui/components/FocusedAgentPanel', () => {
 
   it('should render single border with cyan color', () => {
     const { lastFrame } = render(
-      <FocusedAgentPanel
-        agent={mockAgent}
-        activeSkills={[]}
-        objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
-        eventLog={[]}
-        toolCalls={[]}
-      />,
+      <FocusedAgentPanel agent={mockAgent} activeSkills={[]} objectives={[]} eventLog={[]} />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('┌');
@@ -201,11 +132,7 @@ describe('tui/components/FocusedAgentPanel', () => {
         agent={mockAgent}
         activeSkills={['tdd', 'debugging']}
         objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
         eventLog={[]}
-        toolCalls={[]}
       />,
     );
     const frame = lastFrame() ?? '';
@@ -216,76 +143,17 @@ describe('tui/components/FocusedAgentPanel', () => {
 
   it('should render "No skills" when activeSkills is empty', () => {
     const { lastFrame } = render(
-      <FocusedAgentPanel
-        agent={mockAgent}
-        activeSkills={[]}
-        objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
-        eventLog={[]}
-        toolCalls={[]}
-      />,
+      <FocusedAgentPanel agent={mockAgent} activeSkills={[]} objectives={[]} eventLog={[]} />,
     );
     expect(lastFrame()).toContain('No skills');
   });
 
   it('should render emoji avatar in agent header', () => {
     const { lastFrame } = render(
-      <FocusedAgentPanel
-        agent={mockAgent}
-        activeSkills={[]}
-        objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
-        eventLog={[]}
-        toolCalls={[]}
-      />,
+      <FocusedAgentPanel agent={mockAgent} activeSkills={[]} objectives={[]} eventLog={[]} />,
     );
     // BackendDev → backend 키워드 매칭 → ⚙️
     expect(lastFrame()).toContain('⚙️');
-  });
-
-  it('should render sparkline section', () => {
-    const { lastFrame } = render(
-      <FocusedAgentPanel
-        agent={mockAgent}
-        activeSkills={[]}
-        objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
-        eventLog={[]}
-        toolCalls={[]}
-      />,
-    );
-    const frame = lastFrame() ?? '';
-    expect(frame).toContain('─── Activity');
-    // 빈 toolCalls → 모두 ▁
-    expect(frame).toContain('▁');
-  });
-
-  it('should filter toolCalls by agentId for sparkline', () => {
-    const now = Date.now();
-    const toolCalls = [
-      { agentId: 'agent-1', toolName: 'bash', timestamp: now - 1000, status: 'completed' as const },
-      { agentId: 'agent-2', toolName: 'read', timestamp: now - 2000, status: 'completed' as const },
-    ];
-    // agent-1만 해당: sparkline에 activity가 있어야 함 (최소 ▁ 이상)
-    const { lastFrame } = render(
-      <FocusedAgentPanel
-        agent={mockAgent}
-        activeSkills={[]}
-        objectives={[]}
-        tools={[]}
-        inputs={[]}
-        outputs={{}}
-        eventLog={[]}
-        toolCalls={toolCalls}
-      />,
-    );
-    expect(lastFrame()).toContain('─── Activity');
   });
 
   describe('Context section', () => {
@@ -295,11 +163,7 @@ describe('tui/components/FocusedAgentPanel', () => {
           agent={mockAgent}
           activeSkills={[]}
           objectives={[]}
-          tools={[]}
-          inputs={[]}
-          outputs={{}}
           eventLog={[]}
-          toolCalls={[]}
           contextDecisions={['Use JWT for auth', 'Add rate limiting']}
           contextNotes={[]}
         />,
@@ -316,11 +180,7 @@ describe('tui/components/FocusedAgentPanel', () => {
           agent={mockAgent}
           activeSkills={[]}
           objectives={[]}
-          tools={[]}
-          inputs={[]}
-          outputs={{}}
           eventLog={[]}
-          toolCalls={[]}
           contextDecisions={[]}
           contextNotes={['Review existing codebase']}
         />,
@@ -336,11 +196,7 @@ describe('tui/components/FocusedAgentPanel', () => {
           agent={mockAgent}
           activeSkills={[]}
           objectives={[]}
-          tools={[]}
-          inputs={[]}
-          outputs={{}}
           eventLog={[]}
-          toolCalls={[]}
           contextDecisions={[]}
           contextNotes={[]}
         />,
@@ -351,16 +207,7 @@ describe('tui/components/FocusedAgentPanel', () => {
 
     it('renders No context when props omitted', () => {
       const { lastFrame } = render(
-        <FocusedAgentPanel
-          agent={mockAgent}
-          activeSkills={[]}
-          objectives={[]}
-          tools={[]}
-          inputs={[]}
-          outputs={{}}
-          eventLog={[]}
-          toolCalls={[]}
-        />,
+        <FocusedAgentPanel agent={mockAgent} activeSkills={[]} objectives={[]} eventLog={[]} />,
       );
       const frame = lastFrame() ?? '';
       expect(frame).toContain('No context');

--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import type { DashboardNode, EventLogEntry, ToolCallRecord } from '../dashboard-types';
+import type { DashboardNode, EventLogEntry } from '../dashboard-types';
 import { STATUS_ICONS, getNodeStatusColor, BORDER_COLORS, getAgentAvatar } from '../utils/theme';
 import {
   formatObjective,
-  formatToolIO,
   formatLogTail,
   formatSectionDivider,
   formatEnhancedProgressBar,
-  formatActivitySparkline,
-  type ToolIOData,
 } from './focused-agent.pure';
 import { ContextSection } from './ContextSection';
 
@@ -17,11 +14,7 @@ export interface FocusedAgentPanelProps {
   agent: DashboardNode | null;
   objectives: string[];
   activeSkills: string[];
-  tools: string[];
-  inputs: string[];
-  outputs: ToolIOData;
   eventLog: EventLogEntry[];
-  toolCalls: ToolCallRecord[];
   contextDecisions?: string[];
   contextNotes?: string[];
   width?: number;
@@ -65,11 +58,7 @@ export function FocusedAgentPanel({
   agent,
   objectives,
   activeSkills,
-  tools,
-  inputs,
-  outputs,
   eventLog,
-  toolCalls,
   contextDecisions = [],
   contextNotes = [],
   width,
@@ -95,10 +84,7 @@ export function FocusedAgentPanel({
   const statusLabel = agent.status.toUpperCase();
   const progressBar = formatEnhancedProgressBar(agent.progress);
   const objective = formatObjective(objectives);
-  const toolIO = formatToolIO(tools, inputs, outputs);
   const logs = formatLogTail(eventLog);
-  const agentToolCalls = toolCalls.filter(tc => tc.agentId === agent.id);
-  const sparkline = formatActivitySparkline(agentToolCalls);
 
   return (
     <Box
@@ -136,14 +122,6 @@ export function FocusedAgentPanel({
       ) : (
         <Text dimColor>No skills</Text>
       )}
-
-      {/* Activity Sparkline */}
-      <SectionDivider title="Activity" />
-      <Text>{sparkline}</Text>
-
-      {/* Tools / IO Section */}
-      <SectionDivider title="Tools / IO" />
-      <Text>{toolIO}</Text>
 
       {/* Context Section */}
       <SectionDivider title="Context" />

--- a/apps/mcp-server/src/tui/components/activity-visualizer.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/activity-visualizer.pure.spec.ts
@@ -1,307 +1,173 @@
 import { describe, it, expect } from 'vitest';
-import {
-  renderLiveContext,
-  aggregateForBarChart,
-  renderBarChart,
-  type BarChartItem,
-} from './activity-visualizer.pure';
-import type { ToolCallRecord } from '../dashboard-types';
+import { renderAgentRoster, renderAgentEvents } from './activity-visualizer.pure';
+import type { DashboardNode, EventLogEntry } from '../dashboard-types';
+import { createDefaultDashboardNode } from '../dashboard-types';
 import { estimateDisplayWidth } from '../utils/display-width';
 
-describe('renderLiveContext', () => {
-  const NOW = 100_000;
+function makeAgents(): Map<string, DashboardNode> {
+  const agents = new Map<string, DashboardNode>();
+  agents.set(
+    'plan-mode',
+    createDefaultDashboardNode({
+      id: 'plan-mode',
+      name: 'plan-mode',
+      stage: 'PLAN',
+      status: 'running',
+      isPrimary: true,
+      progress: 75,
+    }),
+  );
+  agents.set(
+    'security',
+    createDefaultDashboardNode({
+      id: 'security',
+      name: 'security',
+      stage: 'EVAL',
+      status: 'idle',
+      isPrimary: false,
+      progress: 0,
+    }),
+  );
+  return agents;
+}
 
+describe('renderAgentRoster', () => {
   it('returns empty array for height <= 0', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'completed' },
-    ];
-    expect(renderLiveContext(calls, null, 40, 0, NOW)).toEqual([]);
+    expect(renderAgentRoster(new Map(), 40, 0)).toEqual([]);
   });
 
   it('returns empty array for width <= 0', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'completed' },
-    ];
-    expect(renderLiveContext(calls, null, 0, 5, NOW)).toEqual([]);
-    expect(renderLiveContext(calls, null, -1, 5, NOW)).toEqual([]);
+    expect(renderAgentRoster(new Map(), 0, 5)).toEqual([]);
+    expect(renderAgentRoster(new Map(), -1, 5)).toEqual([]);
   });
 
-  it('returns Live header only when no calls', () => {
-    const lines = renderLiveContext([], null, 40, 5, NOW);
-    expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('Live');
+  it('includes Agents header as first line', () => {
+    const lines = renderAgentRoster(makeAgents(), 80, 10);
+    expect(lines[0]).toContain('Agents');
   });
 
-  it('always includes Live header', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 5, NOW);
-    expect(lines[0]).toContain('Live');
+  it('shows agent names', () => {
+    const lines = renderAgentRoster(makeAgents(), 80, 10);
+    const content = lines.join('\n');
+    expect(content).toContain('plan-mode');
+    expect(content).toContain('security');
   });
 
-  it('shows current mode when provided', () => {
-    const lines = renderLiveContext([], 'PLAN', 40, 5, NOW);
-    expect(lines).toHaveLength(2);
-    expect(lines[1]).toContain('Mode');
-    expect(lines[1]).toContain('PLAN');
+  it('shows running status icon', () => {
+    const lines = renderAgentRoster(makeAgents(), 80, 10);
+    const content = lines.join('\n');
+    expect(content).toContain('●');
   });
 
-  it('omits mode line when currentMode is null', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 5, NOW);
-    const modeLines = lines.filter(l => l.includes('Mode'));
-    expect(modeLines).toHaveLength(0);
+  it('shows agent progress', () => {
+    const lines = renderAgentRoster(makeAgents(), 80, 10);
+    const content = lines.join('\n');
+    expect(content).toContain('75%');
   });
 
-  it('shows unique tools newest first', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 10_000, status: 'completed' },
-      { agentId: 'a1', toolName: 'Bash', timestamp: NOW - 5_000, status: 'completed' },
-      { agentId: 'a1', toolName: 'Grep', timestamp: NOW, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 10, NOW);
-    expect(lines).toHaveLength(4);
-    expect(lines[1]).toContain('Grep');
-    expect(lines[2]).toContain('Bash');
-    expect(lines[3]).toContain('Read');
-  });
-
-  it('deduplicates tool names (keeps most recent)', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 10_000, status: 'completed' },
-      { agentId: 'a2', toolName: 'Read', timestamp: NOW, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 10, NOW);
-    const readLines = lines.filter(l => l.includes('Read'));
-    expect(readLines).toHaveLength(1);
-  });
-
-  it('shows hot indicator for calls < 5s old', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 2_000, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 5, NOW);
-    expect(lines[1]).toContain('◉');
-  });
-
-  it('shows recent indicator for calls 5-30s old', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 10_000, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 5, NOW);
-    expect(lines[1]).toContain('○');
-  });
-
-  it('shows older indicator for calls >= 30s old', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 60_000, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 5, NOW);
-    expect(lines[1]).toContain('·');
-  });
-
-  it('shows agent context when agentId is not unknown', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'architect', toolName: 'Read', timestamp: NOW, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 5, NOW);
-    expect(lines[1]).toContain('architect');
-    expect(lines[1]).toContain('Read');
-  });
-
-  it('omits agent context when agentId is unknown', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'unknown', toolName: 'Read', timestamp: NOW, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 5, NOW);
-    expect(lines[1]).not.toContain('unknown');
-    expect(lines[1]).toContain('Read');
+  it('shows No agents when map is empty', () => {
+    const lines = renderAgentRoster(new Map(), 80, 5);
+    expect(lines.join('\n')).toContain('No agents');
   });
 
   it('respects height limit', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'tool1', timestamp: NOW, status: 'completed' },
-      { agentId: 'a1', toolName: 'tool2', timestamp: NOW - 1_000, status: 'completed' },
-      { agentId: 'a1', toolName: 'tool3', timestamp: NOW - 2_000, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, 'PLAN', 40, 3, NOW);
-    expect(lines).toHaveLength(3);
+    const lines = renderAgentRoster(makeAgents(), 80, 2);
+    expect(lines.length).toBeLessThanOrEqual(2);
   });
 
   it('truncates lines to width', () => {
-    const calls: ToolCallRecord[] = [
-      {
-        agentId: 'very-long-agent-name',
-        toolName: 'VeryLongToolNameThatExceedsWidth',
-        timestamp: NOW,
-        status: 'completed',
-      },
-    ];
-    const lines = renderLiveContext(calls, null, 15, 5, NOW);
+    const lines = renderAgentRoster(makeAgents(), 20, 10);
     for (const line of lines) {
-      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(15);
+      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(20);
     }
   });
 
-  it('does not filter by time window — old calls still visible', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW - 120_000, status: 'completed' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 5, NOW);
-    expect(lines).toHaveLength(2);
-    expect(lines[1]).toContain('Read');
+  it('primary agents appear before non-primary', () => {
+    const lines = renderAgentRoster(makeAgents(), 80, 10);
+    const planIdx = lines.findIndex(l => l.includes('plan-mode'));
+    const secIdx = lines.findIndex(l => l.includes('security'));
+    expect(planIdx).toBeGreaterThan(-1);
+    expect(secIdx).toBeGreaterThan(-1);
+    expect(planIdx).toBeLessThan(secIdx);
   });
 
-  it('ignores error-status calls', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: NOW, status: 'error' },
-    ];
-    const lines = renderLiveContext(calls, null, 40, 5, NOW);
+  it('returns only header when height is 1', () => {
+    const lines = renderAgentRoster(makeAgents(), 80, 1);
     expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('Agents');
   });
 });
 
-describe('aggregateForBarChart', () => {
-  it('returns empty array for empty input', () => {
-    expect(aggregateForBarChart([])).toEqual([]);
-  });
-
-  it('counts calls per tool and sorts descending', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: 1, status: 'completed' },
-      { agentId: 'a1', toolName: 'Read', timestamp: 2, status: 'completed' },
-      { agentId: 'a2', toolName: 'Bash', timestamp: 3, status: 'completed' },
-      { agentId: 'a1', toolName: 'Read', timestamp: 4, status: 'completed' },
-      { agentId: 'a2', toolName: 'Grep', timestamp: 5, status: 'completed' },
-      { agentId: 'a2', toolName: 'Grep', timestamp: 6, status: 'completed' },
-    ];
-    const result = aggregateForBarChart(calls);
-    expect(result).toEqual([
-      { tool: 'Read', count: 3 },
-      { tool: 'Grep', count: 2 },
-      { tool: 'Bash', count: 1 },
-    ]);
-  });
-
-  it('limits results to maxTools (default 10)', () => {
-    const calls: ToolCallRecord[] = [];
-    for (let i = 0; i < 15; i++) {
-      calls.push({ agentId: 'a1', toolName: `tool_${i}`, timestamp: i, status: 'completed' });
-    }
-    const result = aggregateForBarChart(calls);
-    expect(result).toHaveLength(10);
-  });
-
-  it('respects custom maxTools', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: 1, status: 'completed' },
-      { agentId: 'a1', toolName: 'Bash', timestamp: 2, status: 'completed' },
-      { agentId: 'a1', toolName: 'Grep', timestamp: 3, status: 'completed' },
-    ];
-    const result = aggregateForBarChart(calls, 2);
-    expect(result).toHaveLength(2);
-  });
-
-  it('returns single tool correctly', () => {
-    const calls: ToolCallRecord[] = [
-      { agentId: 'a1', toolName: 'Read', timestamp: 1, status: 'completed' },
-    ];
-    expect(aggregateForBarChart(calls)).toEqual([{ tool: 'Read', count: 1 }]);
-  });
-});
-
-describe('renderBarChart', () => {
-  const sampleData: BarChartItem[] = [
-    { tool: 'Read', count: 10 },
-    { tool: 'Bash', count: 5 },
-    { tool: 'Grep', count: 2 },
+describe('renderAgentEvents', () => {
+  const eventLog: EventLogEntry[] = [
+    { timestamp: '10:00:01', message: 'agent: plan-mode activated', level: 'info' },
+    { timestamp: '10:00:05', message: 'agent: security started', level: 'info' },
+    { timestamp: '10:00:10', message: 'error: timeout', level: 'error' },
   ];
 
-  it('returns empty array for empty data', () => {
-    expect(renderBarChart([], 80, 10)).toEqual([]);
-  });
-
   it('returns empty array for height <= 0', () => {
-    expect(renderBarChart(sampleData, 80, 0)).toEqual([]);
+    expect(renderAgentEvents(eventLog, 40, 0)).toEqual([]);
   });
 
   it('returns empty array for width <= 0', () => {
-    expect(renderBarChart(sampleData, 0, 10)).toEqual([]);
-    expect(renderBarChart(sampleData, -1, 10)).toEqual([]);
+    expect(renderAgentEvents(eventLog, 0, 5)).toEqual([]);
+    expect(renderAgentEvents(eventLog, -1, 5)).toEqual([]);
   });
 
-  it('includes Activity header as first line', () => {
-    const lines = renderBarChart(sampleData, 80, 10);
-    expect(lines[0]).toContain('Activity');
+  it('includes Events header as first line', () => {
+    const lines = renderAgentEvents(eventLog, 80, 10);
+    expect(lines[0]).toContain('Events');
   });
 
-  it('includes tool names in output', () => {
-    const lines = renderBarChart(sampleData, 80, 10);
+  it('shows event messages', () => {
+    const lines = renderAgentEvents(eventLog, 80, 10);
     const content = lines.join('\n');
-    expect(content).toContain('Read');
-    expect(content).toContain('Bash');
-    expect(content).toContain('Grep');
+    expect(content).toContain('plan-mode activated');
   });
 
-  it('includes counts in output', () => {
-    const lines = renderBarChart(sampleData, 80, 10);
-    const content = lines.join('\n');
-    expect(content).toContain('10');
-    expect(content).toContain('5');
-    expect(content).toContain('2');
+  it('shows No events when log is empty', () => {
+    const lines = renderAgentEvents([], 80, 5);
+    expect(lines.join('\n')).toContain('No events');
   });
 
-  it('includes bar characters', () => {
-    const lines = renderBarChart(sampleData, 80, 10);
-    const content = lines.join('\n');
-    expect(content).toContain('█');
-    expect(content).toContain('░');
-  });
-
-  it('limits output to height lines', () => {
-    const lines = renderBarChart(sampleData, 80, 3);
-    expect(lines.length).toBeLessThanOrEqual(3);
+  it('respects height limit', () => {
+    const lines = renderAgentEvents(eventLog, 80, 2);
+    expect(lines.length).toBeLessThanOrEqual(2);
   });
 
   it('truncates lines to width', () => {
-    const lines = renderBarChart(sampleData, 30, 10);
+    const lines = renderAgentEvents(eventLog, 20, 10);
     for (const line of lines) {
-      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(30);
+      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(20);
     }
   });
 
-  it('highest count tool has full bar (no empty chars)', () => {
-    const lines = renderBarChart(sampleData, 80, 10);
-    const readLine = lines.find(l => l.includes('Read'));
-    expect(readLine).toBeDefined();
-    expect(readLine).not.toContain('░');
+  it('shows events in chronological order (oldest first)', () => {
+    const lines = renderAgentEvents(eventLog, 80, 10);
+    const firstIdx = lines.findIndex(l => l.includes('plan-mode activated'));
+    const lastIdx = lines.findIndex(l => l.includes('timeout'));
+    expect(firstIdx).toBeGreaterThan(-1);
+    expect(lastIdx).toBeGreaterThan(-1);
+    expect(firstIdx).toBeLessThan(lastIdx);
   });
 
-  it('renders single item correctly', () => {
-    const lines = renderBarChart([{ tool: 'Read', count: 5 }], 80, 5);
-    expect(lines).toHaveLength(2); // header + 1 row
-    expect(lines[1]).toContain('Read');
-    expect(lines[1]).toContain('5');
+  it('returns only header when height is 1', () => {
+    const lines = renderAgentEvents(eventLog, 80, 1);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('Events');
   });
 
-  it('renders correctly with very narrow width (width < BAR_FIXED_OVERHEAD)', () => {
-    const lines = renderBarChart(sampleData, 15, 5);
-    // barWidth = max(1, 15-20) = 1, should still render without error
-    expect(lines.length).toBeGreaterThan(0);
-    for (const line of lines) {
-      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(15);
-    }
-  });
-
-  it('renders safely when count is 0 (maxCount fallback to 1)', () => {
-    const data: BarChartItem[] = [{ tool: 'Read', count: 0 }];
-    const lines = renderBarChart(data, 80, 5);
-    expect(lines).toHaveLength(2);
-    // bar should be all empty (count=0, maxCount=1 → filled=0)
-    expect(lines[1]).toContain('░');
-    expect(lines[1]).not.toContain('█');
+  it('shows most recent events when log exceeds height', () => {
+    const manyEvents: EventLogEntry[] = Array.from({ length: 20 }, (_, i) => ({
+      timestamp: `10:00:${String(i).padStart(2, '0')}`,
+      message: `event-${i}`,
+      level: 'info' as const,
+    }));
+    const lines = renderAgentEvents(manyEvents, 80, 5);
+    const content = lines.join('\n');
+    // 최근 이벤트(event-16 ~ event-19)가 보여야 함
+    expect(content).toContain('event-19');
+    // 오래된 이벤트(event-0)는 보이지 않아야 함
+    expect(content).not.toContain('event-0');
   });
 });

--- a/apps/mcp-server/src/tui/components/activity-visualizer.pure.ts
+++ b/apps/mcp-server/src/tui/components/activity-visualizer.pure.ts
@@ -1,93 +1,71 @@
-import type { ToolCallRecord } from '../dashboard-types';
-import type { Mode } from '../types';
-import { truncateToDisplayWidth, padEndDisplayWidth } from '../utils/display-width';
+import type { DashboardNode, EventLogEntry } from '../dashboard-types';
+import { STATUS_ICONS } from '../utils/theme';
+import { truncateToDisplayWidth } from '../utils/display-width';
 
-export interface BarChartItem {
-  tool: string;
-  count: number;
-}
+const AGENT_NAME_WIDTH = 18;
+const AGENT_STAGE_WIDTH = 5;
 
-export function aggregateForBarChart(calls: ToolCallRecord[], maxTools = 10): BarChartItem[] {
-  if (calls.length === 0) return [];
+const STATUS_PRIORITY: Record<string, number> = {
+  running: 0,
+  blocked: 1,
+  idle: 2,
+  error: 3,
+  done: 4,
+};
 
-  const toolCounts = new Map<string, number>();
-  for (const call of calls) {
-    toolCounts.set(call.toolName, (toolCounts.get(call.toolName) ?? 0) + 1);
+export function renderAgentRoster(
+  agents: Map<string, DashboardNode>,
+  width: number,
+  height: number,
+): string[] {
+  if (height <= 0 || width <= 0) return [];
+
+  const lines: string[] = [truncateToDisplayWidth('🤖 Agents', width)];
+  if (height <= 1) return lines;
+
+  if (agents.size === 0) {
+    lines.push(truncateToDisplayWidth('  No agents', width));
+    return lines.slice(0, height);
   }
 
-  return [...toolCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, maxTools)
-    .map(([tool, count]) => ({ tool, count }));
-}
+  const sorted = [...agents.values()].sort((a, b) => {
+    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
+    return (STATUS_PRIORITY[a.status] ?? 5) - (STATUS_PRIORITY[b.status] ?? 5);
+  });
 
-const TOOL_NAME_WIDTH = 12;
-const BAR_FIXED_OVERHEAD = TOOL_NAME_WIDTH + 2 + 2 + 4; // "name [bar] cnt"
-
-export function renderBarChart(data: BarChartItem[], width: number, height: number): string[] {
-  if (data.length === 0 || height <= 0 || width <= 0) return [];
-
-  const lines: string[] = [truncateToDisplayWidth('📊 Activity', width)];
-
-  const barWidth = Math.max(1, width - BAR_FIXED_OVERHEAD);
-  const maxCount = data[0]?.count || 1;
-
-  for (const item of data) {
+  for (const agent of sorted) {
     if (lines.length >= height) break;
-
-    const name = padEndDisplayWidth(
-      truncateToDisplayWidth(item.tool, TOOL_NAME_WIDTH),
-      TOOL_NAME_WIDTH,
-    );
-    const filled = Math.round((item.count / maxCount) * barWidth);
-    const empty = barWidth - filled;
-    const bar = '█'.repeat(filled) + '░'.repeat(empty);
-    const countStr = String(item.count).padStart(4);
-
-    lines.push(truncateToDisplayWidth(`${name} [${bar}] ${countStr}`, width));
+    const icon = STATUS_ICONS[agent.status] ?? '?';
+    const name = truncateToDisplayWidth(agent.name, AGENT_NAME_WIDTH).padEnd(AGENT_NAME_WIDTH);
+    const stage = agent.stage.padEnd(AGENT_STAGE_WIDTH);
+    const pct = `${agent.progress}%`.padStart(4);
+    lines.push(truncateToDisplayWidth(`${icon} ${name} ${stage} ${pct}`, width));
   }
 
   return lines.slice(0, height);
 }
 
-const LIVE_AGENT_NAME_WIDTH = 15;
-const LIVE_HOT_WINDOW_MS = 5_000;
-const LIVE_RECENT_WINDOW_MS = 30_000;
-const LIVE_HOT_SEC = LIVE_HOT_WINDOW_MS / 1000;
-const LIVE_RECENT_SEC = LIVE_RECENT_WINDOW_MS / 1000;
-
-export function renderLiveContext(
-  calls: ToolCallRecord[],
-  currentMode: Mode | null,
+export function renderAgentEvents(
+  eventLog: EventLogEntry[],
   width: number,
   height: number,
-  now?: number,
 ): string[] {
-  const currentTime = now ?? Date.now();
   if (height <= 0 || width <= 0) return [];
 
-  const lines: string[] = [truncateToDisplayWidth('💬 Live', width)];
+  const lines: string[] = [truncateToDisplayWidth('📋 Events', width)];
+  if (height <= 1) return lines;
 
-  if (currentMode) {
-    lines.push(truncateToDisplayWidth(`⟫ Mode: ${currentMode}`, width));
+  if (eventLog.length === 0) {
+    lines.push(truncateToDisplayWidth('  No events', width));
+    return lines.slice(0, height);
   }
 
-  const maxItems = height - lines.length;
-  const seen = new Set<string>();
+  const maxItems = height - 1;
+  const tail = eventLog.slice(-maxItems);
 
-  for (let i = calls.length - 1; i >= 0 && seen.size < maxItems; i--) {
-    const call = calls[i];
-    if (call.status === 'error') continue;
-    if (seen.has(call.toolName)) continue;
-    seen.add(call.toolName);
-
-    const ageSec = Math.floor((currentTime - call.timestamp) / 1000);
-    const ageIndicator = ageSec < LIVE_HOT_SEC ? '◉' : ageSec < LIVE_RECENT_SEC ? '○' : '·';
-    const agent =
-      call.agentId !== 'unknown'
-        ? truncateToDisplayWidth(call.agentId, LIVE_AGENT_NAME_WIDTH) + ' '
-        : '';
-    lines.push(truncateToDisplayWidth(`${ageIndicator} ${agent}${call.toolName}`, width));
+  for (const entry of tail) {
+    if (lines.length >= height) break;
+    lines.push(truncateToDisplayWidth(`${entry.timestamp} ${entry.message}`, width));
   }
 
   return lines.slice(0, height);

--- a/apps/mcp-server/src/tui/components/focused-agent.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/focused-agent.pure.spec.ts
@@ -1,16 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
   formatObjective,
-  formatChecklist,
-  formatToolIO,
   formatLogTail,
   formatSectionDivider,
-  formatProgressBar,
   formatEnhancedProgressBar,
-  formatActivitySparkline,
   formatEnhancedChecklist,
 } from './focused-agent.pure';
-import type { TaskItem, EventLogEntry } from '../dashboard-types';
+import type { EventLogEntry } from '../dashboard-types';
 
 describe('tui/components/focused-agent.pure', () => {
   describe('formatObjective', () => {
@@ -39,76 +35,6 @@ describe('tui/components/focused-agent.pure', () => {
     it('should return empty string for empty objectives', () => {
       const result = formatObjective([]);
       expect(result).toBe('');
-    });
-  });
-
-  describe('formatChecklist', () => {
-    it('should show completed tasks with [x] and pending with [ ]', () => {
-      const tasks: TaskItem[] = [
-        { id: '1', subject: 'Write tests', completed: true },
-        { id: '2', subject: 'Implement feature', completed: false },
-      ];
-
-      const result = formatChecklist(tasks);
-      expect(result).toContain('[x] Write tests');
-      expect(result).toContain('[ ] Implement feature');
-    });
-
-    it('should show overflow count when exceeding maxItems', () => {
-      const tasks: TaskItem[] = Array.from({ length: 10 }, (_, i) => ({
-        id: String(i),
-        subject: `Task ${i}`,
-        completed: false,
-      }));
-
-      const result = formatChecklist(tasks, 6);
-      const lines = result.split('\n');
-      expect(lines).toHaveLength(7); // 6 items + overflow
-      expect(lines[6]).toBe('(+4 more)');
-    });
-
-    it('should not show overflow when within maxItems', () => {
-      const tasks: TaskItem[] = [{ id: '1', subject: 'Only task', completed: false }];
-
-      const result = formatChecklist(tasks, 6);
-      expect(result).not.toContain('more');
-    });
-
-    it('should return empty string for empty tasks', () => {
-      const result = formatChecklist([]);
-      expect(result).toBe('');
-    });
-  });
-
-  describe('formatToolIO', () => {
-    it('should format tools, inputs, and outputs', () => {
-      const result = formatToolIO(['grep', 'read'], ['src/app.ts', 'src/main.ts'], {
-        files: 3,
-        commits: 1,
-      });
-
-      expect(result).toContain('Tools: grep / read');
-      expect(result).toContain('IN : src/app.ts, src/main.ts');
-      expect(result).toContain('OUT: files(3) / commits(1)');
-    });
-
-    it('should show "none" for empty tools', () => {
-      const result = formatToolIO([], [], {});
-      expect(result).toContain('Tools: none');
-      expect(result).toContain('IN : none');
-      expect(result).toContain('OUT: none');
-    });
-
-    it('should skip zero-value outputs', () => {
-      const result = formatToolIO(['read'], ['a.ts'], { files: 0, commits: 2 });
-      expect(result).not.toContain('files(0)');
-      expect(result).toContain('commits(2)');
-    });
-
-    it('should skip undefined outputs', () => {
-      const result = formatToolIO(['read'], ['a.ts'], { files: undefined, commits: 1 });
-      expect(result).not.toContain('files');
-      expect(result).toContain('commits(1)');
     });
   });
 
@@ -171,38 +97,6 @@ describe('tui/components/focused-agent.pure', () => {
     });
   });
 
-  describe('formatProgressBar', () => {
-    it('should return filled and empty segments', () => {
-      const { filled, empty } = formatProgressBar(50, 20);
-      expect(filled).toBe('██████████');
-      expect(empty).toBe('░░░░░░░░░░');
-    });
-
-    it('should handle 0% progress', () => {
-      const { filled, empty } = formatProgressBar(0, 10);
-      expect(filled).toBe('');
-      expect(empty).toBe('░░░░░░░░░░');
-    });
-
-    it('should handle 100% progress', () => {
-      const { filled, empty } = formatProgressBar(100, 10);
-      expect(filled).toBe('██████████');
-      expect(empty).toBe('');
-    });
-
-    it('should clamp values above 100', () => {
-      const { filled, empty } = formatProgressBar(150, 10);
-      expect(filled).toBe('██████████');
-      expect(empty).toBe('');
-    });
-
-    it('should clamp values below 0', () => {
-      const { filled, empty } = formatProgressBar(-10, 10);
-      expect(filled).toBe('');
-      expect(empty).toBe('░░░░░░░░░░');
-    });
-  });
-
   describe('formatEnhancedProgressBar', () => {
     it('0%: 전체 ░, label "0%"', () => {
       const result = formatEnhancedProgressBar(0, 20);
@@ -232,43 +126,6 @@ describe('tui/components/focused-agent.pure', () => {
       const result = formatEnhancedProgressBar(-10, 10);
       expect(result.bar).toBe('░'.repeat(10));
       expect(result.label).toBe('0%');
-    });
-  });
-
-  describe('formatActivitySparkline', () => {
-    const NOW = 1_000_000;
-
-    it('빈 배열 → 모두 ▁ (최소 높이)', () => {
-      const result = formatActivitySparkline([], 10, 60_000, NOW);
-      expect(result).toBe('▁'.repeat(10));
-      expect(result).toHaveLength(10);
-    });
-
-    it('단일 스파이크 → 마지막 버킷만 █', () => {
-      const calls = [{ timestamp: NOW - 1000 }];
-      const result = formatActivitySparkline(calls, 10, 60_000, NOW);
-      expect(result[result.length - 1]).toBe('█');
-      expect(result.slice(0, -1)).toBe('▁'.repeat(9));
-    });
-
-    it('윈도우 밖 호출 무시', () => {
-      const calls = [{ timestamp: NOW - 70_000 }];
-      const result = formatActivitySparkline(calls, 10, 60_000, NOW);
-      expect(result).toBe('▁'.repeat(10));
-    });
-
-    it('bucketCount만큼 문자 반환', () => {
-      const result = formatActivitySparkline([], 20, 60_000, NOW);
-      expect(result).toHaveLength(20);
-    });
-
-    it('균등 분포 → 모두 같은 높이 문자', () => {
-      const bucketSize = 60_000 / 5;
-      const calls = [0, 1, 2, 3, 4].map(i => ({
-        timestamp: NOW - (i * bucketSize + bucketSize / 2),
-      }));
-      const result = formatActivitySparkline(calls, 5, 60_000, NOW);
-      expect(new Set(result.split('')).size).toBe(1);
     });
   });
 

--- a/apps/mcp-server/src/tui/components/focused-agent.pure.ts
+++ b/apps/mcp-server/src/tui/components/focused-agent.pure.ts
@@ -8,32 +8,6 @@ export function formatObjective(objectives: string[], maxLines = 3): string {
   return lines.join('\n');
 }
 
-/** @deprecated Use formatEnhancedChecklist instead (supports ✔/◻ icons). */
-export function formatChecklist(tasks: TaskItem[], maxItems = 6): string {
-  const visible = tasks.slice(0, maxItems);
-  const lines = visible.map(t => (t.completed ? `[x] ${t.subject}` : `[ ] ${t.subject}`));
-  if (tasks.length > maxItems) {
-    lines.push(`(+${tasks.length - maxItems} more)`);
-  }
-  return lines.join('\n');
-}
-
-export interface ToolIOData {
-  files?: number;
-  commits?: number;
-  [key: string]: number | undefined;
-}
-
-export function formatToolIO(tools: string[], inputs: string[], outputs: ToolIOData): string {
-  const toolLine = `Tools: ${tools.join(' / ') || 'none'}`;
-  const inLine = `IN : ${inputs.join(', ') || 'none'}`;
-  const outParts = Object.entries(outputs)
-    .filter(([, v]) => v !== undefined && v > 0)
-    .map(([k, v]) => `${k}(${v})`);
-  const outLine = `OUT: ${outParts.join(' / ') || 'none'}`;
-  return `${toolLine}\n${inLine}\n${outLine}`;
-}
-
 export function formatLogTail(events: EventLogEntry[], maxLines = 10): string {
   const tail = events.slice(-maxLines);
   return tail.map(e => `${e.timestamp} ${e.message}`).join('\n');
@@ -49,21 +23,6 @@ export function formatSectionDivider(title: string, width = 50): string {
   return `${prefix}${title}${suffix}${'─'.repeat(remaining)}`;
 }
 
-/**
- * Format a progress bar with filled and empty segments.
- * Returns [filledStr, emptyStr] for separate styling.
- * @deprecated Use formatEnhancedProgressBar instead (supports braille chars + label).
- */
-export function formatProgressBar(progress: number, width = 40): { filled: string; empty: string } {
-  const clamped = Math.max(0, Math.min(100, progress));
-  const filledCount = Math.round((clamped / 100) * width);
-  const emptyCount = width - filledCount;
-  return {
-    filled: '█'.repeat(filledCount),
-    empty: '░'.repeat(emptyCount),
-  };
-}
-
 /** Enhanced progress bar using braille characters for finer granularity. */
 export function formatEnhancedProgressBar(
   progress: number,
@@ -76,33 +35,6 @@ export function formatEnhancedProgressBar(
     bar: '⣿'.repeat(filledCount) + '░'.repeat(emptyCount),
     label: `${clamped}%`,
   };
-}
-
-const SPARK_CHARS = '▁▂▃▄▅▆▇█';
-
-/**
- * Generate a sparkline showing tool call frequency over the last N seconds.
- * Each character represents one time bucket; height = relative call count.
- */
-export function formatActivitySparkline(
-  toolCalls: Array<{ timestamp: number }>,
-  bucketCount = 20,
-  windowMs = 60_000,
-  now?: number,
-): string {
-  const currentTime = now ?? Date.now();
-  const bucketSize = windowMs / bucketCount;
-  const buckets = new Array<number>(bucketCount).fill(0);
-
-  for (const call of toolCalls) {
-    const age = currentTime - call.timestamp;
-    if (age < 0 || age >= windowMs) continue;
-    const idx = Math.min(bucketCount - 1, Math.floor(age / bucketSize));
-    buckets[bucketCount - 1 - idx]++;
-  }
-
-  const max = Math.max(1, ...buckets);
-  return buckets.map(b => SPARK_CHARS[Math.round((b / max) * (SPARK_CHARS.length - 1))]).join('');
 }
 
 /** Enhanced checklist with ✔/◻ icons and overflow indicator. */

--- a/apps/mcp-server/src/tui/components/index.ts
+++ b/apps/mcp-server/src/tui/components/index.ts
@@ -10,24 +10,11 @@ export {
 export { FocusedAgentPanel, type FocusedAgentPanelProps } from './FocusedAgentPanel';
 export { ChecklistPanel, type ChecklistPanelProps } from './ChecklistPanel';
 export { resolveChecklistTasks } from './checklist-panel.pure';
-export {
-  formatObjective,
-  formatChecklist,
-  formatToolIO,
-  formatLogTail,
-  formatSectionDivider,
-  formatProgressBar,
-  type ToolIOData,
-} from './focused-agent.pure';
+export { formatObjective, formatLogTail, formatSectionDivider } from './focused-agent.pure';
 export { StageHealthBar, type StageHealthBarProps } from './StageHealthBar';
 export { computeStageHealth, detectBottlenecks } from './stage-health.pure';
 export { computeGridLayout } from './grid-layout.pure';
 export { ActivityVisualizer, type ActivityVisualizerProps } from './ActivityVisualizer';
-export {
-  aggregateForBarChart,
-  renderBarChart,
-  renderLiveContext,
-  type BarChartItem,
-} from './activity-visualizer.pure';
+export { renderAgentRoster, renderAgentEvents } from './activity-visualizer.pure';
 export { SessionTabBar } from './SessionTabBar';
 export type { SessionTabBarProps } from './SessionTabBar';

--- a/apps/mcp-server/src/tui/dashboard-app.spec.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.spec.tsx
@@ -100,7 +100,7 @@ describe('DashboardApp', () => {
     expect(frame).toContain('security-');
   });
 
-  it('passes tool names as inputs to FocusedAgentPanel', async () => {
+  it('shows focused agent in FocusedAgentPanel without Tools/IO section', async () => {
     const eventBus = new TuiEventBus();
     const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
     await tick();
@@ -121,9 +121,9 @@ describe('DashboardApp', () => {
     await tick();
 
     const frame = lastFrame() ?? '';
-    // IN line should show tool name, not "none"
-    expect(frame).toContain('IN :');
-    expect(frame).not.toMatch(/IN\s*:\s*none/);
+    // Tools/IO section should not be visible
+    expect(frame).not.toContain('IN :');
+    expect(frame).not.toContain('─── Tools / IO');
   });
 
   it('focuses on primary running agent', async () => {

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -33,14 +33,6 @@ export function DashboardApp({
 
   const stageHealth = useMemo(() => computeStageHealth(state.agents), [state.agents]);
 
-  const tools = useMemo(() => {
-    const seen = new Set<string>();
-    for (const e of state.eventLog) {
-      seen.add(e.message.split(' [')[0]);
-    }
-    return [...seen];
-  }, [state.eventLog]);
-
   const bottlenecks = useMemo(() => detectBottlenecks(state.eventLog), [state.eventLog]);
 
   const grid = useMemo(
@@ -72,11 +64,7 @@ export function DashboardApp({
             agent={focusedAgent}
             objectives={state.objectives}
             activeSkills={state.activeSkills}
-            tools={tools}
-            inputs={tools}
-            outputs={state.outputStats}
             eventLog={state.eventLog}
-            toolCalls={state.toolCalls}
             contextDecisions={state.contextDecisions}
             contextNotes={state.contextNotes}
             width={grid.focusedAgent.width}
@@ -105,8 +93,8 @@ export function DashboardApp({
               height={grid.flowMap.height}
             />
             <ActivityVisualizer
-              toolCalls={state.toolCalls}
-              currentMode={state.currentMode}
+              agents={state.agents}
+              eventLog={state.eventLog}
               width={grid.monitorPanel.width}
               height={grid.monitorPanel.height}
             />
@@ -123,11 +111,7 @@ export function DashboardApp({
               agent={focusedAgent}
               objectives={state.objectives}
               activeSkills={state.activeSkills}
-              tools={tools}
-              inputs={tools}
-              outputs={state.outputStats}
               eventLog={state.eventLog}
-              toolCalls={state.toolCalls}
               contextDecisions={state.contextDecisions}
               contextNotes={state.contextNotes}
               width={grid.focusedAgent.width}

--- a/apps/mcp-server/src/tui/eventbus-ui.integration.spec.tsx
+++ b/apps/mcp-server/src/tui/eventbus-ui.integration.spec.tsx
@@ -518,6 +518,7 @@ describe('EventBus ↔ UI Integration', () => {
     it('should handle error scenario: activate → error deactivation → re-activate', async () => {
       const eventBus = new TuiEventBus();
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
+      await tick(); // ensure useEffect subscribes before emitting
 
       // 1. Activate agent
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {

--- a/apps/mcp-server/src/tui/events/parse-agent.spec.ts
+++ b/apps/mcp-server/src/tui/events/parse-agent.spec.ts
@@ -121,84 +121,42 @@ describe('parseAgentFromToolName', () => {
     });
   });
 
-  describe('mapped general tools', () => {
-    it('should return agent info for search_rules', () => {
-      expect(parseAgentFromToolName('search_rules', {})).toEqual({
-        agentId: 'search_rules',
-        name: 'search_rules',
-        role: 'query',
-        isPrimary: false,
-      });
-    });
-
-    it('should return agent info for get_project_config', () => {
-      expect(parseAgentFromToolName('get_project_config', {})).toEqual({
-        agentId: 'get_project_config',
-        name: 'get_project_config',
-        role: 'config',
-        isPrimary: false,
-      });
-    });
-
-    it('should return agent info for get_agent_details', () => {
-      expect(parseAgentFromToolName('get_agent_details', { agentName: 'test' })).toEqual({
-        agentId: 'get_agent_details',
-        name: 'get_agent_details',
-        role: 'query',
-        isPrimary: false,
-      });
-    });
-
-    it('should return agent info for analyze_task', () => {
-      expect(parseAgentFromToolName('analyze_task', {})).toEqual({
-        agentId: 'analyze_task',
-        name: 'analyze_task',
-        role: 'analysis',
-        isPrimary: false,
-      });
-    });
-
-    it('should return agent info for update_context', () => {
-      expect(parseAgentFromToolName('update_context', {})).toEqual({
-        agentId: 'update_context',
-        name: 'update_context',
-        role: 'context',
-        isPrimary: false,
-      });
-    });
-
-    it('should return agent info for recommend_skills', () => {
-      expect(parseAgentFromToolName('recommend_skills', {})).toEqual({
-        agentId: 'recommend_skills',
-        name: 'recommend_skills',
-        role: 'skill',
-        isPrimary: false,
-      });
-    });
-
-    it('should return agent info for cleanup_context', () => {
-      expect(parseAgentFromToolName('cleanup_context', {})).toEqual({
-        agentId: 'cleanup_context',
-        name: 'cleanup_context',
-        role: 'context',
-        isPrimary: false,
-      });
-    });
-
-    it('should return agent info for dispatch_agents', () => {
-      expect(parseAgentFromToolName('dispatch_agents', { mode: 'EVAL' })).toEqual({
-        agentId: 'dispatch_agents',
-        name: 'dispatch_agents',
-        role: 'orchestrator',
-        isPrimary: false,
-      });
-    });
-  });
-
   describe('unhandled tools', () => {
     it('should return null for completely unknown tool names', () => {
       expect(parseAgentFromToolName('unknown_tool', {})).toBeNull();
       expect(parseAgentFromToolName('some_other_tool', {})).toBeNull();
+    });
+
+    it('should return null for search_rules (MCP tool, not an agent)', () => {
+      expect(parseAgentFromToolName('search_rules', {})).toBeNull();
+    });
+
+    it('should return null for update_context (MCP tool, not an agent)', () => {
+      expect(parseAgentFromToolName('update_context', {})).toBeNull();
+    });
+
+    it('should return null for analyze_task (MCP tool, not an agent)', () => {
+      expect(parseAgentFromToolName('analyze_task', {})).toBeNull();
+    });
+
+    it('should return null for get_project_config (MCP tool, not an agent)', () => {
+      expect(parseAgentFromToolName('get_project_config', {})).toBeNull();
+    });
+
+    it('should return null for dispatch_agents (MCP tool, not an agent)', () => {
+      expect(parseAgentFromToolName('dispatch_agents', {})).toBeNull();
+    });
+
+    it('should return null for generate_checklist (MCP tool, not an agent)', () => {
+      expect(parseAgentFromToolName('generate_checklist', {})).toBeNull();
+    });
+
+    it('should return null for recommend_skills (MCP tool, not an agent)', () => {
+      expect(parseAgentFromToolName('recommend_skills', {})).toBeNull();
+    });
+
+    it('should return null for cleanup_context (MCP tool, not an agent)', () => {
+      expect(parseAgentFromToolName('cleanup_context', {})).toBeNull();
     });
   });
 });

--- a/apps/mcp-server/src/tui/events/parse-agent.ts
+++ b/apps/mcp-server/src/tui/events/parse-agent.ts
@@ -7,25 +7,6 @@ const MODE_KEYWORD_TO_AGENT: Record<string, string> = {
   AUTO: 'auto-mode',
 };
 
-/** Maps general codingbuddy tools to agent roles for TUI visibility */
-const TOOL_AGENT_MAP: Record<string, string> = {
-  search_rules: 'query',
-  get_agent_details: 'query',
-  get_project_config: 'config',
-  set_project_root: 'config',
-  suggest_config_updates: 'config',
-  recommend_skills: 'skill',
-  get_skill: 'skill',
-  list_skills: 'skill',
-  analyze_task: 'analysis',
-  generate_checklist: 'checklist',
-  read_context: 'context',
-  update_context: 'context',
-  cleanup_context: 'context',
-  get_code_conventions: 'conventions',
-  dispatch_agents: 'orchestrator',
-};
-
 export function parseAgentFromToolName(
   toolName: string,
   args: Record<string, unknown> | undefined,
@@ -40,16 +21,6 @@ export function parseAgentFromToolName(
 
   if (toolName === 'prepare_parallel_agents') {
     return parseParallelAgents(args);
-  }
-
-  const role = TOOL_AGENT_MAP[toolName];
-  if (role) {
-    return {
-      agentId: toolName,
-      name: toolName,
-      role,
-      isPrimary: false,
-    };
   }
 
   return null;

--- a/apps/mcp-server/src/tui/events/tui-interceptor.spec.ts
+++ b/apps/mcp-server/src/tui/events/tui-interceptor.spec.ts
@@ -84,7 +84,7 @@ describe('TuiInterceptor', () => {
       );
     });
 
-    it('should emit events for mapped general tools like search_rules', async () => {
+    it('should NOT emit agent events for MCP tools like search_rules', async () => {
       const activatedHandler = vi.fn();
       const deactivatedHandler = vi.fn();
       eventBus.on(TUI_EVENTS.AGENT_ACTIVATED, activatedHandler);
@@ -96,18 +96,8 @@ describe('TuiInterceptor', () => {
 
       await new Promise(resolve => setImmediate(resolve));
 
-      expect(activatedHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          agentId: 'search_rules',
-          role: 'query',
-        }),
-      );
-      expect(deactivatedHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          agentId: 'search_rules',
-          reason: 'completed',
-        }),
-      );
+      expect(activatedHandler).not.toHaveBeenCalled();
+      expect(deactivatedHandler).not.toHaveBeenCalled();
     });
 
     it('should not emit agent events for unknown tools', async () => {


### PR DESCRIPTION
## Summary

Closes #549

Replaces the tool-invocation-based TUI display with a genuine agent visibility system. Previously, `TOOL_AGENT_MAP` caused MCP tools (e.g. `search_rules`, `parse_mode`) to be misidentified as dashboard agents, polluting the agent roster with false entries. This PR removes that mapping entirely and rebuilds the visualizer around real agent state.

- **Remove `TOOL_AGENT_MAP`** from `parse-agent.ts` — MCP tools are no longer mistaken for `DashboardNode` agents
- **Simplify `FocusedAgentPanel`** — drop `tools`, `inputs`, `outputs`, `toolCalls` props; panel now renders only agent-scoped data
- **Replace `ActivityVisualizer` internals** — remove `aggregateForBarChart` / `renderBarChart` / `renderLiveContext`; introduce `renderAgentRoster` (primary-first, status-priority sort) and `renderAgentEvents` (chronological tail of event log)
- **Update `ActivityVisualizer` props** — `toolCalls + currentMode` → `agents + eventLog`; propagate changes through `dashboard-app.tsx`
- **Delete deprecated pure functions** — `formatToolIO`, `formatActivitySparkline`, `formatChecklist`, `formatProgressBar` removed from `focused-agent.pure.ts`
- **Clean up `index.ts`** — remove stale re-exports; add `renderAgentRoster` / `renderAgentEvents`
- **Fix React Rules of Hooks violation** — two `useMemo` calls moved before the early `width ≤ 0 || height ≤ 0` return in `ActivityVisualizer.tsx`

## Test plan

- [ ] All existing tests pass (`yarn workspace codingbuddy test`) — 169 files, 3842 tests, 0 failures
- [ ] `renderAgentRoster` — 10 new unit tests covering primary-first ordering, status-priority sort, icon rendering
- [ ] `renderAgentEvents` — 11 new unit tests covering chronological display, tail slicing, empty state
- [ ] `ActivityVisualizer` component — 9 new tests covering updated props contract
- [ ] `FocusedAgentPanel` — verified no regressions after prop removal
- [ ] `parse-agent` / `tui-interceptor` — updated specs confirm MCP tools are no longer treated as agents