### PR TITLE
add ai-ml-engineer to ACT_PRIMARY_AGENTS (#562)

### DIFF
--- a/apps/mcp-server/src/keyword/keyword.service.spec.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.spec.ts
@@ -991,6 +991,7 @@ describe('KeywordService', () => {
       expect(result.available_act_agents).toContain('backend-developer');
       expect(result.available_act_agents).toContain('devops-engineer');
       expect(result.available_act_agents).toContain('agent-architect');
+      expect(result.available_act_agents).toContain('ai-ml-engineer');
     });
 
     it('does not return recommended_act_agent in ACT mode', async () => {

--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -13,6 +13,7 @@ export const ACT_PRIMARY_AGENTS = [
   'tooling-engineer', // Config/build tools specialist - highest priority for pattern matching
   'platform-engineer', // IaC, Kubernetes, multi-cloud specialist - high priority for infra tasks
   'data-engineer', // Database/schema specialist - high priority for data tasks
+  'ai-ml-engineer', // ML frameworks, LLM integration, embeddings, fine-tuning
   'mobile-developer', // Mobile app specialist - detected by project files
   'frontend-developer',
   'backend-developer',
@@ -76,6 +77,10 @@ export const ACT_AGENT_DISPLAY_INFO: Record<ActPrimaryAgent, AgentDisplayInfo> =
   'data-engineer': {
     name: 'Data Engineer',
     description: 'Database, schema design, migrations, analytics',
+  },
+  'ai-ml-engineer': {
+    name: 'AI/ML Engineer',
+    description: 'ML frameworks, LLM integration, embeddings, fine-tuning',
   },
   'mobile-developer': {
     name: 'Mobile Developer',

--- a/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
+++ b/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
@@ -304,6 +304,8 @@ describe('ActAgentStrategy', () => {
         'Create embeddings for vector search', // matches /embedding/i
         '딥러닝 모델 학습시켜줘', // matches /딥\s*러닝|deep\s*learning/i
         'Fine-tune the LLM model', // matches /fine.?tun/i
+        'LLM 파인튜닝해줘', // matches /파인.?튜닝|fine.?tun/i (Korean)
+        '임베딩 모델 구현', // matches /임베딩|embedding/i (Korean)
       ];
 
       it.each(aiMlPrompts)('should detect ai-ml-engineer intent: "%s"', async prompt => {


### PR DESCRIPTION
## Summary

Fixes a silent bug where AI/ML intent patterns were never matched because `ai-ml-engineer` was missing from `ACT_PRIMARY_AGENTS`.

- `inferFromIntentPatterns()` checks `availableAgents.includes(targetAgent)` before pattern matching — since `ai-ml-engineer` was absent from the list, all AI/ML patterns were silently skipped
- AI/ML prompts (e.g. "LLM 파인튜닝해줘", "임베딩 모델 구현") fell through to the `frontend-developer` default

## Changes

- **`keyword.types.ts`**: Add `'ai-ml-engineer'` to `ACT_PRIMARY_AGENTS` array and `ACT_AGENT_DISPLAY_INFO` record
- **`act-agent.strategy.spec.ts`**: Add Korean test cases — `'LLM 파인튜닝해줘'` and `'임베딩 모델 구현'`
- **`keyword.service.spec.ts`**: Add `ai-ml-engineer` assertion to `available_act_agents` test

## Test Plan

- [x] `ai-ml-engineer` added to `ACT_PRIMARY_AGENTS`
- [x] `ai-ml-engineer` added to `ACT_AGENT_DISPLAY_INFO`
- [x] Korean prompt `LLM 파인튜닝해줘` resolves to `ai-ml-engineer`
- [x] Korean prompt `임베딩 모델 구현` resolves to `ai-ml-engineer`
- [x] No regression — all 3887 existing tests pass

## Related

Closes #562
Part of #560