### PR TITLE
add data-scientist as ACT primary agent (#566)

### DIFF
--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -8,11 +8,18 @@ export const MODE_AGENTS = ['plan-mode', 'act-mode', 'eval-mode', 'auto-mode'] a
 /** Primary Agents for PLAN mode - centralized definition */
 export const PLAN_PRIMARY_AGENTS = ['solution-architect', 'technical-planner'] as const;
 
-/** Primary Agents for ACT mode - centralized definition */
+/**
+ * Primary Agents for ACT mode - centralized definition.
+ *
+ * NOTE: Array order here does NOT reflect intent-pattern priority.
+ * Intent matching priority is determined by INTENT_PATTERN_CHECKS in intent-pattern-checks.ts.
+ * This array is used for type-safe validation and display info mapping only.
+ */
 export const ACT_PRIMARY_AGENTS = [
   'tooling-engineer', // Config/build tools specialist - highest priority for pattern matching
   'platform-engineer', // IaC, Kubernetes, multi-cloud specialist - high priority for infra tasks
   'data-engineer', // Database/schema specialist - high priority for data tasks
+  'data-scientist', // EDA, statistical analysis, ML modeling, visualization, Jupyter notebooks
   'ai-ml-engineer', // ML frameworks, LLM integration, embeddings, fine-tuning
   'mobile-developer', // Mobile app specialist - detected by project files
   'frontend-developer',
@@ -80,6 +87,10 @@ export const ACT_AGENT_DISPLAY_INFO: Record<ActPrimaryAgent, AgentDisplayInfo> =
   'data-engineer': {
     name: 'Data Engineer',
     description: 'Database, schema design, migrations, analytics',
+  },
+  'data-scientist': {
+    name: 'Data Scientist',
+    description: 'EDA, statistical analysis, ML modeling, data visualization, Jupyter notebooks',
   },
   'ai-ml-engineer': {
     name: 'AI/ML Engineer',

--- a/apps/mcp-server/src/keyword/patterns/data-science.patterns.ts
+++ b/apps/mcp-server/src/keyword/patterns/data-science.patterns.ts
@@ -1,0 +1,102 @@
+/**
+ * Data Scientist Intent Patterns
+ *
+ * These patterns detect prompts related to data analysis, visualization,
+ * statistical modeling, and ML modeling tasks.
+ * Priority: 8th (after data-engineer; distinct from ETL/schema work).
+ *
+ * Confidence Levels:
+ * - 0.95: Highly specific data science libraries and concepts (pandas, EDA, jupyter)
+ * - 0.90: Core data science tasks (data visualization, statistics, regression model)
+ * - 0.85: Broader terms scoped to data science context
+ *
+ * Distinction from data-engineer:
+ * - data-engineer: ETL, schema design, migrations, SQL, databases
+ * - data-scientist: EDA, statistical analysis, ML modeling, visualization, notebooks
+ *
+ * Distinction from ai-ml-engineer:
+ * - ai-ml-engineer: LLM integration, RAG, prompt engineering, deep learning frameworks (PyTorch, TensorFlow)
+ * - data-scientist: Classical ML (scikit-learn), EDA, statistical analysis, data visualization
+ *
+ * @example
+ * "Pandas로 데이터 분석해줘" → data-scientist (0.95)
+ * "matplotlib 시각화 코드 작성" → data-scientist (0.95)
+ * "EDA 스크립트 구현" → data-scientist (0.95)
+ */
+
+import type { IntentPattern } from './intent-patterns.types';
+
+export const DATA_SCIENCE_INTENT_PATTERNS: ReadonlyArray<IntentPattern> = [
+  // Data science library patterns (0.95) - highly specific
+  {
+    pattern: /pandas|numpy|matplotlib|seaborn|plotly/i,
+    confidence: 0.95,
+    description: 'Data science libraries (pandas/numpy/matplotlib/seaborn/plotly)',
+  },
+  {
+    pattern: /jupyter|\.ipynb|주피터/i,
+    confidence: 0.95,
+    description: 'Jupyter notebook (incl. Korean: 주피터)',
+  },
+  {
+    pattern: /scikit.?learn|sklearn/i,
+    confidence: 0.95,
+    description: 'scikit-learn ML library',
+  },
+  // EDA / analysis patterns (0.95)
+  {
+    pattern: /탐색적\s*분석|EDA|exploratory\s*data\s*analysis/i,
+    confidence: 0.95,
+    description: 'Exploratory data analysis (EDA)',
+  },
+  {
+    pattern: /데이터\s*분석\s*(스크립트|코드|구현|작성)|data\s*analysis\s*(script|code|implement)/i,
+    confidence: 0.95,
+    description: 'Data analysis script/code',
+  },
+  // Visualization patterns (0.90) - scoped to avoid stealing frontend chart work
+  {
+    pattern: /데이터\s*시각화|data\s*visualization/i,
+    confidence: 0.9,
+    description: 'Data visualization',
+  },
+  // Statistical modeling (0.90)
+  {
+    pattern: /통계\s*(분석|모델|검정)|statistical\s*(analysis|model|test)/i,
+    confidence: 0.9,
+    description: 'Statistical analysis/modeling',
+  },
+  {
+    pattern: /상관관계\s*분석|correlation\s*analysis/i,
+    confidence: 0.9,
+    description: 'Correlation analysis',
+  },
+  // ML modeling (0.90) - scoped with _analysis/_model to avoid overlap with ai-ml-engineer
+  {
+    pattern: /회귀\s*(분석|모델)|regression\s*(analysis|model)/i,
+    confidence: 0.9,
+    description: 'Regression analysis/modeling',
+  },
+  {
+    pattern: /분류\s*(모델|알고리즘)|classification\s*(model|algorithm)/i,
+    confidence: 0.9,
+    description: 'Classification modeling',
+  },
+  {
+    pattern: /피처\s*엔지니어링|feature\s*engineering/i,
+    confidence: 0.9,
+    description: 'Feature engineering',
+  },
+  // Scientific computing libraries (0.90) - agent JSON references scipy/statsmodels
+  {
+    pattern: /scipy|statsmodels/i,
+    confidence: 0.9,
+    description: 'Scientific computing libraries (scipy/statsmodels)',
+  },
+  // Standalone data analysis (0.85) - lower confidence to avoid false positives
+  {
+    pattern: /데이터\s*분석/i,
+    confidence: 0.85,
+    description: 'Data analysis (Korean, standalone)',
+  },
+];

--- a/apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts
+++ b/apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts
@@ -12,11 +12,12 @@
  * 5. security-engineer - Security implementation, vulnerability fixes, auth/authz, encryption
  * 6. systems-developer - Rust, C, C++, FFI, WASM, embedded, low-level optimization
  * 7. data-engineer - Database, schema, migrations
- * 8. ai-ml-engineer - ML frameworks, LLM, embeddings
- * 9. backend-developer - APIs, servers, authentication
- * 10. frontend-developer - React, Vue, Angular, UI components, CSS
- * 11. devops-engineer - CI/CD, Docker, deployment, monitoring
- * 12. mobile-developer - React Native, Flutter, iOS/Android (MOVED DOWN - "mobile develop" patterns are greedy)
+ * 8. data-scientist - EDA, pandas/numpy/sklearn, data visualization, Jupyter notebooks
+ * 9. ai-ml-engineer - ML frameworks, LLM, embeddings
+ * 10. backend-developer - APIs, servers, authentication
+ * 11. frontend-developer - React, Vue, Angular, UI components, CSS
+ * 12. devops-engineer - CI/CD, Docker, deployment, monitoring
+ * 13. mobile-developer - React Native, Flutter, iOS/Android (MOVED DOWN - "mobile develop" patterns are greedy)
  */
 
 import type { IntentPatternCheck } from './intent-patterns.types';
@@ -27,6 +28,7 @@ import { PLATFORM_INTENT_PATTERNS } from './platform.patterns';
 import { SECURITY_INTENT_PATTERNS } from './security.patterns';
 import { SYSTEMS_INTENT_PATTERNS } from './systems.patterns';
 import { DATA_INTENT_PATTERNS } from './data.patterns';
+import { DATA_SCIENCE_INTENT_PATTERNS } from './data-science.patterns';
 import { AI_ML_INTENT_PATTERNS } from './ai-ml.patterns';
 import { BACKEND_INTENT_PATTERNS } from './backend.patterns';
 import { FRONTEND_INTENT_PATTERNS } from './frontend.patterns';
@@ -70,6 +72,11 @@ export const INTENT_PATTERN_CHECKS: ReadonlyArray<IntentPatternCheck> = [
     agent: 'data-engineer',
     patterns: DATA_INTENT_PATTERNS,
     category: 'Data',
+  },
+  {
+    agent: 'data-scientist',
+    patterns: DATA_SCIENCE_INTENT_PATTERNS,
+    category: 'DataScience',
   },
   {
     agent: 'ai-ml-engineer',

--- a/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
+++ b/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
@@ -300,6 +300,100 @@ describe('ActAgentStrategy', () => {
       });
     });
 
+    describe('data-scientist patterns', () => {
+      // Patterns that match data-science.patterns.ts (13 patterns total):
+      // - /pandas|numpy|matplotlib|seaborn|plotly/i (0.95)
+      // - /jupyter|\.ipynb|주피터/i (0.95)
+      // - /scikit.?learn|sklearn/i (0.95)
+      // - /탐색적\s*분석|EDA|exploratory\s*data\s*analysis/i (0.95)
+      // - /데이터\s*분석\s*(스크립트|코드|구현|작성)|data\s*analysis\s*(script|code|implement)/i (0.95)
+      // - /데이터\s*시각화|data\s*visualization/i (0.90)
+      // - /통계\s*(분석|모델|검정)|statistical\s*(analysis|model|test)/i (0.90)
+      // - /상관관계\s*분석|correlation\s*analysis/i (0.90)
+      // - /회귀\s*(분석|모델)|regression\s*(analysis|model)/i (0.90)
+      // - /분류\s*(모델|알고리즘)|classification\s*(model|algorithm)/i (0.90)
+      // - /피처\s*엔지니어링|feature\s*engineering/i (0.90)
+      // - /scipy|statsmodels/i (0.90)
+      // - /데이터\s*분석/i (0.85) - standalone Korean
+      const dataScientistPrompts = [
+        'Pandas로 데이터 분석해줘', // matches /pandas/i (0.95)
+        'matplotlib 시각화 코드 작성', // matches /matplotlib/i (0.95)
+        'EDA 스크립트 구현해줘', // matches /EDA/i (0.95)
+        'sklearn 분류 모델 만들어줘', // matches /scikit.?learn|sklearn/i (0.95)
+        '주피터 노트북 작성해줘', // matches /주피터/i (0.95)
+        '데이터 분석 코드 작성해줘', // matches /데이터\s*분석\s*(코드)/i (0.95)
+        '데이터 시각화 구현해줘', // matches /데이터\s*시각화/i (0.90)
+        '통계 분석 코드 작성해줘', // matches /통계\s*(분석)/i (0.90)
+        '상관관계 분석해줘', // matches /상관관계\s*분석/i (0.90)
+        '회귀 모델 만들어줘', // matches /회귀\s*(모델)/i (0.90)
+        '피처 엔지니어링 코드 작성', // matches /피처\s*엔지니어링/i (0.90)
+        '분류 알고리즘 구현해줘', // matches /분류\s*(모델|알고리즘)/i (0.90)
+      ];
+
+      it.each(dataScientistPrompts)('should detect data-scientist intent: "%s"', async prompt => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt,
+            availableAgents: ['data-scientist', 'data-engineer', 'frontend-developer'],
+          }),
+        );
+
+        expect(result.agentName).toBe('data-scientist');
+        expect(result.source).toBe('intent');
+      });
+    });
+
+    describe('data-scientist boundary cases', () => {
+      it('should NOT route "Create a migration script" to data-scientist (→ data-engineer)', async () => {
+        const result = await strategy.resolve(
+          createActContext({ prompt: 'Create a migration script' }),
+        );
+        expect(result.agentName).toBe('data-engineer');
+        expect(result.agentName).not.toBe('data-scientist');
+      });
+
+      it('should NOT route "데이터베이스 스키마 설계" to data-scientist (→ data-engineer)', async () => {
+        const result = await strategy.resolve(
+          createActContext({ prompt: '데이터베이스 스키마 설계해줘' }),
+        );
+        expect(result.agentName).toBe('data-engineer');
+        expect(result.agentName).not.toBe('data-scientist');
+      });
+
+      it('should NOT route "Train a PyTorch model" to data-scientist (→ ai-ml-engineer)', async () => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt: 'Train a PyTorch model',
+            availableAgents: ['data-scientist', 'ai-ml-engineer', 'backend-developer'],
+          }),
+        );
+        expect(result.agentName).toBe('ai-ml-engineer');
+        expect(result.agentName).not.toBe('data-scientist');
+      });
+
+      it('should route "데이터 분석해줘" to data-scientist (standalone 0.85 pattern)', async () => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt: '데이터 분석해줘',
+            availableAgents: ['data-scientist', 'data-engineer', 'frontend-developer'],
+          }),
+        );
+        expect(result.agentName).toBe('data-scientist');
+        expect(result.source).toBe('intent');
+      });
+
+      it('should route "scipy 통계 분석 코드" to data-scientist (scipy 0.90 pattern)', async () => {
+        const result = await strategy.resolve(
+          createActContext({
+            prompt: 'scipy 통계 분석 코드 작성해줘',
+            availableAgents: ['data-scientist', 'data-engineer', 'backend-developer'],
+          }),
+        );
+        expect(result.agentName).toBe('data-scientist');
+        expect(result.source).toBe('intent');
+      });
+    });
+
     describe('platform-engineer patterns', () => {
       // Need to check platform.patterns.ts for actual patterns
       const platformPrompts = [

--- a/packages/rules/.ai-rules/agents/data-scientist.json
+++ b/packages/rules/.ai-rules/agents/data-scientist.json
@@ -1,0 +1,156 @@
+{
+  "name": "Data Scientist",
+  "description": "Data science specialist for exploratory data analysis, statistical modeling, ML model development, and data visualization. Handles EDA, feature engineering, model training, and Jupyter notebook development.",
+  "role": {
+    "title": "Senior Data Scientist",
+    "type": "primary",
+    "expertise": [
+      "Exploratory Data Analysis (EDA)",
+      "Statistical Analysis & Modeling",
+      "Machine Learning (supervised/unsupervised)",
+      "Data Visualization (matplotlib, seaborn, plotly)",
+      "Feature Engineering",
+      "Jupyter Notebook Development",
+      "pandas, numpy, scikit-learn workflows",
+      "TDD (Test-Driven Development)",
+      "Augmented Coding Practices"
+    ],
+    "tech_stack": {
+      "note": "This agent supports multiple data science stacks. See project.md for your project's specific configuration.",
+      "python_libraries": [
+        "pandas",
+        "numpy",
+        "matplotlib",
+        "seaborn",
+        "plotly",
+        "scikit-learn",
+        "scipy",
+        "statsmodels"
+      ],
+      "notebooks": ["Jupyter Notebook", "JupyterLab", "Google Colab"],
+      "ml_frameworks": ["scikit-learn", "XGBoost", "LightGBM", "CatBoost"],
+      "version_considerations": {
+        "api_versioning": "Pin library versions in requirements.txt or pyproject.toml",
+        "breaking_changes": "Test notebooks in isolated environments when upgrading"
+      }
+    },
+    "tech_stack_reference": "See project.md 'Tech Stack' section for your project's data science configuration",
+    "responsibilities": [
+      "Perform exploratory data analysis (EDA) with statistical summaries",
+      "Build and evaluate ML models (regression, classification, clustering)",
+      "Create data visualizations for insights and reporting",
+      "Engineer features for model improvement",
+      "Develop and maintain Jupyter notebooks",
+      "Write comprehensive tests for data pipelines with 90%+ coverage",
+      "Follow augmented coding principles (Kent Beck)"
+    ]
+  },
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/project.md",
+    ".ai-rules/rules/augmented-coding.md"
+  ],
+  "activation": {
+    "trigger": "STRICT: When in PLAN or ACT mode with data analysis/visualization/ML modeling tasks, this Agent MUST be automatically activated",
+    "rule": "STRICT: When data science tasks are active, this Agent's workflow framework MUST be used",
+    "file_patterns": [
+      "\\.ipynb$",
+      ".*eda.*\\.py$",
+      ".*analysis.*\\.py$",
+      ".*model.*\\.py$",
+      ".*visualiz.*\\.py$",
+      "notebooks/"
+    ],
+    "intent_patterns": {
+      "korean": [
+        "데이터 분석",
+        "탐색적 분석",
+        "EDA",
+        "시각화",
+        "통계",
+        "회귀",
+        "분류",
+        "상관관계",
+        "주피터",
+        "피처 엔지니어링"
+      ],
+      "english": [
+        "EDA",
+        "exploratory",
+        "data analysis",
+        "visualization",
+        "regression",
+        "classification",
+        "pandas",
+        "numpy",
+        "matplotlib",
+        "seaborn",
+        "scikit-learn",
+        "jupyter"
+      ]
+    },
+    "mandatory_checklist": {
+      "🔴 language": {
+        "rule": "MUST respond in the language specified in communication.language",
+        "verification_key": "language"
+      },
+      "🔴 tdd_cycle": {
+        "rule": "MUST follow TDD cycle for data processing logic (Red -> Green -> Refactor) - See augmented-coding.md",
+        "verification_key": "tdd_cycle"
+      },
+      "🔴 type_safety": {
+        "rule": "MUST use type annotations for Python data science code",
+        "verification_key": "type_safety"
+      },
+      "🔴 test_coverage": {
+        "rule": "MUST maintain 90%+ test coverage for data processing logic",
+        "verification_key": "test_coverage"
+      },
+      "🔴 self_verification": {
+        "rule": "After implementation, verify all checklist items were followed",
+        "verification_key": "self_verification"
+      }
+    },
+    "verification_guide": {
+      "language": "Verify all response text follows communication.language setting",
+      "tdd_cycle": "Verify failing test written first, minimal implementation, refactor step completed",
+      "type_safety": "Verify all functions have type annotations, no implicit any/untyped parameters",
+      "test_coverage": "Run coverage command, verify 90%+ for data processing logic",
+      "self_verification": "Review mandatory_checklist items, cross-reference with verification_guide"
+    }
+  },
+  "distinction_from_data_engineer": {
+    "data_engineer": "ETL pipelines, database schema design, migrations, SQL queries, data infrastructure",
+    "data_scientist": "EDA, statistical analysis, ML modeling, data visualization, Jupyter notebook development"
+  },
+  "tdd_cycle": {
+    "reference": "See augmented-coding.md 'TDD Cycle (Strict Adherence)' section",
+    "summary": "Follow Red -> Green -> Refactor cycle",
+    "data_science_specific": [
+      "Test data transformation functions with known input/output pairs",
+      "Test model evaluation metrics with fixtures",
+      "Test visualization outputs for structure, not pixel-perfect rendering",
+      "Use deterministic seeds (random_state) for reproducible ML tests"
+    ]
+  },
+  "communication": {
+    "approach": [
+      "Start by understanding the data and analysis requirements",
+      "Propose EDA approach before modeling",
+      "Explain statistical decisions clearly",
+      "Reference visualization best practices",
+      "Document assumptions and data quality issues"
+    ]
+  },
+  "reference": {
+    "augmented_coding": {
+      "source": "augmented-coding.md",
+      "description": "Complete TDD principles and workflow"
+    },
+    "project_rules": "See .ai-rules/rules/",
+    "related_specialists": {
+      "data_engineer": ".ai-rules/agents/data-engineer.json - For ETL, schema design, migrations",
+      "ai_ml_engineer": ".ai-rules/agents/ai-ml-engineer.json - For LLM integration, RAG, deep learning frameworks"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #566 (part of #560)

Adds `data-scientist` as a new ACT primary agent, separating data science work (EDA, ML modeling, visualization) from `data-engineer` (ETL, schema design, migrations).

## Changes

| File | Type | Description |
|------|------|-------------|
| `packages/rules/.ai-rules/agents/data-scientist.json` | New | Agent definition with EDA, statistical analysis, ML modeling, visualization expertise |
| `apps/mcp-server/src/keyword/patterns/data-science.patterns.ts` | New | 13 intent patterns (confidence 0.85–0.95) |
| `apps/mcp-server/src/keyword/patterns/intent-pattern-checks.ts` | Modified | Insert `data-scientist` at priority 8 (after `data-engineer`, before `ai-ml-engineer`) |
| `apps/mcp-server/src/keyword/keyword.types.ts` | Modified | Add to `ACT_PRIMARY_AGENTS` and `ACT_AGENT_DISPLAY_INFO` |
| `apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts` | Modified | 17 test cases (12 positive + 5 boundary) |

## Agent Distinction

| Agent | Focus |
|-------|-------|
| `data-engineer` | ETL pipelines, database schema, migrations, data infrastructure |
| `data-scientist` | EDA, statistical analysis, ML modeling, visualization, Jupyter notebooks |

## Intent Patterns

| Pattern | Confidence |
|---------|------------|
| `pandas\|numpy\|matplotlib\|seaborn\|plotly` | 0.95 |
| `jupyter\|\.ipynb\|주피터` | 0.95 |
| `scikit.?learn\|sklearn` | 0.95 |
| `탐색적 분석\|EDA\|exploratory data analysis` | 0.95 |
| `데이터 분석 (스크립트\|코드\|구현\|작성)` | 0.95 |
| `데이터 시각화\|data visualization` | 0.90 |
| `통계 (분석\|모델\|검정)` | 0.90 |
| `상관관계 분석\|correlation analysis` | 0.90 |
| `회귀 (분석\|모델)\|regression (analysis\|model)` | 0.90 |
| `분류 (모델\|알고리즘)\|classification (model\|algorithm)` | 0.90 |
| `피처 엔지니어링\|feature engineering` | 0.90 |
| `scipy\|statsmodels` | 0.90 |
| `데이터 분석` (standalone Korean) | 0.85 |

## Test Coverage

- **12 positive cases**: pandas, matplotlib, EDA, sklearn, 주피터, 데이터 분석 코드, 데이터 시각화, 통계 분석, 상관관계 분석, 회귀 모델, 피처 엔지니어링, 분류 알고리즘
- **5 boundary cases**:
  - `"Create a migration script"` → `data-engineer` (no regression)
  - `"데이터베이스 스키마 설계"` → `data-engineer` (no regression)
  - `"Train a PyTorch model"` → `ai-ml-engineer` (no regression)
  - `"데이터 분석해줘"` → `data-scientist` (standalone 0.85 pattern)
  - `"scipy 통계 분석 코드"` → `data-scientist` (scipy 0.90 pattern)

## Acceptance Criteria

- [x] `data-scientist.json` created with full role definition
- [x] `data-science.patterns.ts` created with data science patterns (separate file, consistent with per-agent pattern file convention)
- [x] `data-scientist` added to `ACT_PRIMARY_AGENTS`
- [x] `data-scientist` added to `INTENT_PATTERN_CHECKS` at priority 8
- [x] Unit test: `"Pandas로 데이터 분석"` → `data-scientist`
- [x] Unit test: `"matplotlib 시각화 코드 작성"` → `data-scientist`
- [x] Unit test: `"EDA 스크립트 구현"` → `data-scientist`
- [x] `data-engineer` still selected for ETL/schema/migration prompts (regression confirmed)
- [x] All 3,950 tests pass