### PR TITLE
add MCP configuration and project root detection

### DIFF
--- a/.antigravity/config.json
+++ b/.antigravity/config.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "codingbuddy": {
+      "command": "npx",
+      "args": ["-y", "codingbuddy"],
+      "env": {
+        "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+      }
+    }
+  }
+}

--- a/.antigravity/rules/instructions.md
+++ b/.antigravity/rules/instructions.md
@@ -96,9 +96,11 @@ See agent details in [packages/rules/.ai-rules/agents/README.md](../../packages/
 
 **When user message starts with PLAN, ACT, EVAL, or AUTO keyword (or localized: Korean 계획/실행/평가/자동, Japanese 計画/実行/評価/自動, Chinese 计划/执行/评估/自动, Spanish PLANIFICAR/ACTUAR/EVALUAR/AUTOMÁTICO):**
 
-1. **IMMEDIATELY** follow the mode-specific rules from `packages/rules/.ai-rules/rules/core.md`
-2. Apply the mode's workflow **EXACTLY**
-3. Do NOT proceed with your own interpretation
+1. **IMMEDIATELY** call `parse_mode` MCP tool with the user's prompt
+2. Follow the returned `instructions` **EXACTLY**
+3. Apply the returned `rules` as context
+4. If `warnings` are present, inform the user
+5. **Fallback** (MCP unavailable): Follow mode-specific rules from `packages/rules/.ai-rules/rules/core.md`
 
 **This is MANDATORY, not optional.**
 
@@ -108,6 +110,7 @@ Failure to follow mode rules when these keywords are present will result in:
 - Quality issues not caught before deployment
 
 **Red Flags** (STOP if you think these):
+
 | Thought | Reality |
 |---------|---------|
 | "I can handle EVAL myself" | NO. Follow mode rules FIRST. |
@@ -117,6 +120,69 @@ Failure to follow mode rules when these keywords are present will result in:
 </CODINGBUDDY_CRITICAL_RULE>
 
 Example: `EVAL` → **즉시** EVAL 모드 규칙 적용 → Devil's Advocate Analysis 수행
+
+---
+
+## MCP Server Integration
+
+codingbuddy MCP 서버가 설정되어 있다면, 다음 도구들을 활용하세요:
+
+### 핵심 도구
+
+| 도구 | 용도 |
+|------|------|
+| `parse_mode` | PLAN/ACT/EVAL/AUTO 모드 키워드 파싱 + Agent/rules 로딩 |
+| `search_rules` | 규칙 및 가이드라인 검색 |
+| `get_agent_details` | 전문 Agent 프로필 및 전문 분야 조회 |
+| `recommend_skills` | 프롬프트 기반 스킬 추천 → `get_skill` 호출 |
+| `get_skill` | 스킬 전체 내용 로딩 |
+| `update_context` | 컨텍스트 문서 업데이트 (결정, 노트, 진행상황) |
+
+> 전체 도구 목록(17개)은 [antigravity.md](../../packages/rules/.ai-rules/adapters/antigravity.md#mcp-tools)를 참조하세요.
+
+### 설정 방법
+
+MCP 서버 설정은 `.antigravity/config.json`에 추가합니다:
+
+```json
+{
+  "mcpServers": {
+    "codingbuddy": {
+      "command": "npx",
+      "args": ["-y", "codingbuddy"],
+      "env": {
+        "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+      }
+    }
+  }
+}
+```
+
+자세한 설정 가이드: [packages/rules/.ai-rules/adapters/antigravity.md](../../packages/rules/.ai-rules/adapters/antigravity.md)
+
+---
+
+## Skills
+
+codingbuddy 스킬은 MCP tool chain을 통해 접근합니다:
+
+1. **자동 추천**: `recommend_skills({ prompt: "사용자 메시지" })` → AI가 적합한 스킬 추천
+2. **수동 검색**: `list_skills()` → `get_skill("스킬명")` → 스킬 내용 로딩
+3. **슬래시 커맨드**: 사용자가 `/<command>` 입력 시 → `get_skill` 호출
+
+> **Note:** `parse_mode`는 `included_skills`에 매칭된 스킬을 자동 포함합니다.
+> PLAN/ACT/EVAL/AUTO 키워드 사용 시 별도의 `recommend_skills` 호출이 불필요합니다.
+
+---
+
+## Context Document
+
+`docs/codingbuddy/context.md`에 모드 간 결정사항을 지속합니다:
+
+- `parse_mode`가 자동으로 컨텍스트 문서를 읽기/생성
+- **각 모드 완료 전**: `update_context` 호출 필수
+- PLAN/AUTO 모드: 기존 내용 초기화 후 새로 시작
+- ACT/EVAL 모드: 기존 내용에 새 섹션 추가
 
 ---
 
@@ -132,7 +198,7 @@ Use `task_boundary` tool for tracking progress in different modes:
 
 ### Communication
 
-- **Always respond in Korean (한국어)** as specified in common rules
+- **Follow project's configured language setting** — use `get_project_config` MCP tool to retrieve current language setting
 - Use structured markdown formatting
 - Provide clear, actionable feedback
 

--- a/packages/rules/.ai-rules/adapters/antigravity.md
+++ b/packages/rules/.ai-rules/adapters/antigravity.md
@@ -1,193 +1,465 @@
 # Antigravity Integration Guide
 
-This guide explains how to use the common AI rules (`.ai-rules/`) in Antigravity (Google Gemini-based coding assistant).
+Guide for using codingbuddy with Antigravity (Google Gemini-based coding assistant).
 
 ## Overview
 
-Antigravity uses the `.antigravity/` directory for its custom instructions and configuration, referencing the common rules from `.ai-rules/`.
+codingbuddy integrates with Antigravity in two ways:
 
-## Integration Method
+1. **`.antigravity/rules/instructions.md`** - Antigravity-specific rules and guidelines (always-on instructions)
+2. **MCP Server** - codingbuddy MCP tools for workflow management
 
-### 1. Create Antigravity Configuration
+## Two Usage Contexts
 
-Create `.antigravity/rules/instructions.md` to reference common rules:
+### End Users (Your Project)
+
+End users access rules **only through MCP tools**. No local rule files needed.
+
+```json
+// .antigravity/config.json
+{
+  "mcpServers": {
+    "codingbuddy": {
+      "command": "npx",
+      "args": ["-y", "codingbuddy"],
+      "env": {
+        "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+      }
+    }
+  }
+}
+```
+
+> **Important:** Antigravity의 `roots/list` MCP capability 지원 여부는 미확인입니다.
+> `CODINGBUDDY_PROJECT_ROOT` 없이는 서버가 프로젝트의 `codingbuddy.config.json`을 찾지 못하여
+> `language` 등 설정이 기본값으로 동작합니다. 항상 이 환경변수를 프로젝트의 절대 경로로 설정하세요.
+
+Optional: Create `.antigravity/rules/instructions.md` for basic integration:
 
 ```markdown
-# Antigravity Instructions
+# codingbuddy Integration
 
-## Common AI Rules Reference
-
-This project follows shared AI coding rules from `.ai-rules/` for consistency across all AI assistants (Cursor, Claude Code, Antigravity, etc.).
-
-### 📚 Core Workflow (PLAN/ACT/EVAL/AUTO)
-
-**Source**: `.ai-rules/rules/core.md`
-
-#### Work Modes
-
-You have four modes of operation:
-
-1. **PLAN mode** - Define a plan without making changes
-2. **ACT mode** - Execute the plan and make changes
-3. **EVAL mode** - Analyze results and propose improvements
-4. **AUTO mode** - Autonomous PLAN → ACT → EVAL cycle until quality achieved
-
-**Mode Flow**:
-- Start in PLAN mode by default
-- Move to ACT when user types `ACT`
-- Return to PLAN after ACT completes (automatic)
-- Move to EVAL only when user explicitly types `EVAL`
-- Move to AUTO when user types `AUTO` (autonomous cycle)
-
-**Mode Indicators**:
-- Print `# Mode: PLAN` in plan mode
-- Print `# Mode: ACT` in act mode
-- Print `# Mode: EVAL` in eval mode
-
-See full workflow details in `.ai-rules/rules/core.md`
-
-### 🏗️ Project Context
-
-**Source**: `.ai-rules/rules/project.md`
-
-#### Tech Stack
-
-See project `package.json`.
-
-#### Project Structure
-```
-src/
-├── app/          # Next.js App Router
-├── entities/     # Domain entities (business logic)
-├── features/     # Feature-specific UI components
-├── widgets/      # Composite widgets
-└── shared/       # Common modules
+When PLAN, ACT, EVAL keywords detected → call `parse_mode` MCP tool.
+Follow the returned instructions and rules exactly.
 ```
 
-See full project setup in `.ai-rules/rules/project.md`
+### Monorepo Contributors
 
-### 🎯 Augmented Coding Principles
+Contributors to the codingbuddy repository can use direct file references:
 
-**Source**: `.ai-rules/rules/augmented-coding.md`
-
-#### TDD Cycle
-1. **Red**: Write a failing test
-2. **Green**: Implement minimum code to pass
-3. **Refactor**: Improve structure after tests pass
-
-#### Core Principles
-- **TDD for core logic** (entities, shared/utils, hooks)
-- **Test-after for UI** (features, widgets)
-- **SOLID principles** and code quality standards
-- **90%+ test coverage** goal
-- **No mocking** - test real behavior
-
-See full augmented coding guide in `.ai-rules/rules/augmented-coding.md`
-
-### 🤖 Specialist Agents
-
-**Source**: `.ai-rules/agents/`
-
-Available specialist agents:
-- **Frontend Developer** - React/Next.js, TDD, design system
-- **Code Reviewer** - Quality evaluation, architecture analysis
-- **Architecture Specialist** - Layer boundaries, dependency direction
-- **Test Strategy Specialist** - Test coverage, TDD workflow
-- **Performance Specialist** - Bundle size, rendering optimization
-- **Security Specialist** - OAuth 2.0, JWT, XSS/CSRF protection
-- **Accessibility Specialist** - WCAG 2.1 AA compliance
-- **SEO Specialist** - Metadata API, structured data
-- **Design System Specialist** - Design system usage
-- **Documentation Specialist** - Documentation quality
-- **Code Quality Specialist** - SOLID, DRY, complexity
-- **DevOps Engineer** - Docker, Datadog, deployment
-
-See agent details in `.ai-rules/agents/README.md`
-
-## Antigravity-Specific Features
-
-### Task Boundaries
-
-Antigravity supports `task_boundary` tool for tracking progress:
-```python
-task_boundary(
-  TaskName="Implementing Feature",
-  Mode="EXECUTION",
-  TaskSummary="Created component with TDD",
-  TaskStatus="Writing tests",
-  PredictedTaskSize=10
-)
+```
+Project Root/
+├── .antigravity/
+│   ├── rules/
+│   │   └── instructions.md          # References .ai-rules
+│   └── config.json                  # MCP server configuration
+└── packages/rules/.ai-rules/       # Single Source of Truth
 ```
 
-### Artifact Management
+## DRY Principle
 
-Antigravity uses artifact files for:
-- Implementation plans: `implementation_plan.md`
-- Task tracking: `task.md`
-- Walkthroughs: `walkthrough.md`
+**Single Source of Truth**: `packages/rules/.ai-rules/`
 
-### Communication
+- All Agent definitions, rules, skills managed only in `.ai-rules/`
+- `.antigravity/rules/instructions.md` acts as a **pointer only**
+- No duplication, only references
 
-- **Follow project's configured language setting**
-- Use structured markdown formatting
-- Provide clear, actionable feedback
+## Configuration Files
 
-## Directory Structure
+### .antigravity/config.json
+
+MCP server configuration for codingbuddy tools:
+
+```json
+{
+  "mcpServers": {
+    "codingbuddy": {
+      "command": "npx",
+      "args": ["-y", "codingbuddy"],
+      "env": {
+        "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+      }
+    }
+  }
+}
+```
+
+**MCP configuration paths:**
+- **Project-level**: `.antigravity/config.json`
+
+**Project root resolution priority** (in `mcp.service.ts`):
+1. `CODINGBUDDY_PROJECT_ROOT` environment variable (highest priority)
+2. `roots/list` MCP capability (support unconfirmed in Antigravity)
+3. `findProjectRoot()` automatic detection (fallback)
+
+### .antigravity/rules/instructions.md
+
+Always-on instructions automatically applied to all Antigravity conversations:
+
+```markdown
+# codingbuddy Guidelines
+
+## Workflow
+When PLAN, ACT, EVAL, or AUTO keywords detected → call `parse_mode` MCP tool.
+Follow the returned instructions and rules exactly.
+
+## References
+- Core workflow: packages/rules/.ai-rules/rules/core.md
+- Project context: packages/rules/.ai-rules/rules/project.md
+- Coding principles: packages/rules/.ai-rules/rules/augmented-coding.md
+- Agents: packages/rules/.ai-rules/agents/
+```
+
+### Directory Structure
 
 ```
 .antigravity/
 ├── rules/
-│   └── instructions.md  # This file - references .ai-rules
-└── config.json          # Antigravity configuration (if needed)
+│   └── instructions.md    # Always-on instructions (references .ai-rules)
+└── config.json             # MCP server configuration
 
-.ai-rules/              # Common rules for all AI tools
+.ai-rules/
 ├── rules/
-│   ├── core.md          # Workflow modes
-│   ├── project.md       # Project setup
-│   └── augmented-coding.md  # TDD principles
+│   ├── core.md              # Workflow (PLAN/ACT/EVAL/AUTO)
+│   ├── project.md           # Tech stack, architecture
+│   └── augmented-coding.md  # TDD, code quality
 ├── agents/
-│   └── *.json          # Specialist agents
+│   └── *.json               # 35 agent definitions
+├── skills/
+│   └── */SKILL.md           # Skill definitions
 └── adapters/
-    └── antigravity.md  # This guide
+    └── antigravity.md       # This guide
 ```
 
-## Usage in Antigravity
+## Usage
 
-### Reference Rules Directly
-
-When working with Antigravity, it automatically has access to:
-- `.ai-rules/rules/` for workflow and coding standards
-- `.ai-rules/agents/` for specialist domain knowledge
-- Project-specific configuration in `.antigravity/rules/`
-
-### Workflow Example
+### Mode Keywords
 
 ```
-User: Build a new newsletter feature
-
-AI: # Mode: PLAN
-    ## 📋 Plan Overview
-    [Following .ai-rules/rules/core.md workflow]
-    [Using .ai-rules/rules/project.md tech stack]
-    [Applying .ai-rules/rules/augmented-coding.md TDD principles]
-    
-User: ACT
-
-AI: # Mode: ACT
-    [Execute with .ai-rules/agents/frontend-developer.json guidelines]
-
-User: EVAL
-
-AI: # Mode: EVAL
-    [Evaluate with .ai-rules/agents/code-reviewer.json framework]
+PLAN Design user authentication feature
 ```
 
-## Benefits
+→ `parse_mode` MCP tool is called, loading appropriate Agent and rules
 
-- ✅ Same rules as Cursor and other AI tools (consistency)
-- ✅ Leverage Antigravity's task tracking and artifacts
-- ✅ Access to all specialist agent knowledge
-- ✅ Easy to update: change `.ai-rules/` once, all tools benefit
+### Specialist Usage
+
+```
+EVAL Review from security perspective
+```
+
+→ security-specialist activated
+
+### Auto Mode
+
+```
+AUTO implement user dashboard
+```
+
+→ Autonomous PLAN → ACT → EVAL cycling
+
+## MCP Tools
+
+Available codingbuddy MCP tools in Antigravity:
+
+| Tool | Purpose |
+|------|---------|
+| `parse_mode` | Parse mode keywords (PLAN/ACT/EVAL/AUTO) + load Agent/rules |
+| `search_rules` | Search rules and guidelines by query |
+| `get_agent_details` | Get specific Agent profile and expertise |
+| `get_project_config` | Get project configuration (language, tech stack) |
+| `get_code_conventions` | Get project code conventions and style guide |
+| `suggest_config_updates` | Analyze project and suggest config updates |
+| `recommend_skills` | Recommend skills based on prompt → then call `get_skill` |
+| `get_skill` | Load full skill content by name (e.g., `get_skill("systematic-debugging")`) |
+| `list_skills` | List all available skills with optional filtering |
+| `get_agent_system_prompt` | Get complete system prompt for a specialist agent |
+| `prepare_parallel_agents` | Prepare specialist agents for sequential execution |
+| `dispatch_agents` | Get Task tool-ready dispatch params (Claude Code optimized) |
+| `generate_checklist` | Generate contextual checklists (security, a11y, performance) |
+| `analyze_task` | Analyze task for risk assessment and specialist recommendations |
+| `read_context` | Read context document (`docs/codingbuddy/context.md`) |
+| `update_context` | Update context document with decisions, notes, progress |
+| `cleanup_context` | Manually trigger context document cleanup |
+| `set_project_root` | ~~Set project root directory~~ **(deprecated)** — use `CODINGBUDDY_PROJECT_ROOT` env var instead |
+
+## Specialist Agents Execution
+
+Antigravity does not have a `Task` tool for spawning background subagents. When `parse_mode` returns `parallelAgentsRecommendation`, execute specialists **sequentially**.
+
+### Auto-Detection
+
+The MCP server automatically detects Antigravity as the client and returns a sequential execution hint in `parallelAgentsRecommendation.hint`. No manual configuration is needed.
+
+### Sequential Workflow
+
+```
+parse_mode returns parallelAgentsRecommendation
+  ↓
+Call prepare_parallel_agents with recommended specialists
+  ↓
+For each specialist (sequentially):
+  - Announce: "Analyzing from [icon] [specialist-name] perspective..."
+  - Apply the specialist's system prompt as analysis context
+  - Analyze the target code/design from that specialist's viewpoint
+  - Record findings
+  ↓
+Consolidate all specialist findings into unified summary
+```
+
+### Example (EVAL mode)
+
+```
+parse_mode({ prompt: "EVAL review auth implementation" })
+→ parallelAgentsRecommendation:
+    specialists: ["security-specialist", "accessibility-specialist", "performance-specialist"]
+
+prepare_parallel_agents({
+  mode: "EVAL",
+  specialists: ["security-specialist", "accessibility-specialist", "performance-specialist"]
+})
+→ agents[]: each has systemPrompt
+
+Sequential analysis:
+  1. 🔒 Security: Apply security-specialist prompt, analyze, record findings
+  2. ♿ Accessibility: Apply accessibility-specialist prompt, analyze, record findings
+  3. ⚡ Performance: Apply performance-specialist prompt, analyze, record findings
+
+Present: Consolidated findings from all 3 specialists
+```
+
+### Consuming dispatchReady from parse_mode
+
+When `parse_mode` returns `dispatchReady`, the specialist system prompts are pre-built. In Antigravity, use the `dispatchParams.prompt` field as analysis context (ignore `subagent_type` — it is Claude Code specific):
+
+```
+parse_mode returns dispatchReady
+  ↓
+dispatchReady.primaryAgent
+  → Use as the main analysis context
+  ↓
+dispatchReady.parallelAgents[] (if present)
+  → For each: the dispatchParams.prompt field contains the specialist's system prompt.
+    Apply the prompt as analysis context, analyze sequentially, record findings
+  ↓
+Consolidate all findings
+```
+
+> **Fallback:** If `dispatchReady` is not present in the `parse_mode` response, call `prepare_parallel_agents` MCP tool to retrieve specialist system prompts.
+
+### Visibility Pattern
+
+When executing sequential specialists, display clear status messages:
+
+**Start:**
+```
+🔄 Executing N specialist analyses sequentially...
+   → 🔒 security-specialist
+   → ♿ accessibility-specialist
+   → ⚡ performance-specialist
+```
+
+**During:**
+```
+🔍 Analyzing from 🔒 security-specialist perspective... (1/3)
+```
+
+**Completion:**
+```
+📊 Specialist Analysis Complete:
+
+🔒 Security:
+   [findings summary]
+
+♿ Accessibility:
+   [findings summary]
+
+⚡ Performance:
+   [findings summary]
+```
+
+### Handling Failures
+
+When `prepare_parallel_agents` returns `failedAgents`:
+
+```
+⚠️ Some agents failed to load:
+   ✗ performance-specialist: Profile not found
+
+Continuing with 2/3 agents...
+```
+
+**Strategy:**
+- Continue with successfully loaded agents
+- Report failures clearly to user
+- Document which agents couldn't be loaded in final report
+
+### Specialist Icons
+
+| Icon | Specialist |
+|------|------------|
+| 🔒 | security-specialist |
+| ♿ | accessibility-specialist |
+| ⚡ | performance-specialist |
+| 📏 | code-quality-specialist |
+| 🧪 | test-strategy-specialist |
+| 🏛️ | architecture-specialist |
+| 📚 | documentation-specialist |
+| 🔍 | seo-specialist |
+| 🎨 | design-system-specialist |
+| 📨 | event-architecture-specialist |
+| 🔗 | integration-specialist |
+| 📊 | observability-specialist |
+| 🔄 | migration-specialist |
+| 🌐 | i18n-specialist |
+
+### When to Use Specialist Execution
+
+Specialist execution is recommended when `parse_mode` returns a `parallelAgentsRecommendation` field:
+
+| Mode | Default Specialists | Use Case |
+|------|---------------------|----------|
+| **PLAN** | architecture-specialist, test-strategy-specialist | Validate architecture and test approach |
+| **ACT** | code-quality-specialist, test-strategy-specialist | Verify implementation quality |
+| **EVAL** | security-specialist, accessibility-specialist, performance-specialist, code-quality-specialist | Comprehensive multi-dimensional review |
+
+### Specialist Activation Scope
+
+Each workflow mode activates different specialist agents:
+
+- **PLAN mode**: Architecture and test strategy specialists validate design
+- **ACT mode**: Code quality and test strategy specialists verify implementation
+- **EVAL mode**: Security, accessibility, performance, and code quality specialists provide comprehensive review
+
+**Important:** Specialists from one mode do NOT carry over to the next mode. Each mode has its own recommended specialist set.
+
+## Skills
+
+Antigravity accesses codingbuddy skills through three patterns:
+
+1. **Auto-recommend** — AI calls `recommend_skills` based on intent detection
+2. **Browse and select** — User calls `list_skills` to discover, then `get_skill` to load
+3. **Slash-command** — User types `/<command>`, AI maps to `get_skill`
+
+### Using Skills in Antigravity
+
+**Method 1: MCP Tool Chain (End Users — Recommended)**
+
+The AI should follow this chain when a skill might apply:
+
+1. `recommend_skills({ prompt: "user's message" })` — Get skill recommendations
+2. `get_skill("skill-name")` — Load the recommended skill's full content
+3. Follow the skill instructions in the response
+
+Example flow:
+```
+User: "There is a bug in the authentication logic"
+→ AI calls recommend_skills({ prompt: "There is a bug in the authentication logic" })
+→ Response: { recommendations: [{ skillName: "systematic-debugging", ... }], nextAction: "Call get_skill..." }
+→ AI calls get_skill("systematic-debugging")
+→ AI follows the systematic-debugging skill instructions
+```
+
+**Method 2: File Reference (Monorepo Contributors Only)**
+
+Reference skill files directly from `.ai-rules/skills/` directory in your prompts.
+
+> **Note:** `parse_mode` already embeds matched skill content in `included_skills` — no separate `get_skill` call needed when using mode keywords (PLAN/ACT/EVAL/AUTO).
+
+### Skill Discovery
+
+Use `list_skills` to browse available skills before deciding which one to load:
+
+```
+list_skills()                                    # Browse all skills
+list_skills({ minPriority: 1, maxPriority: 3 })  # Filter by priority
+```
+
+**Discovery flow:**
+
+1. `list_skills()` — Browse available skills and descriptions
+2. Identify the skill relevant to the current task
+3. `get_skill("skill-name")` — Load the full skill content
+4. Follow the skill instructions
+
+> **Tip:** Use `recommend_skills` when you want AI to automatically pick the best skill. Use `list_skills` when you want to manually browse and select.
+
+### Slash-Command Mapping
+
+Antigravity has no native slash-command skill invocation. When a user types `/<command>`, the AI must call `get_skill` to replicate the behavior of Claude Code's built-in Skill tool.
+
+**Rule:** When user input matches `/<command>`, call `get_skill("<skill-name>")` and follow the returned instructions. This table is a curated subset — use `list_skills()` to discover all available skills.
+
+| User Types | MCP Call |
+|---|---|
+| `/debug` or `/debugging` | `get_skill("systematic-debugging")` |
+| `/tdd` | `get_skill("test-driven-development")` |
+| `/brainstorm` | `get_skill("brainstorming")` |
+| `/plan` or `/write-plan` | `get_skill("writing-plans")` |
+| `/execute` or `/exec` | `get_skill("executing-plans")` |
+| `/design` or `/frontend` | `get_skill("frontend-design")` |
+| `/refactor` | `get_skill("refactoring")` |
+| `/security` or `/audit` | `get_skill("security-audit")` |
+| `/pr` | `get_skill("pr-all-in-one")` |
+| `/review` or `/pr-review` | `get_skill("pr-review")` |
+| `/parallel` or `/agents` | `get_skill("dispatching-parallel-agents")` |
+| `/subagent` | `get_skill("subagent-driven-development")` |
+
+For unrecognized slash commands, call `recommend_skills({ prompt: "<user's full message>" })` to find the closest match.
+
+> **Disambiguation:** `/plan` (with slash prefix) triggers `get_skill("writing-plans")`. `PLAN` (without slash, at message start) triggers `parse_mode`. Similarly, `/execute` triggers `get_skill("executing-plans")` while `ACT` triggers `parse_mode`. The slash prefix is the distinguishing signal.
+
+### Proactive Skill Activation
+
+Antigravity lacks session hooks that automatically enforce skill invocation (unlike Claude Code). The AI must detect intent patterns and call `recommend_skills` proactively — without waiting for the user to explicitly request a skill.
+
+**Rule:** When the user's message suggests a skill would help, call `recommend_skills` at the start of the response — before any other action. The `recommend_skills` engine matches trigger patterns across multiple languages and is the authoritative source of truth.
+
+Common trigger examples (not exhaustive):
+
+| User Intent Signal | Likely Skill |
+|---|---|
+| Bug report, error, "not working", exception | `systematic-debugging` |
+| "Brainstorm", "build", "create", "implement" | `brainstorming` |
+| "Test first", TDD, write tests before code | `test-driven-development` |
+| "Plan", "design", implementation approach | `writing-plans` |
+| PR, commit, code review workflow | `pr-all-in-one` |
+
+```
+User: "I need to plan the implementation for user authentication"
+→ AI calls recommend_skills({ prompt: "plan implementation for user authentication" })
+→ Loads writing-plans via get_skill
+→ Follows skill instructions to create structured plan
+```
+
+> **Note:** When the user message starts with a mode keyword (`PLAN`, `ACT`, `EVAL`, `AUTO`), `parse_mode` already handles skill matching automatically via `included_skills` — no separate `recommend_skills` call is needed.
+
+### Available Skills
+
+Highlighted skills (use `list_skills()` for the complete list):
+
+- `brainstorming/SKILL.md` - Idea → Design
+- `test-driven-development/SKILL.md` - TDD workflow
+- `systematic-debugging/SKILL.md` - Systematic debugging
+- `writing-plans/SKILL.md` - Implementation plan writing
+- `executing-plans/SKILL.md` - Plan execution
+- `subagent-driven-development/SKILL.md` - Subagent development
+- `dispatching-parallel-agents/SKILL.md` - Parallel Agent dispatch
+- `frontend-design/SKILL.md` - Frontend design
+
+## AGENTS.md
+
+Industry standard format compatible with all AI tools (Antigravity, Cursor, Claude Code, Codex, etc.):
+
+```markdown
+# AGENTS.md
+
+This project uses codingbuddy MCP server to manage AI Agents.
+
+## Quick Start
+...
+```
+
+See `AGENTS.md` in project root for details.
 
 ## PR All-in-One Skill
 
@@ -210,7 +482,7 @@ Unified commit and PR workflow that:
 
 ### Configuration
 
-Create `.claude/pr-config.json` in your project root. Required settings:
+Create `.claude/pr-config.json` in your project root (this path is used by the skill regardless of IDE). Required settings:
 - `defaultTargetBranch`: Target branch for PRs
 - `issueTracker`: `jira`, `github`, `linear`, `gitlab`, or `custom`
 - `issuePattern`: Regex pattern for issue ID extraction
@@ -239,7 +511,7 @@ Access skill files directly from `.ai-rules/skills/pr-all-in-one/` directory in 
 
 ## AUTO Mode
 
-AUTO mode enables autonomous PLAN -> ACT -> EVAL cycling until quality criteria are met.
+AUTO mode enables autonomous PLAN → ACT → EVAL cycling until quality criteria are met.
 
 ### Triggering AUTO Mode
 
@@ -251,29 +523,19 @@ Use the `AUTO` keyword (or localized versions) at the start of your message:
 | Korean | `자동` |
 | Japanese | `自動` |
 | Chinese | `自动` |
-| Spanish | `AUTOMATICO` |
+| Spanish | `AUTOMÁTICO` |
 
 ### Example Usage
 
 ```
-User: AUTO Build a new payment system feature
-
-AI: # Mode: AUTO (Iteration 1/3)
-    ## Phase: PLAN
-    [Following .ai-rules/rules/core.md workflow]
-
-    ## Phase: ACT
-    [Execute with .ai-rules guidelines]
-
-    ## Phase: EVAL
-    [Evaluate with quality criteria]
-
-    ### Quality Status
-    - Critical: 0
-    - High: 0
-
-    ✅ AUTO mode completed successfully!
+AUTO implement user authentication feature
 ```
+
+```
+자동 사용자 인증 기능 구현해줘
+```
+
+When AUTO keyword is detected, Antigravity calls `parse_mode` MCP tool which returns AUTO mode instructions.
 
 ### Workflow
 
@@ -283,20 +545,6 @@ AI: # Mode: AUTO (Iteration 1/3)
 4. **Loop/Exit**: Continues cycling until:
    - Success: `Critical = 0 AND High = 0`
    - Failure: Max iterations reached (default: 3)
-
-### Antigravity-Specific Integration
-
-AUTO mode works with Antigravity's task boundary tracking:
-
-```python
-task_boundary(
-  TaskName="AUTO: Feature Implementation",
-  Mode="AUTO_ITERATION",
-  TaskSummary="Iteration 1/3 - PLAN phase completed",
-  TaskStatus="Executing ACT phase",
-  PredictedTaskSize=30
-)
-```
 
 ### Configuration
 
@@ -317,9 +565,160 @@ module.exports = {
 - Bug fixes needing comprehensive testing
 - Code quality improvements with measurable criteria
 
+### Antigravity-Specific Integration
+
+AUTO mode works with Antigravity's `task_boundary` tool for progress tracking:
+
+```python
+task_boundary(
+  TaskName="AUTO: Feature Implementation",
+  Mode="AUTO_ITERATION",
+  TaskSummary="Iteration 1/3 - PLAN phase completed",
+  TaskStatus="Executing ACT phase",
+  PredictedTaskSize=30
+)
+```
+
+> **Antigravity limitation:** AUTO mode에는 강제 루프 메커니즘이 없습니다. 자세한 내용은 [Known Limitations](#known-limitations)를 참조하세요.
+
+## Context Document Management
+
+codingbuddy uses a fixed-path context document (`docs/codingbuddy/context.md`) to persist decisions across mode transitions.
+
+### How It Works
+
+| Mode | Behavior |
+|------|----------|
+| PLAN / AUTO | Resets (clears) existing content and starts fresh |
+| ACT / EVAL | Appends new section to existing content |
+
+### Required Workflow
+
+1. `parse_mode` automatically reads/creates the context document
+2. Review `contextDocument` in the response for previous decisions
+3. **Before completing each mode:** call `update_context` to persist current work
+
+### Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `read_context` | Read current context document |
+| `update_context` | Persist decisions, notes, progress, findings |
+| `cleanup_context` | Summarize older sections to reduce document size |
+
+### Antigravity-Specific Note
+
+Unlike Claude Code, Antigravity has no hooks to enforce `update_context` calls. You must **manually remember** to call `update_context` before concluding each mode to avoid losing context across sessions.
+
+## Antigravity-Specific Features
+
+### Task Boundaries
+
+Antigravity supports `task_boundary` tool for tracking progress across workflow modes:
+
+```python
+task_boundary(
+  TaskName="Implementing Feature",
+  Mode="EXECUTION",
+  TaskSummary="Created component with TDD",
+  TaskStatus="Writing tests",
+  PredictedTaskSize=10
+)
+```
+
+**Mode mapping with codingbuddy workflow:**
+
+| codingbuddy Mode | task_boundary Mode | Use Case |
+|------------------|-------------------|----------|
+| PLAN | `PLANNING` | Creating implementation plans |
+| ACT | `EXECUTION` | Executing implementation |
+| EVAL | `VERIFICATION` | Evaluating quality |
+| AUTO | `AUTO_ITERATION` | Autonomous cycling |
+
+### Artifact Management
+
+Antigravity uses artifact files for structured output:
+- Implementation plans: `implementation_plan.md`
+- Task tracking: `task.md`
+- Walkthroughs: `walkthrough.md`
+
+These artifacts complement codingbuddy's context document (`docs/codingbuddy/context.md`). Use both: artifacts for Antigravity-native tracking, and `update_context` for cross-mode persistence.
+
+### Communication
+
+- **Follow project's configured language setting** — use `get_project_config` MCP tool to retrieve current language setting
+- Use structured markdown formatting
+- Provide clear, actionable feedback
+
+## Known Limitations
+
+Antigravity environment does not support several features available in Claude Code:
+
+| Feature | Status | Workaround |
+|---------|--------|------------|
+| **Task tool** (background subagents) | ❌ Not available | Use `prepare_parallel_agents` for sequential execution |
+| **Native Skill tool** (`/skill-name`) | ❌ Not available | Use MCP tool chain: `recommend_skills` → `get_skill` |
+| **Session hooks** (PreToolUse, etc.) | ❌ Not available | Rely on `.antigravity/rules/instructions.md` for always-on instructions |
+| **Autonomous loop mechanism** | ❌ Not available | AUTO mode depends on Antigravity AI voluntarily looping |
+| **Context compaction hooks** | ❌ Not available | Manually call `update_context` before ending each mode |
+| **`dispatch_agents` full usage** | ⚠️ Partial | Use `dispatchReady.dispatchParams.prompt` as analysis context; `prepare_parallel_agents` as fallback |
+| **`restart_tui`** | ❌ Not applicable | Claude Code TUI-only tool |
+
+### AUTO Mode Reliability
+
+AUTO mode documents autonomous PLAN → ACT → EVAL cycling. In Antigravity, this depends entirely on the AI model voluntarily continuing the loop — there is no enforcement mechanism like Claude Code's hooks. Results may vary:
+
+- The AI may stop after one iteration instead of looping
+- Quality exit criteria (`Critical = 0 AND High = 0`) are advisory, not enforced
+- For reliable multi-iteration workflows, prefer manual `PLAN` → `ACT` → `EVAL` cycling
+
+## Verification Status
+
+> Initial documentation based on code analysis and Antigravity public documentation. Runtime verification pending.
+
+| Pattern | Status | Notes |
+|---------|--------|-------|
+| MCP Configuration | ✅ Documented | `.antigravity/config.json` with `CODINGBUDDY_PROJECT_ROOT` |
+| `CODINGBUDDY_PROJECT_ROOT` guidance | ✅ Documented | Priority and fallback behavior explained |
+| MCP Tools Table | ✅ Documented | All 17 tools documented (including 1 deprecated) |
+| Specialist Agents Execution | ✅ Documented | Sequential workflow, dispatchReady, visibility, failures, activation scope |
+| Skills Access Workflow | ✅ Documented | Auto-recommend, browse/select, slash-command mapping |
+| Context Document Management | ✅ Documented | With Antigravity-specific guidance |
+| Known Limitations | ✅ Documented | Task tool, hooks, AUTO mode limitations |
+| Antigravity-Specific Features | ✅ Preserved | task_boundary, artifact management |
+| Antigravity unique capabilities | ⚠️ Partial | task_boundary and artifacts documented; other Gemini-specific features TBD |
+| `roots/list` support | ⚠️ Unknown | Not confirmed in Antigravity documentation |
+| AUTO mode reliability | ⚠️ Documented with caveat | No enforcement mechanism in Antigravity |
+
+## Getting Started
+
+1. Ensure `.ai-rules/` directory exists with all common rules
+2. Configure MCP server in `.antigravity/config.json`:
+   ```json
+   {
+     "mcpServers": {
+       "codingbuddy": {
+         "command": "npx",
+         "args": ["-y", "codingbuddy"],
+         "env": {
+           "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+         }
+       }
+     }
+   }
+   ```
+3. (Optional) Create `.antigravity/rules/instructions.md` for always-on instructions
+4. Start an Antigravity session — MCP tools are now available
+5. Use PLAN/ACT/EVAL/AUTO workflow via `parse_mode` MCP tool
+
 ## Maintenance
 
 When updating rules:
 1. Update `.ai-rules/rules/*.md` for changes affecting all AI tools
 2. Update `.antigravity/rules/instructions.md` only for Antigravity-specific features
 3. Common rules propagate automatically to all sessions
+
+## Reference
+
+- [Antigravity (Google Gemini)](https://developers.google.com/gemini)
+- [codingbuddy MCP API](../../docs/api.md)


### PR DESCRIPTION
## Summary

- Restructure `antigravity.md` from 326-line legacy doc to 724-line comprehensive adapter guide with full cross-adapter parity (kiro.md/cursor.md pattern)
- Add MCP server configuration with `CODINGBUDDY_PROJECT_ROOT` env var and `roots/list` fallback behavior
- Add MCP tools table (17 tools + 1 deprecated), specialist agents sequential execution workflow
- Add skills access workflow (auto-recommend, browse/select, slash-command mapping)
- Add context document management, known limitations, verification status
- Preserve Antigravity-specific features (task_boundary mode mapping, artifact management)
- Update `.antigravity/rules/instructions.md` with `parse_mode` MCP tool integration, skills section, context document section
- Add `.antigravity/config.json` template for MCP server setup

## Test plan

- [x] markdownlint passes on both changed markdown files (0 errors)
- [x] JSON validation passes on `.antigravity/config.json`
- [x] Cross-adapter parity checklist: 25/25 items PASS vs kiro.md reference
- [x] All 4 Issue #618 requirements verified (MCP config, env var, roots/list fallback, priority docs)
- [x] No remaining formatting inconsistencies (`->`, `--`, `|` all normalized)

Closes #618