### PR TITLE
feat(tui): add live.pure.ts with 7 pure display functions

### DIFF
--- a/apps/mcp-server/src/tui/components/index.ts
+++ b/apps/mcp-server/src/tui/components/index.ts
@@ -18,3 +18,13 @@ export { ActivityVisualizer, type ActivityVisualizerProps } from './ActivityVisu
 export { renderAgentTree, renderAgentStatusCard } from './activity-visualizer.pure';
 export { SessionTabBar } from './SessionTabBar';
 export type { SessionTabBarProps } from './SessionTabBar';
+export {
+  formatElapsed,
+  formatRelativeTime,
+  spinnerFrame,
+  pulseIcon,
+  renderSparkline,
+  computeThroughput,
+  formatTimeWithSeconds,
+} from './live.pure';
+export type { ActivitySample } from './live.pure';

--- a/apps/mcp-server/src/tui/components/live.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/live.pure.spec.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatElapsed,
+  formatRelativeTime,
+  spinnerFrame,
+  pulseIcon,
+  renderSparkline,
+  computeThroughput,
+  formatTimeWithSeconds,
+} from './live.pure';
+import type { ActivitySample } from './live.pure';
+
+describe('tui/components/live.pure', () => {
+  describe('formatElapsed', () => {
+    it('0초 경과 → "0s"', () => {
+      const now = 1000000;
+      expect(formatElapsed(now, now)).toBe('0s');
+    });
+
+    it('초 단위만 → "45s"', () => {
+      const start = 1000000;
+      const now = start + 45_000;
+      expect(formatElapsed(start, now)).toBe('45s');
+    });
+
+    it('분+초 → "1m 23s"', () => {
+      const start = 1000000;
+      const now = start + 83_000; // 1분 23초
+      expect(formatElapsed(start, now)).toBe('1m 23s');
+    });
+
+    it('정확히 1분 → "1m 0s"', () => {
+      const start = 1000000;
+      const now = start + 60_000;
+      expect(formatElapsed(start, now)).toBe('1m 0s');
+    });
+
+    it('10분 이상 → "12m 5s"', () => {
+      const start = 1000000;
+      const now = start + 725_000; // 12분 5초
+      expect(formatElapsed(start, now)).toBe('12m 5s');
+    });
+  });
+
+  describe('formatRelativeTime', () => {
+    it('0~2초 차이 → "just now"', () => {
+      const now = 1000000;
+      expect(formatRelativeTime(now, now)).toBe('just now');
+      expect(formatRelativeTime(now - 1000, now)).toBe('just now');
+      expect(formatRelativeTime(now - 2000, now)).toBe('just now');
+    });
+
+    it('3~59초 → "Ns ago"', () => {
+      const now = 1000000;
+      expect(formatRelativeTime(now - 3000, now)).toBe('3s ago');
+      expect(formatRelativeTime(now - 45000, now)).toBe('45s ago');
+      expect(formatRelativeTime(now - 59000, now)).toBe('59s ago');
+    });
+
+    it('60초 이상 → "Nm ago"', () => {
+      const now = 1000000;
+      expect(formatRelativeTime(now - 60000, now)).toBe('1m ago');
+      expect(formatRelativeTime(now - 150000, now)).toBe('2m ago');
+    });
+
+    it('3600초 이상 → "Nh ago"', () => {
+      const now = 10000000;
+      expect(formatRelativeTime(now - 3600000, now)).toBe('1h ago');
+      expect(formatRelativeTime(now - 7200000, now)).toBe('2h ago');
+    });
+  });
+
+  describe('spinnerFrame', () => {
+    const FRAMES = '⠋⠙⠹⠸⠼⠴⠦⠧';
+
+    it('tick 0 → 첫 번째 프레임 "⠋"', () => {
+      expect(spinnerFrame(0)).toBe('⠋');
+    });
+
+    it('tick 7 → 마지막 프레임 "⠧"', () => {
+      expect(spinnerFrame(7)).toBe('⠧');
+    });
+
+    it('tick 8 → 다시 첫 프레임 (순환)', () => {
+      expect(spinnerFrame(8)).toBe('⠋');
+    });
+
+    it('모든 8프레임이 올바른 순서', () => {
+      const frames = Array.from({ length: 8 }, (_, i) => spinnerFrame(i)).join('');
+      expect(frames).toBe(FRAMES);
+    });
+  });
+
+  describe('pulseIcon', () => {
+    it('짝수 tick → "●"', () => {
+      expect(pulseIcon(0)).toBe('●');
+      expect(pulseIcon(2)).toBe('●');
+      expect(pulseIcon(100)).toBe('●');
+    });
+
+    it('홀수 tick → "◉"', () => {
+      expect(pulseIcon(1)).toBe('◉');
+      expect(pulseIcon(3)).toBe('◉');
+      expect(pulseIcon(99)).toBe('◉');
+    });
+  });
+
+  describe('renderSparkline', () => {
+    it('빈 배열 → 빈 문자열', () => {
+      expect(renderSparkline([], 10)).toBe('');
+    });
+
+    it('모두 같은 값 → 최하위 블록 반복', () => {
+      expect(renderSparkline([5, 5, 5], 3)).toBe('▁▁▁');
+    });
+
+    it('오름차순 → 점진적 상승', () => {
+      const result = renderSparkline([0, 1, 2, 3, 4, 5, 6, 7], 8);
+      expect(result).toBe('▁▂▃▄▅▆▇█');
+    });
+
+    it('width보다 샘플 많으면 뒤에서 width개만 사용', () => {
+      const samples = [0, 0, 0, 0, 0, 7]; // 6개 중 마지막 3개만
+      const result = renderSparkline(samples, 3);
+      expect(result).toHaveLength(3);
+    });
+
+    it('width보다 샘플 적으면 샘플 수만큼 출력', () => {
+      const result = renderSparkline([1, 2], 10);
+      expect(result).toHaveLength(2);
+    });
+
+    it('단일 값 → 단일 ▁', () => {
+      expect(renderSparkline([42], 5)).toBe('▁');
+    });
+
+    it('min=max일 때 모두 ▁', () => {
+      expect(renderSparkline([10, 10, 10, 10], 4)).toBe('▁▁▁▁');
+    });
+  });
+
+  describe('computeThroughput', () => {
+    it('빈 배열 → "0.0/min"', () => {
+      expect(computeThroughput([])).toBe('0.0/min');
+    });
+
+    it('단일 샘플 → "0.0/min"', () => {
+      const samples: ActivitySample[] = [{ timestamp: 1000, toolCalls: 5 }];
+      expect(computeThroughput(samples)).toBe('0.0/min');
+    });
+
+    it('1분 동안 5회 호출 → "5.0/min"', () => {
+      const samples: ActivitySample[] = [
+        { timestamp: 0, toolCalls: 0 },
+        { timestamp: 60000, toolCalls: 5 },
+      ];
+      expect(computeThroughput(samples)).toBe('5.0/min');
+    });
+
+    it('30초 동안 3회 호출 → "6.0/min"', () => {
+      const samples: ActivitySample[] = [
+        { timestamp: 0, toolCalls: 0 },
+        { timestamp: 30000, toolCalls: 3 },
+      ];
+      expect(computeThroughput(samples)).toBe('6.0/min');
+    });
+
+    it('여러 샘플의 총합으로 계산', () => {
+      const samples: ActivitySample[] = [
+        { timestamp: 0, toolCalls: 1 },
+        { timestamp: 30000, toolCalls: 2 },
+        { timestamp: 60000, toolCalls: 3 },
+      ];
+      // 총 toolCalls = 1+2+3 = 6, 기간 = 60초 = 1분 → 6.0/min
+      expect(computeThroughput(samples)).toBe('6.0/min');
+    });
+  });
+
+  describe('formatTimeWithSeconds', () => {
+    it('자정 → "00:00:00"', () => {
+      // 2026-01-01T00:00:00Z = 1767225600000
+      const midnight = new Date('2026-01-01T00:00:00Z').getTime();
+      // UTC 기준
+      expect(formatTimeWithSeconds(midnight)).toBe('00:00:00');
+    });
+
+    it('오후 시간 → "14:23:45"', () => {
+      const t = new Date('2026-01-01T14:23:45Z').getTime();
+      expect(formatTimeWithSeconds(t)).toBe('14:23:45');
+    });
+
+    it('한 자리 시/분/초 → 0으로 패딩', () => {
+      const t = new Date('2026-01-01T03:05:09Z').getTime();
+      expect(formatTimeWithSeconds(t)).toBe('03:05:09');
+    });
+  });
+});

--- a/apps/mcp-server/src/tui/components/live.pure.ts
+++ b/apps/mcp-server/src/tui/components/live.pure.ts
@@ -1,0 +1,73 @@
+export interface ActivitySample {
+  timestamp: number;
+  toolCalls: number;
+}
+
+/** Format elapsed time as "Xm Ys" or "Ys". */
+export function formatElapsed(startedAt: number, now: number): string {
+  const totalSec = Math.floor((now - startedAt) / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  return min > 0 ? `${min}m ${sec}s` : `${sec}s`;
+}
+
+/** Format relative time as "just now", "Ns ago", "Nm ago", "Nh ago". */
+export function formatRelativeTime(timestamp: number, now: number): string {
+  const diffSec = Math.floor((now - timestamp) / 1000);
+  if (diffSec <= 2) return 'just now';
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  return `${diffHr}h ago`;
+}
+
+const SPINNER_FRAMES = '⠋⠙⠹⠸⠼⠴⠦⠧';
+
+/** Return spinner braille character for a given tick (8-frame cycle). */
+export function spinnerFrame(tick: number): string {
+  return SPINNER_FRAMES[tick % 8];
+}
+
+/** Alternating pulse icon: ● on even ticks, ◉ on odd ticks. */
+export function pulseIcon(tick: number): string {
+  return tick % 2 === 0 ? '●' : '◉';
+}
+
+const SPARK_CHARS = '▁▂▃▄▅▆▇█';
+
+/** Render a sparkline string from numeric samples using block characters. */
+export function renderSparkline(samples: number[], width: number): string {
+  if (samples.length === 0) return '';
+  const visible = samples.slice(-width);
+  const min = Math.min(...visible);
+  const max = Math.max(...visible);
+  const range = max - min;
+  return visible
+    .map(v => {
+      if (range === 0) return SPARK_CHARS[0];
+      const idx = Math.round(((v - min) / range) * 7);
+      return SPARK_CHARS[idx];
+    })
+    .join('');
+}
+
+/** Compute tool-call throughput as "N.N/min". */
+export function computeThroughput(samples: ActivitySample[]): string {
+  if (samples.length <= 1) return '0.0/min';
+  const first = samples[0];
+  const last = samples[samples.length - 1];
+  const durationMin = (last.timestamp - first.timestamp) / 60000;
+  if (durationMin <= 0) return '0.0/min';
+  const totalCalls = samples.reduce((sum, s) => sum + s.toolCalls, 0);
+  return `${(totalCalls / durationMin).toFixed(1)}/min`;
+}
+
+/** Format a UTC timestamp as "HH:MM:SS". */
+export function formatTimeWithSeconds(now: number): string {
+  const d = new Date(now);
+  const h = String(d.getUTCHours()).padStart(2, '0');
+  const m = String(d.getUTCMinutes()).padStart(2, '0');
+  const s = String(d.getUTCSeconds()).padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}


### PR DESCRIPTION
## Summary
- Add `live.pure.ts` with 7 pure display functions for the TUI live dashboard
  - `formatElapsed` — elapsed time formatting ("1m 23s", "45s")
  - `formatRelativeTime` — relative time ("just now", "3s ago", "1m ago")
  - `spinnerFrame` — 8-frame braille spinner cycle (⠋⠙⠹⠸⠼⠴⠦⠧)
  - `pulseIcon` — alternating pulse icon (● ↔ ◉)
  - `renderSparkline` — sparkline from numeric samples (▁▂▃▄▅▆▇█)
  - `computeThroughput` — tool-call throughput ("5.2/min")
  - `formatTimeWithSeconds` — UTC time formatting ("14:23:45")
- Add `live.pure.spec.ts` with 30 test cases covering all functions and edge cases
- Re-export all functions and `ActivitySample` type from `index.ts`

## Test plan
- [x] All 7 functions implemented as pure functions (no `Date.now()`, no side effects)
- [x] 30/30 vitest tests passing
- [x] Follows existing `.pure.ts` pattern (focused-agent.pure.ts, stage-health.pure.ts)
- [x] lint, format, typecheck, circular, build all pass

Closes #669