### PR TITLE
feat(tui): FlowMap — pulse icons + elapsed labels

### DIFF
--- a/apps/mcp-server/src/tui/components/FlowMap.spec.tsx
+++ b/apps/mcp-server/src/tui/components/FlowMap.spec.tsx
@@ -4,6 +4,7 @@ import { render } from 'ink-testing-library';
 import { FlowMap } from './FlowMap';
 import { createDefaultDashboardNode } from '../dashboard-types';
 import type { Edge } from '../dashboard-types';
+import { pulseIcon, formatElapsed } from './live.pure';
 
 function makeAgents() {
   const agents = new Map();
@@ -95,5 +96,107 @@ describe('tui/components/FlowMap', () => {
     const frame = lastFrame() ?? '';
     // Running agents should have the running icon
     expect(frame).toContain('\u25CF');
+  });
+
+  describe('pulse icons + elapsed labels (tick/now props)', () => {
+    it('should show pulse icon and elapsed label for running agents in narrow mode', () => {
+      const now = 1710700000000;
+      const agents = new Map();
+      agents.set(
+        'a1',
+        createDefaultDashboardNode({
+          id: 'a1',
+          name: 'Architect',
+          stage: 'PLAN',
+          status: 'running',
+          isPrimary: true,
+          startedAt: now - 45_000, // 45 seconds ago
+        }),
+      );
+      const { lastFrame } = render(
+        <FlowMap agents={agents} edges={[]} layoutMode="narrow" width={60} height={10} tick={0} now={now} />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain(pulseIcon(0));
+      expect(frame).toContain(formatElapsed(now - 45_000, now));
+    });
+
+    it('should show pulse icon for running agents in wide mode', () => {
+      const now = 1710700000000;
+      const agents = new Map();
+      agents.set(
+        'a1',
+        createDefaultDashboardNode({
+          id: 'a1',
+          name: 'Architect',
+          stage: 'PLAN',
+          status: 'running',
+          isPrimary: true,
+          startedAt: now - 90_000,
+        }),
+      );
+      const { lastFrame } = render(
+        <FlowMap agents={agents} edges={makeEdges()} layoutMode="wide" width={120} height={20} tick={2} now={now} />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain(pulseIcon(2));
+      expect(frame).toContain(formatElapsed(now - 90_000, now));
+    });
+
+    it('should NOT show pulse icon when no agents are running', () => {
+      const now = 1710700000000;
+      const agents = new Map();
+      agents.set(
+        'a1',
+        createDefaultDashboardNode({
+          id: 'a1',
+          name: 'Architect',
+          stage: 'PLAN',
+          status: 'idle',
+          startedAt: now - 45_000,
+        }),
+      );
+      const { lastFrame } = render(
+        <FlowMap agents={agents} edges={[]} layoutMode="narrow" width={60} height={10} tick={3} now={now} />,
+      );
+      const frame = lastFrame() ?? '';
+      // idle agent should NOT have pulse icons
+      expect(frame).not.toContain(pulseIcon(3));
+      expect(frame).not.toContain('45s');
+    });
+
+    it('should NOT show elapsed without tick/now props', () => {
+      const agents = makeAgents();
+      const { lastFrame } = render(
+        <FlowMap agents={agents} edges={[]} layoutMode="narrow" width={60} height={10} />,
+      );
+      const frame = lastFrame() ?? '';
+      // Without tick/now, no elapsed labels should appear
+      expect(frame).not.toMatch(/\d+m \d+s/);
+      expect(frame).not.toMatch(/\d+s$/m);
+    });
+
+    it('should alternate pulse icon between ticks', () => {
+      const now = 1710700000000;
+      const agents = new Map();
+      agents.set(
+        'a1',
+        createDefaultDashboardNode({
+          id: 'a1',
+          name: 'Architect',
+          stage: 'PLAN',
+          status: 'running',
+          startedAt: now - 10_000,
+        }),
+      );
+      const { lastFrame: frame0 } = render(
+        <FlowMap agents={agents} edges={[]} layoutMode="narrow" width={60} height={10} tick={0} now={now} />,
+      );
+      const { lastFrame: frame1 } = render(
+        <FlowMap agents={agents} edges={[]} layoutMode="narrow" width={60} height={10} tick={1} now={now} />,
+      );
+      expect(frame0()).toContain('●');
+      expect(frame1()).toContain('◉');
+    });
   });
 });

--- a/apps/mcp-server/src/tui/components/FlowMap.tsx
+++ b/apps/mcp-server/src/tui/components/FlowMap.tsx
@@ -5,6 +5,7 @@ import type { Mode } from '../types';
 import { groupByStyle, type ColorCell } from '../utils/color-buffer';
 import { BORDER_COLORS } from '../utils/theme';
 import { renderFlowMap, renderFlowMapSimplified, renderFlowMapCompact } from './flow-map.pure';
+import { pulseIcon, formatElapsed } from './live.pure';
 
 /**
  * Props for FlowMap component.
@@ -21,6 +22,8 @@ export interface FlowMapProps {
   width: number;
   height: number;
   activeStage?: Mode | null;
+  tick?: number;
+  now?: number;
 }
 
 /**
@@ -66,10 +69,20 @@ export function FlowMap({
   width,
   height,
   activeStage = null,
+  tick,
+  now,
 }: FlowMapProps): React.ReactElement {
   // Border consumes 2 chars width + 2 lines height; header "FLOW MAP" takes 1 line
   const contentWidth = Math.max(1, width - 2);
   const contentHeight = Math.max(1, height - 3);
+
+  // liveTick guard: only animate when there are running agents
+  const hasRunningAgents = useMemo(
+    () => [...agents.values()].some(a => a.status === 'running'),
+    [agents],
+  );
+  const liveTick = hasRunningAgents ? (tick ?? 0) : 0;
+  const liveNow = hasRunningAgents ? now : undefined;
 
   const compactContent = useMemo(() => {
     if (layoutMode !== 'narrow') return null;
@@ -85,6 +98,22 @@ export function FlowMap({
     return buf.toLinesDirect();
   }, [agents, edges, contentWidth, contentHeight, layoutMode, activeStage]);
 
+  // Live overlay: pulse icon + elapsed for running agents (depends on liveTick/liveNow)
+  const liveOverlays = useMemo(() => {
+    if (liveNow === undefined) return null;
+    const overlays: Array<{ id: string; icon: string; elapsed: string }> = [];
+    for (const [id, agent] of agents) {
+      if (agent.status === 'running' && agent.startedAt != null) {
+        overlays.push({
+          id,
+          icon: pulseIcon(liveTick),
+          elapsed: formatElapsed(agent.startedAt, liveNow),
+        });
+      }
+    }
+    return overlays.length > 0 ? overlays : null;
+  }, [agents, liveTick, liveNow]);
+
   if (layoutMode === 'narrow') {
     return (
       <Box
@@ -98,6 +127,11 @@ export function FlowMap({
           FLOW MAP
         </Text>
         <Text>{compactContent}</Text>
+        {liveOverlays?.map(o => (
+          <Text key={o.id} color="yellow">
+            {o.icon} {o.elapsed}
+          </Text>
+        ))}
       </Box>
     );
   }
@@ -131,6 +165,11 @@ export function FlowMap({
       </Text>
       {lines.map((row, y) => (
         <ColorRow key={y} cells={row} />
+      ))}
+      {liveOverlays?.map(o => (
+        <Text key={o.id} color="yellow">
+          {o.icon} {o.elapsed}
+        </Text>
       ))}
     </Box>
   );


### PR DESCRIPTION
## Summary
- Add optional `tick` and `now` props to `FlowMapProps` for live animation
- Split rendering: existing `useMemo` stays tick-free (no expensive recomputation), separate `liveOverlays` memo handles pulse + elapsed
- `liveTick` guard: suppresses animation when no agents are running
- Running agents show `pulseIcon(liveTick)` alternating ●/◉ + `formatElapsed(startedAt, now)` label
- 5 new tests covering pulse icons, elapsed labels, idle suppression, and tick alternation

## Test plan
- [x] Pulse icon visible for running agents in narrow mode
- [x] Pulse icon visible for running agents in wide mode
- [x] No pulse icon when all agents are idle
- [x] No elapsed labels without tick/now props (backward compat)
- [x] Pulse icon alternates between ticks (● on even, ◉ on odd)

Closes #676