### PR TITLE
feat(skills): add allowed-tools to 8 skill SKILL.md frontmatters

### DIFF
--- a/packages/rules/.ai-rules/skills/code-explanation/SKILL.md
+++ b/packages/rules/.ai-rules/skills/code-explanation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: code-explanation
 description: Use when explaining complex code to new team members, conducting code reviews, onboarding, or understanding unfamiliar codebases. Provides structured analysis from high-level overview to implementation details.
+allowed-tools: Read, Grep, Glob
 ---
 
 # Code Explanation

--- a/packages/rules/.ai-rules/skills/error-analysis/SKILL.md
+++ b/packages/rules/.ai-rules/skills/error-analysis/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: error-analysis
 description: Use when encountering error messages, stack traces, or unexpected application behavior. Provides structured analysis to understand root cause before attempting any fix.
+allowed-tools: Read, Grep, Glob, Bash(git:*)
 ---
 
 # Error Analysis

--- a/packages/rules/.ai-rules/skills/performance-optimization/SKILL.md
+++ b/packages/rules/.ai-rules/skills/performance-optimization/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: performance-optimization
 description: Use when optimizing code performance, addressing slowness complaints, or measuring application speed improvements
+allowed-tools: Read, Grep, Glob, Bash
 ---
 
 # Performance Optimization

--- a/packages/rules/.ai-rules/skills/pr-review/SKILL.md
+++ b/packages/rules/.ai-rules/skills/pr-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pr-review
 description: Use when conducting manual PR reviews - provides structured checklist covering security, performance, maintainability, and code quality dimensions with anti-sycophancy principles
+allowed-tools: Read, Grep, Glob, Bash(gh:*, git:*)
 ---
 
 # PR Review

--- a/packages/rules/.ai-rules/skills/refactoring/SKILL.md
+++ b/packages/rules/.ai-rules/skills/refactoring/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: refactoring
 description: Use when improving code structure without changing behavior, cleaning up technical debt, or preparing code for new features
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 ---
 
 # Refactoring

--- a/packages/rules/.ai-rules/skills/security-audit/SKILL.md
+++ b/packages/rules/.ai-rules/skills/security-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security-audit
 description: Use when reviewing code for security vulnerabilities, before shipping features, or conducting security assessments. Covers OWASP Top 10, secrets exposure, authentication, and authorization flaws.
+allowed-tools: Read, Grep, Glob, Bash(git:*)
 ---
 
 # Security Audit

--- a/packages/rules/.ai-rules/skills/systematic-debugging/SKILL.md
+++ b/packages/rules/.ai-rules/skills/systematic-debugging/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: systematic-debugging
 description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+allowed-tools: Read, Grep, Glob, Bash
 ---
 
 # Systematic Debugging

--- a/packages/rules/.ai-rules/skills/tech-debt/SKILL.md
+++ b/packages/rules/.ai-rules/skills/tech-debt/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tech-debt
 description: Use when identifying, prioritizing, and planning resolution of technical debt. Provides structured assessment, ROI-based prioritization, and incremental paydown strategies.
+allowed-tools: Read, Grep, Glob
 ---
 
 # Tech Debt


### PR DESCRIPTION
## Summary
- Add `allowed-tools` field to YAML frontmatter of 8 SKILL.md files
- Each skill gets minimum-privilege tool sets matching its purpose:
  - Read-only skills (code-explanation, tech-debt): `Read, Grep, Glob`
  - Analysis + git skills (security-audit, error-analysis): `Read, Grep, Glob, Bash(git:*)`
  - PR review: `Read, Grep, Glob, Bash(gh:*, git:*)`
  - Debugging/profiling (systematic-debugging, performance-optimization): `Read, Grep, Glob, Bash`
  - Code modification (refactoring): `Read, Write, Edit, Grep, Glob, Bash`

## Test plan
- [x] All 8 files have `allowed-tools` added in frontmatter
- [x] YAML syntax valid (markdownlint 0 errors)
- [x] No changes to existing fields or skill body
- [x] Full CI passed: lint, format, typecheck, test (4841 passed), circular, build, ajv validate

Closes #733