### PR TITLE
add verification status section and fix tool count

### DIFF
--- a/.antigravity/rules/instructions.md
+++ b/.antigravity/rules/instructions.md
@@ -138,7 +138,7 @@ If the codingbuddy MCP server is configured, use these tools:
 | `get_skill` | Load full skill content |
 | `update_context` | Update context document (decisions, notes, progress) |
 
-> For the full list of tools (17 total), see [antigravity.md](../../packages/rules/.ai-rules/adapters/antigravity.md#mcp-tools).
+> For the full list of tools (18 total, including 1 deprecated), see [antigravity.md](../../packages/rules/.ai-rules/adapters/antigravity.md#mcp-tools).
 
 ### Configuration
 

--- a/packages/rules/.ai-rules/adapters/antigravity.md
+++ b/packages/rules/.ai-rules/adapters/antigravity.md
@@ -760,6 +760,25 @@ AUTO mode documents autonomous PLAN → ACT → EVAL cycling. In Antigravity, th
 - Quality exit criteria (`Critical = 0 AND High = 0`) are advisory, not enforced
 - For reliable multi-iteration workflows, prefer manual `PLAN` → `ACT` → `EVAL` cycling
 
+## Verification Status
+
+> Audit per [#621](https://github.com/JeremyDev87/codingbuddy/issues/621). Code-level analysis complete, Antigravity runtime verification pending.
+
+| Pattern | Status | Notes |
+|---------|--------|-------|
+| MCP Configuration | ✅ Documented | `.antigravity/config.json` with `CODINGBUDDY_PROJECT_ROOT` |
+| `CODINGBUDDY_PROJECT_ROOT` guidance | ✅ Documented | Priority and fallback behavior explained |
+| MCP Tools Table | ✅ Documented | All 18 tools documented (including 1 deprecated) |
+| Mode keyword detection (instructions.md) | ✅ Documented | `parse_mode` invocation rule with CODINGBUDDY_CRITICAL_RULE |
+| Specialist Agents Execution | ✅ Documented | Sequential workflow, dispatchReady consumption, visibility, failures |
+| Skills workflow (`get_skill`) | ✅ Documented | MCP tool chain, slash-command mapping, proactive activation |
+| Context Document Management | ✅ Documented | With Antigravity-specific guidance |
+| Completion Ordering (`update_context` → `task_boundary`) | ✅ Documented | Strict ordering with rationale |
+| Known Limitations | ✅ Documented | Task tool, hooks, AUTO mode, dispatch_agents limitations |
+| `roots/list` support | ⚠️ Unknown | Not confirmed in Antigravity |
+| AUTO mode reliability | ⚠️ Documented with caveat | No enforcement mechanism in Antigravity |
+| `task_boundary` integration | ⚠️ Unverified | Documented but not tested in live environment |
+
 ## Getting Started
 
 1. Ensure `.ai-rules/` directory exists with all common rules


### PR DESCRIPTION
## Summary

- Add `## Verification Status` section to `antigravity.md` with 12 audit items (9 ✅ documented, 3 ⚠️ unverified/unknown), aligned with cursor.md/kiro.md/opencode.md pattern
- Fix tool count in `.antigravity/rules/instructions.md` from "17 total" to "18 total, including 1 deprecated" for consistency with MCP Tools table (17 active + 1 deprecated `set_project_root`)
- Completes the final remaining items from issue #621 audit (8 gap categories already resolved by prior commits)

## Test plan

- [x] `yarn workspace codingbuddy lint` — passed (0 errors)
- [x] `yarn workspace codingbuddy format:check` — passed
- [x] `yarn workspace codingbuddy typecheck` — passed
- [x] `yarn workspace codingbuddy test:coverage` — passed (4711 tests, 94.42% coverage)
- [x] `yarn workspace codingbuddy circular` — passed (no circular dependencies)
- [x] `yarn workspace codingbuddy build` — passed
- [x] `ajv-cli validate` (agent schemas) — passed
- [x] `markdownlint-cli2` (65 markdown files) — passed (0 errors)
- [x] Cross-adapter consistency verified against cursor.md, kiro.md, opencode.md

Closes #621