### PR TITLE
chore: add .taskmaestro to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ custom.mdc
 docs/codingbuddy/
 .omc/
 .claude/skills/ship/
+.taskmaestro/


### PR DESCRIPTION
## Summary
- Add `.taskmaestro/` directory to `.gitignore` to exclude TaskMaestro session files from version control

## Test plan
- [x] Verify `.taskmaestro/` is listed in `.gitignore`
- [x] No workspace CI checks needed (root config change only)