### PR TITLE
feat(tui): HeaderBar animated spinner + live clock

### DIFF
--- a/apps/mcp-server/src/tui/components/HeaderBar.spec.tsx
+++ b/apps/mcp-server/src/tui/components/HeaderBar.spec.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { HeaderBar } from './HeaderBar';
 
+const FIXED_NOW = new Date('2026-03-18T14:30:45Z').getTime();
+
 describe('tui/components/HeaderBar', () => {
   it('should render title with neon branding', () => {
     const { lastFrame } = render(
@@ -12,6 +14,8 @@ describe('tui/components/HeaderBar', () => {
         globalState="RUNNING"
         layoutMode="wide"
         width={120}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     expect(lastFrame()).toContain('CODINGBUDDY');
@@ -25,6 +29,8 @@ describe('tui/components/HeaderBar', () => {
         globalState="RUNNING"
         layoutMode="wide"
         width={120}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     const frame = lastFrame() ?? '';
@@ -41,6 +47,8 @@ describe('tui/components/HeaderBar', () => {
         globalState="IDLE"
         layoutMode="wide"
         width={120}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     const frame = lastFrame() ?? '';
@@ -48,7 +56,7 @@ describe('tui/components/HeaderBar', () => {
     expect(frame).toContain('○');
   });
 
-  it('should render RUNNING state with filled circle', () => {
+  it('should render RUNNING state with spinner when tick provided', () => {
     const { lastFrame } = render(
       <HeaderBar
         workspace="/repo"
@@ -56,10 +64,12 @@ describe('tui/components/HeaderBar', () => {
         globalState="RUNNING"
         layoutMode="wide"
         width={120}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('●');
+    expect(frame).toContain('⠋');
     expect(frame).toContain('RUNNING');
   });
 
@@ -71,6 +81,8 @@ describe('tui/components/HeaderBar', () => {
         globalState="ERROR"
         layoutMode="wide"
         width={120}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     const frame = lastFrame() ?? '';
@@ -86,6 +98,8 @@ describe('tui/components/HeaderBar', () => {
         globalState="RUNNING"
         layoutMode="narrow"
         width={60}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     const frame = lastFrame() ?? '';
@@ -100,6 +114,8 @@ describe('tui/components/HeaderBar', () => {
         globalState="RUNNING"
         layoutMode="wide"
         width={120}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     const frame = lastFrame() ?? '';
@@ -115,6 +131,8 @@ describe('tui/components/HeaderBar', () => {
         globalState="IDLE"
         layoutMode="medium"
         width={100}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     expect(lastFrame()).toBeTruthy();
@@ -130,6 +148,8 @@ describe('tui/components/HeaderBar', () => {
         globalState="RUNNING"
         layoutMode="wide"
         width={120}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     const frame = lastFrame() ?? '';
@@ -147,6 +167,8 @@ describe('tui/components/HeaderBar', () => {
         globalState="RUNNING"
         layoutMode="wide"
         width={120}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     const frame = lastFrame() ?? '';
@@ -154,7 +176,6 @@ describe('tui/components/HeaderBar', () => {
     expect(frame).toContain('PLAN');
     expect(frame).toContain('ACT');
     expect(frame).toContain('EVAL');
-    // AUTO should not be connected by arrow to EVAL
     expect(frame).not.toMatch(/EVAL[^A]*→[^A]*AUTO/);
   });
 
@@ -166,13 +187,64 @@ describe('tui/components/HeaderBar', () => {
         globalState="RUNNING"
         layoutMode="wide"
         width={120}
+        tick={0}
+        now={FIXED_NOW}
       />,
     );
     const frame = lastFrame() ?? '';
-    // Double border uses ╔ ╗ ╚ ╝ characters
     expect(frame).toContain('╔');
     expect(frame).toContain('╗');
     expect(frame).toContain('╚');
     expect(frame).toContain('╝');
+  });
+
+  // --- Issue #673: Animated spinner + live clock ---
+
+  it('should change spinner frame based on tick value', () => {
+    const { lastFrame } = render(
+      <HeaderBar
+        workspace="/repo"
+        currentMode="PLAN"
+        globalState="RUNNING"
+        layoutMode="wide"
+        width={120}
+        tick={3}
+        now={FIXED_NOW}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('⠸');
+    expect(frame).not.toContain('⠋');
+  });
+
+  it('should display live clock when now is provided', () => {
+    const { lastFrame } = render(
+      <HeaderBar
+        workspace="/repo"
+        currentMode="PLAN"
+        globalState="RUNNING"
+        layoutMode="wide"
+        width={120}
+        tick={0}
+        now={FIXED_NOW}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('14:30:45');
+  });
+
+  it('should render without tick/now for backward compatibility', () => {
+    const { lastFrame } = render(
+      <HeaderBar
+        workspace="/repo"
+        currentMode="PLAN"
+        globalState="RUNNING"
+        layoutMode="wide"
+        width={120}
+      />,
+    );
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('●');
+    expect(frame).toContain('RUNNING');
   });
 });

--- a/apps/mcp-server/src/tui/components/HeaderBar.tsx
+++ b/apps/mcp-server/src/tui/components/HeaderBar.tsx
@@ -8,6 +8,7 @@ import {
   GLOBAL_STATE_COLORS,
   BORDER_COLORS,
 } from '../utils/theme';
+import { spinnerFrame, formatTimeWithSeconds } from './live.pure';
 
 export interface HeaderBarProps {
   workspace: string;
@@ -15,6 +16,8 @@ export interface HeaderBarProps {
   globalState: GlobalRunState;
   layoutMode: LayoutMode;
   width: number;
+  tick?: number;
+  now?: number;
 }
 
 const PROCESS_MODES: Mode[] = ['PLAN', 'ACT', 'EVAL'];
@@ -51,11 +54,19 @@ function ModeFlow({ currentMode }: { currentMode: Mode | null }): React.ReactEle
   );
 }
 
-function StateIndicator({ globalState }: { globalState: GlobalRunState }): React.ReactElement {
-  const icon = GLOBAL_STATE_ICONS[globalState];
+function StateIndicator({
+  globalState,
+  tick,
+}: {
+  globalState: GlobalRunState;
+  tick?: number;
+}): React.ReactElement {
+  const isRunning = globalState === 'RUNNING';
+  const icon =
+    isRunning && tick !== undefined ? spinnerFrame(tick) : GLOBAL_STATE_ICONS[globalState];
   const color = GLOBAL_STATE_COLORS[globalState];
   return (
-    <Text color={color} bold={globalState === 'RUNNING' || globalState === 'ERROR'}>
+    <Text color={color} bold={isRunning || globalState === 'ERROR'}>
       {icon} {globalState}
     </Text>
   );
@@ -67,6 +78,8 @@ export function HeaderBar({
   globalState,
   layoutMode,
   width,
+  tick,
+  now,
 }: HeaderBarProps): React.ReactElement {
   if (layoutMode === 'narrow') {
     return (
@@ -83,7 +96,10 @@ export function HeaderBar({
         <Box flexGrow={1} />
         <ModeFlow currentMode={currentMode} />
         <Box flexGrow={1} />
-        <StateIndicator globalState={globalState} />
+        <StateIndicator globalState={globalState} tick={tick} />
+        {now !== undefined && (
+          <Text dimColor> {formatTimeWithSeconds(now)}</Text>
+        )}
       </Box>
     );
   }
@@ -105,7 +121,10 @@ export function HeaderBar({
           ⟨⟩ CODINGBUDDY AGENT DASHBOARD
         </Text>
         <ModeFlow currentMode={currentMode} />
-        <StateIndicator globalState={globalState} />
+        <StateIndicator globalState={globalState} tick={tick} />
+        {now !== undefined && (
+          <Text dimColor>{formatTimeWithSeconds(now)}</Text>
+        )}
       </Box>
       <Box flexGrow={1} />
       <Box flexShrink={1} overflowX="hidden">


### PR DESCRIPTION
## Summary
- Add optional `tick` and `now` props to `HeaderBarProps` for live updates
- RUNNING state shows animated braille spinner (`spinnerFrame(tick)`) instead of static `●` icon
- Display live clock (`formatTimeWithSeconds(now)`) in both wide and narrow layouts
- Backward compatible: without `tick`/`now`, behavior is unchanged

## Test plan
- [x] Spinner frame changes with tick value (tick=0 → `⠋`, tick=3 → `⠸`)
- [x] Live clock renders formatted UTC time (`14:30:45`)
- [x] Backward compat: RUNNING without tick shows static `●`
- [x] IDLE/ERROR states unaffected by tick
- [x] All 14 HeaderBar tests pass
- [x] lint, format, typecheck, circular, build all pass

Closes #673