### PR TITLE
redesign Activity and Live panels in ActivityVisualizer (#551)

### DIFF
--- a/apps/mcp-server/src/tui/components/ActivityVisualizer.spec.tsx
+++ b/apps/mcp-server/src/tui/components/ActivityVisualizer.spec.tsx
@@ -3,15 +3,15 @@ import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { ActivityVisualizer } from './ActivityVisualizer';
 import { createDefaultDashboardNode } from '../dashboard-types';
-import type { DashboardNode, EventLogEntry } from '../dashboard-types';
+import type { DashboardNode, Edge } from '../dashboard-types';
 
 function makeAgents(): Map<string, DashboardNode> {
   const agents = new Map<string, DashboardNode>();
   agents.set(
-    'plan-mode',
+    'main-agent',
     createDefaultDashboardNode({
-      id: 'plan-mode',
-      name: 'plan-mode',
+      id: 'main-agent',
+      name: 'main-agent',
       stage: 'PLAN',
       status: 'running',
       isPrimary: true,
@@ -19,96 +19,100 @@ function makeAgents(): Map<string, DashboardNode> {
     }),
   );
   agents.set(
-    'security',
+    'solution-architect',
     createDefaultDashboardNode({
-      id: 'security',
-      name: 'security',
-      stage: 'EVAL',
-      status: 'idle',
+      id: 'solution-architect',
+      name: 'solution-architect',
+      stage: 'PLAN',
+      status: 'running',
       isPrimary: false,
-      progress: 0,
+      progress: 30,
     }),
   );
   return agents;
 }
 
-const sampleEvents: EventLogEntry[] = [
-  { timestamp: '10:00:01', message: 'agent: plan-mode activated', level: 'info' },
-  { timestamp: '10:00:05', message: 'agent: security started', level: 'info' },
+const focusedAgent = createDefaultDashboardNode({
+  id: 'main-agent',
+  name: 'main-agent',
+  stage: 'PLAN',
+  status: 'running',
+  isPrimary: true,
+  progress: 50,
+});
+
+const sampleEdges: Edge[] = [
+  { from: 'main-agent', to: 'solution-architect', label: 'delegates', type: 'delegation' },
 ];
+
+const defaultProps = {
+  currentMode: 'PLAN' as const,
+  focusedAgent,
+  agents: makeAgents(),
+  edges: sampleEdges,
+  activeSkills: ['brainstorming'],
+  objectives: ['Design Activity panels'],
+  width: 80,
+  height: 10,
+};
 
 describe('tui/components/ActivityVisualizer', () => {
   it('renders without crashing with data', () => {
-    const { lastFrame } = render(
-      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
-    );
+    const { lastFrame } = render(<ActivityVisualizer {...defaultProps} />);
     expect(lastFrame()).toBeDefined();
   });
 
   it('renders without crashing with empty data', () => {
     const { lastFrame } = render(
-      <ActivityVisualizer agents={new Map()} eventLog={[]} width={80} height={10} />,
+      <ActivityVisualizer
+        {...defaultProps}
+        agents={new Map()}
+        edges={[]}
+        activeSkills={[]}
+        objectives={[]}
+        focusedAgent={null}
+      />,
     );
     expect(lastFrame()).toBeDefined();
   });
 
   it('renders without crashing when width=0 or height=0', () => {
-    expect(() =>
-      render(<ActivityVisualizer agents={new Map()} eventLog={[]} width={0} height={10} />),
-    ).not.toThrow();
-    expect(() =>
-      render(<ActivityVisualizer agents={new Map()} eventLog={[]} width={80} height={0} />),
-    ).not.toThrow();
+    expect(() => render(<ActivityVisualizer {...defaultProps} width={0} />)).not.toThrow();
+    expect(() => render(<ActivityVisualizer {...defaultProps} height={0} />)).not.toThrow();
   });
 
-  it('contains Agents header in left panel', () => {
-    const { lastFrame } = render(
-      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
-    );
-    const frame = lastFrame() ?? '';
-    expect(frame).toContain('Agents');
+  it('contains Activity header in left panel', () => {
+    const { lastFrame } = render(<ActivityVisualizer {...defaultProps} />);
+    expect(lastFrame() ?? '').toContain('Activity');
   });
 
-  it('contains Events header in right panel', () => {
-    const { lastFrame } = render(
-      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
-    );
-    const frame = lastFrame() ?? '';
-    expect(frame).toContain('Events');
+  it('contains Live header in right panel', () => {
+    const { lastFrame } = render(<ActivityVisualizer {...defaultProps} />);
+    expect(lastFrame() ?? '').toContain('Live');
   });
 
-  it('shows agent names in roster', () => {
-    const { lastFrame } = render(
-      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
-    );
-    const frame = lastFrame() ?? '';
-    expect(frame).toContain('plan-mode');
+  it('shows agent name in tree', () => {
+    const { lastFrame } = render(<ActivityVisualizer {...defaultProps} />);
+    expect(lastFrame() ?? '').toContain('main-agent');
   });
 
-  it('shows event messages', () => {
-    const shortEvents: EventLogEntry[] = [
-      { timestamp: '10:00:01', message: 'plan-mode ok', level: 'info' },
-    ];
-    const { lastFrame } = render(
-      <ActivityVisualizer agents={makeAgents()} eventLog={shortEvents} width={80} height={10} />,
-    );
-    const frame = lastFrame() ?? '';
-    expect(frame).toContain('plan-mode ok');
+  it('shows current mode in status card', () => {
+    const { lastFrame } = render(<ActivityVisualizer {...defaultProps} />);
+    expect(lastFrame() ?? '').toContain('PLAN');
   });
 
-  it('does NOT contain old Activity bar chart header', () => {
-    const { lastFrame } = render(
-      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
-    );
-    const frame = lastFrame() ?? '';
-    expect(frame).not.toContain('📊 Activity');
+  it('shows focused agent name in status card', () => {
+    const { lastFrame } = render(<ActivityVisualizer {...defaultProps} />);
+    expect(lastFrame() ?? '').toContain('main-agent');
   });
 
-  it('does NOT contain old Live header', () => {
-    const { lastFrame } = render(
-      <ActivityVisualizer agents={makeAgents()} eventLog={sampleEvents} width={80} height={10} />,
-    );
-    const frame = lastFrame() ?? '';
-    expect(frame).not.toContain('💬 Live');
+  it('does NOT contain old Agents roster header', () => {
+    const { lastFrame } = render(<ActivityVisualizer {...defaultProps} />);
+    expect(lastFrame() ?? '').not.toContain('🤖 Agents');
+  });
+
+  it('does NOT contain old Events header', () => {
+    const { lastFrame } = render(<ActivityVisualizer {...defaultProps} />);
+    expect(lastFrame() ?? '').not.toContain('📋 Events');
   });
 });

--- a/apps/mcp-server/src/tui/components/ActivityVisualizer.tsx
+++ b/apps/mcp-server/src/tui/components/ActivityVisualizer.tsx
@@ -1,33 +1,50 @@
 import React, { useMemo } from 'react';
 import { Box, Text } from 'ink';
-import type { DashboardNode, EventLogEntry } from '../dashboard-types';
-import { renderAgentRoster, renderAgentEvents } from './activity-visualizer.pure';
+import type { DashboardNode, Edge } from '../dashboard-types';
+import type { Mode } from '../types';
+import { renderAgentTree, renderAgentStatusCard } from './activity-visualizer.pure';
 import { BORDER_COLORS } from '../utils/theme';
 
 export interface ActivityVisualizerProps {
+  currentMode: Mode | null;
+  focusedAgent: DashboardNode | null;
   agents: Map<string, DashboardNode>;
-  eventLog: EventLogEntry[];
+  edges: Edge[];
+  activeSkills: string[];
+  objectives: string[];
   width: number;
   height: number;
 }
 
 export function ActivityVisualizer({
+  currentMode,
+  focusedAgent,
   agents,
-  eventLog,
+  edges,
+  activeSkills,
+  objectives,
   width,
   height,
 }: ActivityVisualizerProps): React.ReactElement {
-  const rosterWidth = Math.floor(width * 0.6);
-  const eventsWidth = width - rosterWidth;
+  const treeWidth = Math.floor(width * 0.6);
+  const cardWidth = width - treeWidth;
   const contentHeight = Math.max(1, height - 2);
 
-  const rosterLines = useMemo(
-    () => renderAgentRoster(agents, Math.max(1, rosterWidth - 2), contentHeight),
-    [agents, rosterWidth, contentHeight],
+  const treeLines = useMemo(
+    () => renderAgentTree(agents, edges, activeSkills, Math.max(1, treeWidth - 2), contentHeight),
+    [agents, edges, activeSkills, treeWidth, contentHeight],
   );
-  const eventLines = useMemo(
-    () => renderAgentEvents(eventLog, Math.max(1, eventsWidth - 2), contentHeight),
-    [eventLog, eventsWidth, contentHeight],
+  const cardLines = useMemo(
+    () =>
+      renderAgentStatusCard(
+        focusedAgent,
+        currentMode,
+        objectives,
+        activeSkills,
+        Math.max(1, cardWidth - 2),
+        contentHeight,
+      ),
+    [focusedAgent, currentMode, objectives, activeSkills, cardWidth, contentHeight],
   );
 
   if (width <= 0 || height <= 0) {
@@ -40,10 +57,10 @@ export function ActivityVisualizer({
         borderStyle="single"
         borderColor={BORDER_COLORS.panel}
         flexDirection="column"
-        width={rosterWidth}
+        width={treeWidth}
         height={height}
       >
-        {rosterLines.map((line, i) => (
+        {treeLines.map((line, i) => (
           <Text key={i}>{line}</Text>
         ))}
       </Box>
@@ -51,10 +68,10 @@ export function ActivityVisualizer({
         borderStyle="single"
         borderColor={BORDER_COLORS.panel}
         flexDirection="column"
-        width={eventsWidth}
+        width={cardWidth}
         height={height}
       >
-        {eventLines.map((line, i) => (
+        {cardLines.map((line, i) => (
           <Text key={i}>{line}</Text>
         ))}
       </Box>

--- a/apps/mcp-server/src/tui/components/activity-visualizer.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/activity-visualizer.pure.spec.ts
@@ -1,173 +1,290 @@
 import { describe, it, expect } from 'vitest';
-import { renderAgentRoster, renderAgentEvents } from './activity-visualizer.pure';
-import type { DashboardNode, EventLogEntry } from '../dashboard-types';
+import { renderAgentTree, renderAgentStatusCard } from './activity-visualizer.pure';
+import type { DashboardNode, Edge } from '../dashboard-types';
 import { createDefaultDashboardNode } from '../dashboard-types';
 import { estimateDisplayWidth } from '../utils/display-width';
 
 function makeAgents(): Map<string, DashboardNode> {
   const agents = new Map<string, DashboardNode>();
   agents.set(
-    'plan-mode',
+    'main-agent',
     createDefaultDashboardNode({
-      id: 'plan-mode',
-      name: 'plan-mode',
+      id: 'main-agent',
+      name: 'main-agent',
       stage: 'PLAN',
       status: 'running',
       isPrimary: true,
-      progress: 75,
+      progress: 50,
     }),
   );
   agents.set(
-    'security',
+    'sub-agent-2',
     createDefaultDashboardNode({
-      id: 'security',
-      name: 'security',
+      id: 'sub-agent-2',
+      name: 'sub-agent-2',
       stage: 'EVAL',
-      status: 'idle',
+      status: 'done',
       isPrimary: false,
-      progress: 0,
+      progress: 100,
+    }),
+  );
+  agents.set(
+    'solution-architect',
+    createDefaultDashboardNode({
+      id: 'solution-architect',
+      name: 'solution-architect',
+      stage: 'PLAN',
+      status: 'running',
+      isPrimary: false,
+      progress: 30,
     }),
   );
   return agents;
 }
 
-describe('renderAgentRoster', () => {
+const sampleEdges: Edge[] = [
+  { from: 'main-agent', to: 'solution-architect', label: 'delegates', type: 'delegation' },
+  { from: 'main-agent', to: 'sub-agent-2', label: 'output', type: 'output' },
+];
+
+describe('renderAgentTree', () => {
   it('returns empty array for height <= 0', () => {
-    expect(renderAgentRoster(new Map(), 40, 0)).toEqual([]);
+    expect(renderAgentTree(new Map(), [], [], 40, 0)).toEqual([]);
   });
 
   it('returns empty array for width <= 0', () => {
-    expect(renderAgentRoster(new Map(), 0, 5)).toEqual([]);
-    expect(renderAgentRoster(new Map(), -1, 5)).toEqual([]);
+    expect(renderAgentTree(new Map(), [], [], 0, 5)).toEqual([]);
+    expect(renderAgentTree(new Map(), [], [], -1, 5)).toEqual([]);
   });
 
-  it('includes Agents header as first line', () => {
-    const lines = renderAgentRoster(makeAgents(), 80, 10);
-    expect(lines[0]).toContain('Agents');
+  it('includes Activity header as first line', () => {
+    const lines = renderAgentTree(makeAgents(), sampleEdges, [], 80, 10);
+    expect(lines[0]).toContain('Activity');
   });
 
-  it('shows agent names', () => {
-    const lines = renderAgentRoster(makeAgents(), 80, 10);
+  it('shows primary agent as root node', () => {
+    const lines = renderAgentTree(makeAgents(), sampleEdges, [], 80, 10);
     const content = lines.join('\n');
-    expect(content).toContain('plan-mode');
-    expect(content).toContain('security');
+    expect(content).toContain('main-agent');
   });
 
-  it('shows running status icon', () => {
-    const lines = renderAgentRoster(makeAgents(), 80, 10);
+  it('shows child agents with tree connectors', () => {
+    const lines = renderAgentTree(makeAgents(), sampleEdges, [], 80, 10);
     const content = lines.join('\n');
-    expect(content).toContain('●');
+    expect(content).toContain('solution-architect');
+    expect(content).toContain('sub-agent-2');
   });
 
-  it('shows agent progress', () => {
-    const lines = renderAgentRoster(makeAgents(), 80, 10);
+  it('uses running icon ● for running agents', () => {
+    const lines = renderAgentTree(makeAgents(), sampleEdges, [], 80, 10);
+    expect(lines.join('\n')).toContain('●');
+  });
+
+  it('uses done icon ○ for done agents', () => {
+    const lines = renderAgentTree(makeAgents(), sampleEdges, [], 80, 10);
+    expect(lines.join('\n')).toContain('○');
+  });
+
+  it('shows activeSkills as leaf nodes with (skill) label', () => {
+    const lines = renderAgentTree(makeAgents(), sampleEdges, ['brainstorming'], 80, 10);
     const content = lines.join('\n');
-    expect(content).toContain('75%');
+    expect(content).toContain('brainstorming');
+    expect(content).toContain('skill');
+  });
+
+  it('uses ◉ icon for skill nodes', () => {
+    const lines = renderAgentTree(makeAgents(), sampleEdges, ['brainstorming'], 80, 10);
+    expect(lines.join('\n')).toContain('◉');
   });
 
   it('shows No agents when map is empty', () => {
-    const lines = renderAgentRoster(new Map(), 80, 5);
+    const lines = renderAgentTree(new Map(), [], [], 80, 5);
     expect(lines.join('\n')).toContain('No agents');
   });
 
   it('respects height limit', () => {
-    const lines = renderAgentRoster(makeAgents(), 80, 2);
-    expect(lines.length).toBeLessThanOrEqual(2);
+    const lines = renderAgentTree(makeAgents(), sampleEdges, ['skill1', 'skill2'], 80, 3);
+    expect(lines.length).toBeLessThanOrEqual(3);
   });
 
   it('truncates lines to width', () => {
-    const lines = renderAgentRoster(makeAgents(), 20, 10);
+    const lines = renderAgentTree(makeAgents(), sampleEdges, [], 20, 10);
     for (const line of lines) {
       expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(20);
     }
   });
 
-  it('primary agents appear before non-primary', () => {
-    const lines = renderAgentRoster(makeAgents(), 80, 10);
-    const planIdx = lines.findIndex(l => l.includes('plan-mode'));
-    const secIdx = lines.findIndex(l => l.includes('security'));
-    expect(planIdx).toBeGreaterThan(-1);
-    expect(secIdx).toBeGreaterThan(-1);
-    expect(planIdx).toBeLessThan(secIdx);
+  it('returns only header when height is 1', () => {
+    const lines = renderAgentTree(makeAgents(), sampleEdges, [], 80, 1);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('Activity');
   });
 
-  it('returns only header when height is 1', () => {
-    const lines = renderAgentRoster(makeAgents(), 80, 1);
-    expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('Agents');
+  it('uses tree connector characters', () => {
+    const lines = renderAgentTree(makeAgents(), sampleEdges, [], 80, 10);
+    const content = lines.join('\n');
+    // ├ 또는 └ 트리 연결자가 있어야 함
+    expect(content.includes('├') || content.includes('└')).toBe(true);
+  });
+
+  it('does not show agents not connected to root via edges', () => {
+    const agentsWithDisconnected = new Map(makeAgents());
+    agentsWithDisconnected.set(
+      'disconnected-agent',
+      createDefaultDashboardNode({
+        id: 'disconnected-agent',
+        name: 'disconnected-agent',
+        stage: 'PLAN',
+        status: 'idle',
+        isPrimary: false,
+        progress: 0,
+      }),
+    );
+    const lines = renderAgentTree(agentsWithDisconnected, sampleEdges, [], 80, 15);
+    expect(lines.join('\n')).not.toContain('disconnected-agent');
+  });
+
+  it('uses ○ icon for idle agents (via ACTIVITY_STATUS_ICONS)', () => {
+    const idleAgents = new Map<string, DashboardNode>();
+    idleAgents.set(
+      'root',
+      createDefaultDashboardNode({
+        id: 'root',
+        name: 'root',
+        stage: 'PLAN',
+        status: 'running',
+        isPrimary: true,
+      }),
+    );
+    idleAgents.set(
+      'idle-child',
+      createDefaultDashboardNode({
+        id: 'idle-child',
+        name: 'idle-child',
+        stage: 'PLAN',
+        status: 'idle',
+      }),
+    );
+    const edges: Edge[] = [{ from: 'root', to: 'idle-child', label: '', type: 'delegation' }];
+    const lines = renderAgentTree(idleAgents, edges, [], 80, 10);
+    // idle 에이전트는 ○ 아이콘을 사용해야 함
+    const childLine = lines.find(l => l.includes('idle-child'));
+    expect(childLine).toContain('○');
   });
 });
 
-describe('renderAgentEvents', () => {
-  const eventLog: EventLogEntry[] = [
-    { timestamp: '10:00:01', message: 'agent: plan-mode activated', level: 'info' },
-    { timestamp: '10:00:05', message: 'agent: security started', level: 'info' },
-    { timestamp: '10:00:10', message: 'error: timeout', level: 'error' },
-  ];
+describe('renderAgentStatusCard', () => {
+  const focusedAgent = createDefaultDashboardNode({
+    id: 'solution-architect',
+    name: 'solution-architect',
+    stage: 'PLAN',
+    status: 'running',
+    isPrimary: false,
+    progress: 30,
+  });
 
   it('returns empty array for height <= 0', () => {
-    expect(renderAgentEvents(eventLog, 40, 0)).toEqual([]);
+    expect(renderAgentStatusCard(null, null, [], [], 40, 0)).toEqual([]);
   });
 
   it('returns empty array for width <= 0', () => {
-    expect(renderAgentEvents(eventLog, 0, 5)).toEqual([]);
-    expect(renderAgentEvents(eventLog, -1, 5)).toEqual([]);
+    expect(renderAgentStatusCard(null, null, [], [], 0, 5)).toEqual([]);
+    expect(renderAgentStatusCard(null, null, [], [], -1, 5)).toEqual([]);
   });
 
-  it('includes Events header as first line', () => {
-    const lines = renderAgentEvents(eventLog, 80, 10);
-    expect(lines[0]).toContain('Events');
+  it('includes Live header as first line', () => {
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', [], [], 80, 10);
+    expect(lines[0]).toContain('Live');
   });
 
-  it('shows event messages', () => {
-    const lines = renderAgentEvents(eventLog, 80, 10);
+  it('shows current mode', () => {
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', [], [], 80, 10);
+    expect(lines.join('\n')).toContain('PLAN');
+  });
+
+  it('shows focused agent name', () => {
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', [], [], 80, 10);
+    expect(lines.join('\n')).toContain('solution-architect');
+  });
+
+  it('shows agent running status', () => {
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', [], [], 80, 10);
+    expect(lines.join('\n')).toContain('running');
+  });
+
+  it('shows separator line with ─ character', () => {
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', [], [], 80, 10);
+    expect(lines.join('\n')).toContain('─');
+  });
+
+  it('shows first objective', () => {
+    const objectives = ['Design Activity/Live panels for TUI HUD', 'Another objective'];
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', objectives, [], 80, 10);
+    expect(lines.join('\n')).toContain('Design Activity');
+  });
+
+  it('does NOT show second objective', () => {
+    const objectives = ['First objective', 'Second objective'];
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', objectives, [], 80, 15);
+    expect(lines.join('\n')).not.toContain('Second objective');
+  });
+
+  it('shows active skills with ⚙ prefix', () => {
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', [], ['brainstorming'], 80, 10);
     const content = lines.join('\n');
-    expect(content).toContain('plan-mode activated');
+    expect(content).toContain('⚙');
+    expect(content).toContain('brainstorming');
   });
 
-  it('shows No events when log is empty', () => {
-    const lines = renderAgentEvents([], 80, 5);
-    expect(lines.join('\n')).toContain('No events');
+  it('shows No agent when focusedAgent is null', () => {
+    const lines = renderAgentStatusCard(null, 'PLAN', [], [], 80, 5);
+    expect(lines.join('\n')).toContain('No agent');
   });
 
   it('respects height limit', () => {
-    const lines = renderAgentEvents(eventLog, 80, 2);
-    expect(lines.length).toBeLessThanOrEqual(2);
+    const objectives = ['Long objective text here'];
+    const skills = ['skill1', 'skill2', 'skill3'];
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', objectives, skills, 80, 4);
+    expect(lines.length).toBeLessThanOrEqual(4);
   });
 
   it('truncates lines to width', () => {
-    const lines = renderAgentEvents(eventLog, 20, 10);
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', ['objective'], ['skill'], 20, 10);
     for (const line of lines) {
       expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(20);
     }
   });
 
-  it('shows events in chronological order (oldest first)', () => {
-    const lines = renderAgentEvents(eventLog, 80, 10);
-    const firstIdx = lines.findIndex(l => l.includes('plan-mode activated'));
-    const lastIdx = lines.findIndex(l => l.includes('timeout'));
-    expect(firstIdx).toBeGreaterThan(-1);
-    expect(lastIdx).toBeGreaterThan(-1);
-    expect(firstIdx).toBeLessThan(lastIdx);
+  it('handles null currentMode gracefully', () => {
+    const lines = renderAgentStatusCard(focusedAgent, null, [], [], 80, 5);
+    expect(lines).toBeDefined();
+    expect(lines.length).toBeGreaterThan(0);
+  });
+
+  it('word-wraps long objectives to width', () => {
+    const longObj = 'A'.repeat(30) + ' ' + 'B'.repeat(30);
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', [longObj], [], 40, 10);
+    for (const line of lines) {
+      expect(estimateDisplayWidth(line)).toBeLessThanOrEqual(40);
+    }
   });
 
   it('returns only header when height is 1', () => {
-    const lines = renderAgentEvents(eventLog, 80, 1);
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', [], [], 80, 1);
     expect(lines).toHaveLength(1);
-    expect(lines[0]).toContain('Events');
+    expect(lines[0]).toContain('Live');
   });
 
-  it('shows most recent events when log exceeds height', () => {
-    const manyEvents: EventLogEntry[] = Array.from({ length: 20 }, (_, i) => ({
-      timestamp: `10:00:${String(i).padStart(2, '0')}`,
-      message: `event-${i}`,
-      level: 'info' as const,
-    }));
-    const lines = renderAgentEvents(manyEvents, 80, 5);
-    const content = lines.join('\n');
-    // 최근 이벤트(event-16 ~ event-19)가 보여야 함
-    expect(content).toContain('event-19');
-    // 오래된 이벤트(event-0)는 보이지 않아야 함
-    expect(content).not.toContain('event-0');
+  it('does not show double separator when objectives are empty', () => {
+    const lines = renderAgentStatusCard(focusedAgent, 'PLAN', [], ['brainstorming'], 80, 15);
+    let prevWasSeparator = false;
+    for (const line of lines) {
+      const isSeparator = line.length > 0 && [...line].every(c => c === '─');
+      if (isSeparator && prevWasSeparator) {
+        // 연속 separator 금지
+        expect(isSeparator && prevWasSeparator).toBe(false);
+      }
+      prevWasSeparator = isSeparator;
+    }
   });
 });

--- a/apps/mcp-server/src/tui/components/activity-visualizer.pure.ts
+++ b/apps/mcp-server/src/tui/components/activity-visualizer.pure.ts
@@ -1,26 +1,36 @@
-import type { DashboardNode, EventLogEntry } from '../dashboard-types';
-import { STATUS_ICONS } from '../utils/theme';
-import { truncateToDisplayWidth } from '../utils/display-width';
+import type { DashboardNode, DashboardNodeStatus, Edge } from '../dashboard-types';
+import type { Mode } from '../types';
+import { estimateDisplayWidth, truncateToDisplayWidth } from '../utils/display-width';
 
-const AGENT_NAME_WIDTH = 18;
-const AGENT_STAGE_WIDTH = 5;
+/**
+ * Activity panel status icons per the TUI spec:
+ * ● running · ○ done/idle · ⏸ blocked · ! error
+ *
+ * Intentionally differs from STATUS_ICONS (where done → '✓') to match
+ * the issue #551 design: done and idle both render as '○'.
+ */
+const ACTIVITY_STATUS_ICONS: Readonly<Record<DashboardNodeStatus, string>> = Object.freeze({
+  running: '●',
+  idle: '○',
+  blocked: '⏸',
+  error: '!',
+  done: '○',
+});
 
-const STATUS_PRIORITY: Record<string, number> = {
-  running: 0,
-  blocked: 1,
-  idle: 2,
-  error: 3,
-  done: 4,
-};
+type AgentChild = { type: 'agent'; node: DashboardNode };
+type SkillChild = { type: 'skill'; name: string };
+type TreeChild = AgentChild | SkillChild;
 
-export function renderAgentRoster(
+export function renderAgentTree(
   agents: Map<string, DashboardNode>,
+  edges: Edge[],
+  activeSkills: string[],
   width: number,
   height: number,
 ): string[] {
   if (height <= 0 || width <= 0) return [];
 
-  const lines: string[] = [truncateToDisplayWidth('🤖 Agents', width)];
+  const lines: string[] = [truncateToDisplayWidth('📊 Activity', width)];
   if (height <= 1) return lines;
 
   if (agents.size === 0) {
@@ -28,44 +38,117 @@ export function renderAgentRoster(
     return lines.slice(0, height);
   }
 
-  const sorted = [...agents.values()].sort((a, b) => {
-    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
-    return (STATUS_PRIORITY[a.status] ?? 5) - (STATUS_PRIORITY[b.status] ?? 5);
-  });
+  // Build adjacency map (parent → children)
+  const childrenOf = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!childrenOf.has(edge.from)) childrenOf.set(edge.from, []);
+    childrenOf.get(edge.from)!.push(edge.to);
+  }
 
-  for (const agent of sorted) {
+  // Find root: primary agent or first in map
+  const root = [...agents.values()].find(a => a.isPrimary) ?? [...agents.values()][0];
+
+  // Render root node
+  const rootIcon = ACTIVITY_STATUS_ICONS[root.status] ?? '?';
+  lines.push(truncateToDisplayWidth(`${rootIcon} ${root.name}`, width));
+
+  // Collect children: edge-based agents + activeSkills as leaf nodes
+  const childIds = childrenOf.get(root.id) ?? [];
+  const agentChildren: TreeChild[] = childIds
+    .filter(id => agents.has(id))
+    .map(id => ({ type: 'agent', node: agents.get(id)! }));
+  const skillChildren: TreeChild[] = activeSkills.map(s => ({ type: 'skill', name: s }));
+  const allChildren: TreeChild[] = [...agentChildren, ...skillChildren];
+
+  for (let i = 0; i < allChildren.length; i++) {
     if (lines.length >= height) break;
-    const icon = STATUS_ICONS[agent.status] ?? '?';
-    const name = truncateToDisplayWidth(agent.name, AGENT_NAME_WIDTH).padEnd(AGENT_NAME_WIDTH);
-    const stage = agent.stage.padEnd(AGENT_STAGE_WIDTH);
-    const pct = `${agent.progress}%`.padStart(4);
-    lines.push(truncateToDisplayWidth(`${icon} ${name} ${stage} ${pct}`, width));
+    const isLast = i === allChildren.length - 1;
+    const connector = isLast ? '└' : '├';
+    const item = allChildren[i];
+
+    if (item.type === 'agent') {
+      const icon = ACTIVITY_STATUS_ICONS[item.node.status] ?? '?';
+      lines.push(truncateToDisplayWidth(`  ${connector} ${icon} ${item.node.name}`, width));
+    } else {
+      lines.push(truncateToDisplayWidth(`  ${connector} ◉ ${item.name} (skill)`, width));
+    }
   }
 
   return lines.slice(0, height);
 }
 
-export function renderAgentEvents(
-  eventLog: EventLogEntry[],
+/**
+ * Word-wraps text to fit within the given display width.
+ * Uses estimateDisplayWidth to correctly handle unicode/emoji characters.
+ */
+function wordWrap(text: string, width: number): string[] {
+  if (width <= 0) return [];
+  const words = text.split(' ');
+  const result: string[] = [];
+  let current = '';
+  let currentWidth = 0;
+  for (const word of words) {
+    const wordWidth = estimateDisplayWidth(word);
+    if (current.length === 0) {
+      current = wordWidth <= width ? word : truncateToDisplayWidth(word, width);
+      currentWidth = estimateDisplayWidth(current);
+    } else if (currentWidth + 1 + wordWidth <= width) {
+      current += ' ' + word;
+      currentWidth += 1 + wordWidth;
+    } else {
+      result.push(current);
+      current = wordWidth <= width ? word : truncateToDisplayWidth(word, width);
+      currentWidth = estimateDisplayWidth(current);
+    }
+  }
+  if (current.length > 0) result.push(current);
+  return result;
+}
+
+export function renderAgentStatusCard(
+  focusedAgent: DashboardNode | null,
+  currentMode: Mode | null,
+  objectives: string[],
+  activeSkills: string[],
   width: number,
   height: number,
 ): string[] {
   if (height <= 0 || width <= 0) return [];
 
-  const lines: string[] = [truncateToDisplayWidth('📋 Events', width)];
+  const lines: string[] = [truncateToDisplayWidth('💬 Live', width)];
   if (height <= 1) return lines;
 
-  if (eventLog.length === 0) {
-    lines.push(truncateToDisplayWidth('  No events', width));
+  lines.push(truncateToDisplayWidth(`⟫ Mode: ${currentMode ?? '—'}`, width));
+
+  if (!focusedAgent) {
+    lines.push(truncateToDisplayWidth('  No agent', width));
     return lines.slice(0, height);
   }
 
-  const maxItems = height - 1;
-  const tail = eventLog.slice(-maxItems);
+  lines.push(truncateToDisplayWidth(`🤖 ${focusedAgent.name}`, width));
+  const statusIcon = ACTIVITY_STATUS_ICONS[focusedAgent.status] ?? '?';
+  lines.push(truncateToDisplayWidth(`   ${statusIcon} ${focusedAgent.status}`, width));
 
-  for (const entry of tail) {
+  const separator = truncateToDisplayWidth('─'.repeat(width), width);
+  if (lines.length < height) lines.push(separator);
+
+  // Show first objective only; track whether any content was added
+  let objectivesAdded = false;
+  if (objectives.length > 0 && lines.length < height) {
+    const wrapped = wordWrap(objectives[0], width);
+    for (const wline of wrapped) {
+      if (lines.length >= height) break;
+      lines.push(wline);
+      objectivesAdded = true;
+    }
+  }
+
+  // Only add second separator if objectives were actually shown
+  if (objectivesAdded && lines.length < height) lines.push(separator);
+
+  for (const skill of activeSkills) {
     if (lines.length >= height) break;
-    lines.push(truncateToDisplayWidth(`${entry.timestamp} ${entry.message}`, width));
+    lines.push(truncateToDisplayWidth(`⚙ ${skill}`, width));
   }
 
   return lines.slice(0, height);

--- a/apps/mcp-server/src/tui/components/index.ts
+++ b/apps/mcp-server/src/tui/components/index.ts
@@ -15,6 +15,6 @@ export { StageHealthBar, type StageHealthBarProps } from './StageHealthBar';
 export { computeStageHealth, detectBottlenecks } from './stage-health.pure';
 export { computeGridLayout } from './grid-layout.pure';
 export { ActivityVisualizer, type ActivityVisualizerProps } from './ActivityVisualizer';
-export { renderAgentRoster, renderAgentEvents } from './activity-visualizer.pure';
+export { renderAgentTree, renderAgentStatusCard } from './activity-visualizer.pure';
 export { SessionTabBar } from './SessionTabBar';
 export type { SessionTabBarProps } from './SessionTabBar';

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -93,8 +93,12 @@ export function DashboardApp({
               height={grid.flowMap.height}
             />
             <ActivityVisualizer
+              currentMode={state.currentMode}
+              focusedAgent={focusedAgent}
               agents={state.agents}
-              eventLog={state.eventLog}
+              edges={state.edges}
+              activeSkills={state.activeSkills}
+              objectives={state.objectives}
               width={grid.monitorPanel.width}
               height={grid.monitorPanel.height}
             />


### PR DESCRIPTION
## Summary

Closes #551

Redesigns the two sub-panels inside `ActivityVisualizer` to show meaningful agent-centric information instead of raw tool-call frequency data.

| Panel | Before | After |
|-------|--------|-------|
| **Activity** (left, 60%) | Bar chart of tool call frequency | Agent/skill tree rooted at the primary agent |
| **Live** (right, 40%) | Mode + recent unique tool calls | Status card: mode, focused agent, objective, active skills |

---

## Changes

### `activity-visualizer.pure.ts`
- **Removed**: `aggregateForBarChart`, `renderBarChart`, `renderLiveContext`, `BarChartItem`, `BAR_FIXED_OVERHEAD`, `TOOL_NAME_WIDTH`
- **Added**: `renderAgentTree(agents, edges, activeSkills, width, height)` — builds parent-child tree from `edges`, renders status icons (`●` running · `◉` active skill · `○` done/idle)
- **Added**: `renderAgentStatusCard(focusedAgent, currentMode, objectives, activeSkills, width, height)` — shows mode line, agent name+status, separator, word-wrapped objective, active skills
- **Added**: `ACTIVITY_STATUS_ICONS` frozen constant for icon mapping
- **Added**: Module-level `AgentChild`, `SkillChild`, `TreeChild` union type
- **Fixed**: Word-wrap uses `estimateDisplayWidth` for Unicode/emoji safety

### `ActivityVisualizer.tsx`
- **Removed** `toolCalls` prop
- **Added** props: `currentMode`, `focusedAgent`, `agents`, `edges`, `activeSkills`, `objectives`
- Delegates rendering to `renderAgentTree` and `renderAgentStatusCard`

### `dashboard-app.tsx`
- Passes new props (`agents`, `edges`, `activeSkills`, `objectives`, `focusedAgent`, `currentMode`) to `ActivityVisualizer`
- Removes `toolCalls` prop

### `index.ts`
- Updates public exports to match renamed/added types

### Tests
- `activity-visualizer.pure.spec.ts`: full coverage for `renderAgentTree` (tree structure, icon mapping, truncation, empty state, disconnected agents, idle icons, double-separator guard) and `renderAgentStatusCard` (mode line, agent name, objective word-wrap, skill list, empty state)
- `ActivityVisualizer.spec.tsx`: updated to use new prop interface

---

## Acceptance Criteria

- [x] `Activity` panel displays agent/skill tree rooted at primary agent
- [x] `Activity` panel correctly distinguishes running / done / skill nodes with icons
- [x] `Live` panel displays focused agent name and status
- [x] `Live` panel displays first objective, word-wrapped to panel width
- [x] `Live` panel lists active skills in remaining space
- [x] `toolCalls` prop removed from `ActivityVisualizer`
- [x] All existing tests updated; no new type errors (`tsc --noEmit`)
- [x] Spec coverage maintained for both pure functions