### PR TITLE
chore(skills): add user-invocable: false to background knowledge skills

### DIFF
--- a/packages/rules/.ai-rules/skills/context-management/SKILL.md
+++ b/packages/rules/.ai-rules/skills/context-management/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: context-management
 description: Use when working on long tasks that span multiple sessions, when context compaction is a concern, or when decisions from PLAN mode need to persist through ACT and EVAL modes.
+user-invocable: false
 ---
 
 # Context Management

--- a/packages/rules/.ai-rules/skills/widget-slot-architecture/SKILL.md
+++ b/packages/rules/.ai-rules/skills/widget-slot-architecture/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: widget-slot-architecture
 description: Architecture guide using Next.js App Router's Parallel Routes for Widget-Slot pattern. Separates static layouts from dynamic widgets to achieve separation of concerns, fault isolation, and plug-and-play development.
+user-invocable: false
 ---
 
 # Widget-Slot Architecture (WSA)


### PR DESCRIPTION
## Summary
- Add `user-invocable: false` to `widget-slot-architecture/SKILL.md` and `context-management/SKILL.md`
- These background knowledge skills should not appear in `/` slash command listings
- Only YAML frontmatter modified; no changes to existing fields or skill body content

## Test plan
- [x] Verify both files have `user-invocable: false` in YAML frontmatter
- [x] Verify no YAML syntax errors
- [x] Verify existing fields and body unchanged
- [x] All CI checks pass (lint, format, typecheck, test, circular, build, schema validation, markdown lint)

Closes #736