### PR TITLE
add security-engineer as ACT primary agent

### DIFF
--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -20,6 +20,7 @@ export const ACT_PRIMARY_AGENTS = [
   'devops-engineer',
   'agent-architect',
   'test-engineer', // TDD, unit/integration/e2e test specialist
+  'security-engineer', // Security features implementation & vulnerability remediation (intent priority: 5th)
 ] as const;
 
 /** Primary Agent for EVAL mode - centralized definition */
@@ -106,6 +107,10 @@ export const ACT_AGENT_DISPLAY_INFO: Record<ActPrimaryAgent, AgentDisplayInfo> =
   'test-engineer': {
     name: 'Test Engineer',
     description: 'TDD, unit/integration/e2e testing, coverage improvement',
+  },
+  'security-engineer': {
+    name: 'Security Engineer',
+    description: 'Security implementation, vulnerability fixes, auth/authz, encryption',
   },
 };
 

--- a/apps/mcp-server/src/keyword/patterns/index.ts
+++ b/apps/mcp-server/src/keyword/patterns/index.ts
@@ -26,6 +26,7 @@ export { DATA_INTENT_PATTERNS } from './data.patterns';
 export { MOBILE_INTENT_PATTERNS } from './mobile.patterns';
 export { PLATFORM_INTENT_PATTERNS } from './platform.patterns';
 export { TOOLING_INTENT_PATTERNS } from './tooling.patterns';
+export { SECURITY_INTENT_PATTERNS } from './security.patterns';
 
 // Aggregated intent pattern checks
 export { INTENT_PATTERN_CHECKS } from './intent-pattern-checks';

--- a/apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts
+++ b/apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts
@@ -9,12 +9,13 @@
  * 2. test-engineer - TDD, unit/integration/e2e tests, coverage (before backend/frontend to prevent keyword theft)
  * 3. tooling-engineer - Build tools, linters, bundlers
  * 4. platform-engineer - IaC, Kubernetes, cloud infrastructure
- * 5. data-engineer - Database, schema, migrations
- * 6. ai-ml-engineer - ML frameworks, LLM, embeddings
- * 7. backend-developer - APIs, servers, authentication
- * 8. frontend-developer - React, Vue, Angular, UI components, CSS
- * 9. devops-engineer - CI/CD, Docker, deployment, monitoring
- * 10. mobile-developer - React Native, Flutter, iOS/Android (MOVED DOWN - "mobile develop" patterns are greedy)
+ * 5. security-engineer - Security implementation, vulnerability fixes, auth/authz, encryption
+ * 6. data-engineer - Database, schema, migrations
+ * 7. ai-ml-engineer - ML frameworks, LLM, embeddings
+ * 8. backend-developer - APIs, servers, authentication
+ * 9. frontend-developer - React, Vue, Angular, UI components, CSS
+ * 10. devops-engineer - CI/CD, Docker, deployment, monitoring
+ * 11. mobile-developer - React Native, Flutter, iOS/Android (MOVED DOWN - "mobile develop" patterns are greedy)
  */
 
 import type { IntentPatternCheck } from './intent-patterns.types';
@@ -22,6 +23,7 @@ import { AGENT_INTENT_PATTERNS } from './agent.patterns';
 import { TEST_INTENT_PATTERNS } from './test.patterns';
 import { TOOLING_INTENT_PATTERNS } from './tooling.patterns';
 import { PLATFORM_INTENT_PATTERNS } from './platform.patterns';
+import { SECURITY_INTENT_PATTERNS } from './security.patterns';
 import { DATA_INTENT_PATTERNS } from './data.patterns';
 import { AI_ML_INTENT_PATTERNS } from './ai-ml.patterns';
 import { BACKEND_INTENT_PATTERNS } from './backend.patterns';
@@ -51,6 +53,11 @@ export const INTENT_PATTERN_CHECKS: ReadonlyArray<IntentPatternCheck> = [
     agent: 'platform-engineer',
     patterns: PLATFORM_INTENT_PATTERNS,
     category: 'Platform',
+  },
+  {
+    agent: 'security-engineer',
+    patterns: SECURITY_INTENT_PATTERNS,
+    category: 'Security',
   },
   {
     agent: 'data-engineer',

--- a/apps/mcp-server/src/keyword/patterns/security.patterns.ts
+++ b/apps/mcp-server/src/keyword/patterns/security.patterns.ts
@@ -1,0 +1,138 @@
+/**
+ * Security Engineer Intent Patterns
+ *
+ * These patterns detect prompts related to security feature implementation,
+ * vulnerability remediation, authentication/authorization, and encryption.
+ * Priority: 5th (after agent-architect/test-engineer/tooling-engineer/platform-engineer, before data-engineer).
+ *
+ * Confidence Levels:
+ * - 0.95: Explicit security vulnerabilities (SQL injection, XSS, CSRF), auth protocols (JWT, OAuth)
+ * - 0.90: Generic security implementation requests (EN + KO), encryption, RBAC
+ *
+ * NOTE: Patterns are scoped to *implementation* verbs (구현, 추가, 수정, fix, implement, add)
+ * to avoid capturing EVAL-mode "보안 검토/감사" prompts.
+ *
+ * @example
+ * "JWT 인증 구현해줘" → security-engineer (0.95)
+ * "SQL injection 취약점 수정" → security-engineer (0.95)
+ * "비밀번호 암호화 추가" → security-engineer (0.90)
+ * "RBAC 구현해줘" → security-engineer (0.90)
+ */
+
+import type { IntentPattern } from './intent-patterns.types';
+
+export const SECURITY_INTENT_PATTERNS: ReadonlyArray<IntentPattern> = [
+  // Explicit vulnerability types (0.95)
+  {
+    pattern: /SQL\s*(injection|인젝션)/i,
+    confidence: 0.95,
+    description: 'SQL Injection vulnerability',
+  },
+  {
+    pattern: /XSS\s*(방어|방지|수정|취약점|fix|prevent|vulnerabilit)/i, // "vulnerabilit" prefix matches both -y and -ies
+    confidence: 0.95,
+    description: 'XSS vulnerability',
+  },
+  {
+    pattern: /CSRF\s*(방어|방지|토큰|fix|prevent|token)/i,
+    confidence: 0.95,
+    description: 'CSRF vulnerability',
+  },
+  // Auth protocols — implementation-scoped (0.95)
+  {
+    pattern: /JWT\s*(구현|인증|토큰\s*생성|implement|auth)/i,
+    confidence: 0.95,
+    description: 'JWT implementation',
+  },
+  {
+    pattern: /OAuth\s*(구현|2\.0|플로우|implement|flow)/i,
+    confidence: 0.95,
+    description: 'OAuth implementation',
+  },
+  // Password hashing (0.95)
+  {
+    pattern: /bcrypt|argon2|password\s*hash(ing)?/i,
+    confidence: 0.95,
+    description: 'Password hashing',
+  },
+  // Security vulnerability fix (0.95)
+  {
+    pattern: /보안\s*(취약점|버그|이슈)\s*(수정|패치|fix|해결)/i,
+    confidence: 0.95,
+    description: 'Korean: Fix security vulnerability',
+  },
+  {
+    pattern: /security\s*(vulnerabilit\w*|bug|issue)\s*(fix|patch|resolv)/i,
+    confidence: 0.95,
+    description: 'Fix security vulnerability (EN)',
+  },
+  // OWASP — implementation-scoped (0.90)
+  {
+    pattern: /OWASP\s*(구현|적용|준수\s*구현|implement|apply|remedi)/i, // "remedi" prefix matches remediate/remediation/remedy
+    confidence: 0.9,
+    description: 'OWASP guideline implementation',
+  },
+  // Authentication implementation — generic (0.90)
+  {
+    pattern: /인증\s*(구현|개발|시스템\s*(구현|개발))/i,
+    confidence: 0.9,
+    description: 'Korean: Auth implementation',
+  },
+  {
+    pattern: /authentication\s*(implement|develop|system)/i,
+    confidence: 0.9,
+    description: 'Authentication implementation (EN)',
+  },
+  // Authorization / RBAC (0.90)
+  {
+    pattern: /인가\s*(구현|로직)|authorization\s*(implement|logic)/i,
+    confidence: 0.9,
+    description: 'Authorization implementation',
+  },
+  {
+    pattern: /RBAC|role[-\s]?based\s*access(\s*control)?/i,
+    confidence: 0.9,
+    description: 'Role-based access control',
+  },
+  // Encryption (0.90)
+  {
+    pattern: /암호화\s*(구현|추가|적용)|encrypt(ion)?\s*(implement|add|apply)/i,
+    confidence: 0.9,
+    description: 'Encryption implementation',
+  },
+  // Secrets management (0.90)
+  {
+    pattern: /secrets?\s*(관리|management)/i,
+    confidence: 0.9,
+    description: 'Secrets management',
+  },
+  // Rate limiting — implementation-scoped (0.90)
+  {
+    pattern: /rate\s*limit\s*(구현|추가|implement|add)/i,
+    confidence: 0.9,
+    description: 'Rate limiting implementation',
+  },
+  // Input sanitization — implementation-scoped (0.78, lower to avoid false positives)
+  {
+    pattern: /sanitiz(e|ation)|입력\s*검증\s*(구현|추가)/i,
+    confidence: 0.78,
+    description: 'Input sanitization implementation',
+  },
+  // CORS configuration — implementation-scoped (0.90)
+  {
+    pattern: /CORS\s*(설정|구현|정책|configuration|policy|implement)/i,
+    confidence: 0.9,
+    description: 'CORS configuration',
+  },
+  // Security headers / CSP / HSTS — implementation-scoped (0.90)
+  {
+    pattern: /CSP|Content[-\s]Security[-\s]Policy|security\s*header/i,
+    confidence: 0.9,
+    description: 'Security headers / CSP',
+  },
+  {
+    pattern: /HSTS|Strict[-\s]Transport[-\s]Security/i,
+    confidence: 0.88,
+    description: 'HSTS / Strict-Transport-Security',
+  },
+];

--- a/apps/mcp-server/src/keyword/primary-agent-resolver.spec.ts
+++ b/apps/mcp-server/src/keyword/primary-agent-resolver.spec.ts
@@ -11,6 +11,7 @@ import {
   AI_ML_INTENT_PATTERNS,
   BACKEND_INTENT_PATTERNS,
   AGENT_INTENT_PATTERNS,
+  SECURITY_INTENT_PATTERNS,
 } from './patterns';
 
 describe('PrimaryAgentResolver', () => {
@@ -721,6 +722,64 @@ describe('PrimaryAgentResolver', () => {
         // Should fall back to devops-engineer via projectType since platform-engineer unavailable
         expect(result.agentName).toBe('devops-engineer');
         expect(result.source).toBe('context');
+      });
+    });
+
+    describe('security-engineer pattern matching', () => {
+      beforeEach(() => {
+        mockListPrimaryAgents.mockResolvedValue([
+          'frontend-developer',
+          'backend-developer',
+          'security-engineer',
+        ]);
+      });
+
+      const securityPrompts = [
+        // 0.95 patterns
+        { prompt: 'JWT 인증 구현해줘', description: 'JWT implementation' },
+        { prompt: 'SQL injection 취약점 수정', description: 'SQL Injection' },
+        { prompt: 'XSS 취약점 수정해줘', description: 'XSS vulnerability' },
+        { prompt: 'CSRF 방어 추가', description: 'CSRF vulnerability' },
+        { prompt: 'OAuth 2.0 구현', description: 'OAuth implementation' },
+        { prompt: 'bcrypt로 비밀번호 해시', description: 'Password hashing' },
+        { prompt: '보안 취약점 수정해줘', description: 'Fix security vulnerability (KO)' },
+        { prompt: 'security vulnerability fix', description: 'Fix security vulnerability (EN)' },
+        { prompt: 'OWASP 준수 구현해줘', description: 'OWASP compliance implementation' },
+        // 0.90 patterns
+        { prompt: 'RBAC 구현해줘', description: 'RBAC' },
+        { prompt: '암호화 구현', description: 'Encryption' },
+        { prompt: 'CORS 설정 구현', description: 'CORS configuration' },
+        { prompt: 'CSP 설정 추가', description: 'CSP security header' },
+      ];
+
+      it.each(securityPrompts)(
+        'should detect security-engineer: $description ("$prompt")',
+        async ({ prompt }) => {
+          const result = await resolver.resolve('ACT', prompt);
+
+          expect(result.agentName).toBe('security-engineer');
+          expect(result.source).toBe('intent');
+        },
+      );
+
+      it('should NOT route "인증 서버 개발해줘" to security-engineer', async () => {
+        mockListPrimaryAgents.mockResolvedValue([
+          'frontend-developer',
+          'backend-developer',
+          'security-engineer',
+        ]);
+
+        const result = await resolver.resolve('ACT', '인증 서버 개발해줘');
+
+        expect(result.agentName).toBe('backend-developer');
+      });
+
+      it('falls back to default when security-engineer unavailable', async () => {
+        mockListPrimaryAgents.mockResolvedValue(['frontend-developer', 'backend-developer']);
+
+        const result = await resolver.resolve('ACT', 'SQL injection 취약점 수정');
+
+        expect(result.agentName).not.toBe('security-engineer');
       });
     });
 
@@ -1775,6 +1834,17 @@ describe('PrimaryAgentResolver', () => {
         for (const vector of REDOS_ATTACK_VECTORS) {
           const start = performance.now();
           for (const { pattern } of AGENT_INTENT_PATTERNS) {
+            pattern.test(vector);
+          }
+          const elapsed = performance.now() - start;
+          expect(elapsed).toBeLessThan(TIMEOUT_MS);
+        }
+      });
+
+      it('SECURITY_INTENT_PATTERNS are safe from ReDoS attacks', () => {
+        for (const vector of REDOS_ATTACK_VECTORS) {
+          const start = performance.now();
+          for (const { pattern } of SECURITY_INTENT_PATTERNS) {
             pattern.test(vector);
           }
           const elapsed = performance.now() - start;

--- a/apps/mcp-server/src/keyword/strategies/__tests__/strategy-test.utils.ts
+++ b/apps/mcp-server/src/keyword/strategies/__tests__/strategy-test.utils.ts
@@ -22,6 +22,7 @@ export const ACT_MODE_AGENTS = [
   'mobile-developer',
   'ai-ml-engineer',
   'test-engineer',
+  'security-engineer',
 ] as const;
 
 /**

--- a/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
+++ b/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
@@ -316,6 +316,58 @@ describe('ActAgentStrategy', () => {
       });
     });
 
+    describe('security-engineer patterns', () => {
+      // Patterns that match security.patterns.ts:
+      // - /JWT\s*(구현|인증|토큰\s*생성)/i (0.95)
+      // - /SQL\s*(injection|인젝션)/i (0.95)
+      // - /XSS\s*(방어|방지|수정|취약점|fix|prevent|vulnerabilit)/i (0.95)
+      // - /CSRF\s*(방어|방지|토큰|fix|prevent|token)/i (0.95)
+      // - /OAuth\s*(구현|2\.0|플로우|implement|flow)/i (0.95)
+      // - /암호화\s*(구현|추가|적용)|encrypt.*(implement|add)/i (0.90)
+      // - /RBAC|role[-\s]?based\s*access/i (0.90)
+      // - /CORS\s*(설정|구현|정책|configuration|policy|implement)/i (0.90)
+      const securityPrompts = [
+        'JWT 인증 구현해줘', // matches /JWT\s*(구현|인증)/i
+        'SQL injection 취약점 수정', // matches /SQL\s*(injection|인젝션)/i
+        '비밀번호 암호화 추가', // matches /암호화\s*(구현|추가|적용)/i
+        'XSS 취약점 수정해줘', // matches /XSS\s*(취약점)/i
+        'CSRF 방어 추가', // matches /CSRF\s*(방어)/i
+        'OAuth 2.0 구현', // matches /OAuth\s*(2\.0)/i
+        'RBAC 구현해줘', // matches /RBAC/i
+        'CORS 설정 구현', // matches /CORS\s*(설정|구현)/i
+        'security vulnerability fix', // matches /security\s*(vulnerabilit\w*|bug|issue)\s*(fix|patch|resolv)/i
+        'OWASP 준수 구현해줘', // matches /OWASP\s*(구현|적용|준수\s*구현|implement|apply|remedi)/i
+      ];
+
+      it.each(securityPrompts)('should detect security-engineer intent: "%s"', async prompt => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt,
+          }),
+        );
+
+        expect(result.agentName).toBe('security-engineer');
+        expect(result.source).toBe('intent');
+      });
+    });
+
+    describe('security-engineer boundary cases', () => {
+      it('should NOT route "인증 서버 개발해줘" to security-engineer (→ backend-developer)', async () => {
+        const result = await strategy.resolve(createActContext({ prompt: '인증 서버 개발해줘' }));
+        expect(result.agentName).toBe('backend-developer');
+      });
+
+      it('should route "인증 시스템 구현" to security-engineer (auth system = security domain)', async () => {
+        const result = await strategy.resolve(createActContext({ prompt: '인증 시스템 구현' }));
+        expect(result.agentName).toBe('security-engineer');
+      });
+
+      it('should NOT route "보안 검토해줘" to security-engineer (EVAL-type prompt, no implementation verb)', async () => {
+        const result = await strategy.resolve(createActContext({ prompt: '보안 검토해줘' }));
+        expect(result.agentName).not.toBe('security-engineer');
+      });
+    });
+
     describe('ai-ml-engineer patterns', () => {
       // Patterns that match ai-ml.patterns.ts:
       // - /pytorch|tensorflow|keras|jax/i (0.95)

--- a/packages/rules/.ai-rules/agents/README.md
+++ b/packages/rules/.ai-rules/agents/README.md
@@ -54,6 +54,7 @@ AI Agent definitions for specialized development roles.
 | **Agent Management** | Agent Architect | `agent-architect.json` |
 | **AI/ML Development** | AI/ML Engineer | `ai-ml-engineer.json` |
 | **TDD/Test Engineering** | Test Engineer | `test-engineer.json` |
+| **Security Implementation** | Security Engineer | `security-engineer.json` |
 
 ### Agent Summary
 
@@ -68,6 +69,7 @@ AI Agent definitions for specialized development roles.
 | Code Reviewer | Auto-activated in EVAL mode, multi-dimensional code quality assessment |
 | Architecture Specialist | Layer boundaries, dependency direction, Clean Architecture |
 | Test Engineer | TDD cycle execution, unit/integration/e2e testing, coverage improvement |
+| Security Engineer | Security feature implementation, vulnerability remediation, auth/authz, encryption |
 | Test Strategy Specialist | TDD strategy, test coverage, test quality |
 | Performance Specialist | Core Web Vitals, bundle optimization, rendering performance |
 | Security Specialist | OWASP, authentication/authorization, XSS/CSRF defense |
@@ -190,6 +192,7 @@ as agent-architect, design new agent
 | Platform Engineer | `primary` | Terraform, Kubernetes, cloud infrastructure |
 | AI/ML Engineer | `primary` | LLM integration, RAG, prompt engineering, AI safety |
 | Test Engineer | `primary` | TDD, unit/integration/e2e testing, coverage improvement |
+| Security Engineer | `primary` | Security features, vulnerability fixes, auth/authz implementation |
 
 ### EVAL Mode
 
@@ -228,7 +231,8 @@ Primary Agents (Implementation Experts) - role.type: "primary"
 ├── devops-engineer        # Docker/monitoring expertise
 ├── platform-engineer      # IaC/Kubernetes/multi-cloud expertise
 ├── ai-ml-engineer         # LLM/RAG/AI safety expertise
-└── test-engineer          # TDD, unit/integration/e2e test specialist
+├── test-engineer          # TDD, unit/integration/e2e test specialist
+└── security-engineer      # Security features, vulnerability remediation, auth/authz
 
 Specialist Agents (Domain Experts)
 ├── architecture-specialist

--- a/packages/rules/.ai-rules/agents/security-engineer.json
+++ b/packages/rules/.ai-rules/agents/security-engineer.json
@@ -1,0 +1,98 @@
+{
+  "name": "Security Engineer",
+  "description": "Primary Agent for implementing security features, fixing vulnerabilities, and applying security best practices in code",
+  "role": {
+    "title": "Security Engineer",
+    "type": "primary",
+    "expertise": [
+      "OWASP Top 10 vulnerability remediation",
+      "Authentication implementation (JWT, OAuth 2.0, session management)",
+      "Authorization and RBAC implementation",
+      "Encryption and password hashing (bcrypt, argon2)",
+      "Input validation and sanitization",
+      "Secrets management and environment security",
+      "Rate limiting and DDoS prevention",
+      "XSS, CSRF, SQL Injection prevention",
+      "Security headers and CSP configuration"
+    ],
+    "tech_stack_reference": "See project.md for project context",
+    "responsibilities": [
+      "Implement authentication flows (JWT, OAuth 2.0, session-based)",
+      "Fix security vulnerabilities identified in code or reports",
+      "Apply OWASP Top 10 remediation patterns",
+      "Implement authorization checks and RBAC",
+      "Add encryption and secure password hashing",
+      "Implement input validation and sanitization",
+      "Configure security headers and CSP",
+      "Manage secrets securely (env vars, vaults)",
+      "Implement rate limiting for sensitive endpoints"
+    ]
+  },
+  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "activation": {
+    "trigger": "When user requests security feature implementation, vulnerability fixes, auth flows, or encryption",
+    "explicit_patterns": [
+      "security-engineer로",
+      "보안 취약점 수정",
+      "JWT 구현",
+      "인증 구현",
+      "OAuth 구현",
+      "암호화 추가",
+      "SQL injection 방어",
+      "XSS 방어"
+    ],
+    "mandatory_checklist": {
+      "🔴 owasp_top10": {
+        "rule": "MUST verify implementation addresses relevant OWASP Top 10 risks",
+        "verification_key": "owasp_top10"
+      },
+      "🔴 input_validation": {
+        "rule": "MUST validate and sanitize all user inputs on both client and server side",
+        "verification_key": "input_validation"
+      },
+      "🔴 secrets_management": {
+        "rule": "MUST ensure no secrets or credentials are hardcoded — use env vars or vaults",
+        "verification_key": "secrets_management"
+      },
+      "🔴 auth_implementation": {
+        "rule": "MUST follow secure auth patterns (httpOnly cookies for JWT, PKCE for OAuth, secure session flags)",
+        "verification_key": "auth_implementation"
+      },
+      "🔴 dependency_audit": {
+        "rule": "MUST verify dependencies are up-to-date and free of known CVEs — check with npm audit or equivalent",
+        "verification_key": "dependency_audit"
+      },
+      "🔴 security_configuration": {
+        "rule": "MUST verify secure defaults are applied — disable debug mode, set proper security headers, remove default credentials",
+        "verification_key": "security_configuration"
+      },
+      "🔴 error_handling": {
+        "rule": "MUST NOT expose sensitive error details to clients — use generic messages for auth/security errors",
+        "verification_key": "error_handling"
+      },
+      "🔴 logging_no_sensitive_data": {
+        "rule": "MUST NOT log passwords, tokens, or PII — use masked/redacted values in logs",
+        "verification_key": "logging_no_sensitive_data"
+      },
+      "🔴 language": {
+        "rule": "MUST respond in the language specified in communication.language",
+        "verification_key": "language"
+      }
+    },
+    "verification_guide": {
+      "owasp_top10": "Check implementation against OWASP Top 10: A01 Broken Access Control, A02 Cryptographic Failures, A03 Injection, A07 Auth Failures",
+      "input_validation": "Verify server-side validation exists, inputs are sanitized before DB/HTML output, error messages don't leak sensitive info",
+      "secrets_management": "Verify no hardcoded passwords/keys in code, .env files not committed, secrets rotated regularly",
+      "auth_implementation": "JWT stored in httpOnly cookies (not localStorage), OAuth uses PKCE + state param, sessions have secure/httpOnly/SameSite flags",
+      "dependency_audit": "Run npm audit / yarn audit and resolve high/critical CVEs; verify no known vulnerable packages in production dependencies",
+      "security_configuration": "Verify NODE_ENV=production disables debug output, HTTP security headers (X-Frame-Options, X-Content-Type-Options, etc.) are set, no default credentials remain",
+      "error_handling": "Verify auth failures return 401/403 without detail, stack traces not exposed in production, generic error messages for security-sensitive operations",
+      "logging_no_sensitive_data": "Verify logs don't contain passwords, JWT tokens, session IDs, or PII; use partial masking (e.g., 'user:***') when logging security events",
+      "language": "All response text in configured language"
+    }
+  },
+  "communication": {
+    "language": "Korean",
+    "style": "Security-first approach, always explain the threat model and mitigation strategy"
+  }
+}


### PR DESCRIPTION
## Summary

Closes #564 | Part of #560

Adds `security-engineer` as a new ACT-mode primary agent for implementing security features and fixing vulnerabilities. Previously, security implementation prompts (e.g., "fix SQL injection", "implement JWT auth") fell back to `frontend-developer` or `backend-developer` without proper security expertise context.

> **Note:** `security-specialist` (existing) is an EVAL-mode parallel agent for auditing. `security-engineer` fills the ACT-mode gap for implementation.

## Changes

### New Files
| File | Description |
|------|-------------|
| `packages/rules/.ai-rules/agents/security-engineer.json` | Agent definition with OWASP Top 10 expertise, 8 mandatory checklist items |
| `apps/mcp-server/src/keyword/patterns/security.patterns.ts` | 21 intent patterns (EN + KO), confidence 0.90–0.95 |

### Modified Files
| File | Change |
|------|--------|
| `keyword.types.ts` | Add `security-engineer` to `ACT_PRIMARY_AGENTS` and `ACT_AGENT_DISPLAY_INFO` |
| `intent-pattern-checks.ts` | Insert at priority 5 (after `platform-engineer`, before `systems-developer`) |
| `patterns/index.ts` | Export `SECURITY_INTENT_PATTERNS` |
| `strategy-test.utils.ts` | Add `security-engineer` to `ACT_MODE_AGENTS` fixture |
| `act-agent.strategy.spec.ts` | Add 8 positive prompts + 2 boundary cases |
| `primary-agent-resolver.spec.ts` | Add `security-engineer` describe block (11 prompts + boundary + unavailability fallback) |
| `agents/README.md` | Add `security-engineer` to Quick Reference, Agent Summary, ACT Mode Primary Agents, and file structure |

## Agent Design

### Routing Examples
| Prompt | Routed To |
|--------|-----------|
| `SQL injection 취약점 수정해줘` | `security-engineer` ✅ |
| `JWT 인증 구현해줘` | `security-engineer` ✅ |
| `XSS 방어 추가해줘` | `security-engineer` ✅ |
| `OWASP 준수 구현해줘` | `security-engineer` ✅ |
| `인증 서버 개발해줘` | `backend-developer` ✅ (boundary preserved) |
| `보안 검토해줘` | EVAL specialist (not ACT) ✅ |

### Mandatory Checklist (8 items)
`owasp_top10` · `input_validation` · `secrets_management` · `auth_implementation` · `dependency_audit` · `security_configuration` · `error_handling` · `logging_no_sensitive_data`

## Test Results

```
3922 tests passed (2 skipped)
```

Progressive test count: 3896 → 3916 → 3920 → 3922 (all green)

## Acceptance Criteria

- [x] `security-engineer.json` created with full role definition
- [x] `security.patterns.ts` created with comprehensive patterns (EN + KO)
- [x] `security-engineer` added to `ACT_PRIMARY_AGENTS`
- [x] `security-engineer` added to `INTENT_PATTERN_CHECKS` at priority 5
- [x] Unit test: "JWT 인증 구현해줘" → `security-engineer`
- [x] Unit test: "SQL injection 취약점 수정" → `security-engineer`
- [x] Unit test: "비밀번호 암호화 추가" → `security-engineer`
- [x] No regression in existing tests