### PR TITLE
fix(tui): remove duplicate tick/now props in FocusedAgentPanelProps

### DIFF
--- a/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
+++ b/apps/mcp-server/src/tui/components/FocusedAgentPanel.tsx
@@ -23,8 +23,6 @@ export interface FocusedAgentPanelProps {
   now?: number;
   width?: number;
   height?: number;
-  tick?: number;
-  now?: number;
 }
 
 function SectionDivider({ title }: { title: string }): React.ReactElement {


### PR DESCRIPTION
## Summary

- Remove duplicate `tick` and `now` properties in `FocusedAgentPanelProps` interface
- PR #677 (`1c7467b`) added `tick`/`now` props that were already introduced by PR #674 (`b28e37c`), causing `TS2300: Duplicate identifier` TypeScript errors
- Git auto-merge passed without text conflict, but the semantic duplication broke the `publish-canary` CI build

## Test plan

- [x] `yarn workspace codingbuddy typecheck` passes (no TS2300 errors)
- [x] `yarn workspace codingbuddy build` succeeds
- [x] `yarn workspace codingbuddy test:coverage` all tests pass
- [x] `yarn workspace codingbuddy lint` passes
- [x] `yarn workspace codingbuddy circular` no circular deps