### PR TITLE
feat(skill): add context: fork + agent to 4 analysis skills

### DIFF
--- a/packages/rules/.ai-rules/skills/code-explanation/SKILL.md
+++ b/packages/rules/.ai-rules/skills/code-explanation/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: code-explanation
 description: Use when explaining complex code to new team members, conducting code reviews, onboarding, or understanding unfamiliar codebases. Provides structured analysis from high-level overview to implementation details.
+context: fork
+agent: Explore
 ---
 
 # Code Explanation

--- a/packages/rules/.ai-rules/skills/performance-optimization/SKILL.md
+++ b/packages/rules/.ai-rules/skills/performance-optimization/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: performance-optimization
 description: Use when optimizing code performance, addressing slowness complaints, or measuring application speed improvements
+context: fork
+agent: general-purpose
 ---
 
 # Performance Optimization

--- a/packages/rules/.ai-rules/skills/pr-review/SKILL.md
+++ b/packages/rules/.ai-rules/skills/pr-review/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pr-review
 description: Use when conducting manual PR reviews - provides structured checklist covering security, performance, maintainability, and code quality dimensions with anti-sycophancy principles
+context: fork
+agent: Explore
 ---
 
 # PR Review

--- a/packages/rules/.ai-rules/skills/security-audit/SKILL.md
+++ b/packages/rules/.ai-rules/skills/security-audit/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: security-audit
 description: Use when reviewing code for security vulnerabilities, before shipping features, or conducting security assessments. Covers OWASP Top 10, secrets exposure, authentication, and authorization flaws.
+context: fork
+agent: general-purpose
 ---
 
 # Security Audit


### PR DESCRIPTION
## Summary

- Add `context: fork` and `agent` fields to 4 analysis/research skill SKILL.md frontmatters
- `code-explanation`: `context: fork`, `agent: Explore` (read-only exploration)
- `security-audit`: `context: fork`, `agent: general-purpose` (needs bash/grep access)
- `pr-review`: `context: fork`, `agent: Explore` (read-only diff analysis)
- `performance-optimization`: `context: fork`, `agent: general-purpose` (needs bash execution)
- All 4 skills already contain explicit step-by-step task instructions suitable for fork mode

## Test plan

- [x] Verify YAML frontmatter syntax is valid (markdownlint: 0 errors)
- [x] Verify agent JSON schemas still valid (ajv: 35/35 valid)
- [x] Verify existing `name` and `description` fields unchanged
- [x] Verify each skill has explicit task process for meaningful fork results

Closes #735