### PR TITLE
feat(skills): add argument-hint to 6 skill frontmatters

### DIFF
--- a/packages/rules/.ai-rules/skills/code-explanation/SKILL.md
+++ b/packages/rules/.ai-rules/skills/code-explanation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: code-explanation
 description: Use when explaining complex code to new team members, conducting code reviews, onboarding, or understanding unfamiliar codebases. Provides structured analysis from high-level overview to implementation details.
+argument-hint: [file-or-symbol]
 ---
 
 # Code Explanation

--- a/packages/rules/.ai-rules/skills/legacy-modernization/SKILL.md
+++ b/packages/rules/.ai-rules/skills/legacy-modernization/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: legacy-modernization
 description: Use when modernizing legacy code or migrating outdated patterns to current best practices. Covers assessment, strangler fig pattern, incremental migration, and risk management.
+argument-hint: [target-module-or-path]
 ---
 
 # Legacy Modernization

--- a/packages/rules/.ai-rules/skills/mcp-builder/SKILL.md
+++ b/packages/rules/.ai-rules/skills/mcp-builder/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mcp-builder
 description: Use when building or extending MCP (Model Context Protocol) servers. Covers NestJS-based server design, Tools/Resources/Prompts capability design, transport implementation (stdio/SSE), and testing strategies.
+argument-hint: [capability-name]
 ---
 
 # MCP Builder

--- a/packages/rules/.ai-rules/skills/pr-all-in-one/SKILL.md
+++ b/packages/rules/.ai-rules/skills/pr-all-in-one/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pr-all-in-one
 description: Unified commit and PR workflow. Auto-commits changes, creates/updates PRs with smart issue linking and multi-language support.
+argument-hint: [target-branch] [issue-id]
 ---
 
 # PR All-in-One

--- a/packages/rules/.ai-rules/skills/pr-review/SKILL.md
+++ b/packages/rules/.ai-rules/skills/pr-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pr-review
 description: Use when conducting manual PR reviews - provides structured checklist covering security, performance, maintainability, and code quality dimensions with anti-sycophancy principles
+argument-hint: [pr-url-or-number]
 ---
 
 # PR Review

--- a/packages/rules/.ai-rules/skills/security-audit/SKILL.md
+++ b/packages/rules/.ai-rules/skills/security-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security-audit
 description: Use when reviewing code for security vulnerabilities, before shipping features, or conducting security assessments. Covers OWASP Top 10, secrets exposure, authentication, and authorization flaws.
+argument-hint: [scope-or-path]
 ---
 
 # Security Audit


### PR DESCRIPTION
## Summary

- Add `argument-hint` field to YAML frontmatter for 6 skills that accept arguments
- Enables CLI autocomplete hints during `/` skill invocation
- Target skills: pr-all-in-one, pr-review, code-explanation, mcp-builder, security-audit, legacy-modernization

## Test plan

- [x] All 6 SKILL.md files have `argument-hint` added in frontmatter
- [x] Hint values match usage described in each skill body
- [x] No YAML syntax errors (markdownlint passed)
- [x] No changes to existing fields or skill body content
- [x] All CI checks passed (lint, format, typecheck, circular, build, ajv validate, markdownlint)

Closes #734