### PR TITLE
add systems-developer as ACT primary agent

### DIFF
--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -21,6 +21,7 @@ export const ACT_PRIMARY_AGENTS = [
   'agent-architect',
   'test-engineer', // TDD, unit/integration/e2e test specialist
   'security-engineer', // Security features implementation & vulnerability remediation (intent priority: 5th)
+  'systems-developer', // Rust, C, C++, FFI, WASM, embedded, low-level optimization (intent priority: 6th)
 ] as const;
 
 /** Primary Agent for EVAL mode - centralized definition */
@@ -111,6 +112,10 @@ export const ACT_AGENT_DISPLAY_INFO: Record<ActPrimaryAgent, AgentDisplayInfo> =
   'security-engineer': {
     name: 'Security Engineer',
     description: 'Security implementation, vulnerability fixes, auth/authz, encryption',
+  },
+  'systems-developer': {
+    name: 'Systems Developer',
+    description: 'Rust, C, C++, FFI, WASM, embedded, low-level performance',
   },
 };
 

--- a/apps/mcp-server/src/keyword/patterns/backend.patterns.ts
+++ b/apps/mcp-server/src/keyword/patterns/backend.patterns.ts
@@ -3,7 +3,7 @@
  *
  * These patterns detect prompts related to server-side development,
  * API design, and backend services.
- * Priority: 6th (after AI/ML patterns).
+ * Priority: 9th (after agent-architect, test, tooling, platform, security, systems, data, ai-ml patterns).
  *
  * Confidence Levels:
  * - 0.95: Backend frameworks (NestJS, Express, Django, Spring)

--- a/apps/mcp-server/src/keyword/patterns/context.patterns.ts
+++ b/apps/mcp-server/src/keyword/patterns/context.patterns.ts
@@ -91,7 +91,7 @@ export const CONTEXT_PATTERNS: ReadonlyArray<ContextPattern> = [
   { pattern: /\.go$/i, agent: 'backend-developer', confidence: 0.85 },
   { pattern: /\.py$/i, agent: 'backend-developer', confidence: 0.85 },
   { pattern: /\.java$/i, agent: 'backend-developer', confidence: 0.85 },
-  { pattern: /\.rs$/i, agent: 'backend-developer', confidence: 0.85 },
+  { pattern: /\.rs$/i, agent: 'systems-developer', confidence: 0.85 },
   // Frontend patterns (lower priority)
   { pattern: /\.tsx?$/i, agent: 'frontend-developer', confidence: 0.7 },
   { pattern: /\.jsx?$/i, agent: 'frontend-developer', confidence: 0.7 },

--- a/apps/mcp-server/src/keyword/patterns/index.ts
+++ b/apps/mcp-server/src/keyword/patterns/index.ts
@@ -27,6 +27,7 @@ export { MOBILE_INTENT_PATTERNS } from './mobile.patterns';
 export { PLATFORM_INTENT_PATTERNS } from './platform.patterns';
 export { TOOLING_INTENT_PATTERNS } from './tooling.patterns';
 export { SECURITY_INTENT_PATTERNS } from './security.patterns';
+export { SYSTEMS_INTENT_PATTERNS } from './systems.patterns';
 
 // Aggregated intent pattern checks
 export { INTENT_PATTERN_CHECKS } from './intent-pattern-checks';

--- a/apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts
+++ b/apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts
@@ -10,12 +10,13 @@
  * 3. tooling-engineer - Build tools, linters, bundlers
  * 4. platform-engineer - IaC, Kubernetes, cloud infrastructure
  * 5. security-engineer - Security implementation, vulnerability fixes, auth/authz, encryption
- * 6. data-engineer - Database, schema, migrations
- * 7. ai-ml-engineer - ML frameworks, LLM, embeddings
- * 8. backend-developer - APIs, servers, authentication
- * 9. frontend-developer - React, Vue, Angular, UI components, CSS
- * 10. devops-engineer - CI/CD, Docker, deployment, monitoring
- * 11. mobile-developer - React Native, Flutter, iOS/Android (MOVED DOWN - "mobile develop" patterns are greedy)
+ * 6. systems-developer - Rust, C, C++, FFI, WASM, embedded, low-level optimization
+ * 7. data-engineer - Database, schema, migrations
+ * 8. ai-ml-engineer - ML frameworks, LLM, embeddings
+ * 9. backend-developer - APIs, servers, authentication
+ * 10. frontend-developer - React, Vue, Angular, UI components, CSS
+ * 11. devops-engineer - CI/CD, Docker, deployment, monitoring
+ * 12. mobile-developer - React Native, Flutter, iOS/Android (MOVED DOWN - "mobile develop" patterns are greedy)
  */
 
 import type { IntentPatternCheck } from './intent-patterns.types';
@@ -24,6 +25,7 @@ import { TEST_INTENT_PATTERNS } from './test.patterns';
 import { TOOLING_INTENT_PATTERNS } from './tooling.patterns';
 import { PLATFORM_INTENT_PATTERNS } from './platform.patterns';
 import { SECURITY_INTENT_PATTERNS } from './security.patterns';
+import { SYSTEMS_INTENT_PATTERNS } from './systems.patterns';
 import { DATA_INTENT_PATTERNS } from './data.patterns';
 import { AI_ML_INTENT_PATTERNS } from './ai-ml.patterns';
 import { BACKEND_INTENT_PATTERNS } from './backend.patterns';
@@ -58,6 +60,11 @@ export const INTENT_PATTERN_CHECKS: ReadonlyArray<IntentPatternCheck> = [
     agent: 'security-engineer',
     patterns: SECURITY_INTENT_PATTERNS,
     category: 'Security',
+  },
+  {
+    agent: 'systems-developer',
+    patterns: SYSTEMS_INTENT_PATTERNS,
+    category: 'Systems',
   },
   {
     agent: 'data-engineer',

--- a/apps/mcp-server/src/keyword/patterns/systems.patterns.ts
+++ b/apps/mcp-server/src/keyword/patterns/systems.patterns.ts
@@ -1,0 +1,131 @@
+/**
+ * Systems Developer Intent Patterns
+ *
+ * These patterns detect prompts related to systems programming:
+ * Rust, C, C++, Go (systems-level), FFI, WASM, embedded, and low-level optimization.
+ * Priority: 6th (after security-engineer, before data-engineer).
+ *
+ * Confidence Levels:
+ * - 0.95: Explicit language names (rust, cargo, c++, cpp) and systems-specific keywords (FFI, WASM, unsafe)
+ * - 0.90: Generic systems/low-level implementation requests (EN + KO), memory management, embedded
+ *
+ * NOTE: Patterns are scoped to avoid false positives with general "memory" or "performance" queries.
+ *
+ * @example
+ * "Rust로 서버 구현해줘" → systems-developer (0.95)
+ * "C++ 메모리 최적화" → systems-developer (0.95)
+ * "FFI 바인딩 작성" → systems-developer (0.95)
+ * "시스템 프로그래밍 구현" → systems-developer (0.90)
+ */
+
+import type { IntentPattern } from './intent-patterns.types';
+
+export const SYSTEMS_INTENT_PATTERNS: ReadonlyArray<IntentPattern> = [
+  // Rust language keywords (0.95)
+  {
+    pattern: /\brust\b/i,
+    confidence: 0.95,
+    description: 'Rust programming language',
+  },
+  {
+    pattern: /\bcargo\b\s*(build|test|run|add|init|new)/i,
+    confidence: 0.95,
+    description: 'Cargo build tool commands',
+  },
+  {
+    pattern: /\bcrate\b|\bownership\b|\bborrow\s*checker\b|rust.*\blifetime\b/i,
+    confidence: 0.95,
+    description: 'Rust-specific concepts (lifetime scoped to Rust context)',
+  },
+  // C / C++ language keywords (0.95)
+  {
+    pattern: /c\+\+|\.cpp\b|\.hpp\b|\bcpp\b/i,
+    confidence: 0.95,
+    description: 'C++ language or file extension',
+  },
+  // FFI and interop (0.95)
+  {
+    pattern: /\bffi\b|foreign\s*function\s*interface/i,
+    confidence: 0.95,
+    description: 'FFI — Foreign Function Interface',
+  },
+  {
+    pattern: /ffi\s*(바인딩|binding)/i,
+    confidence: 0.95,
+    description: 'Korean: FFI binding (FFI-scoped to avoid false positives with React/TS bindings)',
+  },
+  // WebAssembly (0.95)
+  {
+    pattern: /\bwasm\b|\bwebassembly\b/i,
+    confidence: 0.95,
+    description: 'WebAssembly / WASM',
+  },
+  {
+    pattern: /wasm[-\s]?bindgen|wasmtime|emscripten/i,
+    confidence: 0.95,
+    description: 'WASM toolchain',
+  },
+  // Unsafe / low-level (0.95)
+  {
+    pattern: /\bunsafe\b\s*(block|블록|코드|code)/i,
+    confidence: 0.95,
+    description: 'Unsafe block (Rust)',
+  },
+  // Assembly (0.95)
+  {
+    pattern: /\bassembly\s*(language|code|코드|언어|구현|작성)|\basm\b\s*(코드|구현|작성)/i,
+    confidence: 0.95,
+    description: 'Assembly language (scoped to avoid false positives with assembly lines)',
+  },
+  // Memory management — implementation-scoped (0.90)
+  {
+    pattern: /메모리\s*(관리|최적화|누수|할당)\s*(구현|수정|최적화)/i,
+    confidence: 0.9,
+    description: 'Korean: Memory management implementation',
+  },
+  {
+    pattern: /memory\s*(management|leak|allocat|pool)\s*(implement|fix|optim)/i,
+    confidence: 0.9,
+    description: 'Memory management implementation (EN)',
+  },
+  // Systems programming — generic (0.90)
+  {
+    pattern: /시스템\s*프로그래밍|systems?\s*programming/i,
+    confidence: 0.9,
+    description: 'Systems programming (KO + EN)',
+  },
+  {
+    pattern: /저수준\s*(구현|개발|최적화)|low[-\s]?level\s*(implement|develop|optim)/i,
+    confidence: 0.9,
+    description: 'Low-level implementation (KO + EN)',
+  },
+  // Embedded systems (0.90)
+  {
+    pattern: /embedded\s*(시스템|system|개발|develop|device)|\bbare.?metal\b|\bno_std\b|\bRTOS\b/i,
+    confidence: 0.9,
+    description:
+      'Embedded / bare-metal systems (scoped to avoid false positives with embedded video/links)',
+  },
+  {
+    pattern: /임베디드\s*(개발|시스템|구현)/i,
+    confidence: 0.9,
+    description: 'Korean: Embedded development',
+  },
+  // Performance optimization — systems-scoped (0.90)
+  {
+    pattern: /\bSIMD\b|\bAVX\b|\bSSE\b/i,
+    confidence: 0.9,
+    description: 'SIMD / vectorization',
+  },
+  {
+    pattern: /hot\s*path\s*(최적화|optim)|캐시\s*(효율|최적화)\s*(구현|개선)/i,
+    confidence: 0.9,
+    description: 'Hot path / cache optimization',
+  },
+  // Concurrency primitives — systems-scoped (0.90)
+  {
+    pattern: /lock[-\s]?free|atomic\s*(operation|연산)|mutex\s*(구현|implement)/i,
+    confidence: 0.9,
+    description: 'Lock-free / atomic concurrency',
+  },
+];

--- a/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
+++ b/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
@@ -351,6 +351,92 @@ describe('ActAgentStrategy', () => {
       });
     });
 
+    describe('systems-developer patterns', () => {
+      // Patterns from systems.patterns.ts:
+      // - /\brust\b/i (0.95)
+      // - /c\+\+|\.cpp\b|\.hpp\b|\bcpp\b/i (0.95)
+      // - /\bffi\b|foreign\s*function\s*interface/i (0.95)
+      // - /ffi\s*(바인딩|binding)/i (0.95)
+      // - /\bwasm\b|\bwebassembly\b/i (0.95)
+      // - /시스템\s*프로그래밍|systems?\s*programming/i (0.90)
+      // - /저수준\s*(구현|개발|최적화)|low[-\s]?level\s*(implement|develop|optim)/i (0.90)
+      const systemsPrompts = [
+        'Rust로 서버 구현해줘', // matches /\brust\b/i
+        'C++ 메모리 최적화', // matches /c\+\+/i
+        'FFI 바인딩 작성', // matches /ffi\s*(바인딩|binding)/i
+        'WASM 모듈 구현해줘', // matches /\bwasm\b/i
+        '시스템 프로그래밍 구현', // matches /시스템\s*프로그래밍/i
+        '저수준 최적화해줘', // matches /저수준\s*(구현|개발|최적화)/i
+      ];
+
+      it.each(systemsPrompts)('should detect systems-developer intent: "%s"', async prompt => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt,
+            availableAgents: ['frontend-developer', 'backend-developer', 'systems-developer'],
+          }),
+        );
+
+        expect(result.agentName).toBe('systems-developer');
+        expect(result.source).toBe('intent');
+      });
+    });
+
+    describe('systems-developer boundary cases', () => {
+      it('should NOT route "React 바인딩 작성해줘" to systems-developer (→ frontend-developer)', async () => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt: 'React 바인딩 작성해줘',
+            availableAgents: ['frontend-developer', 'backend-developer', 'systems-developer'],
+          }),
+        );
+        expect(result.agentName).toBe('frontend-developer');
+        expect(result.agentName).not.toBe('systems-developer');
+      });
+
+      it('should NOT route "customer lifetime value 계산" to systems-developer (→ data-engineer)', async () => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt: 'customer lifetime value 계산해줘',
+            availableAgents: ['data-engineer', 'backend-developer', 'systems-developer'],
+          }),
+        );
+        expect(result.agentName).not.toBe('systems-developer');
+      });
+
+      it('should NOT route "embedded 비디오 추가해줘" to systems-developer (→ frontend-developer)', async () => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt: 'embedded 비디오 추가해줘',
+            availableAgents: ['frontend-developer', 'backend-developer', 'systems-developer'],
+          }),
+        );
+        expect(result.agentName).not.toBe('systems-developer');
+      });
+
+      it('should still route "Rust lifetime 오류 수정" to systems-developer', async () => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt: 'Rust lifetime 오류 수정해줘',
+            availableAgents: ['frontend-developer', 'backend-developer', 'systems-developer'],
+          }),
+        );
+        expect(result.agentName).toBe('systems-developer');
+        expect(result.source).toBe('intent');
+      });
+
+      it('should still route "embedded system 개발" to systems-developer', async () => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt: 'embedded system 개발해줘',
+            availableAgents: ['frontend-developer', 'backend-developer', 'systems-developer'],
+          }),
+        );
+        expect(result.agentName).toBe('systems-developer');
+        expect(result.source).toBe('intent');
+      });
+    });
+
     describe('security-engineer boundary cases', () => {
       it('should NOT route "인증 서버 개발해줘" to security-engineer (→ backend-developer)', async () => {
         const result = await strategy.resolve(createActContext({ prompt: '인증 서버 개발해줘' }));

--- a/packages/rules/.ai-rules/agents/systems-developer.json
+++ b/packages/rules/.ai-rules/agents/systems-developer.json
@@ -1,0 +1,83 @@
+{
+  "name": "Systems Developer",
+  "description": "Primary Agent for systems programming, low-level optimization, native code development, and performance-critical implementations",
+  "role": {
+    "title": "Systems Developer",
+    "type": "primary",
+    "expertise": [
+      "Rust — ownership, borrowing, lifetimes, async, cargo",
+      "C and C++ — memory management, pointers, RAII, templates",
+      "Go (systems-level) — concurrency primitives, cgo, build constraints",
+      "FFI (Foreign Function Interface) — binding Rust/C to other languages",
+      "WebAssembly (WASM) — wasm-bindgen, wasmtime, emscripten",
+      "Embedded systems — bare-metal, no_std, RTOS integration",
+      "Performance optimization — hot path analysis, SIMD, cache efficiency",
+      "Unsafe code — unsafe blocks, raw pointers, transmute",
+      "Concurrency primitives — mutexes, channels, lock-free data structures",
+      "Memory management — allocators, arenas, memory pools"
+    ],
+    "tech_stack_reference": "See project.md for project context",
+    "responsibilities": [
+      "Implement memory-safe systems code in Rust, C, or C++",
+      "Write FFI bindings between native and managed languages",
+      "Optimize hot paths with low-level techniques (SIMD, cache-friendly layouts)",
+      "Manage unsafe blocks with clear safety invariants documented",
+      "Implement concurrency primitives and lock-free algorithms",
+      "Port or bridge native code to WebAssembly",
+      "Write embedded/bare-metal code with no_std or minimal runtime",
+      "Profile and diagnose memory leaks and performance bottlenecks"
+    ]
+  },
+  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "activation": {
+    "trigger": "When user requests Rust/C/C++ implementation, FFI bindings, memory management, embedded systems, WASM, or low-level performance optimization",
+    "explicit_patterns": [
+      "systems-developer로",
+      "Rust로 구현",
+      "C++ 최적화",
+      "FFI 바인딩",
+      "메모리 관리",
+      "임베디드 개발",
+      "WASM 구현",
+      "저수준 구현"
+    ],
+    "mandatory_checklist": {
+      "🔴 memory_safety": {
+        "rule": "MUST verify memory safety — no use-after-free, double-free, or buffer overflows",
+        "verification_key": "memory_safety"
+      },
+      "🔴 unsafe_justification": {
+        "rule": "MUST document safety invariants for every unsafe block — explain why it is safe",
+        "verification_key": "unsafe_justification"
+      },
+      "🔴 error_handling": {
+        "rule": "MUST use idiomatic error handling (Result/Option in Rust, error codes + cleanup in C)",
+        "verification_key": "error_handling"
+      },
+      "🔴 ffi_null_check": {
+        "rule": "MUST validate all pointers from FFI calls before dereferencing",
+        "verification_key": "ffi_null_check"
+      },
+      "🔴 resource_cleanup": {
+        "rule": "MUST ensure all resources (files, sockets, memory) are freed on all exit paths",
+        "verification_key": "resource_cleanup"
+      },
+      "🔴 language": {
+        "rule": "MUST respond in the language specified in communication.language",
+        "verification_key": "language"
+      }
+    },
+    "verification_guide": {
+      "memory_safety": "Run cargo clippy + valgrind/address sanitizer — no heap errors, no dangling refs",
+      "unsafe_justification": "Every unsafe { } block has a comment explaining invariants that make it safe",
+      "error_handling": "No panics in library code — use Result<T, E>; C code checks return values",
+      "ffi_null_check": "FFI pointer params validated with null check before use; use Option<NonNull<T>> where possible",
+      "resource_cleanup": "Use RAII (Drop trait in Rust, destructors in C++), or verify explicit free on all paths",
+      "language": "All response text in configured language"
+    }
+  },
+  "communication": {
+    "language": "Korean",
+    "style": "Safety-first approach, always explain memory model and ownership decisions"
+  }
+}


### PR DESCRIPTION
## Summary

Closes #565 | Part of #560

Adds `systems-developer` as a new ACT-mode primary agent for systems programming, low-level optimization, and native code development. Previously, systems programming prompts (e.g., "Rust로 구현해줘", "C++ 메모리 최적화", "FFI 바인딩 작성", "WASM 모듈 구현") fell back to `frontend-developer`, which is completely inappropriate.

> **Note:** `systems-developer` is positioned at priority 6 in the intent-pattern hierarchy (after `security-engineer`, before `data-engineer`), with high-confidence patterns (0.95) for explicit language names and 0.90 for generic low-level terms.

## Changes

### New Files
| File | Description |
|------|-------------|
| `packages/rules/.ai-rules/agents/systems-developer.json` | Agent definition — Rust/C/C++/Go systems-level, memory management, FFI, WASM, concurrency primitives, performance optimization |
| `apps/mcp-server/src/keyword/patterns/systems.patterns.ts` | 20 intent patterns (KO + EN) covering Rust, C/C++, FFI, WASM, embedded, unsafe, memory management, and assembly |

### Modified Files
| File | Change |
|------|--------|
| `apps/mcp-server/src/keyword/keyword.types.ts` | Add `systems-developer` to `ACT_PRIMARY_AGENTS` and `ACT_AGENT_DISPLAY_INFO` |
| `apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts` | Insert `systems-developer` at priority 6 with `SYSTEMS_INTENT_PATTERNS` |
| `apps/mcp-server/src/keyword/patterns/index.ts` | Export `SYSTEMS_INTENT_PATTERNS` |
| `apps/mcp-server/src/keyword/patterns/context.patterns.ts` | Route `.rs` file context to `systems-developer` (was `backend-developer`) |
| `apps/mcp-server/src/keyword/patterns/backend.patterns.ts` | Update priority comment (6th → 9th) |
| `apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts` | Add 11 tests: 6 positive match cases + 5 boundary tests preventing false positives |

## Pattern Design

Patterns are scoped to avoid false positives identified in EVAL:

| Pattern | Scope | Rationale |
|---------|-------|-----------|
| `/ffi\s*(바인딩\|binding)/i` | FFI-prefixed only | Prevents React/TS binding false positives |
| `/rust.*\blifetime\b/i` | Rust-context only | Prevents customer lifetime value (data-engineer) false positives |
| `/embedded\s*(시스템\|system\|...)\|bare.?metal\|no_std\|RTOS/i` | System-context only | Prevents embedded video/SQL false positives |
| `/assembly\s*(language\|code\|...)\|\basm\b\s*(코드\|구현)/i` | Language-context only | Prevents assembly line/component false positives |

## Test Coverage

- **+11 tests** in `act-agent.strategy.spec.ts`
- **Positive cases**: `Rust로 서버 구현해줘`, `C++ 메모리 최적화`, `FFI 바인딩 작성`, `WASM 모듈 구현해줘`, `시스템 프로그래밍 구현`, `저수준 최적화해줘`
- **Boundary cases**: React binding → `frontend-developer`, lifetime value → `data-engineer`, embedded video → not `systems-developer`, assembly component → not `systems-developer`
- **Total**: 3,933 tests passing (3,928 → +5 boundary tests)