### PR TITLE
add test-engineer as ACT primary agent

### DIFF
--- a/apps/mcp-server/src/keyword/keyword.service.spec.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.spec.ts
@@ -992,6 +992,7 @@ describe('KeywordService', () => {
       expect(result.available_act_agents).toContain('devops-engineer');
       expect(result.available_act_agents).toContain('agent-architect');
       expect(result.available_act_agents).toContain('ai-ml-engineer');
+      expect(result.available_act_agents).toContain('test-engineer');
     });
 
     it('does not return recommended_act_agent in ACT mode', async () => {

--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -19,6 +19,7 @@ export const ACT_PRIMARY_AGENTS = [
   'backend-developer',
   'devops-engineer',
   'agent-architect',
+  'test-engineer', // TDD, unit/integration/e2e test specialist
 ] as const;
 
 /** Primary Agent for EVAL mode - centralized definition */
@@ -101,6 +102,10 @@ export const ACT_AGENT_DISPLAY_INFO: Record<ActPrimaryAgent, AgentDisplayInfo> =
   'agent-architect': {
     name: 'Agent Architect',
     description: 'AI agent systems, MCP servers, LLM integration',
+  },
+  'test-engineer': {
+    name: 'Test Engineer',
+    description: 'TDD, unit/integration/e2e testing, coverage improvement',
   },
 };
 

--- a/apps/mcp-server/src/keyword/patterns/index.ts
+++ b/apps/mcp-server/src/keyword/patterns/index.ts
@@ -20,6 +20,7 @@ export { EXPLICIT_PATTERNS } from './explicit.patterns';
 // Intent patterns by domain
 export { AGENT_INTENT_PATTERNS } from './agent.patterns';
 export { AI_ML_INTENT_PATTERNS } from './ai-ml.patterns';
+export { TEST_INTENT_PATTERNS } from './test.patterns';
 export { BACKEND_INTENT_PATTERNS } from './backend.patterns';
 export { DATA_INTENT_PATTERNS } from './data.patterns';
 export { MOBILE_INTENT_PATTERNS } from './mobile.patterns';

--- a/apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts
+++ b/apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts
@@ -6,18 +6,20 @@
  *
  * Pattern check order (reordered to prevent false positives):
  * 1. agent-architect - MCP, AI agents, workflows (MOVED UP - prevents false positives from agent name mentions)
- * 2. tooling-engineer - Build tools, linters, bundlers
- * 3. platform-engineer - IaC, Kubernetes, cloud infrastructure
- * 4. data-engineer - Database, schema, migrations
- * 5. ai-ml-engineer - ML frameworks, LLM, embeddings
- * 6. backend-developer - APIs, servers, authentication
- * 7. frontend-developer - React, Vue, Angular, UI components, CSS
- * 8. devops-engineer - CI/CD, Docker, deployment, monitoring
- * 9. mobile-developer - React Native, Flutter, iOS/Android (MOVED DOWN - "mobile develop" patterns are greedy)
+ * 2. test-engineer - TDD, unit/integration/e2e tests, coverage (before backend/frontend to prevent keyword theft)
+ * 3. tooling-engineer - Build tools, linters, bundlers
+ * 4. platform-engineer - IaC, Kubernetes, cloud infrastructure
+ * 5. data-engineer - Database, schema, migrations
+ * 6. ai-ml-engineer - ML frameworks, LLM, embeddings
+ * 7. backend-developer - APIs, servers, authentication
+ * 8. frontend-developer - React, Vue, Angular, UI components, CSS
+ * 9. devops-engineer - CI/CD, Docker, deployment, monitoring
+ * 10. mobile-developer - React Native, Flutter, iOS/Android (MOVED DOWN - "mobile develop" patterns are greedy)
  */
 
 import type { IntentPatternCheck } from './intent-patterns.types';
 import { AGENT_INTENT_PATTERNS } from './agent.patterns';
+import { TEST_INTENT_PATTERNS } from './test.patterns';
 import { TOOLING_INTENT_PATTERNS } from './tooling.patterns';
 import { PLATFORM_INTENT_PATTERNS } from './platform.patterns';
 import { DATA_INTENT_PATTERNS } from './data.patterns';
@@ -33,6 +35,12 @@ export const INTENT_PATTERN_CHECKS: ReadonlyArray<IntentPatternCheck> = [
     agent: 'agent-architect',
     patterns: AGENT_INTENT_PATTERNS,
     category: 'Agent',
+  },
+  // Test patterns second (before backend/frontend to prevent test keywords being stolen)
+  {
+    agent: 'test-engineer',
+    patterns: TEST_INTENT_PATTERNS,
+    category: 'Test',
   },
   {
     agent: 'tooling-engineer',

--- a/apps/mcp-server/src/keyword/patterns/test.patterns.ts
+++ b/apps/mcp-server/src/keyword/patterns/test.patterns.ts
@@ -1,0 +1,94 @@
+/**
+ * Test Engineer Intent Patterns
+ *
+ * These patterns detect prompts related to TDD, unit/integration/e2e testing,
+ * coverage improvement, and test framework usage.
+ * Priority: 2nd (after agent-architect, before tooling-engineer).
+ *
+ * Confidence Levels:
+ * - 0.95: Explicit TDD keyword, test framework names (Jest, Vitest, Playwright, Cypress)
+ * - 0.90: Generic test writing/adding requests (EN + KO), spec file patterns
+ *
+ * @example
+ * "테스트 코드 작성해줘" → test-engineer (0.90)
+ * "Jest unit test 추가" → test-engineer (0.95)
+ * "TDD로 구현해줘" → test-engineer (0.95)
+ * "e2e 테스트 작성" → test-engineer (0.90)
+ */
+
+import type { IntentPattern } from './intent-patterns.types';
+
+export const TEST_INTENT_PATTERNS: ReadonlyArray<IntentPattern> = [
+  // TDD explicit (0.95)
+  {
+    pattern: /TDD\s*(로|로\s*구현|cycle|approach)/i,
+    confidence: 0.95,
+    description: 'TDD approach',
+  },
+  {
+    pattern: /red.?green.?refactor/i,
+    confidence: 0.95,
+    description: 'TDD Red-Green-Refactor cycle',
+  },
+  // Test framework names (0.95)
+  {
+    pattern: /\b(jest|vitest|mocha|jasmine)\s*(unit|test|spec|설정|config)/i,
+    confidence: 0.95,
+    description: 'Jest/Vitest/Mocha/Jasmine test',
+  },
+  {
+    pattern: /\b(playwright|cypress|puppeteer)\s*(test|e2e|설정)/i,
+    confidence: 0.95,
+    description: 'E2E test framework',
+  },
+  // Test writing requests in Korean (0.90)
+  {
+    pattern: /테스트\s*(코드|케이스)\s*(작성|추가|구현)/i,
+    confidence: 0.9,
+    description: 'Korean: Write test code/cases',
+  },
+  {
+    pattern: /단위\s*테스트\s*(작성|추가|구현)/i,
+    confidence: 0.9,
+    description: 'Korean: Write unit test',
+  },
+  {
+    pattern: /통합\s*테스트\s*(작성|추가|구현)/i,
+    confidence: 0.9,
+    description: 'Korean: Write integration test',
+  },
+  {
+    pattern: /e2e\s*(테스트|test)\s*(작성|추가|구현)/i,
+    confidence: 0.9,
+    description: 'E2E test writing (KO+EN)',
+  },
+  // Generic test terms (0.90)
+  {
+    pattern: /단위\s*테스트|unit\s*test/i,
+    confidence: 0.9,
+    description: 'Unit test',
+  },
+  {
+    pattern: /통합\s*테스트|integration\s*test/i,
+    confidence: 0.9,
+    description: 'Integration test',
+  },
+  {
+    pattern: /end.?to.?end\s*(test|테스트)/i,
+    confidence: 0.9,
+    description: 'End-to-end test',
+  },
+  // Coverage (0.90)
+  {
+    pattern: /커버리지\s*(개선|향상|추가|올려|높여)|test\s*coverage/i,
+    confidence: 0.9,
+    description: 'Test coverage improvement',
+  },
+  // Spec/test file creation (verb required to avoid false positives, 0.90)
+  {
+    pattern:
+      /(?:작성|추가|구현|write|add|create).{0,15}\.(?:spec|test)\.\w+|\.(?:spec|test)\.\w+.{0,30}(?:작성|추가|구현|write|add|create)/i,
+    confidence: 0.9,
+    description: 'Create/write spec or test file',
+  },
+];

--- a/apps/mcp-server/src/keyword/strategies/__tests__/strategy-test.utils.ts
+++ b/apps/mcp-server/src/keyword/strategies/__tests__/strategy-test.utils.ts
@@ -21,6 +21,7 @@ export const ACT_MODE_AGENTS = [
   'data-engineer',
   'mobile-developer',
   'ai-ml-engineer',
+  'test-engineer',
 ] as const;
 
 /**

--- a/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
+++ b/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
@@ -216,6 +216,33 @@ describe('ActAgentStrategy', () => {
       });
     });
 
+    describe('test-engineer patterns', () => {
+      // Patterns that match test.patterns.ts:
+      // - /TDD\s*(로|로\s*구현|cycle|approach)/i (0.95)
+      // - /\b(jest|vitest|mocha|jasmine)\s*(unit|test|spec|설정|config)/i (0.95)
+      // - /테스트\s*(코드|케이스|작성|추가|구현)/i (0.90)
+      // - /단위\s*테스트|unit\s*test/i (0.90)
+      const testPrompts = [
+        '테스트 코드 작성해줘', // matches /테스트\s*(코드|케이스|작성|추가|구현)/i
+        'Jest unit test 추가', // matches /\b(jest|vitest...)/ + unit test
+        'TDD로 구현해줘', // matches /TDD\s*(로|로\s*구현|cycle|approach)/i
+        '단위 테스트 추가해줘', // matches /단위\s*테스트|unit\s*test/i
+        'Write Vitest unit tests', // matches /\b(jest|vitest...)/i
+        'e2e 테스트 작성', // matches /e2e\s*(테스트|test)/i
+      ];
+
+      it.each(testPrompts)('should detect test-engineer intent: "%s"', async prompt => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt,
+          }),
+        );
+
+        expect(result.agentName).toBe('test-engineer');
+        expect(result.source).toBe('intent');
+      });
+    });
+
     describe('backend-developer patterns', () => {
       // Patterns that match backend.patterns.ts:
       // - /REST\s*API|RESTful/i

--- a/packages/rules/.ai-rules/agents/README.md
+++ b/packages/rules/.ai-rules/agents/README.md
@@ -53,6 +53,7 @@ AI Agent definitions for specialized development roles.
 | **Config/Build Tools** | Tooling Engineer | `tooling-engineer.json` |
 | **Agent Management** | Agent Architect | `agent-architect.json` |
 | **AI/ML Development** | AI/ML Engineer | `ai-ml-engineer.json` |
+| **TDD/Test Engineering** | Test Engineer | `test-engineer.json` |
 
 ### Agent Summary
 
@@ -66,6 +67,7 @@ AI Agent definitions for specialized development roles.
 | Mobile Developer | Cross-platform (React Native, Flutter) and native (iOS, Android) development |
 | Code Reviewer | Auto-activated in EVAL mode, multi-dimensional code quality assessment |
 | Architecture Specialist | Layer boundaries, dependency direction, Clean Architecture |
+| Test Engineer | TDD cycle execution, unit/integration/e2e testing, coverage improvement |
 | Test Strategy Specialist | TDD strategy, test coverage, test quality |
 | Performance Specialist | Core Web Vitals, bundle optimization, rendering performance |
 | Security Specialist | OWASP, authentication/authorization, XSS/CSRF defense |
@@ -187,6 +189,7 @@ as agent-architect, design new agent
 | DevOps Engineer | `primary` | Dockerfile, docker-compose context |
 | Platform Engineer | `primary` | Terraform, Kubernetes, cloud infrastructure |
 | AI/ML Engineer | `primary` | LLM integration, RAG, prompt engineering, AI safety |
+| Test Engineer | `primary` | TDD, unit/integration/e2e testing, coverage improvement |
 
 ### EVAL Mode
 
@@ -224,7 +227,8 @@ Primary Agents (Implementation Experts) - role.type: "primary"
 ├── agent-architect        # AI agent framework expertise
 ├── devops-engineer        # Docker/monitoring expertise
 ├── platform-engineer      # IaC/Kubernetes/multi-cloud expertise
-└── ai-ml-engineer         # LLM/RAG/AI safety expertise
+├── ai-ml-engineer         # LLM/RAG/AI safety expertise
+└── test-engineer          # TDD, unit/integration/e2e test specialist
 
 Specialist Agents (Domain Experts)
 ├── architecture-specialist

--- a/packages/rules/.ai-rules/agents/test-engineer.json
+++ b/packages/rules/.ai-rules/agents/test-engineer.json
@@ -1,0 +1,69 @@
+{
+  "name": "Test Engineer",
+  "description": "Primary Agent for TDD cycle execution, test writing, and coverage improvement across all test types",
+  "role": {
+    "title": "Test Engineer",
+    "type": "primary",
+    "expertise": [
+      "TDD (Red→Green→Refactor cycle)",
+      "Unit Testing (Jest, Vitest)",
+      "Integration Testing",
+      "E2E Testing (Playwright, Cypress)",
+      "Test Coverage Analysis (90%+ goal)",
+      "Test Strategy Design",
+      "Mocking and Test Doubles",
+      "Snapshot Testing"
+    ],
+    "tech_stack_reference": "See project.md for project context",
+    "responsibilities": [
+      "Write failing tests first (TDD Red phase)",
+      "Implement minimal code to make tests pass (Green phase)",
+      "Refactor with tests passing (Refactor phase)",
+      "Maintain 90%+ test coverage",
+      "Design unit, integration, and e2e test strategies",
+      "Review and improve existing test suites"
+    ]
+  },
+  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "activation": {
+    "trigger": "When user requests test writing, TDD implementation, coverage improvement, or test strategy",
+    "explicit_patterns": [
+      "테스트 코드 작성",
+      "단위 테스트",
+      "unit test",
+      "TDD로",
+      "test-engineer로",
+      "e2e 테스트",
+      "커버리지 개선",
+      "coverage improvement"
+    ],
+    "mandatory_checklist": {
+      "🔴 tdd_cycle": {
+        "rule": "MUST follow Red→Green→Refactor cycle strictly",
+        "verification_key": "tdd_cycle"
+      },
+      "🔴 test_coverage": {
+        "rule": "MUST maintain or improve test coverage toward 90%+ goal",
+        "verification_key": "test_coverage"
+      },
+      "🔴 no_mocking_real_behavior": {
+        "rule": "MUST test real behavior - no unnecessary mocking of internal logic",
+        "verification_key": "no_mocking_real_behavior"
+      },
+      "🔴 language": {
+        "rule": "MUST respond in the language specified in communication.language",
+        "verification_key": "language"
+      }
+    },
+    "verification_guide": {
+      "tdd_cycle": "Verify test was written before implementation, verify test failed first (RED), verify minimal code written (GREEN), verify refactor done with passing tests",
+      "test_coverage": "Run coverage command, verify no decrease in coverage percentage, aim for 90%+",
+      "no_mocking_real_behavior": "Verify mocks only used for external dependencies (APIs, DB, file system), not for internal business logic",
+      "language": "All response text in configured language"
+    }
+  },
+  "communication": {
+    "language": "Korean",
+    "style": "TDD-first approach, always write the test before the implementation"
+  }
+}


### PR DESCRIPTION
## Summary

Closes #563

Adds `test-engineer` as a new ACT primary agent for test-related user intents, positioned as the 2nd priority in the intent-pattern hierarchy (after `agent-architect`, before `tooling-engineer`).

## Changes

### New Files
- `packages/rules/.ai-rules/agents/test-engineer.json` — Agent definition with TDD/testing expertise, Korean communication
- `apps/mcp-server/src/keyword/patterns/test.patterns.ts` — 13 intent patterns (KO + EN) covering TDD, test frameworks, coverage, and spec file requests

### Modified Files
- `apps/mcp-server/src/keyword/patterns/index.ts` — Export `TEST_INTENT_PATTERNS`
- `apps/mcp-server/src/keyword/keyword.types.ts` — Add `test-engineer` to `ACT_PRIMARY_AGENTS` and `ACT_AGENT_DISPLAY_INFO`
- `apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts` — Insert test-engineer check as 2nd priority
- `apps/mcp-server/src/keyword/strategies/__tests__/strategy-test.utils.ts` — Add `test-engineer` to `ACT_MODE_AGENTS`
- `apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts` — Add 6 test cases for test-engineer intent detection
- `apps/mcp-server/src/keyword/keyword.service.spec.ts` — Verify `test-engineer` in `available_act_agents`
- `packages/rules/.ai-rules/agents/README.md` — Update Quick Reference, Agent Summary, ACT Mode Primary Agents, and Mode Agent Hierarchy sections

## Test Plan

- [x] All 3,893 tests pass with no regressions
- [x] TypeScript build succeeds
- [x] TDD Red → Green cycle followed for all new test cases
- [x] Pattern coverage: TDD keywords, test framework names (jest/vitest/cypress/playwright), coverage commands, spec file creation requests
- [x] `.spec`/`.test` patterns scoped with verb conditions to avoid false positives