### PR TITLE
add specialist agents execution pattern and cross-adapter parity

### DIFF
--- a/.codex/rules/system-prompt.md
+++ b/.codex/rules/system-prompt.md
@@ -118,6 +118,22 @@ All specialist agents are defined in `packages/rules/.ai-rules/agents/` director
 
 For complete agent documentation, see [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md)
 
+### Specialist Execution
+
+When `parse_mode` returns `parallelAgentsRecommendation` or `dispatchReady`, execute specialists **sequentially**:
+
+1. Announce specialists being analyzed
+2. For each specialist: apply its system prompt as analysis context, analyze, record findings
+3. Consolidate all findings into a unified summary
+
+**Preferred workflow:**
+- If `dispatchReady.parallelAgents[]` exists: use `dispatchParams.prompt` directly
+- Otherwise: call `prepare_parallel_agents` MCP tool to get system prompts
+
+**Note:** `subagent_type` and `run_in_background` are Claude Code-specific parameters — ignore them in Codex.
+
+See [packages/rules/.ai-rules/adapters/codex.md](../../packages/rules/.ai-rules/adapters/codex.md#specialist-agents-execution) for the full workflow.
+
 ---
 
 ## 🔴 MANDATORY: Keyword Mode Detection

--- a/packages/rules/.ai-rules/adapters/codex.md
+++ b/packages/rules/.ai-rules/adapters/codex.md
@@ -47,6 +47,14 @@ Project Root/
 └── packages/rules/.ai-rules/      # Single Source of Truth
 ```
 
+## DRY Principle
+
+**Single Source of Truth**: `packages/rules/.ai-rules/`
+
+- All Agent definitions, rules, skills managed only in `.ai-rules/`
+- `.codex/rules/system-prompt.md` acts as a **pointer only**
+- No duplication, only references
+
 ## Integration Method
 
 ### Option 1: Using .github/copilot-instructions.md
@@ -176,6 +184,171 @@ Key tools:
 | `recommend_skills` | Recommend skills based on user prompt with multi-language support |
 | `get_skill` | Load full skill content by name |
 | `list_skills` | List all available skills with optional filtering |
+| `get_agent_details` | Get detailed profile of a specialist agent |
+| `get_agent_system_prompt` | Get complete system prompt for a specialist agent |
+| `prepare_parallel_agents` | Prepare specialist agents for sequential execution |
+| `dispatch_agents` | Get Task tool-ready dispatch params (Claude Code optimized) |
+| `generate_checklist` | Generate contextual checklists (security, a11y, performance) |
+| `analyze_task` | Analyze task for risk assessment and specialist recommendations |
+| `get_code_conventions` | Get project code conventions from config files (tsconfig, eslint, prettier) |
+| `suggest_config_updates` | Analyze project and suggest config updates based on detected changes |
+| `read_context` | Read context document (`docs/codingbuddy/context.md`) |
+| `update_context` | Update context document with decisions, notes, progress |
+| `cleanup_context` | Manually trigger context document cleanup |
+
+## Specialist Agents Execution
+
+Codex does not have a `Task` tool for spawning background subagents. When `parse_mode` returns `parallelAgentsRecommendation`, execute specialists **sequentially**.
+
+### Auto-Detection
+
+The MCP server automatically detects Codex as the client and returns a sequential execution hint in `parallelAgentsRecommendation.hint`. No manual configuration is needed.
+
+### Sequential Workflow
+
+```
+parse_mode returns parallelAgentsRecommendation
+  ↓
+Call prepare_parallel_agents with recommended specialists
+  ↓
+For each specialist (sequentially):
+  - Announce: "🔍 Analyzing from [icon] [specialist-name] perspective..."
+  - Apply the specialist's system prompt as analysis context
+  - Analyze the target code/design from that specialist's viewpoint
+  - Record findings
+  ↓
+Consolidate all specialist findings into unified summary
+```
+
+### Example (EVAL mode)
+
+```
+parse_mode({ prompt: "EVAL review auth implementation" })
+→ parallelAgentsRecommendation:
+    specialists: ["security-specialist", "accessibility-specialist", "performance-specialist"]
+
+prepare_parallel_agents({
+  mode: "EVAL",
+  specialists: ["security-specialist", "accessibility-specialist", "performance-specialist"]
+})
+→ agents[]: each has systemPrompt
+
+Sequential analysis:
+  1. 🔒 Security: Apply security-specialist prompt, analyze, record findings
+  2. ♿ Accessibility: Apply accessibility-specialist prompt, analyze, record findings
+  3. ⚡ Performance: Apply performance-specialist prompt, analyze, record findings
+
+Present: Consolidated findings from all 3 specialists
+```
+
+### Using dispatchReady (Auto-Dispatch)
+
+When `parse_mode` returns a `dispatchReady` field, use it directly without calling `prepare_parallel_agents`:
+
+```
+parse_mode returns dispatchReady
+  ↓
+Use dispatchReady.primaryAgent.dispatchParams.prompt as primary analysis context
+  ↓
+For each dispatchReady.parallelAgents[] (sequentially):
+  - Apply dispatchParams.prompt as specialist analysis context
+  - Analyze from that specialist's viewpoint
+  - Record findings
+  ↓
+Consolidate all findings
+```
+
+**Key fields:**
+- `dispatchReady.primaryAgent.dispatchParams.prompt` — Primary agent system prompt. Use as the main analysis context.
+- `dispatchReady.parallelAgents[].dispatchParams.prompt` — Each specialist's system prompt. Apply as analysis context for sequential execution.
+- `subagent_type` — Claude Code Task tool parameter. **Ignore in Codex.**
+
+> **Known limitation:** Codex cannot execute specialists in parallel. The `parallelAgents[]` array is consumed sequentially. True parallel execution requires Claude Code's Task tool.
+>
+> **Fallback:** If `dispatchReady` is not present in the `parse_mode` response, call `prepare_parallel_agents` MCP tool to retrieve specialist system prompts.
+
+### Visibility Pattern
+
+**Start Message:**
+```
+🚀 Running N specialist analyses sequentially...
+   → [icon] [specialist-name]
+   → [icon] [specialist-name]
+   → [icon] [specialist-name]
+```
+
+**Per-Specialist:**
+```
+🔍 Analyzing from [icon] [specialist-name] perspective...
+
+[Analysis content]
+```
+
+**Completion Message:**
+```
+📊 Specialist Analysis Complete:
+
+[icon] [Specialist Name]:
+   [findings summary]
+
+[icon] [Specialist Name]:
+   [findings summary]
+```
+
+### Handling Failures
+
+When `prepare_parallel_agents` returns `failedAgents`:
+
+```
+⚠️ Some agents failed to load:
+   ✗ performance-specialist: Profile not found
+
+Continuing with 3/4 agents...
+```
+
+**Strategy:**
+- Continue with successfully loaded agents
+- Report failures clearly to user
+- Document which agents couldn't be loaded in final report
+
+### Specialist Icons
+
+| Icon | Specialist |
+|------|------------|
+| 🔒 | security-specialist |
+| ♿ | accessibility-specialist |
+| ⚡ | performance-specialist |
+| 📏 | code-quality-specialist |
+| 🧪 | test-strategy-specialist |
+| 🏛️ | architecture-specialist |
+| 📚 | documentation-specialist |
+| 🔍 | seo-specialist |
+| 🎨 | design-system-specialist |
+| 📨 | event-architecture-specialist |
+| 🔗 | integration-specialist |
+| 📊 | observability-specialist |
+| 🔄 | migration-specialist |
+| 🌐 | i18n-specialist |
+
+### When to Use Specialist Execution
+
+Specialist execution is recommended when `parse_mode` returns a `parallelAgentsRecommendation` field:
+
+| Mode | Default Specialists | Use Case |
+|------|---------------------|----------|
+| **PLAN** | architecture-specialist, test-strategy-specialist | Validate architecture and test approach |
+| **ACT** | code-quality-specialist, test-strategy-specialist | Verify implementation quality |
+| **EVAL** | security-specialist, accessibility-specialist, performance-specialist, code-quality-specialist | Comprehensive multi-dimensional review |
+
+### Specialist Activation Scope
+
+Each workflow mode activates different specialist agents:
+
+- **PLAN mode**: Architecture and test strategy specialists validate design
+- **ACT mode**: Code quality and test strategy specialists verify implementation
+- **EVAL mode**: Security, accessibility, performance, and code quality specialists provide comprehensive review
+
+**Important:** Specialists from one mode do NOT carry over to the next mode. Each mode has its own recommended specialist set.
 
 ## GitHub Copilot Workspace Integration
 
@@ -203,13 +376,28 @@ When using Copilot Workspace:
 2. Keep `.github/copilot-instructions.md` concise (Copilot's context limit)
 3. Link to detailed rules in `.ai-rules/` rather than duplicating
 
+## AGENTS.md
+
+Industry standard format compatible with all AI tools (Codex, Cursor, Claude Code, Kiro, etc.):
+
+```markdown
+# AGENTS.md
+
+This project uses codingbuddy MCP server to manage AI Agents.
+
+## Quick Start
+...
+```
+
+See `AGENTS.md` in project root for details.
+
 ## Skills
 
 Codex accesses codingbuddy skills through three patterns:
 
 1. **Auto-recommend** — AI calls `recommend_skills` based on intent detection
 2. **Browse and select** — User calls `list_skills` to discover, then `get_skill` to load
-3. **Direct load** — AI calls `get_skill` with a known skill name
+3. **Slash-command** — User types `/<command>`, AI maps to `get_skill`
 
 ### Using Skills in Codex
 
@@ -258,6 +446,56 @@ AI calls list_skills({ minPriority: 1, maxPriority: 3 })
 ```
 
 > **Tip:** Use `recommend_skills` when you want AI to automatically pick the best skill. Use `list_skills` when you want to manually browse and select.
+
+### Slash-Command Mapping
+
+Codex has no native slash-command skill invocation. When a user types `/<command>`, the AI must call `get_skill` — this is Codex's equivalent of Claude Code's built-in Skill tool.
+
+**Rule:** When user input matches `/<command>`, call `get_skill("<skill-name>")` and follow the returned instructions. This table is a curated subset — use `list_skills()` to discover all available skills.
+
+| User Types | MCP Call |
+|---|---|
+| `/debug` or `/debugging` | `get_skill("systematic-debugging")` |
+| `/tdd` | `get_skill("test-driven-development")` |
+| `/brainstorm` | `get_skill("brainstorming")` |
+| `/plan` or `/write-plan` | `get_skill("writing-plans")` |
+| `/execute` or `/exec` | `get_skill("executing-plans")` |
+| `/design` or `/frontend` | `get_skill("frontend-design")` |
+| `/refactor` | `get_skill("refactoring")` |
+| `/security` or `/audit` | `get_skill("security-audit")` |
+| `/pr` | `get_skill("pr-all-in-one")` |
+| `/review` or `/pr-review` | `get_skill("pr-review")` |
+| `/parallel` or `/agents` | `get_skill("dispatching-parallel-agents")` |
+| `/subagent` | `get_skill("subagent-driven-development")` |
+
+For unrecognized slash commands, call `recommend_skills({ prompt: "<user's full message>" })` to find the closest match.
+
+> **Disambiguation:** `/plan` (with slash prefix) triggers `get_skill("writing-plans")`. `PLAN` (without slash, at message start) triggers `parse_mode`. Similarly, `/execute` triggers `get_skill("executing-plans")` while `ACT` triggers `parse_mode`. The slash prefix is the distinguishing signal.
+
+### Proactive Skill Activation
+
+Codex lacks session hooks that automatically enforce skill invocation (unlike Claude Code). The AI must detect intent patterns and call `recommend_skills` proactively — without waiting for the user to explicitly request a skill.
+
+**Rule:** When the user's message suggests a skill would help, call `recommend_skills` at the start of the response — before any other action. The `recommend_skills` engine matches trigger patterns across multiple languages and is the authoritative source of truth.
+
+Common trigger examples (not exhaustive):
+
+| User Intent Signal | Likely Skill |
+|---|---|
+| Bug report, error, "not working", exception | `systematic-debugging` |
+| "Brainstorm", "build", "create", "implement" | `brainstorming` |
+| "Test first", TDD, write tests before code | `test-driven-development` |
+| "Plan", "design", implementation approach | `writing-plans` |
+| PR, commit, code review workflow | `pr-all-in-one` |
+
+```
+User: "I need to plan the implementation for user authentication"
+→ AI calls recommend_skills({ prompt: "plan implementation for user authentication" })
+→ Loads writing-plans via get_skill
+→ Follows skill instructions to create structured plan
+```
+
+> **Note:** When the user message starts with a mode keyword (`PLAN`, `ACT`, `EVAL`, `AUTO`), `parse_mode` already handles skill matching automatically via `included_skills` — no separate `recommend_skills` call is needed.
 
 ### Available Skills
 
@@ -321,6 +559,35 @@ If no config file exists, the skill guides you through interactive setup:
 
 Use `cat .ai-rules/skills/pr-all-in-one/SKILL.md` to access skill documentation directly.
 
+## Context Document Management
+
+codingbuddy uses a fixed-path context document (`docs/codingbuddy/context.md`) to persist decisions across mode transitions.
+
+### How It Works
+
+| Mode | Behavior |
+|------|----------|
+| PLAN / AUTO | Resets (clears) existing content and starts fresh |
+| ACT / EVAL | Appends new section to existing content |
+
+### Required Workflow
+
+1. `parse_mode` automatically reads/creates the context document
+2. Review `contextDocument` in the response for previous decisions
+3. **Before completing each mode:** call `update_context` to persist current work
+
+### Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `read_context` | Read current context document |
+| `update_context` | Persist decisions, notes, progress, findings |
+| `cleanup_context` | Summarize older sections to reduce document size |
+
+### Codex-Specific Note
+
+Unlike Claude Code, Codex has no hooks or enforcement mechanisms to ensure `update_context` is called. The AI must **voluntarily remember** to call `update_context` before concluding each mode. Without this call, decisions and progress from the current mode will be lost across sessions or context compaction.
+
 ## AUTO Mode
 
 AUTO mode enables autonomous PLAN -> ACT -> EVAL cycling until quality criteria are met.
@@ -377,3 +644,75 @@ module.exports = {
 - Complex refactoring with quality verification
 - Bug fixes needing comprehensive testing
 - Code quality improvements with measurable criteria
+
+> **Codex limitation:** AUTO mode has no enforcement mechanism in Codex. See [Known Limitations](#known-limitations) for details.
+
+## Known Limitations
+
+Codex environment does not support several features available in Claude Code:
+
+| Feature | Status | Workaround |
+|---------|--------|------------|
+| **Task tool** (background subagents) | ❌ Not available | Use `prepare_parallel_agents` for sequential execution |
+| **Native Skill tool** (`/skill-name`) | ❌ Not available | Use MCP tool chain: `recommend_skills` → `get_skill` |
+| **Background subagent execution** | ❌ Not available | All specialist analyses run sequentially in the main thread |
+| **Session hooks** (PreToolUse, etc.) | ❌ Not available | Rely on `.codex/rules/system-prompt.md` for always-on instructions |
+| **Autonomous loop mechanism** | ❌ Not available | AUTO mode depends on Codex AI voluntarily looping |
+| **Context compaction hooks** | ❌ Not available | Manually call `update_context` before ending each mode |
+| **`dispatch_agents` full usage** | ⚠️ Partial | Returns Claude Code-specific `dispatchParams`; use `prepare_parallel_agents` as fallback |
+| **`roots/list` MCP capability** | ⚠️ Unconfirmed | Set `CODINGBUDDY_PROJECT_ROOT` env var explicitly |
+| **`restart_tui`** | ❌ Not applicable | Claude Code TUI-only tool |
+
+### AUTO Mode Reliability
+
+AUTO mode documents autonomous PLAN → ACT → EVAL cycling. In Codex, this depends entirely on the AI model voluntarily continuing the loop — there is no enforcement mechanism like Claude Code's hooks. Results may vary:
+
+- The AI may stop after one iteration instead of looping
+- Quality exit criteria (`Critical = 0 AND High = 0`) are advisory, not enforced
+- For reliable multi-iteration workflows, prefer manual `PLAN` → `ACT` → `EVAL` cycling
+
+## Getting Started
+
+1. Ensure `.ai-rules/` directory exists with all common rules
+2. Configure MCP server with `CODINGBUDDY_PROJECT_ROOT`:
+   ```jsonc
+   // Codex MCP configuration
+   {
+     "mcpServers": {
+       "codingbuddy": {
+         "command": "npx",
+         "args": ["-y", "codingbuddy"],
+         "env": {
+           "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+         }
+       }
+     }
+   }
+   ```
+3. Verify `.codex/rules/system-prompt.md` references `.ai-rules/` correctly
+4. Start a Codex session — MCP tools are now available
+5. Use PLAN/ACT/EVAL/AUTO workflow via `parse_mode` MCP tool
+
+## Verification Status
+
+> Documentation based on code analysis and Codex/GitHub Copilot public documentation. Runtime verification status tracked below.
+
+| Pattern | Status | Notes |
+|---------|--------|-------|
+| MCP Tool Access | ✅ Verified | MCP tools accessible via codingbuddy MCP server |
+| PLAN/ACT/EVAL Modes | ✅ Verified | `parse_mode` keyword detection and mode-specific rules |
+| Keyword Invocation | ✅ Verified | Mode keywords (PLAN/ACT/EVAL/AUTO) and localized variants |
+| Skills (MCP Tools) | ✅ Verified | `recommend_skills` → `get_skill` tool chain |
+| Specialist Agents Execution | ✅ Verified | Sequential workflow with `prepare_parallel_agents` |
+| AUTO Mode | ✅ Documented | Workflow documented; runtime loop verification pending |
+| Context Document Management | ✅ Documented | `update_context` / `read_context` workflow documented |
+| `roots/list` MCP Capability | ⚠️ Unconfirmed | Not confirmed in Codex/GitHub Copilot documentation |
+| Known Limitations | ✅ Documented | Task tool, hooks, AUTO mode, background subagent, dispatch_agents limitations |
+| Task Tool / Background Subagent | ❌ Not supported | Sequential execution only; no parallel subagent spawning |
+
+## Reference
+
+- [GitHub Copilot Documentation](https://docs.github.com/copilot)
+- [codingbuddy Documentation](../../docs/)
+- [Common AI Rules](../../packages/rules/.ai-rules/)
+- [Agent Definitions](../../packages/rules/.ai-rules/agents/)


### PR DESCRIPTION
## Summary

- Add sequential specialist execution workflow for Codex adapter with `dispatchReady` (preferred) and `prepare_parallel_agents` (fallback) patterns
- Add comprehensive MCP Tools table covering all 19 available tools
- Add cross-adapter parity sections: DRY Principle, Context Document Management, Known Limitations, Verification Status, AGENTS.md, Slash-Command Mapping, Getting Started, Reference
- Update `.codex/rules/system-prompt.md` with specialist execution instructions

## Test plan

- [x] `ajv-cli validate` — 35 agent JSON schemas valid
- [x] `markdownlint-cli2` — 65 markdown files, 0 errors
- [x] `yarn workspace codingbuddy lint` — 0 errors
- [x] `yarn workspace codingbuddy format:check` — pass
- [x] `yarn workspace codingbuddy typecheck` — 0 errors
- [x] `yarn workspace codingbuddy test:coverage` — 4751 tests passed, 94.42% coverage
- [x] `yarn workspace codingbuddy circular` — no circular deps
- [x] `yarn workspace codingbuddy build` — success

Closes #625