### PR TITLE
feat(skills): add disable-model-invocation to side-effect skills

### DIFF
--- a/packages/rules/.ai-rules/skills/database-migration/SKILL.md
+++ b/packages/rules/.ai-rules/skills/database-migration/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: database-migration
 description: Use when performing database schema changes, data migrations, large table modifications, or when zero-downtime deployment is required - guides systematic, reversible database changes with rollback planning
+disable-model-invocation: true
 ---
 
 # Database Migration

--- a/packages/rules/.ai-rules/skills/deployment-checklist/SKILL.md
+++ b/packages/rules/.ai-rules/skills/deployment-checklist/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deployment-checklist
 description: Use before deploying to staging or production. Covers pre-deploy validation, environment verification, rollback planning, health checks, and post-deploy monitoring.
+disable-model-invocation: true
 ---
 
 # Deployment Checklist

--- a/packages/rules/.ai-rules/skills/incident-response/SKILL.md
+++ b/packages/rules/.ai-rules/skills/incident-response/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: incident-response
 description: Use when production incident occurs, alerts fire, service degradation detected, or on-call escalation needed - guides systematic organizational response before technical fixes
+disable-model-invocation: true
 ---
 
 # Incident Response

--- a/packages/rules/.ai-rules/skills/pr-all-in-one/SKILL.md
+++ b/packages/rules/.ai-rules/skills/pr-all-in-one/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pr-all-in-one
 description: Unified commit and PR workflow. Auto-commits changes, creates/updates PRs with smart issue linking and multi-language support.
+disable-model-invocation: true
 ---
 
 # PR All-in-One


### PR DESCRIPTION
## Summary
- Add `disable-model-invocation: true` to YAML frontmatter of 4 side-effect skills: `pr-all-in-one`, `deployment-checklist`, `incident-response`, `database-migration`
- `ship/SKILL.md` already had the field — no changes needed

## Test plan
- [x] Verified all 5 target files have `disable-model-invocation: true` in frontmatter
- [x] Verified YAML syntax is valid (no parse errors)
- [x] Verified no existing fields were modified
- [x] Verified no skill body content was changed
- [x] All CI checks passed (lint, format, typecheck, test, circular, build, ajv, markdownlint)

Closes #732