### PR TITLE
add multi-provider model support with provider-level prefixes

### DIFF
--- a/apps/mcp-server/src/cli/init/prompts/model-prompt.spec.ts
+++ b/apps/mcp-server/src/cli/init/prompts/model-prompt.spec.ts
@@ -9,6 +9,7 @@ import {
 // Mock @inquirer/prompts
 vi.mock('@inquirer/prompts', () => ({
   select: vi.fn(),
+  input: vi.fn(),
 }));
 
 describe('model-prompt', () => {
@@ -20,7 +21,6 @@ describe('model-prompt', () => {
       const choices = getModelChoices();
 
       expect(choices).toBeInstanceOf(Array);
-      expect(choices.length).toBeGreaterThanOrEqual(3);
     });
 
     it('should have required properties for each choice', () => {
@@ -34,13 +34,12 @@ describe('model-prompt', () => {
       }
     });
 
-    it('should include Opus, Sonnet, and Haiku models', () => {
+    it('should include Opus and Sonnet models', () => {
       const choices = getModelChoices();
       const values = choices.map((c: ModelChoice) => c.value);
 
       expect(values.some((v: string) => v.includes('opus'))).toBe(true);
       expect(values.some((v: string) => v.includes('sonnet'))).toBe(true);
-      expect(values.some((v: string) => v.includes('haiku'))).toBe(true);
     });
 
     it('should have Sonnet as first choice (recommended)', () => {
@@ -50,13 +49,56 @@ describe('model-prompt', () => {
       expect(choices[0].name).toContain('Recommended');
     });
 
-    it('should mark Haiku as not recommended', () => {
+    it('should return at least 10 choices (multi-provider + custom)', () => {
       const choices = getModelChoices();
-      const haikuChoice = choices.find((c: ModelChoice) => c.value.includes('haiku'));
+      expect(choices.length).toBeGreaterThanOrEqual(10);
+    });
 
-      expect(haikuChoice).toBeDefined();
-      expect(haikuChoice!.name).toContain('Not recommended');
-      expect(haikuChoice!.description).toContain('not recommended');
+    it('should include at least one OpenAI model (gpt- prefix)', () => {
+      const choices = getModelChoices();
+      const hasGpt = choices.some((c: ModelChoice) => c.value.startsWith('gpt-'));
+      expect(hasGpt).toBe(true);
+    });
+
+    it('should include at least one Google model (gemini- prefix)', () => {
+      const choices = getModelChoices();
+      const hasGemini = choices.some((c: ModelChoice) => c.value.startsWith('gemini-'));
+      expect(hasGemini).toBe(true);
+    });
+
+    it('should include __custom__ escape hatch choice', () => {
+      const choices = getModelChoices();
+      const hasCustom = choices.some((c: ModelChoice) => c.value === '__custom__');
+      expect(hasCustom).toBe(true);
+    });
+
+    it('should include at least one xAI model (grok- prefix)', () => {
+      const choices = getModelChoices();
+      const hasGrok = choices.some((c: ModelChoice) => c.value.startsWith('grok-'));
+      expect(hasGrok).toBe(true);
+    });
+
+    it('should include at least one DeepSeek model (deepseek- prefix)', () => {
+      const choices = getModelChoices();
+      const hasDeepSeek = choices.some((c: ModelChoice) => c.value.startsWith('deepseek-'));
+      expect(hasDeepSeek).toBe(true);
+    });
+
+    it('should include latest OpenAI models (GPT-5 or o4-mini)', () => {
+      const choices = getModelChoices();
+      const values = choices.map((c: ModelChoice) => c.value);
+      expect(values).toContain('gpt-5');
+      expect(values).toContain('o4-mini');
+    });
+
+    it('should include provider info in descriptions', () => {
+      const choices = getModelChoices();
+      const gptChoice = choices.find((c: ModelChoice) => c.value.startsWith('gpt-'));
+      expect(gptChoice?.description).toContain('OpenAI');
+      const geminiChoice = choices.find((c: ModelChoice) => c.value.startsWith('gemini-'));
+      expect(geminiChoice?.description).toContain('Google');
+      const claudeChoice = choices.find((c: ModelChoice) => c.value.includes('sonnet'));
+      expect(claudeChoice?.description).toContain('Anthropic');
     });
   });
 
@@ -113,6 +155,31 @@ describe('model-prompt', () => {
       const result = await promptModelSelection();
 
       expect(result).toBe(DEFAULT_MODEL_CHOICE);
+    });
+
+    it('should prompt for custom model ID when __custom__ is selected', async () => {
+      const { select, input } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+      const mockInput = vi.mocked(input);
+      mockSelect.mockResolvedValue('__custom__');
+      mockInput.mockResolvedValue('my-custom-model-v1');
+
+      const result = await promptModelSelection();
+
+      expect(mockInput).toHaveBeenCalled();
+      expect(result).toBe('my-custom-model-v1');
+    });
+
+    it('should return selected model directly when not __custom__', async () => {
+      const { select, input } = await import('@inquirer/prompts');
+      const mockSelect = vi.mocked(select);
+      const mockInput = vi.mocked(input);
+      mockSelect.mockResolvedValue('gpt-4o');
+
+      const result = await promptModelSelection();
+
+      expect(result).toBe('gpt-4o');
+      expect(mockInput).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/mcp-server/src/cli/init/prompts/model-prompt.ts
+++ b/apps/mcp-server/src/cli/init/prompts/model-prompt.ts
@@ -4,8 +4,19 @@
  * Interactive CLI prompt for AI model selection
  */
 
-import { select } from '@inquirer/prompts';
-import { CLAUDE_OPUS_4, CLAUDE_SONNET_4, CLAUDE_HAIKU_35, DEFAULT_MODEL } from '../../../model';
+import { select, input } from '@inquirer/prompts';
+import {
+  CLAUDE_OPUS_4,
+  CLAUDE_SONNET_4,
+  DEFAULT_MODEL,
+  GPT_4O,
+  GPT_5,
+  O4_MINI,
+  GEMINI_25_PRO,
+  GEMINI_25_FLASH,
+  GROK_3,
+  DEEPSEEK_CHAT,
+} from '../../../model';
 
 /**
  * Model choice option for the CLI prompt
@@ -23,38 +34,90 @@ export const DEFAULT_MODEL_CHOICE = DEFAULT_MODEL;
 
 /**
  * Get available model choices for the CLI prompt
+ *
+ * Returns choices grouped by provider: Anthropic, OpenAI, Google, xAI, DeepSeek, and a custom escape hatch.
  */
 export function getModelChoices(): ModelChoice[] {
   return [
+    // Anthropic (default)
     {
       name: 'Claude Sonnet 4 (Recommended)',
       value: CLAUDE_SONNET_4,
-      description: 'Balanced performance and cost',
+      description: 'Balanced performance and cost · Anthropic',
     },
     {
       name: 'Claude Opus 4',
       value: CLAUDE_OPUS_4,
-      description: 'Most capable, best for complex tasks',
+      description: 'Most capable · Anthropic',
+    },
+    // OpenAI
+    {
+      name: 'GPT-5',
+      value: GPT_5,
+      description: 'Latest flagship model · OpenAI',
     },
     {
-      name: 'Claude Haiku 3.5 (Not recommended)',
-      value: CLAUDE_HAIKU_35,
-      description: 'Fastest but least capable - not recommended for coding tasks',
+      name: 'GPT-4o',
+      value: GPT_4O,
+      description: 'Multimodal model · OpenAI',
+    },
+    {
+      name: 'o4-mini',
+      value: O4_MINI,
+      description: 'Fast reasoning model · OpenAI',
+    },
+    // Google
+    {
+      name: 'Gemini 2.5 Pro',
+      value: GEMINI_25_PRO,
+      description: 'Advanced reasoning · Google',
+    },
+    {
+      name: 'Gemini 2.5 Flash',
+      value: GEMINI_25_FLASH,
+      description: 'Fast and efficient · Google',
+    },
+    // xAI
+    {
+      name: 'Grok 3',
+      value: GROK_3,
+      description: 'Multimodal reasoning · xAI',
+    },
+    // DeepSeek
+    {
+      name: 'DeepSeek Chat',
+      value: DEEPSEEK_CHAT,
+      description: 'Cost-efficient coding model · DeepSeek',
+    },
+    // Escape hatch
+    {
+      name: 'Other (enter manually)',
+      value: '__custom__',
+      description: 'Any model ID not listed above',
     },
   ];
 }
 
 /**
- * Prompt user to select a default model
- * @param message - Custom message for the prompt
- * @returns Selected model ID
+ * Prompt user to select an AI model interactively.
+ *
+ * If the user selects "Other", a follow-up text input prompt collects a free-text model ID.
  */
 export async function promptModelSelection(message = 'Select default AI model:'): Promise<string> {
   const choices = getModelChoices();
 
-  return select({
+  const selected = await select({
     message,
     choices,
     default: DEFAULT_MODEL_CHOICE,
   });
+
+  if (selected === '__custom__') {
+    return input({
+      message: 'Enter model ID:',
+      validate: (value: string) => value.trim().length > 0 || 'Model ID cannot be empty',
+    });
+  }
+
+  return selected;
 }

--- a/apps/mcp-server/src/model/model.constants.spec.ts
+++ b/apps/mcp-server/src/model/model.constants.spec.ts
@@ -1,8 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { CLAUDE_OPUS_4, CLAUDE_SONNET_4, CLAUDE_HAIKU_35, DEFAULT_MODEL } from './model.constants';
+import {
+  CLAUDE_OPUS_4,
+  CLAUDE_SONNET_4,
+  CLAUDE_HAIKU_35,
+  GPT_4O,
+  GPT_4O_MINI,
+  O3_MINI,
+  O1_MINI,
+  O4_MINI,
+  GPT_5,
+  GEMINI_25_PRO,
+  GEMINI_25_FLASH,
+  GROK_3,
+  DEEPSEEK_CHAT,
+  DEEPSEEK_REASONER,
+  DEFAULT_MODEL,
+} from './model.constants';
 
 describe('model.constants', () => {
-  describe('model IDs', () => {
+  describe('Claude model IDs', () => {
     it('should have valid Claude Opus 4 model ID', () => {
       expect(CLAUDE_OPUS_4).toBe('claude-opus-4-20250514');
       expect(CLAUDE_OPUS_4).toMatch(/^claude-opus-4-\d{8}$/);
@@ -19,6 +35,58 @@ describe('model.constants', () => {
     });
   });
 
+  describe('OpenAI model IDs', () => {
+    it('should have valid GPT-4o model ID', () => {
+      expect(GPT_4O).toBe('gpt-4o');
+    });
+
+    it('should have valid GPT-4o mini model ID', () => {
+      expect(GPT_4O_MINI).toBe('gpt-4o-mini');
+    });
+
+    it('should have valid o3-mini model ID', () => {
+      expect(O3_MINI).toBe('o3-mini');
+    });
+
+    it('should have valid o1-mini model ID', () => {
+      expect(O1_MINI).toBe('o1-mini');
+    });
+
+    it('should have valid o4-mini model ID', () => {
+      expect(O4_MINI).toBe('o4-mini');
+    });
+
+    it('should have valid GPT-5 model ID', () => {
+      expect(GPT_5).toBe('gpt-5');
+    });
+  });
+
+  describe('xAI model IDs', () => {
+    it('should have valid Grok 3 model ID', () => {
+      expect(GROK_3).toBe('grok-3');
+    });
+  });
+
+  describe('DeepSeek model IDs', () => {
+    it('should have valid DeepSeek Chat model ID', () => {
+      expect(DEEPSEEK_CHAT).toBe('deepseek-chat');
+    });
+
+    it('should have valid DeepSeek Reasoner model ID', () => {
+      expect(DEEPSEEK_REASONER).toBe('deepseek-reasoner');
+    });
+  });
+
+  describe('Google model IDs', () => {
+    it('should have valid Gemini 2.5 Pro model ID', () => {
+      expect(GEMINI_25_PRO).toBe('gemini-2.5-pro');
+    });
+
+    it('should have valid Gemini 2.5 Flash model ID', () => {
+      expect(GEMINI_25_FLASH).toBe('gemini-2.5-flash');
+    });
+  });
+
   describe('DEFAULT_MODEL', () => {
     it('should be Claude Sonnet 4 (balanced choice)', () => {
       expect(DEFAULT_MODEL).toBe(CLAUDE_SONNET_4);
@@ -31,17 +99,56 @@ describe('model.constants', () => {
   });
 
   describe('consistency', () => {
-    it('should have unique model IDs', () => {
-      const models = [CLAUDE_OPUS_4, CLAUDE_SONNET_4, CLAUDE_HAIKU_35];
+    it('should have unique model IDs across all providers', () => {
+      const models = [
+        CLAUDE_OPUS_4,
+        CLAUDE_SONNET_4,
+        CLAUDE_HAIKU_35,
+        GPT_4O,
+        GPT_4O_MINI,
+        O3_MINI,
+        O1_MINI,
+        O4_MINI,
+        GPT_5,
+        GEMINI_25_PRO,
+        GEMINI_25_FLASH,
+        GROK_3,
+        DEEPSEEK_CHAT,
+        DEEPSEEK_REASONER,
+      ];
       const uniqueModels = new Set(models);
       expect(uniqueModels.size).toBe(models.length);
+      expect(uniqueModels.size).toBe(14);
     });
 
-    it('should all start with claude-', () => {
-      const models = [CLAUDE_OPUS_4, CLAUDE_SONNET_4, CLAUDE_HAIKU_35];
-      models.forEach(model => {
+    it('should have Claude models starting with claude-', () => {
+      const claudeModels = [CLAUDE_OPUS_4, CLAUDE_SONNET_4, CLAUDE_HAIKU_35];
+      claudeModels.forEach(model => {
         expect(model).toMatch(/^claude-/);
       });
+    });
+
+    it('should have OpenAI models with correct prefixes', () => {
+      expect(GPT_4O).toMatch(/^gpt-/);
+      expect(GPT_4O_MINI).toMatch(/^gpt-/);
+      expect(O3_MINI).toMatch(/^o3-/);
+      expect(O1_MINI).toMatch(/^o1-/);
+    });
+
+    it('should have Google models starting with gemini-', () => {
+      const googleModels = [GEMINI_25_PRO, GEMINI_25_FLASH];
+      googleModels.forEach(model => {
+        expect(model).toMatch(/^gemini-/);
+      });
+    });
+
+    it('should have xAI models starting with grok-', () => {
+      expect(GROK_3).toMatch(/^grok-/);
+    });
+
+    it('should have DeepSeek models starting with deepseek-', () => {
+      expect(DEEPSEEK_CHAT).toMatch(/^deepseek-/);
+      expect(DEEPSEEK_REASONER).toMatch(/^deepseek-/);
     });
   });
 });

--- a/apps/mcp-server/src/model/model.constants.ts
+++ b/apps/mcp-server/src/model/model.constants.ts
@@ -21,6 +21,45 @@ export const CLAUDE_SONNET_4 = 'claude-sonnet-4-20250514';
  */
 export const CLAUDE_HAIKU_35 = 'claude-haiku-3-5-20241022';
 
+/** OpenAI GPT-4o model */
+export const GPT_4O = 'gpt-4o';
+
+/**
+ * OpenAI GPT-4o mini model
+ * @deprecated Superseded by o4-mini. Kept for backward compatibility with existing consumers.
+ */
+export const GPT_4O_MINI = 'gpt-4o-mini';
+
+/**
+ * OpenAI o3-mini reasoning model
+ * @deprecated Superseded by o4-mini. Kept for backward compatibility with existing consumers.
+ */
+export const O3_MINI = 'o3-mini';
+
+/** OpenAI o1-mini reasoning model */
+export const O1_MINI = 'o1-mini';
+
+/** OpenAI o4-mini reasoning model */
+export const O4_MINI = 'o4-mini';
+
+/** OpenAI GPT-5 model */
+export const GPT_5 = 'gpt-5';
+
+/** Google Gemini 2.5 Pro model */
+export const GEMINI_25_PRO = 'gemini-2.5-pro';
+
+/** Google Gemini 2.5 Flash model */
+export const GEMINI_25_FLASH = 'gemini-2.5-flash';
+
+/** xAI Grok 3 model */
+export const GROK_3 = 'grok-3';
+
+/** DeepSeek Chat model */
+export const DEEPSEEK_CHAT = 'deepseek-chat';
+
+/** DeepSeek Reasoner model */
+export const DEEPSEEK_REASONER = 'deepseek-reasoner';
+
 /**
  * Default model for CLI and configuration
  * Using Sonnet as the balanced choice for most use cases

--- a/apps/mcp-server/src/model/model.resolver.spec.ts
+++ b/apps/mcp-server/src/model/model.resolver.spec.ts
@@ -14,15 +14,15 @@ describe('formatUnknownModelWarning', () => {
 
     expect(result).toContain('Unknown model ID');
     expect(result).toContain('unknown-model');
-    expect(result).toContain('claude-opus-4');
+    expect(result).toContain('claude-');
     expect(result).toContain('Known prefixes');
   });
 
   it('should include additional prefixes in warning', () => {
-    const result = formatUnknownModelWarning('unknown-model', ['gpt-4', 'gemini']);
+    const result = formatUnknownModelWarning('unknown-model', ['custom-1', 'experimental-']);
 
-    expect(result).toContain('gpt-4');
-    expect(result).toContain('gemini');
+    expect(result).toContain('custom-1');
+    expect(result).toContain('experimental-');
   });
 });
 
@@ -36,12 +36,12 @@ describe('getAllPrefixes', () => {
   });
 
   it('should merge additional prefixes with known prefixes', () => {
-    const additional = ['gpt-4', 'gemini'];
+    const additional = ['llama-4', 'cohere-v2'];
     const result = getAllPrefixes(additional);
 
-    expect(result).toContain('claude-opus-4');
-    expect(result).toContain('gpt-4');
-    expect(result).toContain('gemini');
+    expect(result).toContain('claude-');
+    expect(result).toContain('llama-4');
+    expect(result).toContain('cohere-v2');
     expect(result.length).toBe(KNOWN_MODEL_PREFIXES.length + 2);
   });
 
@@ -59,13 +59,67 @@ describe('isKnownModel', () => {
   });
 
   it('should return false for unknown models', () => {
-    expect(isKnownModel('gpt-4')).toBe(false);
     expect(isKnownModel('unknown-model')).toBe(false);
-    expect(isKnownModel('claude-unknown')).toBe(false);
+    expect(isKnownModel('totally-random')).toBe(false);
+    expect(isKnownModel('some-other-model')).toBe(false);
   });
 
-  it('should have at least 4 known prefixes', () => {
-    expect(KNOWN_MODEL_PREFIXES.length).toBeGreaterThanOrEqual(4);
+  it('should return true for known OpenAI models', () => {
+    expect(isKnownModel('gpt-4o')).toBe(true);
+    expect(isKnownModel('gpt-4o-mini')).toBe(true);
+    expect(isKnownModel('gpt-3.5-turbo')).toBe(true);
+    expect(isKnownModel('o1-mini')).toBe(true);
+    expect(isKnownModel('o3-mini')).toBe(true);
+  });
+
+  it('should return true for known Google models', () => {
+    expect(isKnownModel('gemini-2.5-pro')).toBe(true);
+    expect(isKnownModel('gemini-2.5-flash')).toBe(true);
+    expect(isKnownModel('gemini-1.5-pro')).toBe(true);
+  });
+
+  it('should have at least 14 known prefixes (multi-provider)', () => {
+    expect(KNOWN_MODEL_PREFIXES.length).toBeGreaterThanOrEqual(14);
+  });
+
+  it('should return true for xAI Grok models', () => {
+    expect(isKnownModel('grok-3')).toBe(true);
+    expect(isKnownModel('grok-4.1')).toBe(true);
+  });
+
+  it('should return true for DeepSeek models', () => {
+    expect(isKnownModel('deepseek-chat')).toBe(true);
+    expect(isKnownModel('deepseek-reasoner')).toBe(true);
+    expect(isKnownModel('deepseek-v3')).toBe(true);
+  });
+
+  it('should return true for Mistral models', () => {
+    expect(isKnownModel('mistral-large-latest')).toBe(true);
+    expect(isKnownModel('codestral-latest')).toBe(true);
+  });
+
+  it('should return true for Meta Llama models', () => {
+    expect(isKnownModel('llama-3.3-70b')).toBe(true);
+  });
+
+  it('should return true for Cohere models', () => {
+    expect(isKnownModel('command-r-plus')).toBe(true);
+  });
+
+  it('should return true for Alibaba Qwen models', () => {
+    expect(isKnownModel('qwen-2.5-coder')).toBe(true);
+  });
+
+  it('should return true for Microsoft Phi models', () => {
+    expect(isKnownModel('phi-4')).toBe(true);
+  });
+
+  it('should recognize future model versions automatically (provider-level prefix)', () => {
+    expect(isKnownModel('claude-sonnet-5-20260101')).toBe(true);
+    expect(isKnownModel('gpt-6-turbo')).toBe(true);
+    expect(isKnownModel('gemini-4.0-ultra')).toBe(true);
+    expect(isKnownModel('grok-5')).toBe(true);
+    expect(isKnownModel('deepseek-v5')).toBe(true);
   });
 
   it('should return false for empty string', () => {
@@ -74,17 +128,17 @@ describe('isKnownModel', () => {
 
   describe('additionalPrefixes', () => {
     it('should recognize models with additional prefixes', () => {
-      expect(isKnownModel('gpt-4-turbo', ['gpt-4'])).toBe(true);
-      expect(isKnownModel('gemini-pro', ['gemini'])).toBe(true);
+      expect(isKnownModel('cohere-v2-large', ['cohere-v2'])).toBe(true);
+      expect(isKnownModel('inflection-3', ['inflection-'])).toBe(true);
     });
 
     it('should still recognize default prefixes when additional prefixes provided', () => {
-      expect(isKnownModel('claude-opus-4-20250514', ['gpt-4'])).toBe(true);
+      expect(isKnownModel('claude-opus-4-20250514', ['inflection-'])).toBe(true);
     });
 
     it('should handle empty additional prefixes array', () => {
       expect(isKnownModel('claude-opus-4-20250514', [])).toBe(true);
-      expect(isKnownModel('gpt-4', [])).toBe(false);
+      expect(isKnownModel('unknown-model', [])).toBe(false);
     });
   });
 });
@@ -153,11 +207,11 @@ describe('resolveModel', () => {
 
     it('should not include warning when model matches additionalPrefixes', () => {
       const result = resolveModel({
-        globalDefaultModel: 'gpt-4-turbo',
-        additionalPrefixes: ['gpt-4'],
+        globalDefaultModel: 'inflection-3',
+        additionalPrefixes: ['inflection-'],
       });
 
-      expect(result.model).toBe('gpt-4-turbo');
+      expect(result.model).toBe('inflection-3');
       expect(result.source).toBe('global');
       expect(result.warning).toBeUndefined();
     });
@@ -165,12 +219,56 @@ describe('resolveModel', () => {
     it('should include additionalPrefixes in warning message', () => {
       const result = resolveModel({
         globalDefaultModel: 'unknown-model',
-        additionalPrefixes: ['gpt-4', 'gemini'],
+        additionalPrefixes: ['custom-1', 'experimental-'],
       });
 
       expect(result.warning).toBeDefined();
-      expect(result.warning).toContain('gpt-4');
-      expect(result.warning).toContain('gemini');
+      expect(result.warning).toContain('custom-1');
+      expect(result.warning).toContain('experimental-');
+    });
+  });
+
+  describe('multi-provider models', () => {
+    it('should resolve GPT model without warning', () => {
+      const result = resolveModel({ globalDefaultModel: 'gpt-4o' });
+      expect(result.model).toBe('gpt-4o');
+      expect(result.source).toBe('global');
+      expect(result.warning).toBeUndefined();
+    });
+
+    it('should resolve Gemini model without warning', () => {
+      const result = resolveModel({ globalDefaultModel: 'gemini-2.5-pro' });
+      expect(result.model).toBe('gemini-2.5-pro');
+      expect(result.source).toBe('global');
+      expect(result.warning).toBeUndefined();
+    });
+
+    it('should resolve o3-mini without warning', () => {
+      const result = resolveModel({ globalDefaultModel: 'o3-mini' });
+      expect(result.model).toBe('o3-mini');
+      expect(result.source).toBe('global');
+      expect(result.warning).toBeUndefined();
+    });
+
+    it('should resolve Grok model without warning', () => {
+      const result = resolveModel({ globalDefaultModel: 'grok-3' });
+      expect(result.model).toBe('grok-3');
+      expect(result.source).toBe('global');
+      expect(result.warning).toBeUndefined();
+    });
+
+    it('should resolve DeepSeek model without warning', () => {
+      const result = resolveModel({ globalDefaultModel: 'deepseek-chat' });
+      expect(result.model).toBe('deepseek-chat');
+      expect(result.source).toBe('global');
+      expect(result.warning).toBeUndefined();
+    });
+
+    it('should still warn for truly unknown models', () => {
+      const result = resolveModel({ globalDefaultModel: 'truly-unknown-model' });
+      expect(result.model).toBe('truly-unknown-model');
+      expect(result.warning).toBeDefined();
+      expect(result.warning).toContain('Unknown model ID');
     });
   });
 

--- a/apps/mcp-server/src/model/model.resolver.ts
+++ b/apps/mcp-server/src/model/model.resolver.ts
@@ -12,14 +12,38 @@ import { DEFAULT_MODEL } from './model.constants';
 export const SYSTEM_DEFAULT_MODEL = DEFAULT_MODEL;
 
 /**
- * Known Claude model ID patterns for validation
- * Uses prefixes to allow future model versions
+ * Known model ID patterns for validation (multi-provider)
+ *
+ * Uses provider-level prefixes for automatic future model compatibility.
+ * When a new model version is released (e.g., gpt-6, gemini-4),
+ * it is automatically recognized without code changes.
  */
 export const KNOWN_MODEL_PREFIXES = [
-  'claude-opus-4',
-  'claude-sonnet-4',
-  'claude-sonnet-3',
-  'claude-haiku-3',
+  // Anthropic
+  'claude-',
+  // OpenAI
+  'gpt-',
+  'o1', // No trailing dash: matches both standalone 'o1' and 'o1-mini'/'o1-preview'
+  'o3', // No trailing dash: matches both standalone 'o3' and 'o3-mini'
+  'o4', // No trailing dash: matches both standalone 'o4' and 'o4-mini'
+  'chatgpt-',
+  // Google
+  'gemini-',
+  // xAI
+  'grok-',
+  // DeepSeek
+  'deepseek-',
+  // Mistral
+  'mistral-',
+  'codestral-',
+  // Meta
+  'llama-',
+  // Cohere
+  'command-',
+  // Alibaba
+  'qwen-',
+  // Microsoft
+  'phi-',
 ] as const;
 
 /**
@@ -64,7 +88,7 @@ export function formatUnknownModelWarning(
 }
 
 /**
- * Check if a model ID matches known Claude model patterns
+ * Check if a model ID matches known model patterns (multi-provider)
  * @param modelId - Model ID to check
  * @param additionalPrefixes - Optional additional prefixes to recognize
  */

--- a/docs/plans/2026-03-02-multi-provider-model-support.md
+++ b/docs/plans/2026-03-02-multi-provider-model-support.md
@@ -1,0 +1,445 @@
+# Multi-Provider Model Support Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 멀티 프로바이더 모델 지원을 추가하여 모든 주요 AI 프로바이더(Anthropic, OpenAI, Google, xAI, DeepSeek, Mistral, Meta 등)의 모델을 인식하고, 프로바이더 수준 prefix로 미래 모델 출시에도 자동 호환되는 시스템을 구축한다.
+
+**Architecture:** KNOWN_MODEL_PREFIXES를 모델-패밀리 수준에서 프로바이더 수준으로 전환하여 미래 호환성 확보. 상수는 최신 모델로 업데이트하고 CLI 선택지도 2026년 현실을 반영. EVAL 피드백(H1, M1, M2) 동시 수정.
+
+**Tech Stack:** TypeScript, Vitest, @inquirer/prompts (select + input)
+
+**Issue:** https://github.com/JeremyDev87/codingbuddy/issues/622
+
+---
+
+## Task 1~4: 이전 iteration (완료)
+
+Task 1~4는 첫 번째 ACT에서 이미 구현 완료:
+- Task 1: model.constants.ts 상수 추가 ✅
+- Task 2: model.resolver.ts prefix 확장 ✅
+- Task 3: model-prompt.ts CLI 선택지 ✅
+- Task 4: 통합 검증 ✅
+
+---
+
+## Task 5: EVAL 수정 + KNOWN_MODEL_PREFIXES 프로바이더 수준 전환
+
+**Files:**
+- Modify: `apps/mcp-server/src/model/model.resolver.ts:14-31, 75`
+- Modify: `apps/mcp-server/src/model/model.resolver.spec.ts`
+
+### Step 1: 실패 테스트 작성
+
+`model.resolver.spec.ts`에 새 프로바이더 인식 테스트 추가 및 기존 테스트 수정:
+
+```typescript
+// 기존 OpenAI/Google 테스트 유지 + 아래 추가
+
+it('should return true for xAI Grok models', () => {
+  expect(isKnownModel('grok-3')).toBe(true);
+  expect(isKnownModel('grok-4.1')).toBe(true);
+});
+
+it('should return true for DeepSeek models', () => {
+  expect(isKnownModel('deepseek-chat')).toBe(true);
+  expect(isKnownModel('deepseek-reasoner')).toBe(true);
+  expect(isKnownModel('deepseek-v3')).toBe(true);
+});
+
+it('should return true for Mistral models', () => {
+  expect(isKnownModel('mistral-large-latest')).toBe(true);
+  expect(isKnownModel('codestral-latest')).toBe(true);
+});
+
+it('should return true for Meta Llama models', () => {
+  expect(isKnownModel('llama-3.3-70b')).toBe(true);
+});
+
+it('should return true for Cohere models', () => {
+  expect(isKnownModel('command-r-plus')).toBe(true);
+});
+
+it('should return true for Alibaba Qwen models', () => {
+  expect(isKnownModel('qwen-2.5-coder')).toBe(true);
+});
+
+it('should return true for Microsoft Phi models', () => {
+  expect(isKnownModel('phi-4')).toBe(true);
+});
+
+// 미래 호환성 테스트
+it('should recognize future model versions automatically (provider-level prefix)', () => {
+  expect(isKnownModel('claude-sonnet-5-20260101')).toBe(true);
+  expect(isKnownModel('gpt-6-turbo')).toBe(true);
+  expect(isKnownModel('gemini-4.0-ultra')).toBe(true);
+  expect(isKnownModel('grok-5')).toBe(true);
+  expect(isKnownModel('deepseek-v5')).toBe(true);
+});
+```
+
+prefix 개수 테스트 업데이트:
+```typescript
+it('should have at least 14 known prefixes (multi-provider)', () => {
+  expect(KNOWN_MODEL_PREFIXES.length).toBeGreaterThanOrEqual(14);
+});
+```
+
+resolveModel 멀티 프로바이더 테스트 추가:
+```typescript
+it('should resolve Grok model without warning', () => {
+  const result = resolveModel({ globalDefaultModel: 'grok-3' });
+  expect(result.model).toBe('grok-3');
+  expect(result.source).toBe('global');
+  expect(result.warning).toBeUndefined();
+});
+
+it('should resolve DeepSeek model without warning', () => {
+  const result = resolveModel({ globalDefaultModel: 'deepseek-chat' });
+  expect(result.model).toBe('deepseek-chat');
+  expect(result.source).toBe('global');
+  expect(result.warning).toBeUndefined();
+});
+```
+
+EVAL M2 수정 — `getAllPrefixes` 테스트의 stale additional prefix:
+```typescript
+// BEFORE (stale — gpt-4가 이미 known)
+const additional = ['gpt-4', 'gemini'];
+
+// AFTER
+const additional = ['llama-3', 'mistral'];
+```
+
+### Step 2: 테스트 실행하여 실패 확인
+
+Run: `cd apps/mcp-server && npx vitest run src/model/model.resolver.spec.ts`
+Expected: FAIL — Grok, DeepSeek, Mistral 등 미인식
+
+### Step 3: 구현 — KNOWN_MODEL_PREFIXES 프로바이더 수준으로 전환
+
+`model.resolver.ts` 수정:
+
+```typescript
+/**
+ * Known model ID patterns for validation (multi-provider)
+ *
+ * Uses provider-level prefixes for automatic future model compatibility.
+ * When a new model version is released (e.g., gpt-6, gemini-4),
+ * it is automatically recognized without code changes.
+ */
+export const KNOWN_MODEL_PREFIXES = [
+  // Anthropic
+  'claude-',
+  // OpenAI
+  'gpt-',
+  'o1', 'o3', 'o4',
+  'chatgpt-',
+  // Google
+  'gemini-',
+  // xAI
+  'grok-',
+  // DeepSeek
+  'deepseek-',
+  // Mistral
+  'mistral-',
+  'codestral-',
+  // Meta
+  'llama-',
+  // Cohere
+  'command-',
+  // Alibaba
+  'qwen-',
+  // Microsoft
+  'phi-',
+] as const;
+```
+
+EVAL H1 수정 — `isKnownModel` JSDoc 업데이트:
+```typescript
+/**
+ * Check if a model ID matches known model patterns (multi-provider)
+ * @param modelId - Model ID to check
+ * @param additionalPrefixes - Optional additional prefixes to recognize
+ */
+```
+
+### Step 4: 테스트 실행하여 통과 확인
+
+Run: `cd apps/mcp-server && npx vitest run src/model/model.resolver.spec.ts`
+Expected: PASS
+
+### Step 5: 커밋
+
+```bash
+git add apps/mcp-server/src/model/model.resolver.ts apps/mcp-server/src/model/model.resolver.spec.ts
+git commit -m "feat(model): broaden KNOWN_MODEL_PREFIXES to provider-level for future compatibility (#622)"
+```
+
+---
+
+## Task 6: model.constants.ts 최신 모델 추가 + 프로바이더 확장
+
+**Files:**
+- Modify: `apps/mcp-server/src/model/model.constants.ts`
+- Modify: `apps/mcp-server/src/model/model.constants.spec.ts`
+
+### Step 1: 실패 테스트 작성
+
+```typescript
+import {
+  // 기존 imports...
+  O4_MINI, GPT_5,
+  GROK_3, DEEPSEEK_CHAT, DEEPSEEK_REASONER,
+} from './model.constants';
+
+describe('OpenAI model IDs', () => {
+  // 기존 테스트 유지 + 아래 추가
+  it('should have valid o4-mini model ID', () => {
+    expect(O4_MINI).toBe('o4-mini');
+  });
+
+  it('should have valid GPT-5 model ID', () => {
+    expect(GPT_5).toBe('gpt-5');
+  });
+});
+
+describe('xAI model IDs', () => {
+  it('should have valid Grok 3 model ID', () => {
+    expect(GROK_3).toBe('grok-3');
+  });
+});
+
+describe('DeepSeek model IDs', () => {
+  it('should have valid DeepSeek Chat model ID', () => {
+    expect(DEEPSEEK_CHAT).toBe('deepseek-chat');
+  });
+
+  it('should have valid DeepSeek Reasoner model ID', () => {
+    expect(DEEPSEEK_REASONER).toBe('deepseek-reasoner');
+  });
+});
+
+describe('consistency', () => {
+  it('should have unique model IDs across all providers', () => {
+    const models = [
+      CLAUDE_OPUS_4, CLAUDE_SONNET_4, CLAUDE_HAIKU_35,
+      GPT_4O, GPT_4O_MINI, O3_MINI, O1_MINI, O4_MINI, GPT_5,
+      GEMINI_25_PRO, GEMINI_25_FLASH,
+      GROK_3, DEEPSEEK_CHAT, DEEPSEEK_REASONER,
+    ];
+    const uniqueModels = new Set(models);
+    expect(uniqueModels.size).toBe(models.length);
+  });
+
+  it('should have xAI models starting with grok-', () => {
+    expect(GROK_3).toMatch(/^grok-/);
+  });
+
+  it('should have DeepSeek models starting with deepseek-', () => {
+    expect(DEEPSEEK_CHAT).toMatch(/^deepseek-/);
+    expect(DEEPSEEK_REASONER).toMatch(/^deepseek-/);
+  });
+});
+```
+
+### Step 2: 테스트 실행하여 실패 확인
+
+Run: `cd apps/mcp-server && npx vitest run src/model/model.constants.spec.ts`
+Expected: FAIL
+
+### Step 3: 구현 — 상수 추가
+
+`model.constants.ts`에 추가:
+
+```typescript
+// 기존 상수 유지 (GPT_4O, GPT_4O_MINI, O3_MINI, O1_MINI, GEMINI_25_PRO, GEMINI_25_FLASH)
+
+/** OpenAI o4-mini reasoning model */
+export const O4_MINI = 'o4-mini';
+
+/** OpenAI GPT-5 model */
+export const GPT_5 = 'gpt-5';
+
+/** xAI Grok 3 model */
+export const GROK_3 = 'grok-3';
+
+/** DeepSeek Chat model */
+export const DEEPSEEK_CHAT = 'deepseek-chat';
+
+/** DeepSeek Reasoner model */
+export const DEEPSEEK_REASONER = 'deepseek-reasoner';
+```
+
+### Step 4: 테스트 통과 확인
+
+Run: `cd apps/mcp-server && npx vitest run src/model/model.constants.spec.ts`
+Expected: PASS
+
+### Step 5: 커밋
+
+```bash
+git add apps/mcp-server/src/model/model.constants.ts apps/mcp-server/src/model/model.constants.spec.ts
+git commit -m "feat(model): add latest 2026 model constants (GPT-5, o4-mini, Grok, DeepSeek) (#622)"
+```
+
+---
+
+## Task 7: model-prompt.ts CLI 선택지 업데이트
+
+**Files:**
+- Modify: `apps/mcp-server/src/cli/init/prompts/model-prompt.ts`
+- Modify: `apps/mcp-server/src/cli/init/prompts/model-prompt.spec.ts`
+
+### Step 1: 실패 테스트 작성
+
+```typescript
+it('should return at least 10 choices (multi-provider + custom)', () => {
+  const choices = getModelChoices();
+  expect(choices.length).toBeGreaterThanOrEqual(10);
+});
+
+it('should include at least one xAI model (grok- prefix)', () => {
+  const choices = getModelChoices();
+  const hasGrok = choices.some((c: ModelChoice) => c.value.startsWith('grok-'));
+  expect(hasGrok).toBe(true);
+});
+
+it('should include at least one DeepSeek model (deepseek- prefix)', () => {
+  const choices = getModelChoices();
+  const hasDeepSeek = choices.some((c: ModelChoice) => c.value.startsWith('deepseek-'));
+  expect(hasDeepSeek).toBe(true);
+});
+```
+
+EVAL M1 수정 — 중복 테스트 정리:
+- `'should return array of model choices'`의 count assertion (`>= 8`) 제거, array/type 검증만 유지
+- `'should return at least 8 choices'` 테스트를 `>= 10`으로 업데이트하여 단일 count 테스트로 통합
+
+### Step 2: 테스트 실행하여 실패 확인
+
+Run: `cd apps/mcp-server && npx vitest run src/cli/init/prompts/model-prompt.spec.ts`
+Expected: FAIL
+
+### Step 3: 구현 — CLI 선택지 업데이트
+
+```typescript
+import {
+  CLAUDE_OPUS_4, CLAUDE_SONNET_4, DEFAULT_MODEL,
+  GPT_4O, GPT_5, O4_MINI,
+  GEMINI_25_PRO, GEMINI_25_FLASH,
+  GROK_3, DEEPSEEK_CHAT,
+} from '../../../model';
+
+export function getModelChoices(): ModelChoice[] {
+  return [
+    // Anthropic (default)
+    {
+      name: 'Claude Sonnet 4 (Recommended)',
+      value: CLAUDE_SONNET_4,
+      description: 'Balanced performance and cost · Anthropic',
+    },
+    {
+      name: 'Claude Opus 4',
+      value: CLAUDE_OPUS_4,
+      description: 'Most capable · Anthropic',
+    },
+    // OpenAI
+    {
+      name: 'GPT-5',
+      value: GPT_5,
+      description: 'Latest flagship model · OpenAI',
+    },
+    {
+      name: 'GPT-4o',
+      value: GPT_4O,
+      description: 'Multimodal model · OpenAI',
+    },
+    {
+      name: 'o4-mini',
+      value: O4_MINI,
+      description: 'Fast reasoning model · OpenAI',
+    },
+    // Google
+    {
+      name: 'Gemini 2.5 Pro',
+      value: GEMINI_25_PRO,
+      description: 'Advanced reasoning · Google',
+    },
+    {
+      name: 'Gemini 2.5 Flash',
+      value: GEMINI_25_FLASH,
+      description: 'Fast and efficient · Google',
+    },
+    // xAI
+    {
+      name: 'Grok 3',
+      value: GROK_3,
+      description: 'Multimodal reasoning · xAI',
+    },
+    // DeepSeek
+    {
+      name: 'DeepSeek Chat',
+      value: DEEPSEEK_CHAT,
+      description: 'Cost-efficient coding model · DeepSeek',
+    },
+    // Escape hatch
+    {
+      name: 'Other (enter manually)',
+      value: '__custom__',
+      description: 'Any model ID not listed above',
+    },
+  ];
+}
+```
+
+### Step 4: 테스트 통과 확인
+
+Run: `cd apps/mcp-server && npx vitest run src/cli/init/prompts/model-prompt.spec.ts`
+Expected: PASS
+
+### Step 5: 커밋
+
+```bash
+git add apps/mcp-server/src/cli/init/prompts/model-prompt.ts apps/mcp-server/src/cli/init/prompts/model-prompt.spec.ts
+git commit -m "feat(model): update CLI choices with latest 2026 models and more providers (#622)"
+```
+
+---
+
+## Task 8: 통합 검증
+
+### Step 1: 전체 모델 모듈 테스트
+
+Run: `cd apps/mcp-server && npx vitest run src/model/ src/cli/init/prompts/model-prompt.spec.ts`
+Expected: ALL PASS
+
+### Step 2: 전체 프로젝트 테스트
+
+Run: `cd apps/mcp-server && npx vitest run`
+Expected: ALL PASS
+
+### Step 3: TypeScript 컴파일
+
+Run: `npx tsc --noEmit`
+Expected: 에러 없음
+
+---
+
+## 미래 호환성 매트릭스
+
+| 시나리오 | 프로바이더 수준 prefix | 동작 |
+|----------|----------------------|------|
+| OpenAI `gpt-6` 출시 | `'gpt-'` | 자동 인식, 코드 변경 불필요 |
+| Anthropic `claude-sonnet-5` 출시 | `'claude-'` | 자동 인식, 코드 변경 불필요 |
+| Google `gemini-4.0` 출시 | `'gemini-'` | 자동 인식, 코드 변경 불필요 |
+| xAI `grok-5` 출시 | `'grok-'` | 자동 인식, 코드 변경 불필요 |
+| DeepSeek V5 출시 | `'deepseek-'` | 자동 인식, 코드 변경 불필요 |
+| 완전히 새로운 프로바이더 | — | `__custom__`로 입력, 또는 prefix 추가 |
+
+## EVAL 수정 포함 사항
+
+| ID | 심각도 | 수정 위치 |
+|----|--------|----------|
+| H1 | High | Task 5 — `isKnownModel` JSDoc |
+| M1 | Medium | Task 7 — 중복 테스트 정리 |
+| M2 | Medium | Task 5 — `getAllPrefixes` stale test data |


### PR DESCRIPTION
## Summary

- Add model constants for 5 providers: Anthropic (Claude), OpenAI (GPT-5, GPT-4o, o4-mini), Google (Gemini 2.5 Pro/Flash), xAI (Grok 3), DeepSeek (Chat, Reasoner)
- Convert `KNOWN_MODEL_PREFIXES` from model-family level to provider-level (e.g., `'claude-'` instead of `'claude-opus-4'`) for automatic future model compatibility across 9+ providers (Anthropic, OpenAI, Google, xAI, DeepSeek, Mistral, Meta, Cohere, Alibaba, Microsoft)
- Update CLI `codingbuddy init` model selection with 10 choices grouped by provider + `__custom__` escape hatch for any unlisted model ID
- Add `@deprecated` tags for superseded models (GPT-4o mini, o3-mini)
- Maintain full backward compatibility: `DEFAULT_MODEL` remains `claude-sonnet-4-20250514`

## Test plan

- [x] 90 model-related tests pass (constants: 22, resolver: 42, prompt: 19, service: 7)
- [x] 4751 total project tests pass (1 pre-existing flaky test in ipc-client unrelated to changes)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] ESLint clean (0 errors)
- [x] Prettier formatted
- [x] No circular dependencies
- [x] Build succeeds
- [x] Future model compatibility verified: `gpt-6-turbo`, `claude-sonnet-5-20260101`, `gemini-4.0-ultra` all auto-recognized

Closes #622