### PR TITLE
add refactoring and type definition patterns to backend (#567)

### DIFF
--- a/apps/mcp-server/src/keyword/patterns/backend.patterns.spec.ts
+++ b/apps/mcp-server/src/keyword/patterns/backend.patterns.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Backend Developer Intent Patterns Tests
+ *
+ * Tests for BACKEND_INTENT_PATTERNS including:
+ * - Framework-specific patterns (NestJS, Express, Django, etc.)
+ * - API patterns (REST, GraphQL, gRPC)
+ * - Generic development patterns (refactoring, TypeScript types)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BACKEND_INTENT_PATTERNS } from './backend.patterns';
+
+const matchesPattern = (input: string): boolean =>
+  BACKEND_INTENT_PATTERNS.some(({ pattern }) => pattern.test(input));
+
+describe('BACKEND_INTENT_PATTERNS', () => {
+  describe('existing framework patterns', () => {
+    it('should match NestJS', () => {
+      expect(matchesPattern('NestJS API 만들어줘')).toBe(true);
+    });
+
+    it('should match REST API', () => {
+      expect(matchesPattern('REST API 설계해줘')).toBe(true);
+    });
+
+    it('should match server development (Korean)', () => {
+      expect(matchesPattern('서버 개발 해줘')).toBe(true);
+    });
+  });
+
+  describe('refactoring patterns', () => {
+    it('should match Korean refactoring keyword', () => {
+      expect(matchesPattern('리팩토링 해줘')).toBe(true);
+    });
+
+    it('should match English refactor keyword', () => {
+      expect(matchesPattern('refactor this module')).toBe(true);
+    });
+
+    it('should match refactor with various casing', () => {
+      expect(matchesPattern('Refactor the service layer')).toBe(true);
+    });
+
+    it('should have confidence 0.75 for refactoring pattern', () => {
+      const match = BACKEND_INTENT_PATTERNS.find(
+        ({ description }) => description === 'Refactoring',
+      );
+      expect(match?.confidence).toBe(0.75);
+    });
+  });
+
+  describe('TypeScript type definition patterns', () => {
+    it('should match Korean type addition pattern', () => {
+      expect(matchesPattern('타입 추가해줘')).toBe(true);
+    });
+
+    it('should match English type definition pattern', () => {
+      expect(matchesPattern('type definition needed')).toBe(true);
+    });
+
+    it('should match Korean type with spaces', () => {
+      expect(matchesPattern('타입추가 필요해')).toBe(true);
+    });
+
+    it('should have confidence 0.80 for type definition pattern', () => {
+      const match = BACKEND_INTENT_PATTERNS.find(
+        ({ description }) => description === 'TypeScript Type Definition',
+      );
+      expect(match?.confidence).toBe(0.8);
+    });
+  });
+});

--- a/apps/mcp-server/src/keyword/patterns/backend.patterns.ts
+++ b/apps/mcp-server/src/keyword/patterns/backend.patterns.ts
@@ -9,6 +9,8 @@
  * - 0.95: Backend frameworks (NestJS, Express, Django, Spring)
  * - 0.90: API patterns (REST, GraphQL, gRPC), server concepts
  * - 0.85: Generic backend keywords
+ * - 0.80: TypeScript type definitions
+ * - 0.75: Generic development (refactoring)
  *
  * @example
  * "NestJS API 만들어줘" → backend-developer (0.95)
@@ -108,5 +110,17 @@ export const BACKEND_INTENT_PATTERNS: ReadonlyArray<IntentPattern> = [
     pattern: /마이크로서비스|microservice/i,
     confidence: 0.85,
     description: 'Microservice',
+  },
+  // TODO(#568): Move to software-engineer.patterns.ts after software-engineer agent is created
+  // Generic Development Patterns (0.75-0.80) - fallback before DEFAULT_ACT_AGENT
+  {
+    pattern: /리팩토링|refactor/i,
+    confidence: 0.75,
+    description: 'Refactoring',
+  },
+  {
+    pattern: /타입\s*추가|type\s*definition/i,
+    confidence: 0.8,
+    description: 'TypeScript Type Definition',
   },
 ];


### PR DESCRIPTION
## Summary

Implements the **"Expand intent patterns for generic prompts"** section of #567.

Adds two new intent patterns to `backend.patterns.ts` to prevent generic development prompts (`리팩토링`, `refactor`, `타입 추가`, `type definition`) from falling through to the default agent (currently `frontend-developer`).

## Changes

### `apps/mcp-server/src/keyword/patterns/backend.patterns.ts`
- Add `refactoring` pattern — matches `리팩토링|refactor`, confidence `0.75`
- Add `TypeScript type definition` pattern — matches `타입\s*추가|type\s*definition`, confidence `0.80`
- Update JSDoc to document new `0.75` and `0.80` confidence tiers
- Add `TODO(#568)`: these patterns will migrate to `software-engineer.patterns.ts` once the agent is created

### `apps/mcp-server/src/keyword/patterns/backend.patterns.spec.ts` _(new file)_
- 11 tests covering both new patterns and their confidence levels
- Tests use description-based explicit lookup to avoid false positives when more patterns are added

## Acceptance Criteria (from #567)

| Criteria | Status |
|----------|--------|
| `INTENT_PATTERN_CHECKS` reordered with all new agents | ✅ Done in previous commits |
| Generic refactoring prompts route appropriately (not to `frontend-developer`) | ✅ This PR |
| All existing tests pass | ✅ 3961 tests passing |
| `act-mode.json` updated with `software-engineer` + resolution_order | ⏳ Blocked by #568 |

## Notes

- `act-mode.json` update remains blocked until #568 (software-engineer agent) merges
- The new patterns are intentionally placed at the bottom of `BACKEND_INTENT_PATTERNS` as lower-confidence fallbacks before `DEFAULT_ACT_AGENT`

## Related

- Closes part of #567
- Part of #560
- Blocked remaining work: #568