### PR TITLE
document MCP configuration and project root detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ custom.mdc
 .codingbuddy/
 docs/codingbuddy/
 .omc/
+.claude/skills/ship/

--- a/.kiro/rules/guidelines.md
+++ b/.kiro/rules/guidelines.md
@@ -37,13 +37,38 @@ See `packages/rules/.ai-rules/agents/`:
 - Accessibility (WCAG 2.1 AA compliance)
 - SEO, Architecture, Test Strategy, Design System, Documentation, Code Quality, DevOps
 
+### MCP Server Integration
+
+When the codingbuddy MCP server is configured (`.kiro/settings/mcp.json`), use MCP tools for enhanced workflow:
+
+**Core Workflow Tools:**
+- `parse_mode` — Parse PLAN/ACT/EVAL/AUTO keywords and load appropriate Agent/rules
+- `update_context` — Persist decisions and notes to `docs/codingbuddy/context.md` (mandatory at mode completion)
+- `read_context` — Read current context document
+
+**Analysis Tools:**
+- `search_rules` — Search rules and guidelines by query
+- `analyze_task` — Pre-planning task analysis with risk assessment
+- `generate_checklist` — Contextual checklists (security, a11y, performance)
+
+**Agent & Skills Tools:**
+- `get_agent_details` — Get specialist agent profile
+- `recommend_skills` → `get_skill` — Discover and load relevant skills
+- `prepare_parallel_agents` — Get specialist prompts for sequential execution
+
+**Configuration Tools:**
+- `get_project_config` — Get project configuration (language, tech stack)
+- `get_code_conventions` — Get project code conventions
+
+> **Note:** MCP 서버가 설정되어 있지 않은 경우, `.ai-rules/` 디렉토리의 파일을 직접 참조하여 동일한 규칙을 적용할 수 있습니다.
+
 ## 🔴 MANDATORY: Keyword Mode Detection
 
 <CODINGBUDDY_CRITICAL_RULE>
 
 **When user message starts with PLAN, ACT, EVAL, or AUTO keyword (or localized: Korean 계획/실행/평가/자동, Japanese 計画/実行/評価/自動, Chinese 计划/执行/评估/自动, Spanish PLANIFICAR/ACTUAR/EVALUAR/AUTOMÁTICO):**
 
-1. **IMMEDIATELY** follow the mode-specific rules from `packages/rules/.ai-rules/rules/core.md`
+1. **IMMEDIATELY** call `parse_mode` MCP tool (if available) or follow the mode-specific rules from `packages/rules/.ai-rules/rules/core.md`
 2. Apply the mode's workflow **EXACTLY**
 3. Do NOT proceed with your own interpretation
 
@@ -70,7 +95,7 @@ Example: `EVAL` → **즉시** EVAL 모드 규칙 적용 → Devil's Advocate An
 ## Kiro-Specific Features
 
 ### Communication
-- Always respond in Korean (한국어)
+- Follow the `languageInstruction` from `parse_mode` response (or the project's `codingbuddy.config.json` language setting)
 - Use clear, structured markdown formatting
 - Provide actionable, specific feedback
 

--- a/.kiro/settings/mcp.json
+++ b/.kiro/settings/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "codingbuddy": {
+      "command": "npx",
+      "args": ["-y", "codingbuddy"],
+      "env": {
+        "CODINGBUDDY_PROJECT_ROOT": "${workspaceFolder}"
+      }
+    }
+  }
+}

--- a/packages/rules/.ai-rules/adapters/kiro.md
+++ b/packages/rules/.ai-rules/adapters/kiro.md
@@ -1,126 +1,309 @@
 # Kiro Integration Guide
 
-This guide explains how to use the common AI rules (`.ai-rules/`) with Kiro.
+Guide for using codingbuddy with Kiro.
 
 ## Overview
 
-Kiro uses the `.kiro/` directory for custom guidelines and configuration.
+codingbuddy integrates with Kiro in two ways:
 
-## Integration Method
+1. **`.kiro/rules/guidelines.md`** - Kiro-specific rules and guidelines (always-on instructions)
+2. **MCP Server** - codingbuddy MCP tools for workflow management
 
-### Create Kiro Configuration
+## Two Usage Contexts
 
-Create `.kiro/rules/guidelines.md`:
+### End Users (Your Project)
 
-```markdown
-# Kiro Guidelines
+End users access rules **only through MCP tools**. No local rule files needed.
 
-## Common AI Rules
-
-This project uses shared coding rules from `.ai-rules/` for consistency across all AI coding assistants.
-
-### Workflow Reference
-
-See `.ai-rules/rules/core.md` for:
-- **PLAN mode**: Create implementation plans with TDD approach
-- **ACT mode**: Execute changes following quality standards
-- **EVAL mode**: Evaluate code quality and suggest improvements
-
-### Project Context
-
-See `.ai-rules/rules/project.md` for:
-- **Tech Stack**: See project package.json
-- **Architecture**: Layered structure (app → widgets → features → entities → shared)
-- **Conventions**: File naming, import/export rules, pure/impure function separation
-
-### Coding Principles
-
-See `.ai-rules/rules/augmented-coding.md` for:
-- **TDD Cycle**: Red (failing test) → Green (minimal code) → Refactor
-- **Quality Standards**: SOLID principles, DRY, code complexity management
-- **Testing**: 90%+ coverage goal, no mocking, real behavior testing
-- **Commit Discipline**: Separate structural and behavioral changes
-
-### Specialist Knowledge
-
-See `.ai-rules/agents/` for domain expertise:
-- Frontend Development (React/Next.js, TDD, design system)
-- Code Review (quality evaluation, architecture analysis)
-- Security (OAuth 2.0, JWT, XSS/CSRF protection)
-- Performance (bundle optimization, rendering)
-- Accessibility (WCAG 2.1 AA compliance)
-- And more...
-
-## Kiro-Specific Features
-
-[Add Kiro-specific customizations here]
-
-### Communication
-- Follow project's configured language setting
-- Use clear, structured markdown formatting
-- Provide actionable, specific feedback
+```jsonc
+// .kiro/settings/mcp.json
+{
+  "mcpServers": {
+    "codingbuddy": {
+      "command": "npx",
+      "args": ["-y", "codingbuddy"],
+      "env": {
+        "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+      }
+    }
+  }
+}
 ```
 
-## Directory Structure
+> **Important:** Kiro의 `roots/list` MCP capability 지원 여부는 미확인입니다.
+> `CODINGBUDDY_PROJECT_ROOT` 없이는 서버가 프로젝트의 `codingbuddy.config.json`을 찾지 못하여
+> `language` 등 설정이 기본값으로 동작합니다. 항상 이 환경변수를 프로젝트의 절대 경로로 설정하세요.
+
+Optional: Create `.kiro/rules/guidelines.md` for basic integration:
+
+```markdown
+# codingbuddy Integration
+
+When PLAN, ACT, EVAL keywords detected → call `parse_mode` MCP tool.
+Follow the returned instructions and rules exactly.
+```
+
+### Monorepo Contributors
+
+Contributors to the codingbuddy repository can use direct file references:
+
+```
+Project Root/
+├── .kiro/
+│   ├── rules/
+│   │   └── guidelines.md           # References .ai-rules
+│   └── settings/
+│       └── mcp.json                # MCP server configuration
+└── packages/rules/.ai-rules/       # Single Source of Truth
+```
+
+## DRY Principle
+
+**Single Source of Truth**: `packages/rules/.ai-rules/`
+
+- All Agent definitions, rules, skills managed only in `.ai-rules/`
+- `.kiro/rules/guidelines.md` acts as a **pointer only**
+- No duplication, only references
+
+## Configuration Files
+
+### .kiro/settings/mcp.json
+
+MCP server configuration for codingbuddy tools:
+
+```json
+{
+  "mcpServers": {
+    "codingbuddy": {
+      "command": "npx",
+      "args": ["-y", "codingbuddy"],
+      "env": {
+        "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+      }
+    }
+  }
+}
+```
+
+> **Note:** Kiro는 `${VARIABLE}` 문법으로 환경변수 확장을 지원합니다.
+> `${workspaceFolder}` 가 지원되는 경우 절대 경로 대신 사용할 수 있습니다.
+
+**MCP configuration paths:**
+- **Project-level**: `.kiro/settings/mcp.json`
+- **Global**: `~/.kiro/settings/mcp.json`
+
+**Project root resolution priority** (in `mcp.service.ts`):
+1. `CODINGBUDDY_PROJECT_ROOT` environment variable (highest priority)
+2. `roots/list` MCP capability (support unconfirmed in Kiro)
+3. `findProjectRoot()` automatic detection (fallback)
+
+### .kiro/rules/guidelines.md
+
+Always-on instructions automatically applied to all Kiro conversations:
+
+```markdown
+# codingbuddy Guidelines
+
+## Workflow
+When PLAN, ACT, EVAL, or AUTO keywords detected → call `parse_mode` MCP tool.
+Follow the returned instructions and rules exactly.
+
+## References
+- Core workflow: packages/rules/.ai-rules/rules/core.md
+- Project context: packages/rules/.ai-rules/rules/project.md
+- Coding principles: packages/rules/.ai-rules/rules/augmented-coding.md
+- Agents: packages/rules/.ai-rules/agents/
+```
+
+### Directory Structure
 
 ```
 .kiro/
 ├── rules/
-│   └── guidelines.md  # References .ai-rules
-└── config.json        # Kiro configuration (optional)
+│   └── guidelines.md       # Always-on instructions (references .ai-rules)
+└── settings/
+    └── mcp.json             # MCP server configuration
 
 .ai-rules/
 ├── rules/
-│   ├── core.md
-│   ├── project.md
-│   └── augmented-coding.md
+│   ├── core.md              # Workflow (PLAN/ACT/EVAL/AUTO)
+│   ├── project.md           # Tech stack, architecture
+│   └── augmented-coding.md  # TDD, code quality
 ├── agents/
-│   └── *.json
+│   └── *.json               # 35 agent definitions
+├── skills/
+│   └── */SKILL.md           # Skill definitions
 └── adapters/
-    └── kiro.md  # This guide
+    └── kiro.md              # This guide
 ```
 
 ## Usage
 
-### In Kiro Session
+### Mode Keywords
 
 ```
-User: Build a new component
-
-Kiro: # Mode: PLAN
-      [Follows .ai-rules/rules/core.md workflow]
-      [References .ai-rules/rules/project.md for structure]
-      [Applies .ai-rules/rules/augmented-coding.md TDD]
-
-User: ACT
-
-Kiro: # Mode: ACT
-      [Executes with quality standards from .ai-rules]
+PLAN Design user authentication feature
 ```
 
-### Code Generation
+-> `parse_mode` MCP tool is called, loading appropriate Agent and rules
 
-Kiro will generate code following:
-- Project structure from `.ai-rules/rules/project.md`
-- Code quality patterns from `.ai-rules/rules/augmented-coding.md`
-- Specialist knowledge from `.ai-rules/agents/*.json`
+### Specialist Usage
 
-## Benefits
+```
+EVAL Review from security perspective
+```
 
-- ✅ Consistent standards across all AI tools (Cursor, Claude, Antigravity, Q, etc.)
-- ✅ Well-defined workflow and quality expectations
-- ✅ Access to specialist domain knowledge
-- ✅ Easy maintenance: update `.ai-rules/` once, all tools benefit
+-> security-specialist activated
 
-## Kiro-Specific Advantages
+### Auto Mode
 
-[Document Kiro's unique capabilities here and how they complement common rules]
+```
+AUTO implement user dashboard
+```
 
-## Maintenance
+→ Autonomous PLAN → ACT → EVAL cycling
 
-1. Update `.ai-rules/rules/*.md` for changes affecting all AI tools
-2. Update `.kiro/rules/guidelines.md` only for Kiro-specific features
-3. Common rules propagate automatically to all Kiro sessions
+## MCP Tools
+
+Available codingbuddy MCP tools in Kiro:
+
+| Tool | Purpose |
+|------|---------|
+| `parse_mode` | Parse mode keywords (PLAN/ACT/EVAL/AUTO) + load Agent/rules |
+| `search_rules` | Search rules and guidelines by query |
+| `get_agent_details` | Get specific Agent profile and expertise |
+| `get_project_config` | Get project configuration (language, tech stack) |
+| `get_code_conventions` | Get project code conventions and style guide |
+| `suggest_config_updates` | Analyze project and suggest config updates |
+| `recommend_skills` | Recommend skills based on prompt → then call `get_skill` |
+| `get_skill` | Load full skill content by name (e.g., `get_skill("systematic-debugging")`) |
+| `list_skills` | List all available skills with optional filtering |
+| `get_agent_system_prompt` | Get complete system prompt for a specialist agent |
+| `prepare_parallel_agents` | Prepare specialist agents for sequential execution |
+| `dispatch_agents` | Get Task tool-ready dispatch params (Claude Code optimized) |
+| `generate_checklist` | Generate contextual checklists (security, a11y, performance) |
+| `analyze_task` | Analyze task for risk assessment and specialist recommendations |
+| `read_context` | Read context document (`docs/codingbuddy/context.md`) |
+| `update_context` | Update context document with decisions, notes, progress |
+| `cleanup_context` | Manually trigger context document cleanup |
+| `set_project_root` | ~~Set project root directory~~ **(deprecated)** — use `CODINGBUDDY_PROJECT_ROOT` env var instead |
+
+## Specialist Agents Execution
+
+Kiro does not have a `Task` tool for spawning background subagents. When `parse_mode` returns `parallelAgentsRecommendation`, execute specialists **sequentially**.
+
+### Auto-Detection
+
+The MCP server automatically detects Kiro as the client and returns a sequential execution hint in `parallelAgentsRecommendation.hint`. No manual configuration is needed.
+
+### Sequential Workflow
+
+```
+parse_mode returns parallelAgentsRecommendation
+  |
+Call prepare_parallel_agents with recommended specialists
+  |
+For each specialist (sequentially):
+  - Announce: "Analyzing from [icon] [specialist-name] perspective..."
+  - Apply the specialist's system prompt as analysis context
+  - Analyze the target code/design from that specialist's viewpoint
+  - Record findings
+  |
+Consolidate all specialist findings into unified summary
+```
+
+### Example (EVAL mode)
+
+```
+parse_mode({ prompt: "EVAL review auth implementation" })
+-> parallelAgentsRecommendation:
+    specialists: ["security-specialist", "accessibility-specialist", "performance-specialist"]
+
+prepare_parallel_agents({
+  mode: "EVAL",
+  specialists: ["security-specialist", "accessibility-specialist", "performance-specialist"]
+})
+-> agents[]: each has systemPrompt
+
+Sequential analysis:
+  1. 🔒 Security: Apply security-specialist prompt, analyze, record findings
+  2. ♿ Accessibility: Apply accessibility-specialist prompt, analyze, record findings
+  3. ⚡ Performance: Apply performance-specialist prompt, analyze, record findings
+
+Present: Consolidated findings from all 3 specialists
+```
+
+### Specialist Icons
+
+| Icon | Specialist |
+|------|------------|
+| 🔒 | security-specialist |
+| ♿ | accessibility-specialist |
+| ⚡ | performance-specialist |
+| 📏 | code-quality-specialist |
+| 🧪 | test-strategy-specialist |
+| 🏛️ | architecture-specialist |
+| 📚 | documentation-specialist |
+| 🔍 | seo-specialist |
+| 🎨 | design-system-specialist |
+| 📨 | event-architecture-specialist |
+| 🔗 | integration-specialist |
+| 📊 | observability-specialist |
+| 🔄 | migration-specialist |
+| 🌐 | i18n-specialist |
+
+## Skills
+
+### Using Skills in Kiro
+
+**Method 1: MCP Tool Chain (End Users — Recommended)**
+
+The AI should follow this chain when a skill might apply:
+
+1. `recommend_skills({ prompt: "user's message" })` — Get skill recommendations
+2. `get_skill("skill-name")` — Load the recommended skill's full content
+3. Follow the skill instructions in the response
+
+Example flow:
+```
+User: "There is a bug in the authentication logic"
+-> AI calls recommend_skills({ prompt: "There is a bug in the authentication logic" })
+-> Response: { recommendations: [{ skillName: "systematic-debugging", ... }], nextAction: "Call get_skill..." }
+-> AI calls get_skill("systematic-debugging")
+-> AI follows the systematic-debugging skill instructions
+```
+
+**Method 2: File Reference (Monorepo Contributors Only)**
+
+Reference skill files directly from `.ai-rules/skills/` directory in your prompts.
+
+> **Note:** `parse_mode` already embeds matched skill content in `included_skills` — no separate `get_skill` call needed when using mode keywords (PLAN/ACT/EVAL/AUTO).
+
+### Available Skills
+
+- `brainstorming/SKILL.md` - Idea → Design
+- `test-driven-development/SKILL.md` - TDD workflow
+- `systematic-debugging/SKILL.md` - Systematic debugging
+- `writing-plans/SKILL.md` - Implementation plan writing
+- `executing-plans/SKILL.md` - Plan execution
+- `subagent-driven-development/SKILL.md` - Subagent development
+- `dispatching-parallel-agents/SKILL.md` - Parallel Agent dispatch
+- `frontend-design/SKILL.md` - Frontend design
+
+## AGENTS.md
+
+Industry standard format compatible with all AI tools (Kiro, Cursor, Claude Code, Codex, etc.):
+
+```markdown
+# AGENTS.md
+
+This project uses codingbuddy MCP server to manage AI Agents.
+
+## Quick Start
+...
+```
+
+See `AGENTS.md` in project root for details.
 
 ## PR All-in-One Skill
 
@@ -143,7 +326,7 @@ Unified commit and PR workflow that:
 
 ### Configuration
 
-Create `.claude/pr-config.json` in your project root. Required settings:
+Create `.claude/pr-config.json` in your project root (this path is used by the skill regardless of IDE). Required settings:
 - `defaultTargetBranch`: Target branch for PRs
 - `issueTracker`: `jira`, `github`, `linear`, `gitlab`, or `custom`
 - `issuePattern`: Regex pattern for issue ID extraction
@@ -172,7 +355,7 @@ Reference skill files in Kiro by accessing `.ai-rules/skills/pr-all-in-one/` dir
 
 ## AUTO Mode
 
-AUTO mode enables autonomous PLAN -> ACT -> EVAL cycling until quality criteria are met.
+AUTO mode enables autonomous PLAN → ACT → EVAL cycling until quality criteria are met.
 
 ### Triggering AUTO Mode
 
@@ -184,29 +367,19 @@ Use the `AUTO` keyword (or localized versions) at the start of your message:
 | Korean | `자동` |
 | Japanese | `自動` |
 | Chinese | `自动` |
-| Spanish | `AUTOMATICO` |
+| Spanish | `AUTOMÁTICO` |
 
 ### Example Usage
 
 ```
-User: AUTO 새로운 컴포넌트 구현해줘
-
-Kiro: # Mode: AUTO (Iteration 1/3)
-      ## Phase: PLAN
-      [Follows .ai-rules/rules/core.md workflow]
-
-      ## Phase: ACT
-      [Executes with quality standards from .ai-rules]
-
-      ## Phase: EVAL
-      [Evaluates against quality criteria]
-
-      ### Quality Status
-      - Critical: 0
-      - High: 0
-
-      ✅ AUTO mode completed successfully!
+AUTO implement user authentication feature
 ```
+
+```
+자동 사용자 인증 기능 구현해줘
+```
+
+When AUTO keyword is detected, Kiro calls `parse_mode` MCP tool which returns AUTO mode instructions.
 
 ### Workflow
 
@@ -236,9 +409,132 @@ module.exports = {
 - Bug fixes needing comprehensive testing
 - Code quality improvements with measurable criteria
 
+> **Kiro limitation:** AUTO mode에는 강제 루프 메커니즘이 없습니다. 자세한 내용은 [Known Limitations](#known-limitations)를 참조하세요.
+
+## Context Document Management
+
+codingbuddy uses a fixed-path context document (`docs/codingbuddy/context.md`) to persist decisions across mode transitions.
+
+### How It Works
+
+| Mode | Behavior |
+|------|----------|
+| PLAN / AUTO | Resets (clears) existing content and starts fresh |
+| ACT / EVAL | Appends new section to existing content |
+
+### Required Workflow
+
+1. `parse_mode` automatically reads/creates the context document
+2. Review `contextDocument` in the response for previous decisions
+3. **Before completing each mode:** call `update_context` to persist current work
+
+### Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `read_context` | Read current context document |
+| `update_context` | Persist decisions, notes, progress, findings |
+| `cleanup_context` | Summarize older sections to reduce document size |
+
+### Kiro-Specific Note
+
+Unlike Claude Code, Kiro has no hooks to enforce `update_context` calls. You must **manually remember** to call `update_context` before concluding each mode to avoid losing context across sessions.
+
+## Known Limitations
+
+Kiro environment does not support several features available in Claude Code:
+
+| Feature | Status | Workaround |
+|---------|--------|------------|
+| **Task tool** (background subagents) | ❌ Not available | Use `prepare_parallel_agents` for sequential execution |
+| **Native Skill tool** (`/skill-name`) | ❌ Not available | Use MCP tool chain: `recommend_skills` → `get_skill` |
+| **Session hooks** (PreToolUse, etc.) | ❌ Not available | Rely on `.kiro/rules/guidelines.md` for always-on instructions |
+| **Autonomous loop mechanism** | ❌ Not available | AUTO mode depends on Kiro AI voluntarily looping |
+| **Context compaction hooks** | ❌ Not available | Manually call `update_context` before ending each mode |
+| **`dispatch_agents` full usage** | ⚠️ Partial | Returns Claude Code-specific `dispatchParams`; use `prepare_parallel_agents` instead |
+| **`restart_tui`** | ❌ Not applicable | Claude Code TUI-only tool |
+
+### AUTO Mode Reliability
+
+AUTO mode documents autonomous PLAN → ACT → EVAL cycling. In Kiro, this depends entirely on the AI model voluntarily continuing the loop — there is no enforcement mechanism like Claude Code's hooks. Results may vary:
+
+- The AI may stop after one iteration instead of looping
+- Quality exit criteria (`Critical = 0 AND High = 0`) are advisory, not enforced
+- For reliable multi-iteration workflows, prefer manual `PLAN` → `ACT` → `EVAL` cycling
+
+## Kiro-Specific Advantages
+
+Kiro provides unique capabilities that complement codingbuddy's workflow:
+
+### Powers
+
+Self-contained MCP server packages with documentation. Powers extend Kiro's capabilities with pre-built integrations (e.g., AWS, database tools) that can work alongside codingbuddy's MCP tools.
+
+### Hooks
+
+Event-driven automation that triggers on specific events:
+- `onFileChange` - React to file modifications
+- `onSave` - Run actions when files are saved
+- Custom event hooks for CI/CD integration
+
+Hooks can automate quality checks that complement codingbuddy's EVAL mode.
+
+### Steering
+
+Structured development workflow with:
+- **Specs** - Requirements specification documents
+- **Design docs** - Architecture and design decisions
+- **Task lists** - Structured task breakdown and tracking
+
+Steering aligns well with codingbuddy's PLAN mode for structured implementation planning.
+
+### Agent-Native
+
+Kiro is built as an agent-native IDE with:
+- Built-in AI agent with tool permissions
+- Natural language task execution
+- Integrated tool approval workflow
+
+This agent-native architecture provides a natural fit for codingbuddy's agent-based workflow system.
+
+## Verification Status
+
+> Initial documentation based on code analysis and Kiro public documentation. Runtime verification pending.
+
+| Pattern | Status | Notes |
+|---------|--------|-------|
+| MCP Configuration | ✅ Documented | `.kiro/settings/mcp.json` with `CODINGBUDDY_PROJECT_ROOT` |
+| `CODINGBUDDY_PROJECT_ROOT` guidance | ✅ Documented | Priority and fallback behavior explained |
+| MCP Tools Table | ✅ Documented | All 17 tools documented |
+| Specialist Agents Execution | ✅ Documented | Sequential workflow with icons |
+| Context Document Management | ✅ Documented | With Kiro-specific guidance |
+| Known Limitations | ✅ Added | Task tool, hooks, AUTO mode limitations |
+| Kiro Powers integration | ⚠️ Unverified | Documented but not tested in live environment |
+| `roots/list` support | ⚠️ Unknown | Not confirmed in Kiro documentation |
+| AUTO mode reliability | ⚠️ Documented with caveat | No enforcement mechanism in Kiro |
+
 ## Getting Started
 
 1. Ensure `.ai-rules/` directory exists with all common rules
-2. Create `.kiro/rules/guidelines.md` with content above
-3. Start a Kiro session - it will automatically reference common rules
-4. Use PLAN/ACT/EVAL/AUTO workflow as defined in `.ai-rules/rules/core.md`
+2. Configure MCP server in `.kiro/settings/mcp.json`:
+   ```json
+   {
+     "mcpServers": {
+       "codingbuddy": {
+         "command": "npx",
+         "args": ["-y", "codingbuddy"],
+         "env": {
+           "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+         }
+       }
+     }
+   }
+   ```
+3. (Optional) Create `.kiro/rules/guidelines.md` for always-on instructions
+4. Start a Kiro session — MCP tools are now available
+5. Use PLAN/ACT/EVAL/AUTO workflow via `parse_mode` MCP tool
+
+## Reference
+
+- [Kiro MCP Configuration Documentation](https://kiro.dev/docs/mcp/configuration/)
+- [codingbuddy MCP API](../../docs/api.md)


### PR DESCRIPTION
## Summary

- Document MCP server configuration in `.kiro/settings/mcp.json` with `CODINGBUDDY_PROJECT_ROOT` env var for reliable project root resolution
- Add complete MCP tools reference table (17 tools) to `kiro.md` adapter
- Document sequential specialist agent execution workflow (Kiro lacks Task tool)
- Add context document management guide with Kiro-specific notes
- Document known limitations (Task tool, hooks, AUTO mode reliability)
- Add Kiro-specific advantages section (Powers, Hooks, Steering, Agent-Native)
- Update `.kiro/rules/guidelines.md` with MCP tools integration section and dynamic language setting
- Add `.kiro/settings/mcp.json` example configuration file

## Test plan

- [x] `yarn workspace codingbuddy lint` — passed (0 errors)
- [x] `yarn workspace codingbuddy format:check` — passed
- [x] `yarn workspace codingbuddy typecheck` — passed
- [x] `yarn workspace codingbuddy test:coverage` — passed (4711 tests, 94.42%)
- [x] `yarn workspace codingbuddy circular` — passed
- [x] `yarn workspace codingbuddy build` — passed
- [x] `ajv-cli validate` — 35 agent schemas valid
- [x] `markdownlint-cli2` — 65 markdown files, 0 errors

Closes #614