### PR TITLE
add error recovery rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,13 @@ When working in this codebase, use these modes:
 - Pure/impure function separation (different files)
 - 90%+ test coverage goal
 
+## Error Recovery
+
+- On CLI command failure (label not found, permission error, file not found, etc.), automatically try alternatives
+- Do not wait for user confirmation on recoverable errors — recover immediately
+- Only report to user on unrecoverable errors (auth failure, risk of critical data loss, etc.)
+- Never break the workflow on error — try alternatives and continue
+
 ## Communication
 
 Follow the `language` setting in `codingbuddy.config.json` - use `get_project_config` MCP tool to retrieve current language setting.


### PR DESCRIPTION
## Summary
- Add Error Recovery section to CLAUDE.md
- Instructs Claude to auto-recover from recoverable CLI errors (label not found, file not found, permission errors) without waiting for user confirmation
- Only report unrecoverable errors (auth failure, critical data loss risk)
- Prevents workflow interruption on transient/recoverable failures

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Confirm Claude auto-recovers from recoverable errors in future sessions