### PR TITLE
prepare v4.3.0

### DIFF
--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -5,6 +5,34 @@ Todos los cambios notables de este proyecto se documentarán en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/spec/v2.0.0.html).
 
+## [4.3.0] - 2026-02-20
+
+### Agregado
+
+- **TUI FlowMap**: Reemplazar flechas en curva U con conectores de árbol para mejor visualización de jerarquía de agentes (#574)
+- **TUI FlowMap**: Conectar `activeStage` y agregar estadísticas de agentes por etapa (#571)
+- **TUI FlowMap**: Agregar bandera `isParallel` y visualización de modo de ejecución en nodos de agente (#550)
+- **TUI FlowMap**: Extender `renderAgentTree` para soportar renderizado de subárbol de agentes multinivel (#557)
+- **TUI ActivityVisualizer**: Rediseñar paneles Activity y Live para mayor claridad (#551)
+- **TUI Pie de página**: Rastrear y mostrar conteos de invocaciones de Agent, Skill y Tool
+- **TUI ChecklistPanel**: Separar `ChecklistPanel` de `FocusedAgentPanel` para visualización independiente (#548)
+- **TUI Visibilidad de Agente**: Reemplazar visualización centrada en herramientas con visibilidad real del agente (#549)
+- **TUI Reinicio**: Implementar capacidad de reinicio de TUI via herramienta MCP y flag CLI (#545)
+- **Agentes**: Agregar `software-engineer` como agente ACT predeterminado (#568)
+- **Agentes**: Agregar `data-scientist` como agente ACT principal (#566)
+- **Agentes**: Agregar `systems-developer` como agente ACT principal (#565)
+- **Agentes**: Agregar `security-engineer` como agente ACT principal
+- **Agentes**: Agregar `test-engineer` como agente ACT principal (#563)
+- **Patrones de Palabras Clave**: Agregar patrones de refactorización y definición de tipos a la detección de palabras clave del backend (#567)
+
+### Corregido
+
+- **TUI FlowMap**: Mostrar valores de progreso intermedios en barras de progreso (#572)
+- **TUI FlowMap**: Eliminar agentes obsoletos de FlowMap tras completarse (#570)
+- **TUI HeaderBar**: Corregir desbordamiento de barra de encabezado, visualización de ruta de workspace y eliminar prefijo `sess:` (#547)
+- **Tipos de Palabras Clave**: Agregar `ai-ml-engineer` a `ACT_PRIMARY_AGENTS` (#562)
+- **Manejador de Modo**: Auto-heredar `recommendedActAgent` del contexto en modo ACT (#561)
+
 ## [4.2.0] - 2026-02-18
 
 ### Agregado

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,34 @@
 このドキュメントは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) の形式に基づいており、
 [セマンティック バージョニング](https://semver.org/lang/ja/spec/v2.0.0.html) に準拠しています。
 
+## [4.3.0] - 2026-02-20
+
+### 追加
+
+- **TUI FlowMap**: U字カーブ矢印をツリーコネクターに置き換えてエージェント階層の可視化を改善 (#574)
+- **TUI FlowMap**: `activeStage` の連携とステージ別エージェント統計の追加 (#571)
+- **TUI FlowMap**: エージェントノードに `isParallel` フラグと実行モード表示を追加 (#550)
+- **TUI FlowMap**: `renderAgentTree` をマルチレベルエージェントサブツリーレンダリング対応に拡張 (#557)
+- **TUI ActivityVisualizer**: Activity および Live パネルを再設計して視認性向上 (#551)
+- **TUI フッター**: Agent、Skill、Tool の呼び出し回数を追跡・表示
+- **TUI ChecklistPanel**: `ChecklistPanel` を `FocusedAgentPanel` から分離して独立表示 (#548)
+- **TUI エージェント可視性**: ツール中心表示を実際のエージェント可視性に置き換え (#549)
+- **TUI 再起動**: MCP ツールおよび CLI フラグによる TUI 再起動機能を実装 (#545)
+- **エージェント**: `software-engineer` をデフォルト ACT エージェントとして追加 (#568)
+- **エージェント**: `data-scientist` を ACT 主エージェントとして追加 (#566)
+- **エージェント**: `systems-developer` を ACT 主エージェントとして追加 (#565)
+- **エージェント**: `security-engineer` を ACT 主エージェントとして追加
+- **エージェント**: `test-engineer` を ACT 主エージェントとして追加 (#563)
+- **キーワードパターン**: バックエンドキーワード検出にリファクタリングおよび型定義パターンを追加 (#567)
+
+### 修正
+
+- **TUI FlowMap**: プログレスバーに中間進捗値を表示 (#572)
+- **TUI FlowMap**: 完了後に古いエージェントを FlowMap から削除 (#570)
+- **TUI HeaderBar**: ヘッダーバーのオーバーフロー、ワークスペースパス表示、`sess:` プレフィックス削除を修正 (#547)
+- **キーワードタイプ**: `ACT_PRIMARY_AGENTS` に `ai-ml-engineer` を追加 (#562)
+- **モードハンドラー**: ACT モードでコンテキストから `recommendedActAgent` を自動継承 (#561)
+
 ## [4.2.0] - 2026-02-18
 
 ### 追加

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -5,6 +5,34 @@
 이 문서는 [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형식을 따르며,
 [Semantic Versioning](https://semver.org/lang/ko/spec/v2.0.0.html)을 준수합니다.
 
+## [4.3.0] - 2026-02-20
+
+### 추가됨
+
+- **TUI FlowMap**: U-커브 화살표를 트리 커넥터로 교체하여 에이전트 계층 시각화 개선 (#574)
+- **TUI FlowMap**: `activeStage` 연동 및 단계별 에이전트 통계 추가 (#571)
+- **TUI FlowMap**: 에이전트 노드에 `isParallel` 플래그 및 실행 모드 표시 (#550)
+- **TUI FlowMap**: `renderAgentTree`를 다중 레벨 에이전트 서브트리 렌더링 지원으로 확장 (#557)
+- **TUI ActivityVisualizer**: Activity 및 Live 패널 재설계로 가시성 향상 (#551)
+- **TUI 푸터**: Agent, Skill, Tool 호출 횟수 추적 및 표시
+- **TUI ChecklistPanel**: `ChecklistPanel`을 `FocusedAgentPanel`에서 분리하여 독립 표시 (#548)
+- **TUI 에이전트 가시성**: 도구 중심 표시를 실제 에이전트 가시성으로 교체 (#549)
+- **TUI 재시작**: MCP 툴 및 CLI 플래그를 통한 TUI 재시작 기능 구현 (#545)
+- **에이전트**: `software-engineer`를 기본 ACT 에이전트로 추가 (#568)
+- **에이전트**: `data-scientist` ACT 주 에이전트 추가 (#566)
+- **에이전트**: `systems-developer` ACT 주 에이전트 추가 (#565)
+- **에이전트**: `security-engineer` ACT 주 에이전트 추가
+- **에이전트**: `test-engineer` ACT 주 에이전트 추가 (#563)
+- **키워드 패턴**: 백엔드 키워드 감지에 리팩토링 및 타입 정의 패턴 추가 (#567)
+
+### 수정됨
+
+- **TUI FlowMap**: 진행 바에서 중간값 표시 (#572)
+- **TUI FlowMap**: 완료 후 오래된 에이전트 FlowMap에서 제거 (#570)
+- **TUI HeaderBar**: 헤더 바 오버플로우, 워크스페이스 경로 표시, `sess:` 접두사 제거 수정 (#547)
+- **키워드 타입**: `ACT_PRIMARY_AGENTS`에 `ai-ml-engineer` 추가 (#562)
+- **모드 핸들러**: ACT 모드에서 컨텍스트의 `recommendedActAgent` 자동 상속 (#561)
+
 ## [4.2.0] - 2026-02-18
 
 ### 추가됨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.0] - 2026-02-20
+
+### Added
+
+- **TUI FlowMap**: Replace U-curve arrows with tree connectors for cleaner agent hierarchy visualization (#574)
+- **TUI FlowMap**: Wire `activeStage` and add per-stage agent statistics (#571)
+- **TUI FlowMap**: Add `isParallel` flag and execution mode display for agent nodes (#550)
+- **TUI FlowMap**: Extend `renderAgentTree` to support multi-level agent subtree rendering (#557)
+- **TUI ActivityVisualizer**: Redesign Activity and Live panels for improved clarity (#551)
+- **TUI Footer**: Track and display Agent, Skill, and Tool invocation counts
+- **TUI ChecklistPanel**: Split `ChecklistPanel` from `FocusedAgentPanel` for independent display (#548)
+- **TUI Agent Visibility**: Replace tool-centric display with real agent visibility (#549)
+- **TUI Restart**: Implement TUI restart capability via MCP tool and CLI flag (#545)
+- **Agents**: Add `software-engineer` as default ACT agent (#568)
+- **Agents**: Add `data-scientist` as ACT primary agent (#566)
+- **Agents**: Add `systems-developer` as ACT primary agent (#565)
+- **Agents**: Add `security-engineer` as ACT primary agent
+- **Agents**: Add `test-engineer` as ACT primary agent (#563)
+- **Keyword Patterns**: Add refactoring and type definition patterns to backend keyword detection (#567)
+
+### Fixed
+
+- **TUI FlowMap**: Show intermediate progress values in progress bars (#572)
+- **TUI FlowMap**: Remove stale agents from FlowMap after completion (#570)
+- **TUI HeaderBar**: Fix header bar overflow, workspace path display, and remove `sess:` prefix (#547)
+- **Keyword Types**: Add `ai-ml-engineer` to `ACT_PRIMARY_AGENTS` (#562)
+- **Mode Handler**: Auto-inherit `recommendedActAgent` from context in ACT mode (#561)
+
 ## [4.2.0] - 2026-02-18
 
 ### Added

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,34 @@
 本文档格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 并遵循 [语义化版本](https://semver.org/lang/zh-CN/spec/v2.0.0.html)。
 
+## [4.3.0] - 2026-02-20
+
+### 新增
+
+- **TUI FlowMap**: 用树形连接器替换 U 形曲线箭头，改善 Agent 层次可视化 (#574)
+- **TUI FlowMap**: 接入 `activeStage` 并添加每阶段 Agent 统计 (#571)
+- **TUI FlowMap**: 为 Agent 节点添加 `isParallel` 标志和执行模式显示 (#550)
+- **TUI FlowMap**: 扩展 `renderAgentTree` 支持多级 Agent 子树渲染 (#557)
+- **TUI ActivityVisualizer**: 重新设计 Activity 和 Live 面板，提升可读性 (#551)
+- **TUI 页脚**: 追踪并显示 Agent、Skill 和 Tool 调用次数
+- **TUI ChecklistPanel**: 将 `ChecklistPanel` 从 `FocusedAgentPanel` 中拆分，独立显示 (#548)
+- **TUI Agent 可见性**: 以真实 Agent 可见性替换以工具为中心的显示 (#549)
+- **TUI 重启**: 通过 MCP 工具和 CLI 标志实现 TUI 重启功能 (#545)
+- **Agent**: 将 `software-engineer` 添加为默认 ACT Agent (#568)
+- **Agent**: 将 `data-scientist` 添加为 ACT 主 Agent (#566)
+- **Agent**: 将 `systems-developer` 添加为 ACT 主 Agent (#565)
+- **Agent**: 将 `security-engineer` 添加为 ACT 主 Agent
+- **Agent**: 将 `test-engineer` 添加为 ACT 主 Agent (#563)
+- **关键词模式**: 在后端关键词检测中添加重构和类型定义模式 (#567)
+
+### 修复
+
+- **TUI FlowMap**: 在进度条中显示中间进度值 (#572)
+- **TUI FlowMap**: 完成后从 FlowMap 中移除旧 Agent (#570)
+- **TUI HeaderBar**: 修复页眉溢出、工作区路径显示及移除 `sess:` 前缀 (#547)
+- **关键词类型**: 将 `ai-ml-engineer` 添加到 `ACT_PRIMARY_AGENTS` (#562)
+- **模式处理器**: ACT 模式下自动从上下文继承 `recommendedActAgent` (#561)
+
 ## [4.2.0] - 2026-02-18
 
 ### 新增

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Multi-AI Rules MCP Server - One source of truth for AI coding rules across all AI assistants",
   "author": "JeremyDev87",
   "license": "MIT",

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "PLAN/ACT/EVAL workflow with auto-detection, specialist agents, and reusable skills for systematic TDD development",
   "author": {
     "name": "JeremyDev87",

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -2,7 +2,7 @@
 
 # CodingBuddy Claude Code Plugin
 
-> Version 4.1.0
+> Version 4.3.0
 
 Multi-AI Rules for consistent coding practices - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic development.
 

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-claude-plugin",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Claude Code Plugin for CodingBuddy - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills",
   "author": "JeremyDev87",
   "license": "MIT",
@@ -46,7 +46,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "codingbuddy": "^4.2.0"
+    "codingbuddy": "^4.3.0"
   },
   "peerDependenciesMeta": {
     "codingbuddy": {

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-rules",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "AI coding rules for consistent practices across AI assistants",
   "main": "index.js",
   "types": "index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5427,7 +5427,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:4.0.17"
   peerDependencies:
-    codingbuddy: ^4.2.0
+    codingbuddy: ^4.3.0
   peerDependenciesMeta:
     codingbuddy:
       optional: true


### PR DESCRIPTION
## Summary

Prepare release v4.3.0 — bump version from 4.2.0 to 4.3.0 across all packages and update CHANGELOG in 5 languages.

## Changes

- **Version bump**: `4.2.0` → `4.3.0` in `apps/mcp-server`, `packages/rules`, `packages/claude-code-plugin`
- **plugin.json**: Version updated to `4.3.0`
- **CHANGELOG**: Updated in EN / KO / JA / ZH-CN / ES

## What's in v4.3.0

### Added

- **TUI FlowMap**: Replace U-curve arrows with tree connectors for cleaner agent hierarchy visualization (#574)
- **TUI FlowMap**: Wire `activeStage` and add per-stage agent statistics (#571)
- **TUI FlowMap**: Add `isParallel` flag and execution mode display for agent nodes (#550)
- **TUI FlowMap**: Extend `renderAgentTree` to support multi-level agent subtree rendering (#557)
- **TUI ActivityVisualizer**: Redesign Activity and Live panels for improved clarity (#551)
- **TUI Footer**: Track and display Agent, Skill, and Tool invocation counts
- **TUI ChecklistPanel**: Split `ChecklistPanel` from `FocusedAgentPanel` for independent display (#548)
- **TUI Agent Visibility**: Replace tool-centric display with real agent visibility (#549)
- **TUI Restart**: Implement TUI restart capability via MCP tool and CLI flag (#545)
- **Agents**: Add `software-engineer` as default ACT agent (#568)
- **Agents**: Add `data-scientist` as ACT primary agent (#566)
- **Agents**: Add `systems-developer` as ACT primary agent (#565)
- **Agents**: Add `security-engineer` as ACT primary agent
- **Agents**: Add `test-engineer` as ACT primary agent (#563)
- **Keyword Patterns**: Add refactoring and type definition patterns to backend keyword detection (#567)

### Fixed

- **TUI FlowMap**: Show intermediate progress values in progress bars (#572)
- **TUI FlowMap**: Remove stale agents from FlowMap after completion (#570)
- **TUI HeaderBar**: Fix header bar overflow, workspace path display, and remove `sess:` prefix (#547)
- **Keyword Types**: Add `ai-ml-engineer` to `ACT_PRIMARY_AGENTS` (#562)
- **Mode Handler**: Auto-inherit `recommendedActAgent` from context in ACT mode (#561)

## Test Plan

- [x] `verify-release-versions.sh v4.3.0` passes for all 3 packages
- [x] `yarn build:all` exits with code 0
- [x] CHANGELOG entry counts match across all 5 languages