### PR TITLE
add isParallel flag and execution mode display to FlowMap agent nodes (#550)

### DIFF
--- a/apps/mcp-server/src/tui/components/flow-map.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/flow-map.pure.spec.ts
@@ -27,6 +27,7 @@ function makeAgent(
     status: 'idle',
     isPrimary: false,
     progress: 0,
+    isParallel: false,
     ...overrides,
   };
 }
@@ -443,6 +444,61 @@ describe('tui/components/flow-map.pure', () => {
 
       expect(result).toContain('PLAN');
       expect(result).toContain('● 0 active');
+    });
+  });
+
+  describe('drawAgentNode — execution mode display', () => {
+    it('renders ⫸ parallel for isParallel:true specialist node', () => {
+      const agents = new Map([
+        [
+          'sec-1',
+          makeAgent({
+            id: 'sec-1',
+            name: 'security',
+            stage: 'EVAL',
+            isParallel: true,
+          }),
+        ],
+      ]);
+      const result = bufferToString(renderFlowMap(agents, [], 120, 20));
+      expect(result).toContain('⫸ parallel');
+      expect(result).not.toContain('░');
+    });
+
+    it('renders → single for isParallel:false specialist node (non-primary)', () => {
+      const agents = new Map([
+        [
+          'rev-1',
+          makeAgent({
+            id: 'rev-1',
+            name: 'code-reviewer',
+            stage: 'EVAL',
+            isPrimary: false,
+            isParallel: false,
+          }),
+        ],
+      ]);
+      const result = bufferToString(renderFlowMap(agents, [], 120, 20));
+      expect(result).toContain('→ single');
+    });
+
+    it('renders progress bar for isPrimary:true node regardless of isParallel', () => {
+      const agents = new Map([
+        [
+          'arch-1',
+          makeAgent({
+            id: 'arch-1',
+            name: 'Architect',
+            stage: 'PLAN',
+            isPrimary: true,
+            progress: 50,
+          }),
+        ],
+      ]);
+      const result = bufferToString(renderFlowMap(agents, [], 120, 20));
+      expect(result).not.toContain('⫸ parallel');
+      expect(result).not.toContain('→ single');
+      expect(result).toMatch(/[█░]/);
     });
   });
 

--- a/apps/mcp-server/src/tui/components/flow-map.pure.ts
+++ b/apps/mcp-server/src/tui/components/flow-map.pure.ts
@@ -16,6 +16,11 @@ import type { Mode } from '../types';
 
 const NODE_WIDTH = 17;
 const NODE_HEIGHT = 4;
+
+const PARALLEL_STYLES = {
+  parallel: { fg: 'cyan' as const }, // 파랑 — 병렬 실행
+  single: { fg: 'gray' as const }, // 회색 — 단일 실행
+} as const;
 const STAGE_ORDER: Mode[] = ['PLAN', 'ACT', 'EVAL', 'AUTO'];
 const STAGE_SLOT_WIDTH = 8; // arrow + space + max label length
 const PIPELINE_RIGHT_MARGIN = 10;
@@ -148,14 +153,23 @@ function drawAgentNode(
   buf.writeText(x + 2, y + 1, nameStr, getNodeTextStyle(agent.status));
   buf.writeText(x + 2 + nameStr.length + 1, y + 1, icon, STATUS_STYLES[agent.status]);
 
-  // Progress bar (row 2)
-  const barWidth = boxW - 4;
-  const bar = buildProgressBar(agent.progress, barWidth);
-  const filledStr = PROGRESS_BAR_CHARS.filled.repeat(bar.filled);
-  const emptyStr = PROGRESS_BAR_CHARS.empty.repeat(bar.empty);
-  buf.writeText(x + 2, y + 2, filledStr, PROGRESS_BAR_STYLES.filled);
-  if (bar.empty > 0) {
-    buf.writeText(x + 2 + bar.filled, y + 2, emptyStr, PROGRESS_BAR_STYLES.empty);
+  // Row 2: progress bar (Primary) OR execution mode indicator (Specialist)
+  if (agent.isPrimary) {
+    // Primary: progress bar 유지
+    const barWidth = boxW - 4;
+    const bar = buildProgressBar(agent.progress, barWidth);
+    const filledStr = PROGRESS_BAR_CHARS.filled.repeat(bar.filled);
+    const emptyStr = PROGRESS_BAR_CHARS.empty.repeat(bar.empty);
+    buf.writeText(x + 2, y + 2, filledStr, PROGRESS_BAR_STYLES.filled);
+    if (bar.empty > 0) {
+      buf.writeText(x + 2 + bar.filled, y + 2, emptyStr, PROGRESS_BAR_STYLES.empty);
+    }
+  } else if (agent.isParallel) {
+    // Parallel Specialist: ⫸ parallel 표시
+    buf.writeText(x + 2, y + 2, '⫸ parallel', PARALLEL_STYLES.parallel);
+  } else {
+    // Single Specialist: → single 표시
+    buf.writeText(x + 2, y + 2, '→ single', PARALLEL_STYLES.single);
   }
 }
 

--- a/apps/mcp-server/src/tui/components/stage-health.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/stage-health.pure.spec.ts
@@ -11,6 +11,7 @@ function makeAgent(
     status: 'idle',
     isPrimary: false,
     progress: 0,
+    isParallel: false,
     ...overrides,
   };
 }

--- a/apps/mcp-server/src/tui/dashboard-types.spec.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.spec.ts
@@ -64,6 +64,7 @@ describe('tui/dashboard-types', () => {
         status: 'idle',
         isPrimary: false,
         progress: 0,
+        isParallel: false,
       });
     });
 
@@ -84,7 +85,27 @@ describe('tui/dashboard-types', () => {
         status: 'running',
         isPrimary: true,
         progress: 75,
+        isParallel: false,
       });
+    });
+
+    it('should default isParallel to false', () => {
+      const node: DashboardNode = createDefaultDashboardNode({
+        id: 'agent-1',
+        name: 'frontend-developer',
+        stage: 'ACT',
+      });
+      expect(node.isParallel).toBe(false);
+    });
+
+    it('should allow overriding isParallel to true', () => {
+      const node: DashboardNode = createDefaultDashboardNode({
+        id: 'agent-2',
+        name: 'security-specialist',
+        stage: 'EVAL',
+        isParallel: true,
+      });
+      expect(node.isParallel).toBe(true);
     });
 
     it('should allow partial overrides', () => {

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -42,6 +42,7 @@ export interface DashboardNode {
   status: DashboardNodeStatus;
   isPrimary: boolean;
   progress: number;
+  isParallel: boolean; // true when agent runs as part of parallel dispatch
 }
 
 type DashboardNodeRequired = Pick<DashboardNode, 'id' | 'name' | 'stage'>;
@@ -57,6 +58,7 @@ export function createDefaultDashboardNode(
     status: 'idle',
     isPrimary: false,
     progress: 0,
+    isParallel: false,
     ...params,
   };
 }

--- a/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.spec.ts
@@ -1079,6 +1079,91 @@ describe('extractEventsFromResponse', () => {
     });
   });
 
+  describe('prepare_parallel_agents → agent:relationship edges', () => {
+    it('emits AGENT_RELATIONSHIP edges from primary to each specialist', () => {
+      const events = extractEventsFromResponse(
+        'prepare_parallel_agents',
+        makeResponse({
+          agents: [{ agentName: 'security-specialist' }, { agentName: 'performance-specialist' }],
+          mode: 'EVAL',
+          primaryAgentId: 'primary:technical-planner',
+        }),
+      );
+      const relEvents = events.filter(e => e.event === TUI_EVENTS.AGENT_RELATIONSHIP);
+      expect(relEvents).toHaveLength(2);
+      expect(relEvents[0].payload).toMatchObject({
+        from: 'primary:technical-planner',
+        to: 'specialist:security-specialist',
+        label: 'parallel',
+        type: 'delegation',
+      });
+      expect(relEvents[1].payload).toMatchObject({
+        from: 'primary:technical-planner',
+        to: 'specialist:performance-specialist',
+        label: 'parallel',
+        type: 'delegation',
+      });
+    });
+
+    it('does not emit AGENT_RELATIONSHIP edges when primaryAgentId is missing', () => {
+      const events = extractEventsFromResponse(
+        'prepare_parallel_agents',
+        makeResponse({
+          agents: [{ agentName: 'security-specialist' }],
+          mode: 'EVAL',
+        }),
+      );
+      const relEvents = events.filter(e => e.event === TUI_EVENTS.AGENT_RELATIONSHIP);
+      expect(relEvents).toHaveLength(0);
+    });
+  });
+
+  describe('parse_mode → parallelAgentsRecommendation → agent:relationship edges', () => {
+    it('emits AGENT_RELATIONSHIP parallel edges when parallelAgentsRecommendation present', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'PLAN',
+          delegates_to: 'technical-planner',
+          parallelAgentsRecommendation: {
+            specialists: ['architecture-specialist', 'test-strategy-specialist'],
+          },
+        }),
+      );
+      const relEvents = events.filter(e => e.event === TUI_EVENTS.AGENT_RELATIONSHIP);
+      const parallelRels = relEvents.filter(e => e.payload.label === 'parallel');
+      expect(parallelRels).toHaveLength(2);
+      expect(parallelRels[0].payload).toMatchObject({
+        from: 'primary:technical-planner',
+        to: 'specialist:architecture-specialist',
+        label: 'parallel',
+        type: 'delegation',
+      });
+      expect(parallelRels[1].payload).toMatchObject({
+        from: 'primary:technical-planner',
+        to: 'specialist:test-strategy-specialist',
+        label: 'parallel',
+        type: 'delegation',
+      });
+    });
+
+    it('does not emit parallel AGENT_RELATIONSHIP when delegates_to is missing', () => {
+      const events = extractEventsFromResponse(
+        'parse_mode',
+        makeResponse({
+          mode: 'PLAN',
+          parallelAgentsRecommendation: {
+            specialists: ['architecture-specialist'],
+          },
+        }),
+      );
+      const parallelRels = events.filter(
+        e => e.event === TUI_EVENTS.AGENT_RELATIONSHIP && e.payload.label === 'parallel',
+      );
+      expect(parallelRels).toHaveLength(0);
+    });
+  });
+
   describe('other tools', () => {
     it('should return empty array for non-semantic tools', () => {
       expect(extractEventsFromResponse('search_rules', makeResponse({ results: [] }))).toEqual([]);

--- a/apps/mcp-server/src/tui/events/response-event-extractor.ts
+++ b/apps/mcp-server/src/tui/events/response-event-extractor.ts
@@ -153,16 +153,28 @@ function extractFromParseMode(json: Record<string, unknown>): ExtractedEvent[] {
     if (Array.isArray(par.specialists) && par.specialists.length > 0) {
       const specialists = par.specialists.filter((s): s is string => typeof s === 'string');
       if (specialists.length > 0) {
+        const parallelMode =
+          typeof json.mode === 'string' && VALID_MODES.has(json.mode)
+            ? (json.mode as Mode)
+            : 'PLAN';
         events.push({
           event: TUI_EVENTS.PARALLEL_STARTED,
-          payload: {
-            specialists,
-            mode:
-              typeof json.mode === 'string' && VALID_MODES.has(json.mode)
-                ? (json.mode as Mode)
-                : 'PLAN',
-          },
+          payload: { specialists, mode: parallelMode },
         });
+        // Primary → Specialist 관계 엣지
+        if (delegateName) {
+          for (const name of specialists) {
+            events.push({
+              event: TUI_EVENTS.AGENT_RELATIONSHIP,
+              payload: {
+                from: `primary:${delegateName}`,
+                to: `specialist:${name}`,
+                label: 'parallel',
+                type: 'delegation',
+              },
+            });
+          }
+        }
       }
     }
   }
@@ -197,12 +209,31 @@ function extractFromPrepareParallelAgents(json: Record<string, unknown>): Extrac
   const mode: Mode =
     typeof json.mode === 'string' && VALID_MODES.has(json.mode) ? (json.mode as Mode) : 'PLAN';
 
-  return [
+  const primaryAgentId = typeof json.primaryAgentId === 'string' ? json.primaryAgentId : null;
+
+  const events: ExtractedEvent[] = [
     {
       event: TUI_EVENTS.PARALLEL_STARTED,
       payload: { specialists, mode },
     },
   ];
+
+  // Primary → Specialist AGENT_RELATIONSHIP 엣지 emit
+  if (primaryAgentId) {
+    for (const name of specialists) {
+      events.push({
+        event: TUI_EVENTS.AGENT_RELATIONSHIP,
+        payload: {
+          from: primaryAgentId,
+          to: `specialist:${name}`,
+          label: 'parallel',
+          type: 'delegation',
+        },
+      });
+    }
+  }
+
+  return events;
 }
 
 /**

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -303,6 +303,32 @@ describe('dashboardReducer', () => {
     expect(state.agents.size).toBe(0);
   });
 
+  it('handles AGENT_ACTIVATED with isParallel defaulting to false', () => {
+    const action: DashboardAction = {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'a1', name: 'Architect', role: 'architect', isPrimary: true },
+    };
+    const state = dashboardReducer(initialDashboardState, action);
+    expect(state.agents.get('a1')!.isParallel).toBe(false);
+  });
+
+  it('handles PARALLEL_STARTED — sets isParallel:true on all specialist nodes', () => {
+    const action: DashboardAction = {
+      type: 'PARALLEL_STARTED',
+      payload: {
+        specialists: ['security-specialist', 'performance-specialist'],
+        mode: 'EVAL',
+      },
+    };
+    const state = dashboardReducer(initialDashboardState, action);
+    const security = state.agents.get('specialist:security-specialist')!;
+    const perf = state.agents.get('specialist:performance-specialist')!;
+    expect(security.isParallel).toBe(true);
+    expect(perf.isParallel).toBe(true);
+    expect(security.isPrimary).toBe(false);
+    expect(perf.isPrimary).toBe(false);
+  });
+
   it('handles PARALLEL_COMPLETED as no-op', () => {
     const state = dashboardReducer(initialDashboardState, {
       type: 'PARALLEL_COMPLETED',

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -88,6 +88,7 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
         status: 'running',
         isPrimary,
         progress: 0,
+        isParallel: false, // AGENT_ACTIVATED는 항상 단일 에이전트
       });
       const globalState = 'RUNNING' as const;
       const focusedAgentId = selectFocusedAgent(agents, state.focusedAgentId);
@@ -236,6 +237,7 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
           status: 'idle',
           isPrimary: false,
           progress: 0,
+          isParallel: true, // parallel dispatch로 등록된 에이전트
         });
       }
       return { ...state, agents };

--- a/apps/mcp-server/src/tui/hooks/use-focus-agent.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-focus-agent.spec.ts
@@ -9,6 +9,7 @@ function makeNode(overrides: Partial<DashboardNode> & { id: string }): Dashboard
     status: 'idle',
     isPrimary: false,
     progress: 0,
+    isParallel: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Closes #550

Adds visual differentiation between parallel and serial agent execution modes in the TUI FlowMap component, giving users clear insight into how agents are being orchestrated.

- **`isParallel` field on `DashboardNode`** — tracks whether an agent was spawned as part of a parallel execution batch
- **Reducer updates** — `PARALLEL_STARTED` sets `isParallel: true`; `AGENT_ACTIVATED` sets `isParallel: false`
- **`AGENT_RELATIONSHIP` edge emission** — `extractFromPrepareParallelAgents` and `extractFromParseMode` now emit relationship edges to render agent hierarchy in the flow map
- **FlowMap visual indicators** — primary agents keep the existing progress bar; parallel agents display `⫸ parallel`; non-primary serial agents display `→ single`

## Changes

| File | Change |
|------|--------|
| `dashboard-types.ts` | Add `isParallel: boolean` to `DashboardNode` |
| `use-dashboard-state.ts` | Set `isParallel` in `PARALLEL_STARTED` and `AGENT_ACTIVATED` reducers |
| `response-event-extractor.ts` | Emit `AGENT_RELATIONSHIP` edges from parallel agent extraction |
| `flow-map.pure.ts` | Add `PARALLEL_STYLES`, update `drawAgentNode` for execution mode display |
| `*.spec.ts` | Updated tests for all affected modules |

## Test Plan

- [x] All 169 test files / 3853 tests pass
- [x] `tsc --noEmit` — no TypeScript errors
- [x] `isParallel: true` agents render `⫸ parallel` in FlowMap row 2
- [x] Non-primary serial agents render `→ single` in FlowMap row 2
- [x] Primary agents continue to render progress bar unchanged
- [x] `AGENT_RELATIONSHIP` edges correctly connect parallel agents to their orchestrator