### PR TITLE
feat(tui): add useTick hook — heartbeat timer (#670)

### DIFF
--- a/apps/mcp-server/src/tui/hooks/index.ts
+++ b/apps/mcp-server/src/tui/hooks/index.ts
@@ -8,5 +8,6 @@ export { selectFocusedAgent } from './use-focus-agent';
 export { useTerminalSize, getTerminalSize } from './use-terminal-size';
 export type { TerminalSize } from './use-terminal-size';
 export { useClock } from './use-clock';
+export { useTick } from './use-tick';
 export { useMultiSessionState } from './use-multi-session-state';
 export type { SessionState, MultiSessionState } from './use-multi-session-state';

--- a/apps/mcp-server/src/tui/hooks/use-tick.spec.tsx
+++ b/apps/mcp-server/src/tui/hooks/use-tick.spec.tsx
@@ -1,0 +1,65 @@
+import React, { act } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+
+import { useTick } from './use-tick';
+
+function TestComponent({ intervalMs }: { intervalMs?: number }) {
+  const tick = useTick(intervalMs);
+  return <Text>{String(tick)}</Text>;
+}
+
+describe('tui/hooks/useTick', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should start at 0', () => {
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toBe('0');
+  });
+
+  it('should increment after default interval (1000ms)', () => {
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toBe('0');
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(lastFrame()).toBe('1');
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(lastFrame()).toBe('2');
+  });
+
+  it('should support custom interval', () => {
+    const { lastFrame } = render(<TestComponent intervalMs={500} />);
+    expect(lastFrame()).toBe('0');
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(lastFrame()).toBe('1');
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(lastFrame()).toBe('2');
+  });
+
+  it('should cleanup interval on unmount', () => {
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+    const { unmount } = render(<TestComponent />);
+
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/apps/mcp-server/src/tui/hooks/use-tick.ts
+++ b/apps/mcp-server/src/tui/hooks/use-tick.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+
+export function useTick(intervalMs = 1000): number {
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setTick(prev => prev + 1);
+    }, intervalMs);
+
+    return () => clearInterval(id);
+  }, [intervalMs]);
+
+  return tick;
+}


### PR DESCRIPTION
## Summary
- Add `useTick(intervalMs = 1000)` hook that returns a monotonically increasing counter
- Starts at 0, increments every `intervalMs` via `setInterval`, cleans up on unmount
- Single timer source for all live rendering in the TUI dashboard
- Export from `hooks/index.ts` barrel

## Test plan
- [x] Starts at 0
- [x] Increments after default interval (1000ms)
- [x] Supports custom interval
- [x] Cleans up interval on unmount
- [x] All 139 existing hook tests pass (no regressions)
- [x] lint, format, typecheck, circular, build all pass

Closes #670