### PR TITLE
add parallel specialist agents execution pattern

### DIFF
--- a/docs/plans/2026-03-01-kiro-parallel-specialist-agents.md
+++ b/docs/plans/2026-03-01-kiro-parallel-specialist-agents.md
@@ -1,0 +1,240 @@
+# [Kiro] Parallel Specialist Agents Execution Pattern Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Kiro 어댑터에 parallel specialist agents 실행 패턴을 문서화하여 Cursor/OpenCode 어댑터와 패리티를 맞춘다.
+
+**Architecture:** 기존 `kiro.md`의 "Specialist Agents Execution" 섹션(lines 191-253)을 확장하여 `dispatchReady` 소비 패턴, Visibility Pattern, Handling Failures, When to Use 섹션을 추가한다.
+
+**Tech Stack:** Markdown documentation only
+
+**Issue:** https://github.com/JeremyDev87/codingbuddy/issues/616
+
+---
+
+## Task 1: `dispatchReady` 소비 패턴 추가
+
+**Files:**
+- Modify: `packages/rules/.ai-rules/adapters/kiro.md` (line 234 뒤, "### Specialist Icons" 앞에 삽입)
+
+**Step 1: `dispatchReady` 소비 섹션 추가**
+
+기존 "### Example (EVAL mode)" 섹션(line 233) 뒤에 다음 내용을 삽입:
+
+```markdown
+### Consuming dispatchReady from parse_mode
+
+When `parse_mode` returns `dispatchReady`, the specialist system prompts are pre-built. In Kiro, use the `dispatchParams.prompt` field as analysis context (ignore `subagent_type` — it is Claude Code specific):
+
+```
+parse_mode returns dispatchReady
+  ↓
+dispatchReady.primaryAgent
+  → Use as the main analysis context
+  ↓
+dispatchReady.parallelAgents[] (if present)
+  → For each: the dispatchParams.prompt field contains the specialist's system prompt.
+    Apply the prompt as analysis context, analyze sequentially, record findings
+  ↓
+Consolidate all findings
+```
+
+> **Fallback:** If `dispatchReady` is not present in the `parse_mode` response, call `prepare_parallel_agents` MCP tool to retrieve specialist system prompts.
+```
+
+**Step 2: Verify the insertion**
+
+Read the modified file around the insertion point to confirm correct placement.
+
+**Step 3: Commit**
+
+```bash
+git add packages/rules/.ai-rules/adapters/kiro.md
+git commit -m "docs(kiro): add dispatchReady consumption pattern for specialist agents"
+```
+
+---
+
+## Task 2: Visibility Pattern 추가
+
+**Files:**
+- Modify: `packages/rules/.ai-rules/adapters/kiro.md` (Specialist Icons 섹션 뒤에 삽입)
+
+**Step 1: Visibility Pattern 섹션 추가**
+
+"### Specialist Icons" 테이블 뒤에 다음 내용을 삽입:
+
+```markdown
+### Visibility Pattern
+
+When executing sequential specialists, display clear status messages:
+
+**Start:**
+```
+🔄 Executing N specialist analyses sequentially...
+   → 🔒 security-specialist
+   → ♿ accessibility-specialist
+   → ⚡ performance-specialist
+```
+
+**During:**
+```
+🔍 Analyzing from 🔒 security-specialist perspective... (1/3)
+```
+
+**Completion:**
+```
+📊 Specialist Analysis Complete:
+
+🔒 Security:
+   [findings summary]
+
+♿ Accessibility:
+   [findings summary]
+
+⚡ Performance:
+   [findings summary]
+```
+```
+
+**Step 2: Verify the insertion**
+
+Read the modified file to confirm correct placement.
+
+**Step 3: Commit**
+
+```bash
+git add packages/rules/.ai-rules/adapters/kiro.md
+git commit -m "docs(kiro): add visibility pattern for sequential specialist execution"
+```
+
+---
+
+## Task 3: Handling Failures 추가
+
+**Files:**
+- Modify: `packages/rules/.ai-rules/adapters/kiro.md` (Visibility Pattern 뒤에 삽입)
+
+**Step 1: Handling Failures 섹션 추가**
+
+Visibility Pattern 섹션 뒤에 다음 내용을 삽입:
+
+```markdown
+### Handling Failures
+
+When `prepare_parallel_agents` returns `failedAgents`:
+
+```
+⚠️ Some agents failed to load:
+   ✗ performance-specialist: Profile not found
+
+Continuing with 2/3 agents...
+```
+
+**Strategy:**
+- Continue with successfully loaded agents
+- Report failures clearly to user
+- Document which agents couldn't be loaded in final report
+```
+
+**Step 2: Verify the insertion**
+
+Read the modified file to confirm correct placement.
+
+**Step 3: Commit**
+
+```bash
+git add packages/rules/.ai-rules/adapters/kiro.md
+git commit -m "docs(kiro): add failure handling for specialist agent loading"
+```
+
+---
+
+## Task 4: When to Use Parallel Execution 추가
+
+**Files:**
+- Modify: `packages/rules/.ai-rules/adapters/kiro.md` (Handling Failures 뒤에 삽입)
+
+**Step 1: When to Use 섹션 추가**
+
+Handling Failures 섹션 뒤에 다음 내용을 삽입:
+
+```markdown
+### When to Use Specialist Execution
+
+Specialist execution is recommended when `parse_mode` returns a `parallelAgentsRecommendation` field:
+
+| Mode | Default Specialists | Use Case |
+|------|---------------------|----------|
+| **PLAN** | architecture-specialist, test-strategy-specialist | Validate architecture and test approach |
+| **ACT** | code-quality-specialist, test-strategy-specialist | Verify implementation quality |
+| **EVAL** | security-specialist, accessibility-specialist, performance-specialist, code-quality-specialist | Comprehensive multi-dimensional review |
+
+### Specialist Activation Scope
+
+Each workflow mode activates different specialist agents:
+
+- **PLAN mode**: Architecture and test strategy specialists validate design
+- **ACT mode**: Code quality and test strategy specialists verify implementation
+- **EVAL mode**: Security, accessibility, performance, and code quality specialists provide comprehensive review
+
+**Important:** Specialists from one mode do NOT carry over to the next mode. Each mode has its own recommended specialist set.
+```
+
+**Step 2: Verify the insertion**
+
+Read the modified file to confirm correct placement.
+
+**Step 3: Commit**
+
+```bash
+git add packages/rules/.ai-rules/adapters/kiro.md
+git commit -m "docs(kiro): add specialist activation scope and when-to-use guidance"
+```
+
+---
+
+## Task 5: Verification Status 테이블 업데이트
+
+**Files:**
+- Modify: `packages/rules/.ai-rules/adapters/kiro.md` (Verification Status 테이블)
+
+**Step 1: Verification Status 행 업데이트**
+
+기존:
+```
+| Specialist Agents Execution | ✅ Documented | Sequential workflow with icons |
+```
+
+변경:
+```
+| Specialist Agents Execution | ✅ Documented | Sequential workflow, dispatchReady, visibility, failures, activation scope |
+```
+
+**Step 2: Verify the change**
+
+Read the modified file to confirm correct update.
+
+**Step 3: Commit**
+
+```bash
+git add packages/rules/.ai-rules/adapters/kiro.md
+git commit -m "docs(kiro): update verification status for specialist agents section"
+```
+
+---
+
+## Summary
+
+| Task | Description | Lines Affected |
+|------|-------------|----------------|
+| 1 | `dispatchReady` 소비 패턴 | Insert after line 233 |
+| 2 | Visibility Pattern | Insert after Specialist Icons |
+| 3 | Handling Failures | Insert after Visibility Pattern |
+| 4 | When to Use + Activation Scope | Insert after Handling Failures |
+| 5 | Verification Status 업데이트 | Modify line 585 |
+
+**Cross-Adapter Parity 달성:**
+- ✅ Cursor 대비: +dispatchReady, +Visibility, +Failures, +Activation Scope (Cursor보다 상위)
+- ✅ OpenCode 대비: 동일 수준 (dispatchReady, Visibility 포함)
+- ✅ Claude Code 대비: 순차 실행 버전으로 동등 커버리지

--- a/packages/rules/.ai-rules/adapters/kiro.md
+++ b/packages/rules/.ai-rules/adapters/kiro.md
@@ -200,15 +200,15 @@ The MCP server automatically detects Kiro as the client and returns a sequential
 
 ```
 parse_mode returns parallelAgentsRecommendation
-  |
+  ↓
 Call prepare_parallel_agents with recommended specialists
-  |
+  ↓
 For each specialist (sequentially):
   - Announce: "Analyzing from [icon] [specialist-name] perspective..."
   - Apply the specialist's system prompt as analysis context
   - Analyze the target code/design from that specialist's viewpoint
   - Record findings
-  |
+  ↓
 Consolidate all specialist findings into unified summary
 ```
 
@@ -233,6 +233,72 @@ Sequential analysis:
 Present: Consolidated findings from all 3 specialists
 ```
 
+### Consuming dispatchReady from parse_mode
+
+When `parse_mode` returns `dispatchReady`, the specialist system prompts are pre-built. In Kiro, use the `dispatchParams.prompt` field as analysis context (ignore `subagent_type` — it is Claude Code specific):
+
+```
+parse_mode returns dispatchReady
+  ↓
+dispatchReady.primaryAgent
+  → Use as the main analysis context
+  ↓
+dispatchReady.parallelAgents[] (if present)
+  → For each: the dispatchParams.prompt field contains the specialist's system prompt.
+    Apply the prompt as analysis context, analyze sequentially, record findings
+  ↓
+Consolidate all findings
+```
+
+> **Fallback:** If `dispatchReady` is not present in the `parse_mode` response, call `prepare_parallel_agents` MCP tool to retrieve specialist system prompts.
+
+### Visibility Pattern
+
+When executing sequential specialists, display clear status messages:
+
+**Start:**
+```
+🔄 Executing N specialist analyses sequentially...
+   → 🔒 security-specialist
+   → ♿ accessibility-specialist
+   → ⚡ performance-specialist
+```
+
+**During:**
+```
+🔍 Analyzing from 🔒 security-specialist perspective... (1/3)
+```
+
+**Completion:**
+```
+📊 Specialist Analysis Complete:
+
+🔒 Security:
+   [findings summary]
+
+♿ Accessibility:
+   [findings summary]
+
+⚡ Performance:
+   [findings summary]
+```
+
+### Handling Failures
+
+When `prepare_parallel_agents` returns `failedAgents`:
+
+```
+⚠️ Some agents failed to load:
+   ✗ performance-specialist: Profile not found
+
+Continuing with 2/3 agents...
+```
+
+**Strategy:**
+- Continue with successfully loaded agents
+- Report failures clearly to user
+- Document which agents couldn't be loaded in final report
+
 ### Specialist Icons
 
 | Icon | Specialist |
@@ -251,6 +317,26 @@ Present: Consolidated findings from all 3 specialists
 | 📊 | observability-specialist |
 | 🔄 | migration-specialist |
 | 🌐 | i18n-specialist |
+
+### When to Use Specialist Execution
+
+Specialist execution is recommended when `parse_mode` returns a `parallelAgentsRecommendation` field:
+
+| Mode | Default Specialists | Use Case |
+|------|---------------------|----------|
+| **PLAN** | architecture-specialist, test-strategy-specialist | Validate architecture and test approach |
+| **ACT** | code-quality-specialist, test-strategy-specialist | Verify implementation quality |
+| **EVAL** | security-specialist, accessibility-specialist, performance-specialist, code-quality-specialist | Comprehensive multi-dimensional review |
+
+### Specialist Activation Scope
+
+Each workflow mode activates different specialist agents:
+
+- **PLAN mode**: Architecture and test strategy specialists validate design
+- **ACT mode**: Code quality and test strategy specialists verify implementation
+- **EVAL mode**: Security, accessibility, performance, and code quality specialists provide comprehensive review
+
+**Important:** Specialists from one mode do NOT carry over to the next mode. Each mode has its own recommended specialist set.
 
 ## Skills
 
@@ -527,7 +613,7 @@ Kiro environment does not support several features available in Claude Code:
 | **Session hooks** (PreToolUse, etc.) | ❌ Not available | Rely on `.kiro/rules/guidelines.md` for always-on instructions |
 | **Autonomous loop mechanism** | ❌ Not available | AUTO mode depends on Kiro AI voluntarily looping |
 | **Context compaction hooks** | ❌ Not available | Manually call `update_context` before ending each mode |
-| **`dispatch_agents` full usage** | ⚠️ Partial | Returns Claude Code-specific `dispatchParams`; use `prepare_parallel_agents` instead |
+| **`dispatch_agents` full usage** | ⚠️ Partial | Use `dispatchReady.dispatchParams.prompt` as analysis context; `prepare_parallel_agents` as fallback |
 | **`restart_tui`** | ❌ Not applicable | Claude Code TUI-only tool |
 
 ### AUTO Mode Reliability
@@ -582,7 +668,7 @@ This agent-native architecture provides a natural fit for codingbuddy's agent-ba
 | MCP Configuration | ✅ Documented | `.kiro/settings/mcp.json` with `CODINGBUDDY_PROJECT_ROOT` |
 | `CODINGBUDDY_PROJECT_ROOT` guidance | ✅ Documented | Priority and fallback behavior explained |
 | MCP Tools Table | ✅ Documented | All 17 tools documented |
-| Specialist Agents Execution | ✅ Documented | Sequential workflow with icons |
+| Specialist Agents Execution | ✅ Documented | Sequential workflow, dispatchReady, visibility, failures, activation scope |
 | Context Document Management | ✅ Documented | With Kiro-specific guidance |
 | Known Limitations | ✅ Added | Task tool, hooks, AUTO mode limitations |
 | Kiro Powers integration | ⚠️ Unverified | Documented but not tested in live environment |


### PR DESCRIPTION
## Summary

- Add `dispatchReady` consumption pattern for Kiro's sequential specialist execution
- Add visibility pattern (start/during/completion status messages)
- Add failure handling when `prepare_parallel_agents` returns `failedAgents`
- Add when-to-use guidance with mode-specific specialist table
- Add specialist activation scope documentation
- Unify sequential workflow diagram arrows for internal consistency
- Update Known Limitations `dispatch_agents` workaround to reflect `dispatchReady` priority

Cross-adapter parity achieved: Kiro > Cursor, Kiro ≥ OpenCode

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify section ordering: Auto-Detection → Sequential Workflow → Example → dispatchReady → Visibility → Failures → Icons → When to Use → Activation Scope → Skills
- [ ] Verify Verification Status table reflects updated notes
- [ ] Verify Known Limitations `dispatch_agents` row matches new guidance
- [ ] Cross-check with OpenCode adapter (`opencode.md`) for parity

Closes #616