### PR TITLE
fix(tui): stabilize now via useMemo to prevent non-deterministic re-renders

### DIFF
--- a/apps/mcp-server/src/tui/dashboard-app.spec.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.spec.tsx
@@ -159,6 +159,25 @@ describe('DashboardApp', () => {
     expect(frame).not.toContain('/from-state');
   });
 
+  it('memoizes now based on tick to avoid non-deterministic re-renders', () => {
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+    const state = createInitialDashboardState();
+    const { lastFrame, rerender } = render(<DashboardApp externalState={state} />);
+    const frame1 = lastFrame() ?? '';
+
+    // Advance Date.now() by 1 minute — but tick has NOT changed (still 0 from mock)
+    dateNowSpy.mockReturnValue(1700000060000);
+    rerender(<DashboardApp externalState={state} />);
+    const frame2 = lastFrame() ?? '';
+
+    // With useMemo([tick]): now stays cached → frames identical
+    // Without useMemo: now = Date.now() changes → time display differs
+    expect(frame1).toBe(frame2);
+
+    dateNowSpy.mockRestore();
+  });
+
   it('should use externalState when provided (multi-session mode)', () => {
     const mockState = createInitialDashboardState();
     // Modify some fields to verify they propagate

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -27,7 +27,7 @@ export function DashboardApp({
 }: DashboardAppProps): React.ReactElement {
   const { columns, rows, layoutMode } = useTerminalSize();
   const tick = useTick(1000);
-  const now = Date.now();
+  const now = useMemo(() => Date.now(), [tick]);
   const internalState = useDashboardState(externalState ? undefined : eventBus);
   const state = externalState ?? internalState;
   const focusedAgent = state.focusedAgentId


### PR DESCRIPTION
## Summary
- Replace `Date.now()` in `DashboardApp` render body with `useMemo(() => Date.now(), [tick])` to stabilize `now` across non-tick re-renders
- Add test verifying `now` stays consistent when `tick` hasn't changed

## Test plan
- [x] New test: `memoizes now based on tick to avoid non-deterministic re-renders`
- [x] All 4811 existing tests pass (0 regressions)
- [x] Full CI: lint, format, typecheck, test:coverage, circular, build — all pass

Closes #698