### PR TITLE
feat(tui): add elapsed timer + relative timestamps to FocusedAgentPanel

### DIFF
--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.spec.tsx
@@ -156,6 +156,114 @@ describe('tui/components/FocusedAgentPanel', () => {
     expect(lastFrame()).toContain('⚙️');
   });
 
+  describe('elapsed timer and spinner for running agent', () => {
+    it('should show spinner frame and elapsed time when tick and now are provided', () => {
+      const now = 1710000090000;
+      const startedAt = now - 83000; // 1m 23s ago
+      const runningAgent = createDefaultDashboardNode({
+        id: 'agent-1',
+        name: 'BackendDev',
+        stage: 'ACT',
+        status: 'running',
+        isPrimary: true,
+        progress: 50,
+        startedAt,
+      });
+      const { lastFrame } = render(
+        <FocusedAgentPanel
+          agent={runningAgent}
+          activeSkills={[]}
+          objectives={[]}
+          eventLog={[]}
+          tick={0}
+          now={now}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('⠋'); // spinnerFrame(0)
+      expect(frame).toContain('1m 23s');
+    });
+
+    it('should not show spinner/elapsed when agent is not running', () => {
+      const now = 1710000090000;
+      const doneAgent = createDefaultDashboardNode({
+        id: 'agent-1',
+        name: 'BackendDev',
+        stage: 'ACT',
+        status: 'done',
+        isPrimary: true,
+        progress: 100,
+        startedAt: now - 83000,
+      });
+      const { lastFrame } = render(
+        <FocusedAgentPanel
+          agent={doneAgent}
+          activeSkills={[]}
+          objectives={[]}
+          eventLog={[]}
+          tick={0}
+          now={now}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).not.toContain('⠋');
+      expect(frame).not.toContain('1m 23s');
+    });
+
+    it('should not show elapsed when startedAt is missing', () => {
+      const now = 1710000090000;
+      const { lastFrame } = render(
+        <FocusedAgentPanel
+          agent={mockAgent}
+          activeSkills={[]}
+          objectives={[]}
+          eventLog={[]}
+          tick={0}
+          now={now}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('⠋'); // spinner still shows for running
+      expect(frame).not.toContain('m '); // no elapsed time
+    });
+  });
+
+  describe('relative timestamps in event log', () => {
+    it('should show relative timestamps when now is provided and rawTimestamp exists', () => {
+      const now = 1710000060000;
+      const { lastFrame } = render(
+        <FocusedAgentPanel
+          agent={mockAgent}
+          activeSkills={[]}
+          objectives={[]}
+          eventLog={[
+            { timestamp: '10:00:00', message: 'Started', level: 'info', rawTimestamp: now - 5000 },
+          ]}
+          now={now}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('5s ago');
+      expect(frame).toContain('Started');
+    });
+
+    it('should fall back to original timestamp when now is not provided', () => {
+      const { lastFrame } = render(
+        <FocusedAgentPanel
+          agent={mockAgent}
+          activeSkills={[]}
+          objectives={[]}
+          eventLog={[
+            { timestamp: '10:12:01', message: 'ACT start', level: 'info' },
+          ]}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('10:12:01');
+      expect(frame).toContain('ACT start');
+    });
+  });
+
   describe('Context section', () => {
     it('renders context decisions when provided', () => {
       const { lastFrame } = render(

--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
@@ -5,9 +5,11 @@ import { STATUS_ICONS, getNodeStatusColor, BORDER_COLORS, getAgentAvatar } from 
 import {
   formatObjective,
   formatLogTail,
+  formatLogTailRelative,
   formatSectionDivider,
   formatEnhancedProgressBar,
 } from './focused-agent.pure';
+import { spinnerFrame, formatElapsed } from './live.pure';
 import { ContextSection } from './ContextSection';
 
 export interface FocusedAgentPanelProps {
@@ -17,6 +19,8 @@ export interface FocusedAgentPanelProps {
   eventLog: EventLogEntry[];
   contextDecisions?: string[];
   contextNotes?: string[];
+  tick?: number;
+  now?: number;
   width?: number;
   height?: number;
 }
@@ -61,6 +65,8 @@ export function FocusedAgentPanel({
   eventLog,
   contextDecisions = [],
   contextNotes = [],
+  tick,
+  now,
   width,
   height,
 }: FocusedAgentPanelProps): React.ReactElement {
@@ -84,7 +90,10 @@ export function FocusedAgentPanel({
   const statusLabel = agent.status.toUpperCase();
   const progressBar = formatEnhancedProgressBar(agent.progress);
   const objective = formatObjective(objectives);
-  const logs = formatLogTail(eventLog);
+  const logs = now != null ? formatLogTailRelative(eventLog, now) : formatLogTail(eventLog);
+  const isRunning = agent.status === 'running';
+  const showSpinner = isRunning && tick != null;
+  const showElapsed = isRunning && now != null && agent.startedAt != null;
 
   return (
     <Box
@@ -98,10 +107,17 @@ export function FocusedAgentPanel({
       <Box gap={2}>
         <Text>{avatar}</Text>
         <Text bold>{agent.name}</Text>
-        <Text color={statusColor} bold>
-          {icon}
-        </Text>
+        {showSpinner ? (
+          <Text color="cyan">{spinnerFrame(tick!)}</Text>
+        ) : (
+          <Text color={statusColor} bold>
+            {icon}
+          </Text>
+        )}
         <Text color={statusColor}>{statusLabel}</Text>
+        {showElapsed && (
+          <Text dimColor>{formatElapsed(agent.startedAt!, now!)}</Text>
+        )}
         <Text dimColor>{agent.stage}</Text>
       </Box>
 

--- a/apps/mcp-server/src/tui/components/focused-agent.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/focused-agent.pure.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   formatObjective,
   formatLogTail,
+  formatLogTailRelative,
   formatSectionDivider,
   formatEnhancedProgressBar,
   formatEnhancedChecklist,
@@ -94,6 +95,55 @@ describe('tui/components/focused-agent.pure', () => {
     it('should handle title longer than width gracefully', () => {
       const result = formatSectionDivider('VeryLongTitle', 10);
       expect(result).toContain('VeryLongTitle');
+    });
+  });
+
+  describe('formatLogTailRelative', () => {
+    it('should use formatRelativeTime when rawTimestamp is present', () => {
+      const now = 1710000060000;
+      const events: EventLogEntry[] = [
+        { timestamp: '10:00:00', message: 'Started', level: 'info', rawTimestamp: now - 5000 },
+        { timestamp: '10:01:00', message: 'Done', level: 'info', rawTimestamp: now - 1000 },
+      ];
+      const result = formatLogTailRelative(events, now);
+      expect(result).toBe('5s ago Started\njust now Done');
+    });
+
+    it('should fall back to timestamp when rawTimestamp is absent', () => {
+      const now = 1710000060000;
+      const events: EventLogEntry[] = [
+        { timestamp: '10:00:01', message: 'Legacy event', level: 'info' },
+      ];
+      const result = formatLogTailRelative(events, now);
+      expect(result).toBe('10:00:01 Legacy event');
+    });
+
+    it('should handle mixed events (some with rawTimestamp, some without)', () => {
+      const now = 1710000060000;
+      const events: EventLogEntry[] = [
+        { timestamp: '10:00:01', message: 'Old format', level: 'info' },
+        { timestamp: '10:01:00', message: 'New format', level: 'info', rawTimestamp: now - 30000 },
+      ];
+      const result = formatLogTailRelative(events, now);
+      const lines = result.split('\n');
+      expect(lines[0]).toBe('10:00:01 Old format');
+      expect(lines[1]).toBe('30s ago New format');
+    });
+
+    it('should respect maxLines', () => {
+      const now = 1710000060000;
+      const events: EventLogEntry[] = Array.from({ length: 20 }, (_, i) => ({
+        timestamp: `10:00:${String(i).padStart(2, '0')}`,
+        message: `Event ${i}`,
+        level: 'info' as const,
+        rawTimestamp: now - (20 - i) * 1000,
+      }));
+      const result = formatLogTailRelative(events, now, 5);
+      expect(result.split('\n')).toHaveLength(5);
+    });
+
+    it('should return empty string for empty events', () => {
+      expect(formatLogTailRelative([], Date.now())).toBe('');
     });
   });
 

--- a/apps/mcp-server/src/tui/components/focused-agent.pure.ts
+++ b/apps/mcp-server/src/tui/components/focused-agent.pure.ts
@@ -1,4 +1,5 @@
 import type { TaskItem, EventLogEntry } from '../dashboard-types';
+import { formatRelativeTime } from './live.pure';
 
 export function formatObjective(objectives: string[], maxLines = 3): string {
   const lines = objectives.slice(0, maxLines).map(o => `- ${o}`);
@@ -11,6 +12,20 @@ export function formatObjective(objectives: string[], maxLines = 3): string {
 export function formatLogTail(events: EventLogEntry[], maxLines = 10): string {
   const tail = events.slice(-maxLines);
   return tail.map(e => `${e.timestamp} ${e.message}`).join('\n');
+}
+
+/**
+ * Format log tail with relative timestamps when rawTimestamp is available.
+ * Falls back to the original timestamp string otherwise.
+ */
+export function formatLogTailRelative(events: EventLogEntry[], now: number, maxLines = 10): string {
+  const tail = events.slice(-maxLines);
+  return tail
+    .map(e => {
+      const ts = e.rawTimestamp != null ? formatRelativeTime(e.rawTimestamp, now) : e.timestamp;
+      return `${ts} ${e.message}`;
+    })
+    .join('\n');
 }
 
 /**

--- a/apps/mcp-server/src/tui/components/index.ts
+++ b/apps/mcp-server/src/tui/components/index.ts
@@ -10,7 +10,12 @@ export {
 export { FocusedAgentPanel, type FocusedAgentPanelProps } from './FocusedAgentPanel';
 export { ChecklistPanel, type ChecklistPanelProps } from './ChecklistPanel';
 export { resolveChecklistTasks } from './checklist-panel.pure';
-export { formatObjective, formatLogTail, formatSectionDivider } from './focused-agent.pure';
+export {
+  formatObjective,
+  formatLogTail,
+  formatLogTailRelative,
+  formatSectionDivider,
+} from './focused-agent.pure';
 export { StageHealthBar, type StageHealthBarProps } from './StageHealthBar';
 export { computeStageHealth, detectBottlenecks } from './stage-health.pure';
 export { computeGridLayout } from './grid-layout.pure';


### PR DESCRIPTION
## Summary
- Add `formatLogTailRelative` pure function to `focused-agent.pure.ts` — uses `formatRelativeTime` when `rawTimestamp` is available, falls back to original timestamp string
- Add optional `tick` and `now` props to `FocusedAgentPanel` for live updates
- Show animated spinner (`spinnerFrame`) + elapsed timer (`formatElapsed`) in agent header when status is `running`
- Event log uses relative timestamps ("5s ago", "just now") when `now` prop is provided
- Full backward compatibility — existing usage without `tick`/`now` is unchanged

## Test plan
- [x] `formatLogTailRelative` unit tests: rawTimestamp present, absent, mixed, maxLines, empty
- [x] FocusedAgentPanel: spinner + elapsed visible for running agent with `tick`/`now`
- [x] FocusedAgentPanel: no spinner/elapsed for non-running agent
- [x] FocusedAgentPanel: no elapsed when `startedAt` missing
- [x] FocusedAgentPanel: relative timestamps in event log when `now` provided
- [x] FocusedAgentPanel: fallback to original timestamps when `now` omitted
- [x] All 47 component tests passing
- [x] lint, format, typecheck, circular, build — all passing

Closes #674