### PR TITLE
add 'unsafe-inline' to production CSP script-src

### DIFF
--- a/apps/landing-page/__tests__/config/csp-headers.test.ts
+++ b/apps/landing-page/__tests__/config/csp-headers.test.ts
@@ -26,4 +26,12 @@ describe('CSP Headers', () => {
     expect(cspValue).toContain("base-uri 'self'");
     expect(cspValue).toContain("form-action 'self'");
   });
+
+  it('should allow unsafe-inline for script-src to support Next.js PPR', async () => {
+    const headers = await nextConfig.headers!();
+    const cspHeader = headers[0].headers.find(h => h.key === 'Content-Security-Policy');
+    const cspValue = cspHeader!.value;
+
+    expect(cspValue).toContain("'unsafe-inline'");
+  });
 });

--- a/apps/landing-page/next.config.ts
+++ b/apps/landing-page/next.config.ts
@@ -60,14 +60,16 @@ const nextConfig: NextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=31536000; includeSubDomains',
           },
-          // Content Security Policy (stricter in production)
+          // Content Security Policy
+          // 'unsafe-inline' is required for Next.js PPR hydration/streaming inline scripts.
+          // Acceptable for this landing page (no user auth, no sensitive data).
           {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
               process.env.NODE_ENV === 'development'
                 ? "script-src 'self' 'unsafe-eval' 'unsafe-inline'"
-                : "script-src 'self' https://va.vercel-scripts.com",
+                : "script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com",
               "style-src 'self' 'unsafe-inline'",
               "font-src 'self' data:",
               "img-src 'self' data: https: blob:",


### PR DESCRIPTION
## Summary
- Production CSP `script-src` was missing `'unsafe-inline'`, causing Next.js PPR inline scripts to be blocked by the browser
- This resulted in only skeleton loading UI being rendered with no actual content appearing (27 CSP violation errors in console)
- Added `'unsafe-inline'` to production `script-src` directive — acceptable security trade-off for a static landing page with no auth or user data
- Added test to verify `'unsafe-inline'` is present in CSP headers

## Test plan
- [x] All 214 tests pass (36 test files)
- [x] Production build succeeds
- [x] Playwright verification: all widget content renders, 0 console errors
- [x] CSP test validates `'unsafe-inline'` presence
- [x] Lint, format, typecheck, circular dependency checks pass