### PR TITLE
track and display Agent, Skill, and Tool invocation counts in footer

### DIFF
--- a/apps/mcp-server/src/tui/components/StageHealthBar.spec.tsx
+++ b/apps/mcp-server/src/tui/components/StageHealthBar.spec.tsx
@@ -16,7 +16,14 @@ function makeHealth() {
 describe('tui/components/StageHealthBar', () => {
   it('should render stage names with colors', () => {
     const { lastFrame } = render(
-      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} toolCount={128000} width={120} />,
+      <StageHealthBar
+        stageHealth={makeHealth()}
+        bottlenecks={[]}
+        toolCount={128000}
+        agentCount={0}
+        skillCount={0}
+        width={120}
+      />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('PLAN:');
@@ -26,7 +33,14 @@ describe('tui/components/StageHealthBar', () => {
 
   it('should render running/done/error stats', () => {
     const { lastFrame } = render(
-      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} toolCount={0} width={120} />,
+      <StageHealthBar
+        stageHealth={makeHealth()}
+        bottlenecks={[]}
+        toolCount={0}
+        agentCount={0}
+        skillCount={0}
+        width={120}
+      />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('running');
@@ -35,7 +49,14 @@ describe('tui/components/StageHealthBar', () => {
 
   it('should render tool count', () => {
     const { lastFrame } = render(
-      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} toolCount={64000} width={120} />,
+      <StageHealthBar
+        stageHealth={makeHealth()}
+        bottlenecks={[]}
+        toolCount={64000}
+        agentCount={0}
+        skillCount={0}
+        width={120}
+      />,
     );
     expect(lastFrame()).toContain('64k');
   });
@@ -46,6 +67,8 @@ describe('tui/components/StageHealthBar', () => {
         stageHealth={makeHealth()}
         bottlenecks={['tests failing(3)', 'lint errors']}
         toolCount={0}
+        agentCount={0}
+        skillCount={0}
         width={120}
       />,
     );
@@ -60,6 +83,8 @@ describe('tui/components/StageHealthBar', () => {
         stageHealth={makeHealth()}
         bottlenecks={['long bottleneck description']}
         toolCount={50000}
+        agentCount={0}
+        skillCount={0}
         width={60}
       />,
     );
@@ -74,7 +99,14 @@ describe('tui/components/StageHealthBar', () => {
       AUTO: createEmptyStageStats(),
     };
     const { lastFrame } = render(
-      <StageHealthBar stageHealth={empty} bottlenecks={[]} toolCount={0} width={120} />,
+      <StageHealthBar
+        stageHealth={empty}
+        bottlenecks={[]}
+        toolCount={0}
+        agentCount={0}
+        skillCount={0}
+        width={120}
+      />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('PLAN:');
@@ -83,10 +115,51 @@ describe('tui/components/StageHealthBar', () => {
 
   it('should render double border', () => {
     const { lastFrame } = render(
-      <StageHealthBar stageHealth={makeHealth()} bottlenecks={[]} toolCount={0} width={120} />,
+      <StageHealthBar
+        stageHealth={makeHealth()}
+        bottlenecks={[]}
+        toolCount={0}
+        agentCount={0}
+        skillCount={0}
+        width={120}
+      />,
     );
     const frame = lastFrame() ?? '';
     expect(frame).toContain('╔');
     expect(frame).toContain('╝');
+  });
+
+  it('shows agent, skill, and tool counts on right side', () => {
+    const { lastFrame } = render(
+      <StageHealthBar
+        stageHealth={makeHealth()}
+        bottlenecks={[]}
+        toolCount={5}
+        agentCount={3}
+        skillCount={2}
+        width={120}
+      />,
+    );
+    const out = lastFrame() ?? '';
+    expect(out).toContain('🤖 3');
+    expect(out).toContain('⚙ 2');
+    expect(out).toContain('🔧 5');
+  });
+
+  it('formats counts >= 1000 as Nk', () => {
+    const { lastFrame } = render(
+      <StageHealthBar
+        stageHealth={makeHealth()}
+        bottlenecks={[]}
+        toolCount={1500}
+        agentCount={2000}
+        skillCount={0}
+        width={120}
+      />,
+    );
+    const out = lastFrame() ?? '';
+    expect(out).toContain('🤖 2k');
+    expect(out).toContain('🔧 2k');
+    expect(out).toContain('⚙ 0');
   });
 });

--- a/apps/mcp-server/src/tui/components/StageHealthBar.tsx
+++ b/apps/mcp-server/src/tui/components/StageHealthBar.tsx
@@ -3,11 +3,14 @@ import { Box, Text } from 'ink';
 import type { StageStats } from '../dashboard-types';
 import type { Mode } from '../types';
 import { getModeColor, BORDER_COLORS } from '../utils/theme';
+import { formatCount } from './stage-health.pure';
 
 export interface StageHealthBarProps {
   stageHealth: Record<Mode, StageStats>;
   bottlenecks: string[];
   toolCount: number;
+  agentCount: number;
+  skillCount: number;
   width: number;
 }
 
@@ -80,10 +83,10 @@ export function StageHealthBar({
   stageHealth,
   bottlenecks,
   toolCount,
+  agentCount,
+  skillCount,
   width,
 }: StageHealthBarProps): React.ReactElement {
-  const countStr = toolCount >= 1000 ? `${Math.round(toolCount / 1000)}k` : String(toolCount);
-
   return (
     <Box
       borderStyle="double"
@@ -104,7 +107,9 @@ export function StageHealthBar({
               ⚡ Bottlenecks: {bottlenecks.join(' / ')}
             </Text>
           )}
-          <Text dimColor>tools: {countStr}</Text>
+          <Text dimColor>🤖 {formatCount(agentCount)}</Text>
+          <Text dimColor>⚙ {formatCount(skillCount)}</Text>
+          <Text dimColor>🔧 {formatCount(toolCount)}</Text>
         </Box>
       </Box>
     </Box>

--- a/apps/mcp-server/src/tui/components/stage-health.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/stage-health.pure.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeStageHealth, detectBottlenecks } from './stage-health.pure';
+import { computeStageHealth, detectBottlenecks, formatCount } from './stage-health.pure';
 import type { DashboardNode, EventLogEntry } from '../dashboard-types';
 import { createEmptyStageStats } from '../dashboard-types';
 import type { Mode } from '../types';
@@ -54,6 +54,28 @@ describe('tui/components/stage-health.pure', () => {
 
       const result = computeStageHealth(agents);
       expect(result.PLAN.waiting).toBe(2);
+    });
+  });
+
+  describe('formatCount', () => {
+    it('returns string as-is for values below 1000', () => {
+      expect(formatCount(0)).toBe('0');
+      expect(formatCount(1)).toBe('1');
+      expect(formatCount(999)).toBe('999');
+    });
+
+    it('returns Nk for values >= 1000', () => {
+      expect(formatCount(1000)).toBe('1k');
+      expect(formatCount(1001)).toBe('1k');
+      expect(formatCount(1499)).toBe('1k');
+      expect(formatCount(1500)).toBe('2k'); // Math.round 반올림
+      expect(formatCount(2000)).toBe('2k');
+    });
+
+    it('rounds to nearest k', () => {
+      expect(formatCount(9499)).toBe('9k');
+      expect(formatCount(9500)).toBe('10k');
+      expect(formatCount(10000)).toBe('10k');
     });
   });
 

--- a/apps/mcp-server/src/tui/components/stage-health.pure.ts
+++ b/apps/mcp-server/src/tui/components/stage-health.pure.ts
@@ -3,6 +3,13 @@ import type { DashboardNode, StageStats, EventLogEntry } from '../dashboard-type
 import { createEmptyStageStats } from '../dashboard-types';
 
 /**
+ * Format a count for compact display: values >= 1000 are shown as Nk.
+ */
+export function formatCount(n: number): string {
+  return n >= 1000 ? `${Math.round(n / 1000)}k` : String(n);
+}
+
+/**
  * Count agents per stage and status.
  */
 export function computeStageHealth(agents: Map<string, DashboardNode>): Record<Mode, StageStats> {

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -128,6 +128,8 @@ export function DashboardApp({
         stageHealth={stageHealth}
         bottlenecks={bottlenecks}
         toolCount={state.toolInvokeCount}
+        agentCount={state.agentActivateCount}
+        skillCount={state.skillInvokeCount}
         width={grid.stageHealth.width}
       />
     </Box>

--- a/apps/mcp-server/src/tui/dashboard-types.spec.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.spec.ts
@@ -188,6 +188,8 @@ describe('tui/dashboard-types', () => {
         activeSkills: [],
         toolCalls: [],
         toolInvokeCount: 0,
+        agentActivateCount: 0,
+        skillInvokeCount: 0,
         outputStats: { files: 0, commits: 0 },
         contextDecisions: [],
         contextNotes: [],
@@ -196,6 +198,33 @@ describe('tui/dashboard-types', () => {
       };
       expect(state.toolInvokeCount).toBe(0);
       expect(state.outputStats).toEqual({ files: 0, commits: 0 });
+    });
+
+    it('DashboardState includes agentActivateCount and skillInvokeCount fields', () => {
+      const state: DashboardState = {
+        workspace: '/tmp',
+        sessionId: 'test',
+        currentMode: null,
+        globalState: 'IDLE',
+        agents: new Map(),
+        edges: [],
+        focusedAgentId: null,
+        tasks: [],
+        eventLog: [],
+        objectives: [],
+        activeSkills: [],
+        toolCalls: [],
+        toolInvokeCount: 0,
+        agentActivateCount: 0,
+        skillInvokeCount: 0,
+        outputStats: { files: 0, commits: 0 },
+        contextDecisions: [],
+        contextNotes: [],
+        contextMode: null,
+        contextStatus: null,
+      };
+      expect(state.agentActivateCount).toBe(0);
+      expect(state.skillInvokeCount).toBe(0);
     });
 
     it('DashboardGrid has all required sections', () => {

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -158,6 +158,8 @@ export interface DashboardState {
   objectives: string[];
   activeSkills: string[];
   toolInvokeCount: number;
+  agentActivateCount: number;
+  skillInvokeCount: number;
   outputStats: { files: number; commits: number };
   contextDecisions: string[];
   contextNotes: string[];

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.spec.ts
@@ -14,6 +14,73 @@ describe('dashboardReducer', () => {
     expect(state.outputStats).toEqual({ files: 0, commits: 0 });
   });
 
+  it('initializes agentActivateCount and skillInvokeCount to 0', () => {
+    const state = createInitialDashboardState();
+    expect(state.agentActivateCount).toBe(0);
+    expect(state.skillInvokeCount).toBe(0);
+  });
+
+  it('increments agentActivateCount on same agentId re-activation (cumulative counter)', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'a1', name: 'architect', role: 'primary', isPrimary: true },
+    });
+    // 동일 agentId 재활성화 — 누적 카운터이므로 +1 증가
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'a1', name: 'architect', role: 'primary', isPrimary: true },
+    });
+    expect(state.agentActivateCount).toBe(2);
+  });
+
+  it('increments agentActivateCount on AGENT_ACTIVATED', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'a1', name: 'architect', role: 'primary', isPrimary: true },
+    });
+    expect(state.agentActivateCount).toBe(1);
+
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'a2', name: 'security', role: 'specialist', isPrimary: false },
+    });
+    expect(state.agentActivateCount).toBe(2);
+  });
+
+  it('increments skillInvokeCount on SKILL_RECOMMENDED (first time only)', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'SKILL_RECOMMENDED',
+      payload: { skillName: 'tdd', reason: 'writing tests' },
+    });
+    expect(state.skillInvokeCount).toBe(1);
+
+    // 중복 — 증가하지 않아야 함
+    state = dashboardReducer(state, {
+      type: 'SKILL_RECOMMENDED',
+      payload: { skillName: 'tdd', reason: 'still writing tests' },
+    });
+    expect(state.skillInvokeCount).toBe(1);
+  });
+
+  it('resets agentActivateCount and skillInvokeCount on SESSION_RESET', () => {
+    let state = createInitialDashboardState();
+    state = dashboardReducer(state, {
+      type: 'AGENT_ACTIVATED',
+      payload: { agentId: 'a1', name: 'architect', role: 'primary', isPrimary: true },
+    });
+    state = dashboardReducer(state, {
+      type: 'SKILL_RECOMMENDED',
+      payload: { skillName: 'tdd', reason: 'test' },
+    });
+    state = dashboardReducer(state, { type: 'SESSION_RESET', payload: {} as any });
+    expect(state.agentActivateCount).toBe(0);
+    expect(state.skillInvokeCount).toBe(0);
+    expect(state.toolInvokeCount).toBe(0);
+  });
+
   it('handles AGENT_ACTIVATED by adding node', () => {
     const action: DashboardAction = {
       type: 'AGENT_ACTIVATED',

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -49,6 +49,8 @@ export function createInitialDashboardState(): DashboardState {
     objectives: [],
     activeSkills: [],
     toolInvokeCount: 0,
+    agentActivateCount: 0,
+    skillInvokeCount: 0,
     outputStats: { files: 0, commits: 0 },
     contextDecisions: [],
     contextNotes: [],
@@ -92,7 +94,13 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
       });
       const globalState = 'RUNNING' as const;
       const focusedAgentId = selectFocusedAgent(agents, state.focusedAgentId);
-      return { ...state, agents, globalState, focusedAgentId };
+      return {
+        ...state,
+        agents,
+        globalState,
+        focusedAgentId,
+        agentActivateCount: state.agentActivateCount + 1,
+      };
     }
 
     case 'AGENT_DEACTIVATED': {
@@ -221,7 +229,11 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
     case 'SKILL_RECOMMENDED': {
       const { skillName } = action.payload;
       if (state.activeSkills.includes(skillName)) return state;
-      return { ...state, activeSkills: [...state.activeSkills, skillName] };
+      return {
+        ...state,
+        activeSkills: [...state.activeSkills, skillName],
+        skillInvokeCount: state.skillInvokeCount + 1,
+      };
     }
 
     case 'PARALLEL_STARTED': {


### PR DESCRIPTION
## Summary

Closes #556

Adds **Agent activation count** and **Skill invocation count** to the TUI footer (`StageHealthBar`), alongside the existing tool count, giving a complete at-a-glance activity overview.

**Footer right side (before → after):**
```
Before:  tools: 12
After:   🤖 3  ⚙ 2  🔧 12
```

## Changes

### State (`dashboard-types.ts`)
- Added `agentActivateCount: number` to `DashboardState`
- Added `skillInvokeCount: number` to `DashboardState`

### Reducer (`use-dashboard-state.ts`)
- `createInitialDashboardState`: initializes both counters to `0`
- `AGENT_ACTIVATED` case: increments `agentActivateCount` by 1 on every activation
- `SKILL_RECOMMENDED` case: increments `skillInvokeCount` only for first-time skills (deduped)

### Pure logic (`stage-health.pure.ts`)
- Extracted `formatCount(n)` helper: returns `Nk` for values ≥ 1000, otherwise string representation
- Exported for use in `StageHealthBar`

### Component (`StageHealthBar.tsx`)
- Added `agentCount: number` and `skillCount: number` to `StageHealthBarProps`
- Replaced `tools: N` display with `🤖 N  ⚙ N  🔧 N` using `formatCount`

### Wiring (`dashboard-app.tsx`)
- Passed `agentCount={state.agentActivateCount}` and `skillCount={state.skillInvokeCount}` to `StageHealthBar`

## Tests

| File | Tests added |
|------|-------------|
| `dashboard-types.spec.ts` | Type compatibility for new fields |
| `use-dashboard-state.spec.ts` | Counter increment on `AGENT_ACTIVATED`, `SKILL_RECOMMENDED` dedup, same-agentId accumulation |
| `stage-health.pure.spec.ts` | `formatCount` boundary values (0, 999, 1000, 1499, 1500, 9499, 9500) |
| `StageHealthBar.spec.tsx` | Renders `🤖/⚙/🔧` counts; formats ≥ 1000 as `Nk` |

**Total: 169 test files, 3877 tests — all passing**  
**TypeScript strict build: success**

## Test Plan

- [ ] TUI footer shows `🤖 N  ⚙ N  🔧 N` on the right side
- [ ] Counts ≥ 1000 display as `Nk` (e.g. `🔧 2k`)
- [ ] `agentActivateCount` increments on every agent activation
- [ ] `skillInvokeCount` increments only on first-time skill registration
- [ ] All 3877 tests pass: `yarn workspace codingbuddy test -- --run`
- [ ] TypeScript build succeeds: `yarn workspace codingbuddy build`