### PR TITLE
fix(release): add .mcp.json to bump-version and verify-release scripts

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -81,6 +81,20 @@ node -e "
 "
 echo "  ✅ packages/claude-code-plugin/.claude-plugin/plugin.json"
 
+# 6. .mcp.json (if exists — gitignored, local only)
+if [ -f ".mcp.json" ]; then
+  node -e "
+    const fs = require('fs');
+    const p = '.mcp.json';
+    const content = fs.readFileSync(p, 'utf-8');
+    const updated = content.replace(/codingbuddy@[0-9]+\.[0-9]+\.[0-9]+/, 'codingbuddy@$NEW_VERSION');
+    fs.writeFileSync(p, updated);
+  "
+  echo "  ✅ .mcp.json"
+else
+  echo "  ⏭️  .mcp.json (not found, skipped)"
+fi
+
 echo ""
 echo "✅ All files bumped to v$NEW_VERSION"
 echo "   Next: git commit -am \"chore(release): prepare v$NEW_VERSION\""

--- a/scripts/verify-release-versions.sh
+++ b/scripts/verify-release-versions.sh
@@ -62,6 +62,23 @@ for package_info in "${PACKAGES[@]}"; do
   fi
 done
 
+# Check .mcp.json (gitignored, local only)
+if [ -f ".mcp.json" ]; then
+  mcp_version=$(node -e "
+    const content = require('fs').readFileSync('.mcp.json', 'utf-8');
+    const match = content.match(/codingbuddy@([0-9]+\.[0-9]+\.[0-9]+)/);
+    console.log(match ? match[1] : '');
+  ")
+  if [ "$mcp_version" = "$TAG_VERSION" ]; then
+    echo "✅ .mcp.json codingbuddy: @$mcp_version (matches tag)"
+  else
+    echo "❌ .mcp.json codingbuddy: @$mcp_version (tag is v$TAG_VERSION)"
+    ALL_MATCH=false
+  fi
+else
+  echo "⏭️  .mcp.json (not found, skipped)"
+fi
+
 echo ""
 
 if [ "$ALL_MATCH" = true ]; then


### PR DESCRIPTION
## Summary
- Add conditional `.mcp.json` version update to `scripts/bump-version.sh` (step 6)
- Add conditional `.mcp.json` version check to `scripts/verify-release-versions.sh`
- Both scripts handle missing `.mcp.json` gracefully with `if [ -f ]` guard (file is gitignored)

## Test plan
- [x] `bump-version.sh 4.5.0` — updates .mcp.json when present, skips when absent
- [x] `verify-release-versions.sh v4.5.0` — passes when version matches
- [x] `verify-release-versions.sh v9.9.9` — detects mismatch, exits 1
- [x] Agent schema validation passed
- [x] Markdown lint passed

Closes #705