### PR TITLE
docs(plugin): update README version to 4.5.0

### DIFF
--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -2,7 +2,7 @@
 
 # CodingBuddy Claude Code Plugin
 
-> Version 4.4.0
+> Version 4.5.0
 
 Multi-AI Rules for consistent coding practices - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic development.
 


### PR DESCRIPTION
## Summary
- Update claude-code-plugin README version badge from 4.4.0 to 4.5.0 to match the latest release

## Test plan
- [x] All codingbuddy-claude-plugin CI checks passed (lint, format, typecheck, test, circular, build)