### PR TITLE
auto-inherit recommendedActAgent from context in ACT mode (#561)

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
@@ -378,6 +378,17 @@ describe('ModeHandler', () => {
         const response = JSON.parse(responseText as string);
         expect(response.contextWarning).toContain('Failed to create context document');
       });
+
+      it('should not read context before parseMode when mode is PLAN', async () => {
+        const result = await handler.handle('parse_mode', {
+          prompt: 'PLAN design feature',
+        });
+
+        expect(result?.isError).toBeFalsy();
+        const readContextCalls = (mockContextDocService.readContext as ReturnType<typeof vi.fn>)
+          .mock.calls;
+        expect(readContextCalls.length).toBe(0);
+      });
     });
 
     describe('AUTO mode', () => {
@@ -433,6 +444,132 @@ describe('ModeHandler', () => {
 
         expect(result?.isError).toBeFalsy();
         expect(mockContextDocService.appendContext).toHaveBeenCalled();
+      });
+
+      it('should auto-inherit recommendedActAgent from context when not explicitly provided', async () => {
+        mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+          ...mockParseModeResult,
+          mode: 'ACT',
+          originalPrompt: 'implement feature',
+        });
+        mockContextDocService.readContext = vi.fn().mockResolvedValue({
+          exists: true,
+          document: {
+            metadata: {
+              title: 'test-task',
+              createdAt: '2024-01-01T00:00:00.000Z',
+              lastUpdatedAt: '2024-01-01T00:00:00.000Z',
+              currentMode: 'PLAN',
+              status: 'active',
+            },
+            sections: [{ mode: 'PLAN', recommendedActAgent: 'backend-developer' }],
+          },
+        });
+
+        await handler.handle('parse_mode', {
+          prompt: 'ACT implement feature',
+          // recommended_agent NOT provided
+        });
+
+        expect(mockKeywordService.parseMode).toHaveBeenCalledWith('ACT implement feature', {
+          recommendedActAgent: 'backend-developer',
+          verbosity: 'standard',
+        });
+      });
+
+      it('should prefer explicit recommended_agent param over context value', async () => {
+        mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+          ...mockParseModeResult,
+          mode: 'ACT',
+          originalPrompt: 'implement feature',
+        });
+        mockContextDocService.readContext = vi.fn().mockResolvedValue({
+          exists: true,
+          document: {
+            metadata: {
+              title: 'test-task',
+              createdAt: '2024-01-01T00:00:00.000Z',
+              lastUpdatedAt: '2024-01-01T00:00:00.000Z',
+              currentMode: 'PLAN',
+              status: 'active',
+            },
+            sections: [{ mode: 'PLAN', recommendedActAgent: 'backend-developer' }],
+          },
+        });
+
+        await handler.handle('parse_mode', {
+          prompt: 'ACT implement feature',
+          recommended_agent: 'frontend-developer',
+        });
+
+        expect(mockKeywordService.parseMode).toHaveBeenCalledWith('ACT implement feature', {
+          recommendedActAgent: 'frontend-developer',
+          verbosity: 'standard',
+        });
+        // readContext must NOT be called before parseMode when explicit param is provided (performance)
+        expect(mockContextDocService.readContext).not.toHaveBeenCalledBefore(
+          mockKeywordService.parseMode as ReturnType<typeof vi.fn>,
+        );
+      });
+
+      it('should auto-inherit recommendedActAgent when using Korean ACT keyword (실행)', async () => {
+        mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+          ...mockParseModeResult,
+          mode: 'ACT',
+          originalPrompt: '피처 구현',
+        });
+        mockContextDocService.readContext = vi.fn().mockResolvedValue({
+          exists: true,
+          document: {
+            metadata: {
+              title: 'test-task',
+              createdAt: '2024-01-01T00:00:00.000Z',
+              lastUpdatedAt: '2024-01-01T00:00:00.000Z',
+              currentMode: 'PLAN',
+              status: 'active',
+            },
+            sections: [{ mode: 'PLAN', recommendedActAgent: 'backend-developer' }],
+          },
+        });
+
+        await handler.handle('parse_mode', {
+          prompt: '실행 피처 구현',
+        });
+
+        expect(mockKeywordService.parseMode).toHaveBeenCalledWith('실행 피처 구현', {
+          recommendedActAgent: 'backend-developer',
+          verbosity: 'standard',
+        });
+      });
+
+      it('should auto-inherit recommendedActAgent when using Spanish ACT keyword (ACTUAR)', async () => {
+        mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+          ...mockParseModeResult,
+          mode: 'ACT',
+          originalPrompt: 'implementar feature',
+        });
+        mockContextDocService.readContext = vi.fn().mockResolvedValue({
+          exists: true,
+          document: {
+            metadata: {
+              title: 'test-task',
+              createdAt: '2024-01-01T00:00:00.000Z',
+              lastUpdatedAt: '2024-01-01T00:00:00.000Z',
+              currentMode: 'PLAN',
+              status: 'active',
+            },
+            sections: [{ mode: 'PLAN', recommendedActAgent: 'backend-developer' }],
+          },
+        });
+
+        await handler.handle('parse_mode', {
+          prompt: 'ACTUAR implementar feature',
+        });
+
+        expect(mockKeywordService.parseMode).toHaveBeenCalledWith('ACTUAR implementar feature', {
+          recommendedActAgent: 'backend-developer',
+          verbosity: 'standard',
+        });
       });
     });
 

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.ts
@@ -14,6 +14,7 @@ import { StateService } from '../../state/state.service';
 import { ContextDocumentService } from '../../context/context-document.service';
 import { DiagnosticLogService } from '../../diagnostic/diagnostic-log.service';
 import { CONTEXT_FILE_PATH, type ContextDocument } from '../../context/context-document.types';
+import { LOCALIZED_KEYWORD_MAP } from '../../keyword/keyword.types';
 import type {
   Mode,
   DispatchReady,
@@ -118,8 +119,24 @@ export class ModeHandler extends AbstractHandler {
       // This prevents stale config from MCP server startup location issues
       await this.configService.reload();
 
+      // ACT mode: pre-read context to inherit recommendedActAgent if not explicitly provided
+      let resolvedRecommendedAgent = recommendedAgent;
+      const firstWord = prompt.trim().split(/\s+/)[0] ?? '';
+      const isActKeyword =
+        firstWord.toUpperCase() === 'ACT' ||
+        LOCALIZED_KEYWORD_MAP[firstWord] === 'ACT' ||
+        LOCALIZED_KEYWORD_MAP[firstWord.toUpperCase()] === 'ACT';
+      if (isActKeyword && !resolvedRecommendedAgent) {
+        const ctxResult = await this.contextDocService.readContext();
+        const sections = ctxResult.document?.sections ?? [];
+        const lastPlan = [...sections].reverse().find(s => s.mode === 'PLAN' || s.mode === 'AUTO');
+        if (lastPlan?.recommendedActAgent) {
+          resolvedRecommendedAgent = lastPlan.recommendedActAgent;
+        }
+      }
+
       const options = {
-        ...(recommendedAgent && { recommendedActAgent: recommendedAgent }),
+        ...(resolvedRecommendedAgent && { recommendedActAgent: resolvedRecommendedAgent }),
         verbosity,
       };
       const result = await this.keywordService.parseMode(prompt, options);


### PR DESCRIPTION
## Summary

Fixes #561

When the user types `ACT`, `mode.handler.ts` was calling `keywordService.parseMode()` before reading the context document. This meant the `recommendedActAgent` stored by the previous PLAN session was never passed to the agent resolver — it arrived too late.

**Before (broken flow):**
```
1. parseMode(prompt, options)   ← agent resolved here (no context)
2. handleContextDocument()      ← context read here (too late)
```

**After (correct flow):**
```
1. readContext()                ← extract recommendedActAgent
2. parseMode(prompt, options)   ← pass recommendedActAgent from context
3. handleContextDocument()
```

## Changes

### `mode.handler.ts`
- Import `LOCALIZED_KEYWORD_MAP` to detect ACT keywords in all supported languages (EN/KO/JA/ZH/ES)
- Pre-read context document before `parseMode()` when mode is ACT and no explicit `recommended_agent` param is provided
- Extract `recommendedActAgent` from the last `PLAN` or `AUTO` section
- Skip context read entirely when mode is not ACT (performance guard)

### `mode.handler.spec.ts`
- Add test: ACT mode auto-inherits `recommendedActAgent` from context when param not provided
- Add test: Explicit `recommended_agent` param takes precedence over context value
- Add test: `readContext` not called before `parseMode` when explicit param is provided (performance)
- Add test: Korean ACT keyword (`실행`) triggers context inheritance
- Add test: Spanish ACT keyword (`ACTUAR`) triggers context inheritance
- Relocate "should not read context" test to PLAN mode describe block

## Acceptance Criteria

- [x] ACT mode automatically uses `recommendedActAgent` from context document without explicit param
- [x] Explicit `recommended_agent` parameter still takes precedence over context value
- [x] No context read performed when mode is not ACT (performance)
- [x] Unit test: ACT after PLAN auto-inherits recommendation
- [x] Unit test: Explicit param overrides context recommendation
- [x] Localized ACT keywords (KO/ES) also trigger context inheritance

## Test Results

```
✓ 3887 tests passed (2 skipped)
✓ tsc --noEmit — no type errors
```