### PR TITLE
add software-engineer as default ACT agent (#568)

### DIFF
--- a/apps/mcp-server/src/cli/init/prompts/agent-prompt.spec.ts
+++ b/apps/mcp-server/src/cli/init/prompts/agent-prompt.spec.ts
@@ -13,8 +13,8 @@ vi.mock('@inquirer/prompts', () => ({
 
 describe('agent-prompt', () => {
   describe('DEFAULT_PRIMARY_AGENT', () => {
-    it('should be frontend-developer', () => {
-      expect(DEFAULT_PRIMARY_AGENT).toBe('frontend-developer');
+    it('should be software-engineer', () => {
+      expect(DEFAULT_PRIMARY_AGENT).toBe('software-engineer');
     });
   });
 
@@ -44,11 +44,11 @@ describe('agent-prompt', () => {
       }
     });
 
-    it('should include frontend-developer with recommended label', () => {
+    it('should include software-engineer with recommended label', () => {
       const choices = getPrimaryAgentChoices();
-      const frontend = choices.find(c => c.value === 'frontend-developer');
-      expect(frontend).toBeDefined();
-      expect(frontend?.name).toContain('Recommended');
+      const softwareEng = choices.find(c => c.value === 'software-engineer');
+      expect(softwareEng).toBeDefined();
+      expect(softwareEng?.name).toContain('Recommended');
     });
 
     it('should include descriptions for agents', () => {
@@ -78,7 +78,7 @@ describe('agent-prompt', () => {
         message: 'Select your primary development agent:',
         choices: expect.arrayContaining([
           expect.objectContaining({
-            value: 'frontend-developer',
+            value: 'software-engineer',
             name: expect.stringContaining('Recommended'),
           }),
         ]),

--- a/apps/mcp-server/src/keyword/keyword.service.spec.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.spec.ts
@@ -685,7 +685,7 @@ describe('KeywordService', () => {
         expect(result.agent).toBe('plan-mode');
       });
 
-      it('does not include agent field when agent is undefined in config, but delegates_to defaults to frontend-developer', async () => {
+      it('does not include agent field when agent is undefined in config, but delegates_to defaults to software-engineer', async () => {
         const configWithoutAgent: KeywordModesConfig = {
           modes: {
             PLAN: {
@@ -706,8 +706,8 @@ describe('KeywordService', () => {
 
         // agent field is undefined since not in config
         expect(result.agent).toBeUndefined();
-        // delegates_to defaults to 'frontend-developer' for PLAN/ACT modes (dynamic resolution)
-        expect(result.delegates_to).toBe('frontend-developer');
+        // delegates_to defaults to 'software-engineer' for PLAN/ACT modes (dynamic resolution)
+        expect(result.delegates_to).toBe('software-engineer');
         expect(result.primary_agent_source).toBe('default');
       });
     });
@@ -2324,7 +2324,7 @@ describe('KeywordService', () => {
               instructions: 'Design approach.',
               rules: ['rules/core.md'],
               agent: 'plan-mode',
-              // No delegates_to - will fallback to 'frontend-developer'
+              // No delegates_to - will fallback to 'software-engineer'
             },
             ACT: mockConfig.modes.ACT,
             EVAL: mockConfig.modes.EVAL,
@@ -2343,10 +2343,10 @@ describe('KeywordService', () => {
         const result = await serviceWithAgentPrompt.parseMode('PLAN design feature');
 
         // Since no PrimaryAgentResolver is provided and no delegates_to in config,
-        // it will use default 'frontend-developer' (fallback behavior)
-        expect(result.delegates_to).toBe('frontend-developer');
+        // it will use default 'software-engineer' (fallback behavior)
+        expect(result.delegates_to).toBe('software-engineer');
         // Agent system prompt function SHOULD be called with the fallback agent
-        expect(mockLoadAgentSystemPrompt).toHaveBeenCalledWith('frontend-developer', 'PLAN');
+        expect(mockLoadAgentSystemPrompt).toHaveBeenCalledWith('software-engineer', 'PLAN');
         expect(result.included_agent).toBeDefined();
         expect(result.included_agent?.name).toBe('Default Agent');
       });

--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -29,6 +29,7 @@ export const ACT_PRIMARY_AGENTS = [
   'test-engineer', // TDD, unit/integration/e2e test specialist
   'security-engineer', // Security features implementation & vulnerability remediation (intent priority: 5th)
   'systems-developer', // Rust, C, C++, FFI, WASM, embedded, low-level optimization (intent priority: 6th)
+  'software-engineer', // fallback default — no intent patterns, language-agnostic generalist
 ] as const;
 
 /** Primary Agent for EVAL mode - centralized definition */
@@ -44,7 +45,7 @@ export const EVAL_PRIMARY_AGENT = 'code-reviewer' as const;
  *
  * @see ACT_PRIMARY_AGENTS for the full list of ACT mode agents
  */
-export const DEFAULT_ACT_AGENT = 'frontend-developer' as const;
+export const DEFAULT_ACT_AGENT = 'software-engineer' as const;
 
 /** All Primary Agents (Tier 1) - combined list */
 export const ALL_PRIMARY_AGENTS = [
@@ -127,6 +128,10 @@ export const ACT_AGENT_DISPLAY_INFO: Record<ActPrimaryAgent, AgentDisplayInfo> =
   'systems-developer': {
     name: 'Systems Developer',
     description: 'Rust, C, C++, FFI, WASM, embedded, low-level performance',
+  },
+  'software-engineer': {
+    name: 'Software Engineer',
+    description: 'General-purpose engineer — any language, any domain, TDD-first',
   },
 };
 

--- a/apps/mcp-server/src/keyword/patterns/tooling.patterns.ts
+++ b/apps/mcp-server/src/keyword/patterns/tooling.patterns.ts
@@ -13,7 +13,7 @@
  * 6. MOBILE_INTENT_PATTERNS
  * 7. CONTEXT_PATTERNS (file path/extension inference)
  * 8. Project config (primaryAgent setting)
- * 9. Default fallback (frontend-developer) - lowest
+ * 9. Default fallback (software-engineer) - lowest
  *
  * Confidence Levels:
  * - 0.95-0.98: Highly specific config file names (tsconfig, vite.config, etc.)

--- a/apps/mcp-server/src/keyword/primary-agent-resolver.spec.ts
+++ b/apps/mcp-server/src/keyword/primary-agent-resolver.spec.ts
@@ -1211,6 +1211,7 @@ describe('PrimaryAgentResolver', () => {
           'solution-architect',
           'technical-planner',
           'code-reviewer',
+          'software-engineer',
         ]);
       });
 
@@ -1237,15 +1238,15 @@ describe('PrimaryAgentResolver', () => {
         expect(result.source).toBe('context');
       });
 
-      it('suggests frontend-developer when context includes .tsx files', async () => {
+      it('suggests software-engineer when context includes .tsx files', async () => {
         const context: ResolutionContext = {
           filePath: '/project/component.tsx',
         };
 
         const result = await resolver.resolve('ACT', '이 파일 수정해', context);
 
-        // .tsx has lower confidence (0.7), so falls through to default
-        expect(result.agentName).toBe('frontend-developer');
+        // .tsx has lower confidence (0.7), so falls through to default (software-engineer)
+        expect(result.agentName).toBe('software-engineer');
       });
 
       describe('mobile context patterns', () => {
@@ -1716,12 +1717,27 @@ describe('PrimaryAgentResolver', () => {
     });
 
     describe('no pattern match falls back to default', () => {
-      it('returns frontend-developer for unmatched generic prompt', async () => {
+      it('returns software-engineer for unmatched generic prompt', async () => {
+        mockListPrimaryAgents.mockResolvedValueOnce([
+          'frontend-developer',
+          'backend-developer',
+          'agent-architect',
+          'devops-engineer',
+          'solution-architect',
+          'technical-planner',
+          'code-reviewer',
+          'mobile-developer',
+          'data-engineer',
+          'platform-engineer',
+          'tooling-engineer',
+          'ai-ml-engineer',
+          'software-engineer',
+        ]);
         const result = await resolver.resolve('ACT', 'help me with this random task');
 
-        expect(result.agentName).toBe('frontend-developer');
+        expect(result.agentName).toBe('software-engineer');
         expect(result.source).toBe('default');
-        expect(result.reason).toContain('no specific intent detected');
+        expect(result.reason).toContain('no domain detected');
       });
 
       it('returns frontend-developer for Korean generic prompt', async () => {

--- a/apps/mcp-server/src/keyword/primary-agent-resolver.ts
+++ b/apps/mcp-server/src/keyword/primary-agent-resolver.ts
@@ -6,7 +6,7 @@
  * 2. Project configuration
  * 3. Intent analysis (prompt content analysis)
  * 4. Context (file path, project type)
- * 5. Default fallback (frontend-developer)
+ * 5. Default fallback (software-engineer)
  *
  * This is the main entry point for agent resolution.
  * Resolution logic is delegated to mode-specific strategies.

--- a/apps/mcp-server/src/keyword/strategies/__tests__/strategy-test.utils.ts
+++ b/apps/mcp-server/src/keyword/strategies/__tests__/strategy-test.utils.ts
@@ -23,6 +23,8 @@ export const ACT_MODE_AGENTS = [
   'ai-ml-engineer',
   'test-engineer',
   'security-engineer',
+  'systems-developer',
+  'software-engineer',
 ] as const;
 
 /**

--- a/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
+++ b/apps/mcp-server/src/keyword/strategies/act-agent.strategy.spec.ts
@@ -652,7 +652,7 @@ describe('ActAgentStrategy', () => {
   });
 
   describe('default fallback', () => {
-    it('should return frontend-developer by default', async () => {
+    it('should return software-engineer by default', async () => {
       const result = await strategy.resolve(
         createActContext({
           prompt: 'Help me with this feature',
@@ -660,7 +660,7 @@ describe('ActAgentStrategy', () => {
       );
 
       expect(result.agentName).toBe(DEFAULT_ACT_AGENT);
-      expect(result.agentName).toBe('frontend-developer');
+      expect(result.agentName).toBe('software-engineer');
       expect(result.source).toBe('default');
       expect(result.confidence).toBe(1.0);
     });
@@ -686,9 +686,22 @@ describe('ActAgentStrategy', () => {
         }),
       );
 
-      expect(result.agentName).toBe('frontend-developer');
+      expect(result.agentName).toBe('software-engineer');
       expect(result.source).toBe('default');
       expect(result.confidence).toBe(0.5);
+    });
+
+    it('should NOT select software-engineer via intent patterns', async () => {
+      // software-engineer has no intent patterns — it must only appear as default fallback
+      const result = await strategy.resolve(
+        createActContext({
+          prompt: 'Help me with this feature',
+          availableAgents: ['software-engineer', 'backend-developer', 'frontend-developer'],
+        }),
+      );
+
+      expect(result.agentName).toBe('software-engineer');
+      expect(result.source).toBe('default'); // must NOT be 'intent'
     });
   });
 

--- a/apps/mcp-server/src/keyword/strategies/act-agent.strategy.ts
+++ b/apps/mcp-server/src/keyword/strategies/act-agent.strategy.ts
@@ -10,7 +10,7 @@
  * 4. Meta-discussion detection (skip intent patterns if discussing agent names)
  * 5-11. Intent patterns (agent, tooling, platform, data, ai-ml, backend, mobile)
  * 12. Context-based suggestion (file path inference)
- * 13. Default fallback (frontend-developer)
+ * 13. Default fallback (software-engineer)
  */
 
 import { Logger } from '@nestjs/common';
@@ -241,7 +241,7 @@ export class ActAgentStrategy implements ResolutionStrategy {
         DEFAULT_ACT_AGENT,
         'default',
         1.0,
-        'ACT mode default: frontend-developer (no specific intent detected)',
+        'ACT mode default: software-engineer (no domain detected — language-agnostic generalist)',
       );
     }
 
@@ -258,7 +258,7 @@ export class ActAgentStrategy implements ResolutionStrategy {
       DEFAULT_ACT_AGENT,
       'default',
       0.5,
-      'ACT mode fallback: frontend-developer (no agents available)',
+      'ACT mode fallback: software-engineer (no agents available)',
     );
   }
 }

--- a/apps/mcp-server/src/keyword/strategies/plan-agent.strategy.spec.ts
+++ b/apps/mcp-server/src/keyword/strategies/plan-agent.strategy.spec.ts
@@ -256,11 +256,11 @@ describe('PlanAgentStrategy', () => {
       const result = await strategy.resolve(
         createPlanContext({
           prompt: 'Help me with this feature',
-          availableAgents: ['frontend-developer', 'backend-developer'],
+          availableAgents: ['software-engineer', 'frontend-developer', 'backend-developer'],
         }),
       );
 
-      expect(result.agentName).toBe('frontend-developer');
+      expect(result.agentName).toBe('software-engineer');
       expect(result.source).toBe('default');
     });
   });

--- a/packages/rules/.ai-rules/agents/README.md
+++ b/packages/rules/.ai-rules/agents/README.md
@@ -153,7 +153,7 @@ Primary Agent is dynamically determined based on the following priority:
 | 1 | **explicit** | Explicit request in prompt (e.g., "use backend-developer agent") |
 | 2 | **config** | Project configuration's `primaryAgent` setting |
 | 3 | **context** | Inference based on file path (e.g., `.go` → backend-developer) |
-| 4 | **default** | Default value (frontend-developer) |
+| 4 | **default** | Default value (software-engineer) |
 
 ### Primary Agent Request Patterns
 
@@ -225,7 +225,7 @@ Mode Agents (Workflow Orchestrators)
 
 Primary Agents (Implementation Experts) - role.type: "primary"
 ├── tooling-engineer       # Config/build tools specialist (highest priority)
-├── frontend-developer     # React/Next.js expertise (default)
+├── frontend-developer     # React/Next.js expertise
 ├── backend-developer      # Multi-language backend expertise
 ├── agent-architect        # AI agent framework expertise
 ├── devops-engineer        # Docker/monitoring expertise
@@ -1358,7 +1358,7 @@ All agent files are located directly in `.ai-rules/agents/` directory without su
 ├── solution-architect.json          # Primary Agent for PLAN mode (architecture)
 ├── technical-planner.json           # Primary Agent for PLAN mode (implementation)
 ├── tooling-engineer.json            # Primary Agent for ACT mode (config/build tools)
-├── frontend-developer.json          # Primary Agent for ACT mode (default)
+├── frontend-developer.json          # Primary Agent for ACT mode (web UI)
 ├── backend-developer.json           # Primary Agent for ACT mode (backend)
 ├── agent-architect.json             # Primary Agent for agent management
 ├── devops-engineer.json             # Primary Agent for Docker/monitoring

--- a/packages/rules/.ai-rules/agents/act-mode.json
+++ b/packages/rules/.ai-rules/agents/act-mode.json
@@ -12,7 +12,7 @@
       "Achieve 90%+ test coverage",
       "Real-time quality verification"
     ],
-    "delegates_to": "frontend-developer",
+    "delegates_to": "software-engineer",
     "responsibilities": [
       "Execute plans defined in PLAN mode",
       "Strictly follow TDD cycle (Red → Green → Refactor)",
@@ -51,7 +51,7 @@
         "verification_key": "agent_indicator"
       },
       "🔴 delegate_activation": {
-        "rule": "MUST activate delegate agent (frontend-developer) framework for implementation execution",
+        "rule": "MUST activate delegate agent (software-engineer) framework for implementation execution",
         "verification_key": "delegate_activation"
       },
       "🔴 auto_return_to_plan": {
@@ -82,9 +82,9 @@
     }
   },
   "delegate_agent": {
-    "primary": "frontend-developer",
-    "description": "This Mode Agent utilizes the Frontend Developer Agent's implementation workflow",
-    "integration": "Applies Frontend Developer Agent's TDD cycle and code quality checklist"
+    "primary": "software-engineer",
+    "description": "This Mode Agent utilizes the Software Engineer Agent's implementation workflow",
+    "integration": "Applies Software Engineer Agent's TDD cycle and code quality checklist"
   },
   "tdd_cycle": {
     "red_phase": {

--- a/packages/rules/.ai-rules/agents/software-engineer.json
+++ b/packages/rules/.ai-rules/agents/software-engineer.json
@@ -1,0 +1,74 @@
+{
+  "name": "Software Engineer",
+  "description": "General-purpose implementation engineer — any language, any domain, TDD-first",
+  "role": {
+    "title": "Senior Software Engineer",
+    "type": "primary",
+    "expertise": [
+      "TypeScript",
+      "Python",
+      "Go",
+      "Rust",
+      "SQL",
+      "Shell",
+      "TDD (Test-Driven Development)",
+      "SOLID Principles",
+      "Design Patterns",
+      "Refactoring",
+      "Algorithms & Data Structures"
+    ],
+    "default_behavior": "Read existing code context → infer domain → implement accordingly",
+    "responsibilities": [
+      "Analyze existing code context before implementing",
+      "Apply TDD cycle regardless of domain or language",
+      "Implement without domain assumptions",
+      "Follow project's existing patterns and conventions",
+      "Ensure type safety and code quality",
+      "Write tests that reflect real behavior (no mocking)"
+    ],
+    "delegation_rules": {
+      "note": "software-engineer is the fallback of last resort. Delegate to specialists only when domain-specific expertise is clearly needed.",
+      "to_frontend_developer": [
+        "When implementing React/Vue/Angular UI components",
+        "When CSS/styling decisions are the primary concern"
+      ],
+      "to_backend_developer": [
+        "When building REST/GraphQL APIs with framework-specific patterns",
+        "When NestJS/Express/FastAPI conventions are central"
+      ],
+      "to_test_engineer": [
+        "When the primary task is improving test coverage strategy",
+        "When setting up a new testing framework"
+      ]
+    }
+  },
+  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "activation": {
+    "note": "software-engineer intentionally has no intent patterns. It only activates as the fallback of last resort when all other agents fail to match.",
+    "trigger": "Automatic fallback when no domain-specific intent is detected",
+    "rule": "DO NOT match this agent via intent patterns — it is the universal default only"
+  },
+  "workflow": {
+    "tdd_execution": {
+      "core_logic": "Red (failing test) → Green (minimal code) → Refactor (only after tests pass)",
+      "approach": "Language-agnostic TDD: write the test, make it pass, refactor",
+      "verification": "Run tests after each step"
+    },
+    "implementation_approach": {
+      "first_step": "Read existing code to understand conventions and patterns",
+      "type_safety": "Use the project's type system strictly — no unsafe bypasses",
+      "code_quality": "SOLID principles, DRY, minimal complexity",
+      "no_assumptions": "Do not default to web UI, REST APIs, or any specific paradigm"
+    }
+  },
+  "quality_standards": {
+    "type_safety": "Follow project's type system — no any, no unsafe casts",
+    "test_coverage": "Cover core logic with tests appropriate for the domain",
+    "code_quality": "SOLID principles, DRY, single responsibility",
+    "language_agnostic": "Apply best practices for whatever language the project uses"
+  },
+  "communication": {
+    "style": "Execution-focused step-by-step progress reporting",
+    "format": "Show implementation progress, test results, and quality verification"
+  }
+}


### PR DESCRIPTION
## Summary

Closes #568 | Part of #560

Replaces `frontend-developer` with a new `software-engineer` agent as the universal default (`DEFAULT_ACT_AGENT`) for ACT mode. The new agent is intentionally domain-agnostic and language-agnostic — it activates only when no other intent pattern matches.

## Problem

`frontend-developer` was the fallback agent, which introduced inappropriate domain assumptions for non-frontend tasks (NestJS APIs, scripts, Rust/Python/Go code, refactoring, etc.).

## Changes

### New File
- `packages/rules/.ai-rules/agents/software-engineer.json` — full agent definition with no intent patterns (by design)

### Modified Files
| File | Change |
|------|--------|
| `keyword.types.ts` | `DEFAULT_ACT_AGENT = 'software-engineer'`, added to `ACT_PRIMARY_AGENTS` (last position) and `ACT_AGENT_DISPLAY_INFO` |
| `act-agent.strategy.ts` | Updated fallback reason string to reflect new default |
| `act-mode.json` | `delegates_to` updated to `software-engineer` |
| `strategy-test.utils.ts` | Added `software-engineer` to `ACT_MODE_AGENTS` |
| `act-agent.strategy.spec.ts` | Updated default fallback tests, added "NOT selectable via intent patterns" test |
| `primary-agent-resolver.ts` | Fixed stale comment referencing `frontend-developer` |
| `tooling.patterns.ts` | Fixed stale comment referencing `frontend-developer` |
| `README.md` | Updated 3 stale references to `DEFAULT_ACT_AGENT` |
| `*.spec.ts` (4 files) | Updated test expectations to match new default |

## Design Decision

> `software-engineer` intentionally has **no intent patterns**.  
> It only activates when all other agents fail to match.  
> This is the fallback of last resort — not a domain specialist.

Placement at the **last position** in `ACT_PRIMARY_AGENTS` is a deliberate signal that it is not a pattern-match target.

## Test Coverage

- ✅ Unrecognized prompts resolve to `software-engineer` (not `frontend-developer`)
- ✅ `software-engineer` is NOT selectable via intent patterns
- ✅ All 3,962 tests pass — no regression
- ✅ TypeScript strict mode — no build errors