### PR TITLE
feat(tui): add sparkline + throughput to StageHealthBar

### DIFF
--- a/apps/mcp-server/src/tui/components/StageHealthBar.spec.tsx
+++ b/apps/mcp-server/src/tui/components/StageHealthBar.spec.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { StageHealthBar } from './StageHealthBar';
 import { createEmptyStageStats } from '../dashboard-types';
+import type { ActivitySample } from './live.pure';
 
 function makeHealth() {
   return {
@@ -161,5 +162,61 @@ describe('tui/components/StageHealthBar', () => {
     expect(out).toContain('🤖 2k');
     expect(out).toContain('🔧 2k');
     expect(out).toContain('⚙ 0');
+  });
+
+  it('renders sparkline and throughput when activityHistory is provided', () => {
+    const samples: ActivitySample[] = [
+      { timestamp: 1000, toolCalls: 2 },
+      { timestamp: 61000, toolCalls: 5 },
+      { timestamp: 121000, toolCalls: 3 },
+    ];
+    const { lastFrame } = render(
+      <StageHealthBar
+        stageHealth={makeHealth()}
+        bottlenecks={[]}
+        toolCount={0}
+        agentCount={0}
+        skillCount={0}
+        width={120}
+        activityHistory={samples}
+      />,
+    );
+    const out = lastFrame() ?? '';
+    // sparkline block chars should be present
+    expect(out).toMatch(/[▁▂▃▄▅▆▇█]/);
+    // throughput label
+    expect(out).toContain('/min');
+  });
+
+  it('does not render sparkline when activityHistory is undefined', () => {
+    const { lastFrame } = render(
+      <StageHealthBar
+        stageHealth={makeHealth()}
+        bottlenecks={[]}
+        toolCount={0}
+        agentCount={0}
+        skillCount={0}
+        width={120}
+      />,
+    );
+    const out = lastFrame() ?? '';
+    expect(out).not.toMatch(/[▁▂▃▄▅▆▇█]/);
+    expect(out).not.toContain('/min');
+  });
+
+  it('does not render sparkline when activityHistory is empty', () => {
+    const { lastFrame } = render(
+      <StageHealthBar
+        stageHealth={makeHealth()}
+        bottlenecks={[]}
+        toolCount={0}
+        agentCount={0}
+        skillCount={0}
+        width={120}
+        activityHistory={[]}
+      />,
+    );
+    const out = lastFrame() ?? '';
+    expect(out).not.toContain('/min');
   });
 });

--- a/apps/mcp-server/src/tui/components/StageHealthBar.tsx
+++ b/apps/mcp-server/src/tui/components/StageHealthBar.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import type { StageStats } from '../dashboard-types';
+import type { ActivitySample } from './live.pure';
 import type { Mode } from '../types';
 import { getModeColor, BORDER_COLORS } from '../utils/theme';
 import { formatCount } from './stage-health.pure';
+import { renderSparkline, computeThroughput } from './live.pure';
 
 export interface StageHealthBarProps {
   stageHealth: Record<Mode, StageStats>;
@@ -12,6 +14,9 @@ export interface StageHealthBarProps {
   agentCount: number;
   skillCount: number;
   width: number;
+  activityHistory?: ActivitySample[];
+  tick?: number;
+  now?: number;
 }
 
 type DisplayableStage = 'PLAN' | 'ACT' | 'EVAL';
@@ -86,7 +91,12 @@ export function StageHealthBar({
   agentCount,
   skillCount,
   width,
+  activityHistory,
+  tick: _tick,
+  now: _now,
 }: StageHealthBarProps): React.ReactElement {
+  const hasActivity = activityHistory && activityHistory.length > 0;
+
   return (
     <Box
       borderStyle="double"
@@ -95,6 +105,17 @@ export function StageHealthBar({
       flexDirection="column"
     >
       <Box>
+        {hasActivity && (
+          <Box gap={1} marginRight={1}>
+            <Text color="cyan">
+              {renderSparkline(
+                activityHistory.map(s => s.toolCalls),
+                10,
+              )}
+            </Text>
+            <Text dimColor>{computeThroughput(activityHistory)}</Text>
+          </Box>
+        )}
         <Box gap={2}>
           {(['PLAN', 'ACT', 'EVAL'] as const).map(mode => (
             <StageStatDisplay key={mode} mode={mode} stats={stageHealth[mode]} />


### PR DESCRIPTION
## Summary
- Add optional `activityHistory`, `tick`, `now` props to `StageHealthBar`
- When `activityHistory` has data, prepend sparkline chart (`renderSparkline`) and throughput metric (`computeThroughput`) before stage stats
- Existing behavior unchanged when props are omitted (backward compatible)
- Add 3 new tests: sparkline renders, no sparkline without data, no sparkline with empty array

## Test plan
- [x] All 12 StageHealthBar tests pass (9 existing + 3 new)
- [x] Lint, format, typecheck, circular, build all pass
- [x] Existing tests unaffected by optional props

Closes #675