### PR TITLE
refactor(tui): deduplicate ActivitySample interface definition

### DIFF
--- a/apps/mcp-server/src/tui/components/live.pure.ts
+++ b/apps/mcp-server/src/tui/components/live.pure.ts
@@ -1,7 +1,5 @@
-export interface ActivitySample {
-  timestamp: number;
-  toolCalls: number;
-}
+import type { ActivitySample } from '../dashboard-types';
+export type { ActivitySample } from '../dashboard-types';
 
 /** Format elapsed time as "Xm Ys" or "Ys". */
 export function formatElapsed(startedAt: number, now: number): string {


### PR DESCRIPTION
## Summary
- Remove duplicate `ActivitySample` interface from `live.pure.ts`
- Import and re-export from `dashboard-types.ts` (single source of truth)
- No consumer changes needed — backward compatible via re-export

## Test plan
- [x] All 4810 existing tests pass (0 regressions)
- [x] Full CI: lint, format, typecheck, test:coverage, circular, build — all pass

Closes #699