### PR TITLE
fix(tui): correct computeThroughput timestamp unit from ms to seconds

### DIFF
--- a/apps/mcp-server/src/tui/components/live.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/live.pure.spec.ts
@@ -152,7 +152,7 @@ describe('tui/components/live.pure', () => {
     it('1분 동안 5회 호출 → "5.0/min"', () => {
       const samples: ActivitySample[] = [
         { timestamp: 0, toolCalls: 0 },
-        { timestamp: 60000, toolCalls: 5 },
+        { timestamp: 60, toolCalls: 5 },
       ];
       expect(computeThroughput(samples)).toBe('5.0/min');
     });
@@ -160,7 +160,7 @@ describe('tui/components/live.pure', () => {
     it('30초 동안 3회 호출 → "6.0/min"', () => {
       const samples: ActivitySample[] = [
         { timestamp: 0, toolCalls: 0 },
-        { timestamp: 30000, toolCalls: 3 },
+        { timestamp: 30, toolCalls: 3 },
       ];
       expect(computeThroughput(samples)).toBe('6.0/min');
     });
@@ -168,11 +168,19 @@ describe('tui/components/live.pure', () => {
     it('여러 샘플의 총합으로 계산', () => {
       const samples: ActivitySample[] = [
         { timestamp: 0, toolCalls: 1 },
-        { timestamp: 30000, toolCalls: 2 },
-        { timestamp: 60000, toolCalls: 3 },
+        { timestamp: 30, toolCalls: 2 },
+        { timestamp: 60, toolCalls: 3 },
       ];
       // 총 toolCalls = 1+2+3 = 6, 기간 = 60초 = 1분 → 6.0/min
       expect(computeThroughput(samples)).toBe('6.0/min');
+    });
+
+    it('역순 타임스탬프 → "0.0/min" (가드)', () => {
+      const samples: ActivitySample[] = [
+        { timestamp: 60, toolCalls: 2 },
+        { timestamp: 0, toolCalls: 3 },
+      ];
+      expect(computeThroughput(samples)).toBe('0.0/min');
     });
   });
 

--- a/apps/mcp-server/src/tui/components/live.pure.ts
+++ b/apps/mcp-server/src/tui/components/live.pure.ts
@@ -57,7 +57,7 @@ export function computeThroughput(samples: ActivitySample[]): string {
   if (samples.length <= 1) return '0.0/min';
   const first = samples[0];
   const last = samples[samples.length - 1];
-  const durationMin = (last.timestamp - first.timestamp) / 60000;
+  const durationMin = (last.timestamp - first.timestamp) / 60;
   if (durationMin <= 0) return '0.0/min';
   const totalCalls = samples.reduce((sum, s) => sum + s.toolCalls, 0);
   return `${(totalCalls / durationMin).toFixed(1)}/min`;


### PR DESCRIPTION
## Summary

- Fix `computeThroughput` dividing by `60000` (milliseconds) instead of `60` (seconds), causing throughput to display 1000x too high
- `ActivitySample.timestamp` is stored in seconds by the reducer (`use-dashboard-state.ts:236`), but `computeThroughput` assumed milliseconds
- Update test data to use second-based timestamps matching actual reducer output
- Add reverse-order timestamp guard test

## Test plan

- [x] All 31 tests in `live.pure.spec.ts` pass
- [x] lint, format, typecheck, test:coverage, circular, build all pass
- [ ] Manual verification: run TUI dashboard and confirm throughput shows realistic values (e.g., `5.0/min` instead of `5000.0/min`)

Closes #697