### PR TITLE
feat(skills): add skill-creator reference documents

### DIFF
--- a/packages/rules/.ai-rules/skills/skill-creator/references/frontmatter-guide.md
+++ b/packages/rules/.ai-rules/skills/skill-creator/references/frontmatter-guide.md
@@ -42,8 +42,8 @@ description: Use when [trigger condition]. [What it does].
 
 **v2.0 변경사항:**
 - `model` 필드 추가: 권장 AI 모델 지정
-- `effort` 필드 추가: 추론 노력 수준 제어
-- `hooks` 필드 추가: 이벤트 기반 자동 실행
+- `effort` 필드 추가: 추론 노력 수준 제어 (`low/medium/high/max`)
+- `hooks` 필드 추가: 이벤트 기반 자동 실행 (object 타입)
 
 ---
 
@@ -51,17 +51,17 @@ description: Use when [trigger condition]. [What it does].
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `name` | `string` | **Yes** | — | 스킬 고유 식별자 (kebab-case) |
-| `description` | `string` | **Yes** | — | 스킬 용도 및 트리거 조건 설명 |
-| `argument-hint` | `string` | No | — | CLI 인수 힌트 (예: `[file-path]`) |
-| `allowed-tools` | `string` | No | all | 사용 가능한 도구 목록 (쉼표 구분) |
-| `model` | `string` | No | inherit | 권장 AI 모델 |
-| `effort` | `string` | No | inherit | 추론 노력 수준 |
-| `context` | `string` | No | — | 실행 컨텍스트 모드 |
-| `agent` | `string` | No | — | 권장 에이전트 타입 |
-| `disable-model-invocation` | `boolean` | No | `false` | AI 모델 추론 비활성화 |
-| `user-invocable` | `boolean` | No | `true` | 사용자 직접 호출 가능 여부 |
-| `hooks` | `string` | No | — | 이벤트 기반 자동 실행 훅 |
+| `name` | `string` | **Yes** | 디렉토리명 | 슬래시 커맨드명 (소문자, 숫자, 하이픈, 최대 64자) |
+| `description` | `string` | **Yes** | 첫 번째 문단 | 용도 + 자동 트리거 조건 (200자 권장, 최대 1024자) |
+| `argument-hint` | `string` | No | — | 자동완성 인수 힌트 |
+| `allowed-tools` | `string` | No | all | 사용 가능한 도구 목록 |
+| `model` | `string` | No | 세션 기본값 | 모델 오버라이드 |
+| `effort` | `string` | No | 세션 기본값 | `low` / `medium` / `high` / `max` |
+| `context` | `string` | No | inline | `fork`: 격리된 서브에이전트 |
+| `agent` | `string` | No | general-purpose | 서브에이전트 타입 |
+| `disable-model-invocation` | `boolean` | No | `false` | AI 자동 호출 차단 |
+| `user-invocable` | `boolean` | No | `true` | `/` 메뉴에 표시 여부 |
+| `hooks` | `object` | No | — | 스킬 라이프사이클 훅 |
 
 ---
 
@@ -69,17 +69,18 @@ description: Use when [trigger condition]. [What it does].
 
 ### name
 
-스킬의 고유 식별자. 디렉토리명과 일치해야 한다.
+스킬의 고유 식별자. 디렉토리명과 일치해야 하며 슬래시 커맨드(`/name`)로 사용된다.
 
 | Property | Value |
 |----------|-------|
 | Type | `string` |
 | Required | **Yes** |
+| Default | 디렉토리명 |
 | Pattern | `^[a-z][a-z0-9-]*$` |
-| Max Length | 50자 권장 |
+| Max Length | 64자 |
 
 **규칙:**
-- kebab-case만 사용 (`test-driven-development`, 아니면 `testDrivenDevelopment`)
+- 소문자, 숫자, 하이픈만 사용
 - 스킬 디렉토리명과 동일해야 함
 - 단어 2-4개 권장
 
@@ -94,39 +95,47 @@ name: pr-all-in-one
 
 ### description
 
-스킬의 용도, 트리거 조건, 동작을 설명한다. `recommend_skills` 검색의 핵심 매칭 필드.
+스킬의 용도와 자동 트리거 조건을 설명한다. `recommend_skills` 검색의 핵심 매칭 필드.
 
 | Property | Value |
 |----------|-------|
 | Type | `string` |
 | Required | **Yes** |
-| Max Length | 200자 권장 |
+| Default | SKILL.md 첫 번째 문단 |
+| Recommended Length | 200자 |
+| Max Length | 1024자 |
 
 **규칙:**
-- "Use when"으로 시작 권장 (트리거 조건 명시)
-- 구체적인 상황/동작 기술
-- 200자 이내 권장 (검색 최적화)
+- 구체적인 트리거 문구 포함 ("Use when...", "Use this skill when the user asks to...")
+- 3인칭 서술 ("Explains code..." not "Explain code...")
+- 200자 권장, 최대 1024자
 
 **예시:**
 ```yaml
-# Good - 트리거 조건이 명확
+# Good - 트리거 조건이 명확, 3인칭 서술
 description: Use when implementing any feature or bugfix, before writing implementation code
 
-# Good - 여러 트리거 포함
+# Good - 여러 상황 + 결과 기술
 description: Use before deploying to staging or production. Covers pre-deploy validation, environment verification, rollback planning, health checks, and post-deploy monitoring.
+
+# Good - 3인칭으로 동작 기술
+description: Explains code structure, logic flow, and design decisions with context-appropriate detail.
 
 # Bad - 너무 모호
 description: A skill for testing
 
-# Bad - 너무 김
-description: This skill helps developers write better tests by following TDD principles and ensuring code quality through comprehensive test coverage with multiple assertion strategies and edge case handling across different environments and frameworks...
+# Bad - 1인칭/명령형 (2인칭도 피할 것)
+description: Explain the code to me
+
+# Bad - 1024자 초과
+description: This comprehensive skill provides detailed guidance for implementing test-driven development...
 ```
 
 ---
 
 ### argument-hint
 
-사용자가 스킬 호출 시 전달할 수 있는 위치 인수를 안내한다.
+사용자가 스킬 호출 시 전달할 수 있는 위치 인수를 안내한다. 자동완성 UI에 표시된다.
 
 | Property | Value |
 |----------|-------|
@@ -138,7 +147,7 @@ description: This skill helps developers write better tests by following TDD pri
 - 대괄호 `[]`로 각 인수를 감싸기
 - 복수 인수는 공백으로 구분
 - 인수명은 kebab-case
-- 필수 인수와 선택 인수 구분 없음 (모두 선택)
+- 모든 인수는 선택적
 
 **예시:**
 ```yaml
@@ -180,7 +189,7 @@ argument-hint: [target-module-or-path]
 - `Bash` — 셸 명령 실행
 - `Agent` — 서브에이전트 실행
 
-**Bash 필터링:**
+**Bash 필터링 (Claude Code 전용):**
 ```yaml
 # Bash 전체 허용
 allowed-tools: Read, Grep, Glob, Bash
@@ -191,6 +200,8 @@ allowed-tools: Read, Grep, Glob, Bash(git:*)
 # git과 gh 명령만 허용
 allowed-tools: Read, Grep, Glob, Bash(gh:*, git:*)
 ```
+
+> **주의:** Bash 필터(`Bash(git:*)`)는 Claude Code에서만 지원된다. 다른 도구에서는 기본 도구명만 인식한다.
 
 **예시 패턴:**
 
@@ -212,17 +223,17 @@ allowed-tools: Read, Grep, Glob, Bash(gh:*, git:*)
 |----------|-------|
 | Type | `string` |
 | Required | No |
-| Default | 부모 세션 모델 상속 |
+| Default | 세션 기본 모델 |
 
 **사용 가능한 값:**
 - `opus` — 복잡한 추론이 필요한 스킬
-- `sonnet` — 일반적인 코딩 스킬 (기본)
+- `sonnet` — 일반적인 코딩 스킬
 - `haiku` — 간단한 분류/변환 스킬
 
 **사용 시점:**
 - 높은 추론 능력이 필요한 스킬: `opus`
 - 빠른 응답이 중요한 스킬: `haiku`
-- 대부분의 스킬: 미지정 (기본값 사용)
+- 대부분의 스킬: 미지정 (세션 기본값 사용)
 
 **예시:**
 ```yaml
@@ -230,6 +241,8 @@ model: opus    # 복잡한 아키텍처 분석
 model: sonnet  # 일반 코드 작성
 model: haiku   # 간단한 코드 설명
 ```
+
+> **호환성:** Claude Code에서만 자동 전환. 다른 도구에서는 힌트로만 사용.
 
 ---
 
@@ -241,23 +254,23 @@ AI 모델의 추론 노력 수준을 제어한다. v2.0에서 추가.
 |----------|-------|
 | Type | `string` |
 | Required | No |
-| Default | 부모 세션 설정 상속 |
+| Default | 세션 기본값 |
+| Values | `low`, `medium`, `high`, `max` |
 
-**사용 가능한 값:**
+**각 수준의 의미:**
+- `low` — 빠른 분류, 간단한 변환. 최소 추론
+- `medium` — 일반적인 코딩 작업 (기본)
 - `high` — 깊은 분석, 복잡한 문제 해결
-- `medium` — 일반적인 작업 (기본)
-- `low` — 빠른 분류, 간단한 변환
-
-**사용 시점:**
-- 보안 감사, 아키텍처 분석: `high`
-- 대부분의 스킬: 미지정 (기본값)
-- 단순 포맷팅, 분류: `low`
+- `max` — 최대 추론. 보안 감사, 아키텍처 설계 등 가장 까다로운 작업
 
 **예시:**
 ```yaml
-effort: high   # 보안 감사 - 철저한 분석 필요
+effort: max    # 보안 감사 - 최대 추론
+effort: high   # 아키텍처 분석 - 깊은 분석
 effort: low    # 코드 포맷팅 - 빠른 처리
 ```
+
+> **호환성:** Claude Code에서만 자동 적용. 다른 도구에서는 무시.
 
 ---
 
@@ -269,6 +282,7 @@ effort: low    # 코드 포맷팅 - 빠른 처리
 |----------|-------|
 | Type | `string` |
 | Required | No |
+| Default | `inline` (메인 컨텍스트에서 실행) |
 | Values | `fork` |
 
 **`fork`의 의미:**
@@ -286,6 +300,8 @@ effort: low    # 코드 포맷팅 - 빠른 처리
 context: fork  # 격리된 환경에서 PR 리뷰 실행
 ```
 
+> **호환성:** Claude Code에서만 지원. 다른 도구에서는 무시 (inline으로 실행).
+
 ---
 
 ### agent
@@ -296,11 +312,12 @@ context: fork  # 격리된 환경에서 PR 리뷰 실행
 |----------|-------|
 | Type | `string` |
 | Required | No |
+| Default | `general-purpose` |
 | Values | `Explore`, `general-purpose` |
 
 **에이전트 타입:**
 - `Explore` — 빠른 코드 탐색/검색 특화 (읽기 전용)
-- `general-purpose` — 전체 도구 접근 (읽기+쓰기)
+- `general-purpose` — 전체 도구 접근 (읽기+쓰기+Bash)
 
 **사용 시점:**
 - 코드 설명, PR 리뷰 등 읽기 전용: `Explore`
@@ -319,11 +336,13 @@ agent: general-purpose
 allowed-tools: Read, Grep, Glob, Bash(git:*)
 ```
 
+> **호환성:** Claude Code에서만 지원. 다른 도구에서는 무시.
+
 ---
 
 ### disable-model-invocation
 
-`true`로 설정하면 AI 모델이 스킬 내용을 자체적으로 해석하지 않고, 사용자에게 체크리스트/가이드로 직접 제시한다.
+`true`로 설정하면 AI 모델이 스킬을 자동으로 호출하지 않는다. 사용자가 명시적으로 `/skill-name`으로 호출해야만 실행된다.
 
 | Property | Value |
 |----------|-------|
@@ -332,13 +351,13 @@ allowed-tools: Read, Grep, Glob, Bash(git:*)
 | Default | `false` |
 
 **사용 시점:**
-- 부작용(side effect)이 있는 스킬: 커밋, 배포, DB 마이그레이션
-- 체크리스트 기반 스킬: 사람이 직접 확인해야 하는 항목
+- 부작용(side effect)이 있는 스킬: 커밋, 배포, 푸시, DB 마이그레이션
 - 위험한 작업을 포함하는 스킬: 데이터 삭제, 프로덕션 변경
+- 사용자의 명시적 의도가 필요한 스킬
 
 **예시:**
 ```yaml
-# 배포 체크리스트 - 사람이 직접 확인
+# 배포 체크리스트 - 사용자가 명시적으로 호출해야 함
 disable-model-invocation: true
 
 # DB 마이그레이션 - 위험한 작업 포함
@@ -351,11 +370,13 @@ disable-model-invocation: true
 - `incident-response`
 - `pr-all-in-one`
 
+> **호환성:** 모든 도구에서 지원.
+
 ---
 
 ### user-invocable
 
-`false`로 설정하면 사용자가 직접 호출할 수 없고, 시스템 내부에서만 사용된다.
+`false`로 설정하면 사용자가 `/` 메뉴에서 스킬을 볼 수 없고 직접 호출할 수 없다. 시스템 내부에서만 사용된다.
 
 | Property | Value |
 |----------|-------|
@@ -364,18 +385,20 @@ disable-model-invocation: true
 | Default | `true` |
 
 **사용 시점:**
-- 배경 지식 스킬: 다른 스킬이 참조하는 정보
-- 내부 전용 스킬: `parse_mode`에서 자동 로드
+- 배경 지식 스킬: 다른 스킬이나 에이전트가 참조하는 정보
+- 내부 전용 스킬: `parse_mode`에서 자동 로드되는 컨텍스트
 
 **예시:**
 ```yaml
-# 내부 전용 스킬
+# 내부 전용 - 사용자에게 표시하지 않음
 user-invocable: false
 ```
 
 **현재 사용 중인 스킬:**
 - `context-management`
 - `widget-slot-architecture`
+
+> **호환성:** 모든 도구에서 지원.
 
 ---
 
@@ -385,25 +408,39 @@ user-invocable: false
 
 | Property | Value |
 |----------|-------|
-| Type | `string` |
+| Type | `object` |
 | Required | No |
-| Format | `event:action` |
 
-**사용 가능한 이벤트:**
-- `PreToolUse` — 도구 호출 전
-- `PostToolUse` — 도구 호출 후
-- `session-start` — 세션 시작 시
+**훅 이벤트:**
+
+```yaml
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      action: "invoke"
+  PostToolUse:
+    - matcher: "Write"
+      action: "invoke"
+  session-start:
+    action: "load"
+```
+
+**지원 이벤트:**
+- `PreToolUse` — 도구 호출 전 실행
+- `PostToolUse` — 도구 호출 후 실행
+- `session-start` — 세션 시작 시 자동 로드
 
 **예시:**
 ```yaml
 # 커밋 전 자동 리뷰
-hooks: PreToolUse:commit
-
-# 세션 시작 시 자동 로드
-hooks: session-start
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      pattern: "git commit"
+      action: "invoke"
 ```
 
-> **주의:** hooks는 Claude Code에서만 지원된다. 다른 도구에서는 무시된다.
+> **호환성:** Claude Code에서 완전 지원. Kiro에서 이벤트 기반 훅 지원. 다른 도구에서는 무시.
 
 ---
 
@@ -412,61 +449,36 @@ hooks: session-start
 스킬 프론트매터 필드를 결정하기 위한 의사결정 트리:
 
 ```
-스킬 작성 시작
-│
-├─ name, description 작성 (필수)
-│
-├─ 사용자가 직접 호출하는가?
-│  ├─ No → user-invocable: false
-│  └─ Yes
-│     └─ CLI 인수를 받는가?
-│        ├─ Yes → argument-hint: [arg-name]
-│        └─ No → (생략)
-│
-├─ 부작용(side effect)이 있는가?
-│  │  (커밋, 배포, DB 변경, 파일 생성/삭제)
-│  ├─ Yes → disable-model-invocation: true
-│  └─ No
-│     └─ 도구 접근을 제한해야 하는가?
-│        ├─ Yes → allowed-tools: [도구 목록]
-│        └─ No → (전체 도구 허용)
-│
-├─ 격리된 환경이 필요한가?
-│  │  (대량 읽기, 메인 컨텍스트 보호)
-│  ├─ Yes → context: fork
-│  │  └─ 어떤 에이전트가 적합한가?
-│  │     ├─ 읽기 전용 → agent: Explore
-│  │     └─ 쓰기/Bash 필요 → agent: general-purpose
-│  └─ No → (기본 컨텍스트)
-│
-├─ 특정 모델이 필요한가?
-│  ├─ 복잡한 추론 → model: opus
-│  ├─ 간단한 작업 → model: haiku
-│  └─ 일반적 → (기본값 상속)
-│
-├─ 추론 노력을 조정해야 하는가?
-│  ├─ 철저한 분석 → effort: high
-│  ├─ 빠른 처리 → effort: low
-│  └─ 일반적 → (기본값 상속)
-│
-└─ 이벤트 기반 자동 실행이 필요한가?
-   ├─ Yes → hooks: [event:action]
-   └─ No → (수동 실행)
+스킬에 부작용(side effect)이 있는가? (커밋, 푸시, 배포 등)
+├── YES → disable-model-invocation: true
+└── NO → 배경 지식 스킬인가? (아키텍처 참조 등)
+    ├── YES → user-invocable: false
+    └── NO → 기본값 유지
+
+읽기 전용 분석 스킬인가?
+├── YES → context: fork, agent: Explore
+└── NO → Bash 실행이 필요한 분석 스킬인가?
+    ├── YES → context: fork, agent: general-purpose
+    └── NO → 기본 컨텍스트 (inline)
+
+특정 도구만 사용해야 하는가?
+├── YES → allowed-tools: [필요한 도구 목록]
+└── NO → allowed-tools 생략 (전체 허용)
 ```
 
 **의사결정 요약표:**
 
 | 질문 | 조건 | 설정할 필드 |
 |------|------|-------------|
-| 내부 전용? | 사용자 미호출 | `user-invocable: false` |
-| 인수 있음? | CLI에서 인수 전달 | `argument-hint` |
 | 부작용 있음? | 커밋/배포/DB 변경 | `disable-model-invocation: true` |
-| 도구 제한? | 특정 도구만 허용 | `allowed-tools` |
-| 격리 필요? | 독립 실행 | `context: fork` |
-| 에이전트 유형? | fork 시 | `agent` |
-| 모델 지정? | 특수 모델 필요 | `model` |
-| 노력 조정? | 분석 깊이 조절 | `effort` |
-| 자동 실행? | 이벤트 트리거 | `hooks` |
+| 내부 전용? | 사용자 미호출 | `user-invocable: false` |
+| 인수 있음? | CLI에서 인수 전달 | `argument-hint: [arg-name]` |
+| 도구 제한? | 특정 도구만 허용 | `allowed-tools: [도구 목록]` |
+| 격리 필요? | 독립 실행, 읽기 전용 | `context: fork` |
+| 에이전트 유형? | fork 시 | `agent: Explore` 또는 `general-purpose` |
+| 모델 지정? | 특수 모델 필요 | `model: opus` 등 |
+| 노력 조정? | 분석 깊이 조절 | `effort: low/medium/high/max` |
+| 자동 실행? | 이벤트 트리거 | `hooks: { ... }` |
 
 ---
 
@@ -476,10 +488,10 @@ hooks: session-start
 
 ### 작성 원칙
 
-1. **"Use when"으로 시작** — 트리거 조건을 명확히 함
-2. **200자 이내** — 검색 최적화, 간결함 유지
-3. **구체적 상황 기술** — "코딩할 때"가 아닌 "feature 구현 전"
-4. **동작 결과 포함** — 스킬이 무엇을 하는지 기술
+1. **트리거 문구 포함** — "Use when...", "Use this skill when..."
+2. **3인칭 서술** — "Explains code..." (O), "Explain code..." (X)
+3. **200자 권장, 최대 1024자** — 검색 최적화, 간결함 유지
+4. **구체적 상황 기술** — "코딩할 때"가 아닌 "feature 구현 전"
 
 ### 트리거 문구 패턴
 
@@ -489,20 +501,29 @@ hooks: session-start
 | `Use before [동작]ing` | 사전 준비 | `Use before deploying to production` |
 | `Use after [동작]ing` | 사후 검증 | `Use after completing a development branch` |
 | `Use when encountering` | 문제 대응 | `Use when encountering any bug or test failure` |
-| `Use when [조건]` | 조건부 | `Use when starting feature work that needs isolation` |
+| `Use this skill when the user asks to` | 사용자 요청 | `Use this skill when the user asks to review a PR` |
+
+### 3인칭 서술 가이드
+
+| Good (3인칭) | Bad (명령형/2인칭) |
+|-------------|------------------|
+| Explains code structure and logic flow | Explain the code |
+| Generates comprehensive test suites | Generate tests |
+| Analyzes security vulnerabilities | Analyze security |
+| Covers validation, rollback, monitoring | Cover all cases |
 
 ### Good vs Bad Examples
 
 **Good:**
 ```yaml
-# 구체적 트리거 + 동작
+# 트리거 + 3인칭 서술
 description: Use when implementing any feature or bugfix, before writing implementation code
 
-# 여러 상황 + 결과
+# 여러 상황 + 커버리지 기술
 description: Use before deploying to staging or production. Covers pre-deploy validation, environment verification, rollback planning, health checks, and post-deploy monitoring.
 
-# 명확한 적용 범위
-description: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes
+# 3인칭으로 동작 기술
+description: Explains code structure, logic flow, and design decisions with context-appropriate detail.
 ```
 
 **Bad:**
@@ -510,11 +531,14 @@ description: Use when encountering any bug, test failure, or unexpected behavior
 # 너무 모호
 description: A testing skill
 
+# 명령형 (1인칭/2인칭)
+description: Explain the code to me
+
 # 트리거 조건 없음
 description: Helps with code quality
 
-# 너무 김 (200자 초과)
-description: This comprehensive skill provides detailed guidance for implementing test-driven development practices including red-green-refactor cycles with support for multiple testing frameworks and assertion libraries across various programming languages and environments with special attention to edge cases...
+# 1024자 초과
+description: This comprehensive skill provides detailed guidance for implementing test-driven development practices including red-green-refactor cycles with support for multiple testing frameworks and assertion libraries across various programming languages and environments with special attention to edge cases and boundary conditions and performance optimization and integration testing and end-to-end testing and mutation testing and property-based testing and snapshot testing and visual regression testing...
 ```
 
 ### 키워드 매칭 최적화
@@ -567,7 +591,7 @@ agent: general-purpose
 allowed-tools: Read, Grep, Glob, Bash(git:*)
 argument-hint: [scope-or-path]
 model: opus
-effort: high
+effort: max
 ---
 ```
 
@@ -587,7 +611,7 @@ argument-hint: [target-branch] [issue-id]
 ```yaml
 ---
 name: context-management
-description: Background knowledge for managing conversation context and memory across sessions. Not directly invocable.
+description: Background knowledge for managing conversation context and memory across sessions. Not directly invocable by users.
 user-invocable: false
 ---
 ```
@@ -598,7 +622,11 @@ user-invocable: false
 ---
 name: pre-commit-review
 description: Use to automatically review code before committing. Checks for common issues, security vulnerabilities, and code quality.
-hooks: PreToolUse:commit
 allowed-tools: Read, Grep, Glob
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      pattern: "git commit"
+      action: "invoke"
 ---
 ```

--- a/packages/rules/.ai-rules/skills/skill-creator/references/multi-tool-compat.md
+++ b/packages/rules/.ai-rules/skills/skill-creator/references/multi-tool-compat.md
@@ -5,7 +5,7 @@
 ## Table of Contents
 
 - [Compatibility Matrix](#compatibility-matrix)
-  - [Feature Support](#feature-support)
+  - [Skill Loading Feature Support](#skill-loading-feature-support)
   - [Frontmatter Field Support](#frontmatter-field-support)
 - [Skill Loading Methods](#skill-loading-methods)
   - [Loading Flow by Tool](#loading-flow-by-tool)
@@ -16,6 +16,7 @@
   - [Core MCP Tools](#core-mcp-tools)
   - [Specialist Agent Execution](#specialist-agent-execution)
   - [Context Document Management](#context-document-management)
+- [Per-Tool Guide](#per-tool-guide)
 - [Tool-Specific Limitations](#tool-specific-limitations)
 - [Cross-Tool Skill Writing Guide](#cross-tool-skill-writing-guide)
 
@@ -23,31 +24,30 @@
 
 ## Compatibility Matrix
 
-### Feature Support
+### Skill Loading Feature Support
 
-6개 도구의 스킬 관련 기능 지원 현황:
+각 도구의 스킬 로딩 관련 기능 지원 현황:
 
 | Feature | Claude Code | Cursor | Codex | Amazon Q | Kiro | Antigravity |
 |---------|:-----------:|:------:|:-----:|:--------:|:----:|:-----------:|
-| MCP 도구 호출 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 네이티브 Skill 도구 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `recommend_skills` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `get_skill` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `parse_mode` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 병렬 에이전트 실행 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Task tool (background) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| 세션 훅 (hooks) | ✅ | ⚠️ | ❌ | ❌ | ✅ | ❌ |
-| AUTO 모드 루프 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 컨텍스트 문서 강제 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Glob 기반 규칙 활성화 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| `task_boundary` 추적 | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| 이벤트 기반 훅 | ✅ | ⚠️ | ❌ | ❌ | ✅ | ⚠️ |
+| SKILL.md 자동 탐색 | ✅ `.claude/skills/` | ❌ | ❌ | ❌ | ❌ | ❌ |
+| 프론트매터 파싱 | ✅ Full | ⚠️ name/description | ❌ | ❌ | ⚠️ | ❌ |
+| `disable-model-invocation` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `context: fork` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `allowed-tools` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| 레퍼런스 파일 접근 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| MCP 기반 로딩 (`get_skill`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 **범례:** ✅ 지원 | ⚠️ 부분 지원 | ❌ 미지원
 
+**핵심 차이:**
+- **Claude Code**만 네이티브 SKILL.md 파싱을 지원 (프론트매터, 레퍼런스 파일 포함)
+- **다른 5개 도구**는 codingbuddy MCP 서버의 `get_skill` 도구를 통해 스킬을 로드
+- MCP 기반 로딩은 모든 도구에서 동일하게 동작
+
 ### Frontmatter Field Support
 
-각 프론트매터 필드의 도구별 지원 현황:
+각 프론트매터 필드의 도구별 자동 적용 현황:
 
 | Field | Claude Code | Cursor | Codex | Amazon Q | Kiro | Antigravity |
 |-------|:-----------:|:------:|:-----:|:--------:|:----:|:-----------:|
@@ -65,10 +65,11 @@
 
 **⚠️ 부분 지원 상세:**
 - **Cursor `allowed-tools`**: 도구명은 인식하나 Bash 필터(`Bash(git:*)`)는 미지원
-- **Cursor `model`**: 모델 전환은 가능하나 프론트매터에서 자동 적용되지 않음
-- **Codex `allowed-tools`/`model`**: 시스템 프롬프트에서 참고 가능하나 자동 적용 미지원
+- **Cursor `model`**: 모델 전환 가능하나 프론트매터에서 자동 적용되지 않음
 - **Cursor `hooks`**: `.mdc` 규칙의 glob 패턴으로 유사 기능 구현 가능
+- **Codex `allowed-tools`/`model`**: 시스템 프롬프트에서 참고 가능하나 자동 적용 미지원
 - **Kiro `allowed-tools`**: 도구 제한 인식하나 Bash 필터 미지원
+- **Kiro `hooks`**: 이벤트 기반 훅 (`onFileChange`, `onSave`) 지원
 - **Antigravity `allowed-tools`**: 도구명 인식하나 자동 적용 미지원
 
 ---
@@ -82,8 +83,8 @@
 ```
 사용자: /skill-name [args]
   │
-  ├─ (1) 네이티브 Skill 도구 직접 호출
-  │     └─ SKILL.md 로드 → 프론트매터 파싱 → 실행
+  ├─ (1) 네이티브 Skill 도구 직접 호출 (우선)
+  │     └─ SKILL.md 로드 → 프론트매터 파싱 → 레퍼런스 파일 접근 → 실행
   │
   └─ (2) MCP 체인 (대체 경로)
         └─ recommend_skills → get_skill → 내용 반환
@@ -94,6 +95,7 @@
 - `context: fork` 시 자동으로 서브에이전트 생성
 - `allowed-tools` 자동 적용
 - `model`/`effort` 자동 전환
+- 레퍼런스 파일(`references/`) 직접 접근 가능
 
 #### Cursor
 
@@ -128,8 +130,8 @@
 ```
 사용자: 스킬 요청
   │
-  └─ MCP 체인 (설정 시)
-        └─ recommend_skills → get_skill → 내용 참조
+  ├─ MCP 체인 (설정 시)
+  │     └─ recommend_skills → get_skill → 내용 참조
   │
   └─ 직접 참조 (대체)
         └─ .ai-rules/ 디렉토리 직접 읽기
@@ -257,7 +259,7 @@
 #### Amazon Q
 
 ```json
-// AWS Q MCP 설정 (설정 방식은 AWS 문서 참조)
+// AWS Q MCP 설정
 {
   "mcpServers": {
     "codingbuddy": {
@@ -324,7 +326,7 @@
 | `get_agent_details` | 에이전트 프로필 조회 | 에이전트 정보 필요 시 |
 | `get_project_config` | 프로젝트 설정 조회 | 기술 스택/언어 확인 시 |
 | `update_context` | 컨텍스트 문서 업데이트 | 각 모드 완료 시 |
-| `dispatch_agents` | 에이전트 디스패치 파라미터 | 병렬 실행 시 |
+| `dispatch_agents` | 에이전트 디스패치 파라미터 | 병렬/순차 실행 시 |
 | `prepare_parallel_agents` | 병렬 에이전트 프롬프트 준비 | 순차 실행 시 |
 | `generate_checklist` | 도메인별 체크리스트 생성 | 품질 검증 시 |
 | `analyze_task` | 사전 분석 및 리스크 평가 | PLAN 시작 시 |
@@ -374,43 +376,76 @@ parse_mode → dispatchReady
 
 ---
 
+## Per-Tool Guide
+
+각 도구에서 skill-creator를 사용하는 방법:
+
+### Claude Code
+
+```bash
+# 직접 호출 (네이티브)
+/skill-creator create my-skill
+
+# MCP 경유
+# recommend_skills → get_skill 자동 체인
+```
+
+- 프론트매터 모든 필드 자동 적용
+- 레퍼런스 파일 직접 접근 (`references/` 디렉토리)
+- `context: fork`로 격리 실행 가능
+
+### Cursor, Codex, Amazon Q, Kiro, Antigravity
+
+```
+# MCP 체인으로 스킬 로드
+1. recommend_skills({ prompt: "create a new skill" })
+2. get_skill("skill-creator") → SKILL.md 본문 반환
+3. 반환된 지시사항을 따라 스킬 작성
+```
+
+- SKILL.md 본문만 반환 (레퍼런스 파일은 별도 `get_skill` 요청 필요)
+- 프론트매터는 가이드로 참조 (자동 적용 아님)
+- 순차 실행만 지원
+
+---
+
 ## Tool-Specific Limitations
 
 ### Claude Code
-- **강점**: 유일한 병렬 에이전트 실행, 훅 강제, 네이티브 Skill 도구
+- **강점**: 유일한 네이티브 SKILL.md 파싱, 병렬 에이전트, 훅 강제, 모든 프론트매터 지원
 - **제한**: 없음 (모든 기능 지원)
 
 ### Cursor
 - **강점**: glob 기반 규칙 자동 활성화, `.mdc` 규칙 시스템
-- **제한**: 병렬 실행 불가, `context`/`agent` 프론트매터 무시, Bash 필터 미지원
+- **제한**: 병렬 실행 불가, `context`/`agent`/`effort` 미지원, Bash 필터 미지원
 
 ### Codex
 - **강점**: 시스템 프롬프트 기반 심층 통합, 한국어/영어 이중 지원
-- **제한**: 병렬 실행 불가, 세션 훅 미지원, `model`/`effort` 자동 적용 불가
+- **제한**: 병렬 실행 불가, 세션 훅 미지원, 프론트매터 자동 적용 불가
 
 ### Amazon Q
 - **강점**: AWS 서비스 네이티브 통합
-- **제한**: MCP 설정 선택적, 고급 프론트매터 필드 미지원, 문서 최소
+- **제한**: MCP 설정 선택적, 프론트매터 자동 적용 미지원
 
 ### Kiro
 - **강점**: 이벤트 기반 훅, steering 통합, `${workspaceFolder}` 변수 지원
-- **제한**: 병렬 실행 불가, `context`/`agent` 미지원
+- **제한**: 병렬 실행 불가, `context`/`agent`/`effort` 미지원
 
 ### Antigravity
 - **강점**: `task_boundary` 진행 추적, artifact 관리
-- **제한**: 병렬 실행 불가, 훅 미지원, `model`/`effort` 미지원
+- **제한**: 병렬 실행 불가, 훅 미지원, 프론트매터 자동 적용 미지원
 
 ---
 
 ## Cross-Tool Skill Writing Guide
 
-모든 6개 도구에서 호환되는 스킬을 작성하기 위한 가이드라인:
+모든 6개 도구에서 호환되는 스킬을 작성하기 위한 가이드라인.
 
 ### 필수 규칙
 
 1. **`name`과 `description`은 항상 포함** — 모든 도구에서 필수
 2. **마크다운 표준 문법 사용** — 도구별 확장 문법 사용 금지
-3. **도구 특정 API 참조 금지** — `Task tool`, `Agent tool` 등 Claude Code 전용 용어 사용 금지
+3. **도구 특정 API 참조 금지** — 스킬 본문에서 `Task tool`, `Agent tool` 등 Claude Code 전용 용어 사용 금지
 
 ### 권장 규칙
 
@@ -427,14 +462,19 @@ parse_mode → dispatchReady
 - [ ] 도구 특정 기능에 의존하지 않는가?
 - [ ] 순차 실행에서도 동작하는가? (병렬 가정 금지)
 - [ ] Bash 필터 없이도 보안이 유지되는가?
-- [ ] 영어와 한국어 키워드가 모두 포함되었는가? (다국어 지원 시)
+- [ ] 3인칭 서술로 description이 작성되었는가?
 ```
 
 ### 프론트매터 호환성 티어
 
-| Tier | Fields | 지원 도구 |
-|------|--------|----------|
+| Tier | Fields | 자동 적용 도구 수 |
+|------|--------|-----------------|
 | **Universal** | `name`, `description`, `disable-model-invocation`, `user-invocable` | 6/6 |
-| **Broad** | `argument-hint`, `allowed-tools` (기본) | 5-6/6 |
-| **Limited** | `model`, `hooks` | 1-2/6 |
+| **Broad** | `argument-hint` | 6/6 (UI 표시만) |
+| **Moderate** | `allowed-tools` (기본), `model`, `hooks` | 1-3/6 |
 | **Claude Code Only** | `context`, `agent`, `effort`, `allowed-tools` (Bash 필터) | 1/6 |
+
+**스킬 작성 시 권장 전략:**
+- **Universal 티어 필드로 핵심 동작 보장**
+- **상위 티어 필드는 선택적 향상으로 추가**
+- **Claude Code Only 필드는 해당 도구에서의 UX 최적화용**

--- a/packages/rules/.ai-rules/skills/skill-creator/references/schemas.md
+++ b/packages/rules/.ai-rules/skills/skill-creator/references/schemas.md
@@ -1,6 +1,6 @@
 # Skill Evaluation Schemas Reference
 
-JSON 스키마 정의 및 작업 디렉토리 구조 레퍼런스.
+스킬 평가 시스템의 JSON 스키마 정의 및 작업 디렉토리 구조 레퍼런스.
 
 ## Table of Contents
 
@@ -20,161 +20,122 @@ JSON 스키마 정의 및 작업 디렉토리 구조 레퍼런스.
 
 ## Workspace Directory Structure
 
-스킬 개발 및 평가 시 사용하는 작업 디렉토리 구조:
+스킬 평가 시 사용하는 작업 디렉토리 구조. 각 iteration은 스킬 수정 사이클을 나타내며, 각 eval은 `with_skill`(스킬 적용)과 `without_skill`(베이스라인) 비교 실행을 포함한다.
 
 ```
 workspace/
-├── trigger_eval.json              # 자동 평가 트리거 설정
-├── iteration-1/                   # 첫 번째 개발 반복
-│   ├── eval-1/                    # 첫 번째 평가 실행
-│   │   ├── evals.json             # 평가 결과
-│   │   ├── eval_metadata.json     # 평가 메타데이터
-│   │   ├── grading.json           # 채점 결과
-│   │   ├── timing.json            # 실행 시간 측정
-│   │   ├── feedback.json          # 피드백 기록
-│   │   └── benchmark.json         # 벤치마크 비교
-│   └── eval-2/                    # 두 번째 평가 실행
-│       └── ...
-├── iteration-2/                   # 두 번째 개발 반복
-│   └── eval-1/
-│       └── ...
-└── iteration-N/
-    └── eval-N/
-        └── ...
+├── evals.json                     # 평가 시나리오 정의 (전체 iteration 공유)
+├── trigger_eval.json              # 트리거 평가 케이스 (벤치마크 모드)
+└── iteration-N/                   # N번째 스킬 수정 사이클
+    ├── eval-0/                    # 첫 번째 평가 (0-based)
+    │   ├── with_skill/            # 스킬 적용 실행
+    │   │   ├── outputs/           # 생성된 출력 파일
+    │   │   ├── eval_metadata.json # 평가 메타데이터
+    │   │   ├── grading.json       # 채점 결과
+    │   │   └── timing.json        # 실행 시간 측정
+    │   └── without_skill/         # 베이스라인 실행 (스킬 미적용)
+    │       ├── outputs/           # 생성된 출력 파일
+    │       ├── eval_metadata.json # 평가 메타데이터
+    │       ├── grading.json       # 채점 결과
+    │       └── timing.json        # 실행 시간 측정
+    ├── eval-1/                    # 두 번째 평가
+    │   ├── with_skill/
+    │   │   └── ...
+    │   └── without_skill/
+    │       └── ...
+    ├── benchmark.json             # iteration 벤치마크 종합 결과
+    ├── benchmark.md               # 벤치마크 마크다운 리포트
+    └── feedback.json              # 사용자 피드백
 ```
 
 **디렉토리 명명 규칙:**
-- `iteration-N`: 1-based 순차 번호. 스킬 SKILL.md 수정 시마다 새 iteration 생성
-- `eval-N`: 1-based 순차 번호. 동일 iteration 내 재평가 시 증가
-- `trigger_eval.json`: workspace 루트에 위치 (iteration 독립)
+- `iteration-N`: 1-based 순차 번호. SKILL.md 수정 시마다 새 iteration 생성
+- `eval-N`: 0-based 순차 번호. `evals.json`의 각 시나리오에 대응
+- `with_skill/`: 스킬을 적용한 상태에서 평가 실행
+- `without_skill/`: 스킬 없이 베이스라인 실행 (비교 대상)
+- `outputs/`: 각 실행에서 생성된 파일 (코드, 문서 등)
+
+**파일 위치 규칙:**
+- `evals.json`, `trigger_eval.json`: workspace 루트 (iteration 독립)
+- `eval_metadata.json`, `grading.json`, `timing.json`: 각 eval의 `with_skill/` 또는 `without_skill/` 내부
+- `benchmark.json`, `benchmark.md`, `feedback.json`: iteration 루트
 
 ---
 
 ## Schema Definitions
 
-모든 스키마는 JSON Schema Draft 2020-12 기준.
-
 ### 1. evals.json
 
-개별 평가 시나리오의 실행 결과를 기록한다.
+평가 시나리오 목록을 정의한다. workspace 루트에 위치하며 모든 iteration에서 공유된다.
+
+**스키마:**
 
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://codingbuddy.dev/schemas/skill-eval/evals.json",
-  "title": "Skill Evaluation Results",
-  "description": "개별 스킬 평가 시나리오의 실행 결과",
+  "title": "Skill Evaluation Scenarios",
+  "description": "스킬 평가 시나리오 정의",
   "type": "object",
-  "required": ["skill_name", "eval_id", "scenarios", "summary"],
+  "required": ["skill_name", "evals"],
   "properties": {
     "skill_name": {
       "type": "string",
-      "description": "평가 대상 스킬의 name (kebab-case)",
+      "description": "평가 대상 스킬명 (kebab-case)",
       "pattern": "^[a-z][a-z0-9-]*$"
     },
-    "eval_id": {
-      "type": "string",
-      "description": "고유 평가 식별자",
-      "pattern": "^eval-[0-9]+$"
-    },
-    "scenarios": {
+    "evals": {
       "type": "array",
       "description": "평가 시나리오 목록",
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["id", "name", "status", "assertions"],
+        "required": ["id", "prompt", "expected_output", "files"],
         "properties": {
           "id": {
-            "type": "string",
-            "description": "시나리오 식별자"
+            "type": "integer",
+            "minimum": 1,
+            "description": "시나리오 ID (1-based)"
           },
-          "name": {
+          "prompt": {
             "type": "string",
-            "description": "시나리오 설명"
+            "description": "사용자 작업 프롬프트"
           },
-          "status": {
+          "expected_output": {
             "type": "string",
-            "enum": ["pass", "fail", "skip", "error"],
-            "description": "실행 결과 상태"
+            "description": "기대 결과 설명"
           },
-          "assertions": {
+          "files": {
             "type": "array",
-            "description": "검증 항목 목록",
-            "items": {
-              "type": "object",
-              "required": ["check", "expected", "actual", "passed"],
-              "properties": {
-                "check": {
-                  "type": "string",
-                  "description": "검증 항목명"
-                },
-                "expected": {
-                  "description": "기대값 (any type)"
-                },
-                "actual": {
-                  "description": "실제값 (any type)"
-                },
-                "passed": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          "output": {
-            "type": "string",
-            "description": "시나리오 실행 시 생성된 출력 (선택)"
-          },
-          "error_message": {
-            "type": "string",
-            "description": "status=error 시 에러 메시지"
+            "items": { "type": "string" },
+            "description": "입력 파일 경로 목록 (없으면 빈 배열)"
           }
         }
-      }
-    },
-    "summary": {
-      "type": "object",
-      "required": ["total", "passed", "failed", "skipped", "errored"],
-      "properties": {
-        "total": { "type": "integer", "minimum": 0 },
-        "passed": { "type": "integer", "minimum": 0 },
-        "failed": { "type": "integer", "minimum": 0 },
-        "skipped": { "type": "integer", "minimum": 0 },
-        "errored": { "type": "integer", "minimum": 0 }
       }
     }
   }
 }
 ```
 
-**사용 예시:**
+**예시:**
 
 ```json
 {
   "skill_name": "test-driven-development",
-  "eval_id": "eval-1",
-  "scenarios": [
+  "evals": [
     {
-      "id": "scenario-1",
-      "name": "RED phase에서 실패 테스트 작성 확인",
-      "status": "pass",
-      "assertions": [
-        {
-          "check": "test_file_created",
-          "expected": true,
-          "actual": true,
-          "passed": true
-        },
-        {
-          "check": "test_initially_fails",
-          "expected": true,
-          "actual": true,
-          "passed": true
-        }
-      ]
+      "id": 1,
+      "prompt": "Add a function that validates email addresses",
+      "expected_output": "Test file created first with failing test, then implementation, then refactor",
+      "files": ["src/utils/validators.ts"]
+    },
+    {
+      "id": 2,
+      "prompt": "Fix the login timeout bug",
+      "expected_output": "Failing test reproducing the bug, then minimal fix, then cleanup",
+      "files": ["src/auth/login.ts", "src/auth/login.test.ts"]
     }
-  ],
-  "summary": { "total": 1, "passed": 1, "failed": 0, "skipped": 0, "errored": 0 }
+  ]
 }
 ```
 
@@ -182,90 +143,80 @@ workspace/
 
 ### 2. eval_metadata.json
 
-평가 실행의 환경 및 컨텍스트 메타데이터를 기록한다.
+개별 평가 실행의 메타데이터를 기록한다. 각 `with_skill/` 및 `without_skill/` 디렉토리에 위치한다.
+
+**스키마:**
 
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://codingbuddy.dev/schemas/skill-eval/eval_metadata.json",
   "title": "Evaluation Metadata",
-  "description": "평가 실행 환경 및 컨텍스트 메타데이터",
+  "description": "개별 평가 실행의 메타데이터",
   "type": "object",
-  "required": ["eval_id", "iteration", "skill_version", "timestamp", "evaluator"],
+  "required": ["eval_id", "eval_name", "prompt", "assertions"],
   "properties": {
     "eval_id": {
-      "type": "string",
-      "pattern": "^eval-[0-9]+$"
-    },
-    "iteration": {
-      "type": "integer",
-      "minimum": 1,
-      "description": "iteration 번호"
-    },
-    "skill_version": {
-      "type": "string",
-      "description": "평가 시점의 SKILL.md 해시 또는 버전"
-    },
-    "timestamp": {
-      "type": "string",
-      "format": "date-time",
-      "description": "평가 시작 시각 (ISO 8601)"
-    },
-    "duration_ms": {
       "type": "integer",
       "minimum": 0,
-      "description": "전체 평가 소요 시간 (밀리초)"
+      "description": "평가 ID (0-based, evals.json의 id-1에 대응)"
     },
-    "evaluator": {
-      "type": "object",
-      "required": ["type"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["human", "ai", "automated"],
-          "description": "평가 주체 유형"
-        },
-        "model": {
-          "type": "string",
-          "description": "AI 평가 시 사용된 모델 (예: claude-opus-4-20250514)"
-        },
-        "name": {
-          "type": "string",
-          "description": "평가자 이름 또는 식별자"
-        }
-      }
-    },
-    "environment": {
-      "type": "object",
-      "description": "평가 실행 환경 정보",
-      "properties": {
-        "tool": {
-          "type": "string",
-          "description": "사용된 AI 도구 (예: claude-code, cursor)",
-          "enum": ["claude-code", "cursor", "codex", "amazon-q", "kiro", "antigravity"]
-        },
-        "tool_version": {
-          "type": "string"
-        },
-        "os": {
-          "type": "string"
-        },
-        "node_version": {
-          "type": "string"
-        }
-      }
-    },
-    "trigger": {
+    "eval_name": {
       "type": "string",
-      "enum": ["manual", "auto", "ci"],
-      "description": "평가 트리거 방식"
+      "description": "평가의 설명적 이름"
     },
-    "tags": {
+    "prompt": {
+      "type": "string",
+      "description": "사용자 작업 프롬프트 (evals.json에서 복사)"
+    },
+    "assertions": {
       "type": "array",
-      "items": { "type": "string" },
-      "description": "분류 태그"
+      "description": "검증 항목 목록",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "description"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "검증 가능한 항목명"
+          },
+          "description": {
+            "type": "string",
+            "description": "통과 기준 설명"
+          }
+        }
+      }
     }
   }
+}
+```
+
+**예시:**
+
+```json
+{
+  "eval_id": 0,
+  "eval_name": "Email Validation TDD Cycle",
+  "prompt": "Add a function that validates email addresses",
+  "assertions": [
+    {
+      "name": "test_file_created_first",
+      "description": "테스트 파일이 구현 파일보다 먼저 생성됨"
+    },
+    {
+      "name": "test_initially_fails",
+      "description": "구현 전 테스트 실행 시 실패함"
+    },
+    {
+      "name": "minimal_implementation",
+      "description": "테스트를 통과하는 최소한의 코드만 작성됨"
+    },
+    {
+      "name": "refactor_step_present",
+      "description": "GREEN 이후 리팩토링 단계가 수행됨"
+    }
+  ]
 }
 ```
 
@@ -273,441 +224,482 @@ workspace/
 
 ### 3. grading.json
 
-평가 시나리오의 채점 기준 및 점수를 정의한다.
+평가 실행의 채점 결과를 기록한다. 각 assertion에 대한 통과/실패 판정과 근거를 포함한다.
+
+**스키마:**
 
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://codingbuddy.dev/schemas/skill-eval/grading.json",
   "title": "Grading Results",
-  "description": "스킬 평가 채점 기준 및 점수",
+  "description": "평가 채점 결과",
   "type": "object",
-  "required": ["eval_id", "dimensions", "overall_score", "grade"],
+  "required": ["expectations"],
   "properties": {
-    "eval_id": {
-      "type": "string",
-      "pattern": "^eval-[0-9]+$"
-    },
-    "dimensions": {
+    "expectations": {
       "type": "array",
-      "description": "채점 차원 목록",
+      "description": "assertion별 채점 결과",
       "minItems": 1,
       "items": {
         "type": "object",
-        "required": ["name", "weight", "score", "max_score"],
+        "required": ["text", "passed", "evidence"],
         "properties": {
-          "name": {
+          "text": {
             "type": "string",
-            "description": "채점 차원명",
-            "enum": [
-              "correctness",
-              "completeness",
-              "clarity",
-              "structure",
-              "tool-compatibility",
-              "frontmatter-validity",
-              "reference-quality"
-            ]
+            "description": "assertion 설명 (eval_metadata.json의 assertion.description에 대응)"
           },
-          "weight": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1,
-            "description": "가중치 (전체 합=1.0)"
+          "passed": {
+            "type": "boolean",
+            "description": "통과 여부"
           },
-          "score": {
-            "type": "number",
-            "minimum": 0,
-            "description": "획득 점수"
-          },
-          "max_score": {
-            "type": "number",
-            "minimum": 1,
-            "description": "최대 점수"
-          },
-          "rationale": {
+          "evidence": {
             "type": "string",
-            "description": "점수 사유"
+            "description": "판정 근거 (구체적 증거)"
           }
         }
       }
-    },
-    "overall_score": {
-      "type": "number",
-      "minimum": 0,
-      "maximum": 100,
-      "description": "가중 평균 종합 점수 (0-100)"
-    },
-    "grade": {
-      "type": "string",
-      "enum": ["A", "B", "C", "D", "F"],
-      "description": "등급 (A: 90+, B: 80+, C: 70+, D: 60+, F: <60)"
-    },
-    "pass": {
-      "type": "boolean",
-      "description": "합격 여부 (grade C 이상)"
     }
   }
 }
 ```
 
-**채점 차원:**
+**예시:**
 
-| Dimension | Description | Weight (권장) |
-|-----------|-------------|---------------|
-| `correctness` | 스킬 로직이 의도대로 동작하는가 | 0.25 |
-| `completeness` | 모든 요구사항을 충족하는가 | 0.20 |
-| `clarity` | 지시사항이 명확하고 모호하지 않은가 | 0.15 |
-| `structure` | SKILL.md 구조가 표준을 따르는가 | 0.15 |
-| `tool-compatibility` | 6개 도구에서 정상 동작하는가 | 0.10 |
-| `frontmatter-validity` | 프론트매터가 스키마에 맞는가 | 0.10 |
-| `reference-quality` | 레퍼런스 파일이 정확하고 유용한가 | 0.05 |
+```json
+{
+  "expectations": [
+    {
+      "text": "테스트 파일이 구현 파일보다 먼저 생성됨",
+      "passed": true,
+      "evidence": "validators.test.ts가 validators.ts보다 2분 먼저 생성됨 (git log 확인)"
+    },
+    {
+      "text": "구현 전 테스트 실행 시 실패함",
+      "passed": true,
+      "evidence": "RED 단계에서 'Expected isValidEmail to be defined' 에러 확인"
+    },
+    {
+      "text": "테스트를 통과하는 최소한의 코드만 작성됨",
+      "passed": false,
+      "evidence": "초기 구현에서 불필요한 도메인 검증 로직이 포함됨 (asserting 범위 초과)"
+    }
+  ]
+}
+```
+
+**통과율 계산:**
+
+```
+pass_rate = expectations.filter(e => e.passed).length / expectations.length
+```
 
 ---
 
 ### 4. timing.json
 
-평가 및 스킬 실행의 시간 측정 데이터를 기록한다.
+평가 실행의 시간 및 토큰 사용량을 기록한다.
+
+**스키마:**
 
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://codingbuddy.dev/schemas/skill-eval/timing.json",
   "title": "Timing Data",
-  "description": "스킬 평가 시간 측정 데이터",
+  "description": "평가 실행 시간 및 토큰 사용량",
   "type": "object",
-  "required": ["eval_id", "total_ms", "phases"],
+  "required": ["total_tokens", "duration_ms", "total_duration_seconds"],
   "properties": {
-    "eval_id": {
-      "type": "string",
-      "pattern": "^eval-[0-9]+$"
-    },
-    "total_ms": {
+    "total_tokens": {
       "type": "integer",
       "minimum": 0,
-      "description": "전체 소요 시간 (밀리초)"
+      "description": "총 토큰 사용량 (input + output)"
     },
-    "phases": {
-      "type": "array",
-      "description": "단계별 시간 측정",
-      "items": {
-        "type": "object",
-        "required": ["name", "start_ms", "end_ms"],
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "단계명 (예: skill_load, scenario_exec, grading)"
-          },
-          "start_ms": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "시작 오프셋 (밀리초)"
-          },
-          "end_ms": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "종료 오프셋 (밀리초)"
-          },
-          "duration_ms": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "단계 소요 시간 (end_ms - start_ms)"
-          }
-        }
-      }
-    },
-    "token_usage": {
-      "type": "object",
-      "description": "AI 토큰 사용량 (AI 평가 시)",
-      "properties": {
-        "input_tokens": { "type": "integer", "minimum": 0 },
-        "output_tokens": { "type": "integer", "minimum": 0 },
-        "total_tokens": { "type": "integer", "minimum": 0 }
-      }
-    },
-    "tool_calls": {
+    "duration_ms": {
       "type": "integer",
       "minimum": 0,
-      "description": "총 도구 호출 횟수"
+      "description": "실행 시간 (밀리초)"
+    },
+    "total_duration_seconds": {
+      "type": "number",
+      "minimum": 0,
+      "description": "총 실행 시간 (초, 소수점 포함)"
     }
   }
 }
 ```
+
+**예시:**
+
+```json
+{
+  "total_tokens": 45230,
+  "duration_ms": 32150,
+  "total_duration_seconds": 32.15
+}
+```
+
+**벤치마크 비교 시 사용:**
+- `with_skill`과 `without_skill`의 timing.json을 비교하여 스킬 적용에 따른 토큰/시간 오버헤드를 측정
 
 ---
 
 ### 5. feedback.json
 
-평가자 또는 사용자의 정성적 피드백을 기록한다.
+평가에 대한 사용자 피드백을 기록한다. iteration 루트에 위치하며, 여러 eval 실행에 대한 피드백을 통합 관리한다.
+
+**스키마:**
 
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://codingbuddy.dev/schemas/skill-eval/feedback.json",
   "title": "Evaluation Feedback",
-  "description": "스킬 평가에 대한 정성적 피드백",
+  "description": "평가에 대한 사용자 피드백",
   "type": "object",
-  "required": ["eval_id", "entries"],
+  "required": ["reviews", "status"],
   "properties": {
-    "eval_id": {
-      "type": "string",
-      "pattern": "^eval-[0-9]+$"
-    },
-    "entries": {
+    "reviews": {
       "type": "array",
       "description": "피드백 항목 목록",
       "items": {
         "type": "object",
-        "required": ["severity", "category", "message"],
+        "required": ["run_id", "feedback", "timestamp"],
         "properties": {
-          "severity": {
+          "run_id": {
             "type": "string",
-            "enum": ["critical", "high", "medium", "low", "info"],
-            "description": "심각도"
+            "description": "실행 식별자 (예: eval-0-with_skill, eval-1-without_skill)",
+            "pattern": "^eval-[0-9]+-(?:with_skill|without_skill)$"
           },
-          "category": {
+          "feedback": {
             "type": "string",
-            "enum": [
-              "correctness",
-              "usability",
-              "compatibility",
-              "performance",
-              "documentation",
-              "security",
-              "accessibility"
-            ],
-            "description": "피드백 카테고리"
+            "description": "사용자 피드백 내용"
           },
-          "message": {
+          "timestamp": {
             "type": "string",
-            "description": "피드백 내용"
-          },
-          "scenario_id": {
-            "type": "string",
-            "description": "관련 시나리오 ID (선택)"
-          },
-          "suggestion": {
-            "type": "string",
-            "description": "개선 제안 (선택)"
-          },
-          "line_ref": {
-            "type": "string",
-            "description": "SKILL.md 내 관련 라인 참조 (선택)"
+            "format": "date-time",
+            "description": "피드백 작성 시각 (ISO 8601)"
           }
         }
       }
     },
-    "overall_comment": {
+    "status": {
       "type": "string",
-      "description": "종합 코멘트"
+      "enum": ["in_progress", "complete"],
+      "description": "피드백 수집 상태"
     }
   }
 }
 ```
+
+**예시:**
+
+```json
+{
+  "reviews": [
+    {
+      "run_id": "eval-0-with_skill",
+      "feedback": "TDD 사이클이 잘 지켜졌으나, RED 단계에서 에러 메시지 확인이 생략됨",
+      "timestamp": "2026-03-21T14:30:00.000Z"
+    },
+    {
+      "run_id": "eval-0-without_skill",
+      "feedback": "스킬 없이 실행 시 테스트를 나중에 작성하는 경향이 있음",
+      "timestamp": "2026-03-21T14:35:00.000Z"
+    }
+  ],
+  "status": "in_progress"
+}
+```
+
+**run_id 형식:**
+- `eval-{eval_id}-with_skill`: 스킬 적용 실행에 대한 피드백
+- `eval-{eval_id}-without_skill`: 베이스라인 실행에 대한 피드백
 
 ---
 
 ### 6. benchmark.json
 
-스킬 버전 간 또는 기준선 대비 성능을 비교한다.
+iteration 단위의 벤치마크 종합 결과를 기록한다. 모든 eval의 `with_skill` vs `without_skill` 비교 데이터를 집계한다.
+
+**스키마:**
 
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://codingbuddy.dev/schemas/skill-eval/benchmark.json",
-  "title": "Benchmark Comparison",
-  "description": "스킬 버전 간 벤치마크 비교 데이터",
+  "title": "Benchmark Results",
+  "description": "iteration 벤치마크 종합 결과",
   "type": "object",
-  "required": ["eval_id", "baseline", "current", "comparison"],
-  "properties": {
-    "eval_id": {
-      "type": "string",
-      "pattern": "^eval-[0-9]+$"
-    },
-    "baseline": {
-      "type": "object",
-      "required": ["iteration", "eval_id", "overall_score"],
-      "description": "비교 기준 (이전 평가)",
-      "properties": {
-        "iteration": { "type": "integer", "minimum": 1 },
-        "eval_id": { "type": "string" },
-        "overall_score": { "type": "number", "minimum": 0, "maximum": 100 }
-      }
-    },
-    "current": {
-      "type": "object",
-      "required": ["iteration", "eval_id", "overall_score"],
-      "description": "현재 평가",
-      "properties": {
-        "iteration": { "type": "integer", "minimum": 1 },
-        "eval_id": { "type": "string" },
-        "overall_score": { "type": "number", "minimum": 0, "maximum": 100 }
-      }
-    },
-    "comparison": {
-      "type": "object",
-      "required": ["score_delta", "improved_dimensions", "regressed_dimensions"],
-      "properties": {
-        "score_delta": {
-          "type": "number",
-          "description": "점수 변화 (current - baseline)"
-        },
-        "improved_dimensions": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["name", "delta"],
-            "properties": {
-              "name": { "type": "string" },
-              "delta": { "type": "number", "exclusiveMinimum": 0 }
-            }
-          }
-        },
-        "regressed_dimensions": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["name", "delta"],
-            "properties": {
-              "name": { "type": "string" },
-              "delta": { "type": "number", "exclusiveMaximum": 0 }
-            }
-          }
-        },
-        "verdict": {
-          "type": "string",
-          "enum": ["improved", "regressed", "stable"],
-          "description": "종합 판정"
-        }
-      }
-    }
-  }
-}
-```
-
----
-
-### 7. trigger_eval.json
-
-자동 평가 트리거 조건을 설정한다. workspace 루트에 위치하며 iteration과 독립적으로 관리된다.
-
-```json
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://codingbuddy.dev/schemas/skill-eval/trigger_eval.json",
-  "title": "Evaluation Trigger Configuration",
-  "description": "자동 평가 트리거 조건 설정",
-  "type": "object",
-  "required": ["skill_name", "triggers"],
+  "required": ["skill_name", "iteration", "summary", "eval_results"],
   "properties": {
     "skill_name": {
       "type": "string",
-      "pattern": "^[a-z][a-z0-9-]*$",
-      "description": "대상 스킬명"
+      "description": "평가 대상 스킬명",
+      "pattern": "^[a-z][a-z0-9-]*$"
     },
-    "triggers": {
+    "iteration": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "iteration 번호 (1-based)"
+    },
+    "summary": {
+      "type": "object",
+      "description": "전체 eval 통합 요약 통계",
+      "required": ["pass_rate", "tokens", "duration_seconds"],
+      "properties": {
+        "pass_rate": {
+          "type": "object",
+          "required": ["mean", "stddev"],
+          "properties": {
+            "mean": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1,
+              "description": "평균 통과율 (0.0~1.0)"
+            },
+            "stddev": {
+              "type": "number",
+              "minimum": 0,
+              "description": "통과율 표준편차"
+            }
+          }
+        },
+        "tokens": {
+          "type": "object",
+          "required": ["mean", "stddev"],
+          "properties": {
+            "mean": {
+              "type": "number",
+              "minimum": 0,
+              "description": "평균 토큰 사용량"
+            },
+            "stddev": {
+              "type": "number",
+              "minimum": 0,
+              "description": "토큰 표준편차"
+            }
+          }
+        },
+        "duration_seconds": {
+          "type": "object",
+          "required": ["mean", "stddev"],
+          "properties": {
+            "mean": {
+              "type": "number",
+              "minimum": 0,
+              "description": "평균 실행 시간 (초)"
+            },
+            "stddev": {
+              "type": "number",
+              "minimum": 0,
+              "description": "시간 표준편차"
+            }
+          }
+        }
+      }
+    },
+    "eval_results": {
       "type": "array",
-      "description": "트리거 조건 목록",
-      "minItems": 1,
+      "description": "개별 eval 비교 결과",
       "items": {
         "type": "object",
-        "required": ["event", "action"],
+        "required": ["eval_id", "with_skill", "baseline"],
         "properties": {
-          "event": {
-            "type": "string",
-            "enum": [
-              "skill_modified",
-              "reference_modified",
-              "frontmatter_changed",
-              "manual",
-              "schedule",
-              "ci"
-            ],
-            "description": "트리거 이벤트"
+          "eval_id": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "평가 ID (0-based)"
           },
-          "action": {
-            "type": "string",
-            "enum": ["full_eval", "quick_eval", "regression_only"],
-            "description": "실행할 평가 유형"
-          },
-          "conditions": {
+          "with_skill": {
             "type": "object",
-            "description": "추가 조건 (선택)",
+            "required": ["pass_rate", "tokens", "duration"],
+            "description": "스킬 적용 결과",
             "properties": {
-              "min_change_lines": {
-                "type": "integer",
-                "minimum": 1,
-                "description": "최소 변경 라인 수"
+              "pass_rate": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "description": "통과율 (0.0~1.0)"
               },
-              "cooldown_minutes": {
+              "tokens": {
                 "type": "integer",
-                "minimum": 1,
-                "description": "동일 트리거 재실행 대기 시간 (분)"
+                "minimum": 0,
+                "description": "토큰 사용량"
               },
-              "require_passing_baseline": {
-                "type": "boolean",
-                "description": "이전 평가 통과 필수 여부"
+              "duration": {
+                "type": "number",
+                "minimum": 0,
+                "description": "실행 시간 (초)"
+              }
+            }
+          },
+          "baseline": {
+            "type": "object",
+            "required": ["pass_rate", "tokens", "duration"],
+            "description": "베이스라인 (스킬 미적용) 결과",
+            "properties": {
+              "pass_rate": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "tokens": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "duration": {
+                "type": "number",
+                "minimum": 0
               }
             }
           }
         }
       }
+    }
+  }
+}
+```
+
+**예시:**
+
+```json
+{
+  "skill_name": "test-driven-development",
+  "iteration": 1,
+  "summary": {
+    "pass_rate": { "mean": 0.85, "stddev": 0.12 },
+    "tokens": { "mean": 42000, "stddev": 5200 },
+    "duration_seconds": { "mean": 35.5, "stddev": 8.3 }
+  },
+  "eval_results": [
+    {
+      "eval_id": 0,
+      "with_skill": { "pass_rate": 0.75, "tokens": 45230, "duration": 32.15 },
+      "baseline": { "pass_rate": 0.50, "tokens": 38400, "duration": 28.90 }
     },
-    "scenarios_path": {
-      "type": "string",
-      "description": "시나리오 정의 파일 경로 (기본: ./scenarios/)"
-    },
-    "notify": {
-      "type": "object",
-      "description": "평가 완료 알림 설정",
-      "properties": {
-        "on_pass": { "type": "boolean", "default": false },
-        "on_fail": { "type": "boolean", "default": true },
-        "on_regression": { "type": "boolean", "default": true }
+    {
+      "eval_id": 1,
+      "with_skill": { "pass_rate": 1.0, "tokens": 38770, "duration": 38.85 },
+      "baseline": { "pass_rate": 0.25, "tokens": 35200, "duration": 25.40 }
+    }
+  ]
+}
+```
+
+**해석 가이드:**
+- `with_skill.pass_rate > baseline.pass_rate`: 스킬이 품질을 향상시킴
+- `with_skill.tokens > baseline.tokens`: 스킬 적용 시 토큰 오버헤드 발생
+- `summary.pass_rate.stddev`가 낮을수록 일관된 성능
+
+---
+
+### 7. trigger_eval.json
+
+스킬 추천 트리거 평가를 위한 테스트 케이스를 정의한다. `recommend_skills`의 트리거 정확도를 측정하는 벤치마크 모드에서 사용된다.
+
+**스키마:**
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://codingbuddy.dev/schemas/skill-eval/trigger_eval.json",
+  "title": "Trigger Evaluation Cases",
+  "description": "스킬 추천 트리거 정확도 테스트 케이스",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "required": ["query", "should_trigger"],
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "사용자 프롬프트 (테스트 입력)"
+      },
+      "should_trigger": {
+        "type": "boolean",
+        "description": "이 프롬프트에서 스킬이 추천되어야 하는가"
       }
     }
   }
 }
 ```
 
-**트리거 이벤트:**
+**예시:**
 
-| Event | Description | 권장 Action |
-|-------|-------------|-------------|
-| `skill_modified` | SKILL.md 파일 변경 시 | `full_eval` |
-| `reference_modified` | 레퍼런스 파일 변경 시 | `quick_eval` |
-| `frontmatter_changed` | 프론트매터만 변경 시 | `quick_eval` |
-| `manual` | 수동 트리거 | `full_eval` |
-| `schedule` | 정기 실행 (cron) | `regression_only` |
-| `ci` | CI/CD 파이프라인 내 | `full_eval` |
+```json
+[
+  {
+    "query": "Add a new feature to validate user registration",
+    "should_trigger": true
+  },
+  {
+    "query": "Fix the null pointer exception in the payment module",
+    "should_trigger": true
+  },
+  {
+    "query": "What does this function do?",
+    "should_trigger": false
+  },
+  {
+    "query": "Deploy the application to production",
+    "should_trigger": false
+  }
+]
+```
+
+**사용 방법:**
+1. `trigger_eval.json`의 각 `query`를 `recommend_skills`에 전달
+2. 결과에 해당 스킬이 포함되었는지 확인
+3. `should_trigger`와 비교하여 정확도 계산
+
+**정확도 지표:**
+- **Precision**: 추천된 것 중 올바른 비율
+- **Recall**: 추천되어야 할 것 중 실제 추천된 비율
+- **F1 Score**: Precision과 Recall의 조화 평균
 
 ---
 
 ## Schema Relationships
 
 ```
-trigger_eval.json ──triggers──▶ eval_metadata.json
-                                     │
-                                     ▼
-                                evals.json ◀──references── grading.json
-                                     │                         │
-                                     ▼                         ▼
-                               feedback.json            benchmark.json
-                                                             │
-                                                             ▼
-                                                        timing.json
+evals.json (workspace 루트)
+    │
+    │ eval.id → eval_id 매핑
+    ▼
+iteration-N/eval-{id}/
+    ├── with_skill/
+    │   ├── eval_metadata.json ◄── evals.json의 prompt, assertions 정의
+    │   ├── grading.json ◄── eval_metadata.json의 assertions 채점
+    │   └── timing.json ── 독립 측정
+    └── without_skill/
+        ├── eval_metadata.json
+        ├── grading.json
+        └── timing.json
+    │
+    ▼ 집계
+iteration-N/
+    ├── benchmark.json ◄── 모든 eval의 with_skill vs without_skill 비교
+    └── feedback.json ◄── 사용자 피드백 (run_id로 eval 참조)
+
+trigger_eval.json (workspace 루트) ── recommend_skills 정확도 측정 (독립)
 ```
 
 **데이터 흐름:**
-1. `trigger_eval.json`이 평가를 트리거
-2. `eval_metadata.json`에 실행 환경 기록
-3. `evals.json`에 시나리오별 결과 저장
-4. `grading.json`에 채점 결과 산출
-5. `timing.json`에 시간 측정 데이터 기록
-6. `feedback.json`에 정성적 피드백 추가
-7. `benchmark.json`에서 이전 iteration과 비교
+1. `evals.json`에 평가 시나리오 정의
+2. 각 eval에 대해 `with_skill/`과 `without_skill/` 실행
+3. `eval_metadata.json`에 실행 정보 기록
+4. `grading.json`에 assertion별 채점 결과 저장
+5. `timing.json`에 토큰/시간 측정
+6. `benchmark.json`에서 모든 eval 결과 집계 및 비교
+7. `feedback.json`에 사용자 피드백 수집
+8. `trigger_eval.json`으로 추천 정확도 별도 측정
 
-**공통 키:** 모든 스키마는 `eval_id` 필드로 연결된다.
+**ID 매핑:**
+- `evals.json`의 `id` (1-based) → `eval-{id-1}/` 디렉토리 (0-based)
+- `eval_metadata.json`의 `eval_id` (0-based) = 디렉토리의 eval 번호
+- `feedback.json`의 `run_id` = `eval-{eval_id}-{with_skill|without_skill}`
 
 ---
 
@@ -716,13 +708,25 @@ trigger_eval.json ──triggers──▶ eval_metadata.json
 ### ajv CLI로 검증
 
 ```bash
-# 단일 파일 검증
-npx ajv validate -s schemas/evals.schema.json -d workspace/iteration-1/eval-1/evals.json
+# evals.json 검증
+npx ajv-cli@5.0.0 validate \
+  -s schemas/evals.schema.json \
+  -d workspace/evals.json \
+  --spec=draft7
 
-# 전체 workspace 검증
-for f in workspace/iteration-*/eval-*/evals.json; do
-  npx ajv validate -s schemas/evals.schema.json -d "$f"
+# iteration 내 모든 grading.json 검증
+for f in workspace/iteration-*/eval-*/*/grading.json; do
+  npx ajv-cli@5.0.0 validate \
+    -s schemas/grading.schema.json \
+    -d "$f" \
+    --spec=draft7
 done
+
+# trigger_eval.json 검증
+npx ajv-cli@5.0.0 validate \
+  -s schemas/trigger_eval.schema.json \
+  -d workspace/trigger_eval.json \
+  --spec=draft7
 ```
 
 ### 프로그래밍 방식 검증
@@ -734,11 +738,47 @@ import addFormats from 'ajv-formats';
 const ajv = new Ajv({ allErrors: true });
 addFormats(ajv);
 
+// 스키마 로드
 const evalsSchema = require('./schemas/evals.schema.json');
-const validate = ajv.compile(evalsSchema);
+const gradingSchema = require('./schemas/grading.schema.json');
+const timingSchema = require('./schemas/timing.schema.json');
 
-const data = require('./workspace/iteration-1/eval-1/evals.json');
-if (!validate(data)) {
-  console.error('Validation errors:', validate.errors);
+// 검증 함수 컴파일
+const validateEvals = ajv.compile(evalsSchema);
+const validateGrading = ajv.compile(gradingSchema);
+const validateTiming = ajv.compile(timingSchema);
+
+// 데이터 검증
+const evalsData = require('./workspace/evals.json');
+if (!validateEvals(evalsData)) {
+  console.error('evals.json validation errors:', validateEvals.errors);
+}
+```
+
+### 일관성 검증
+
+스키마 간 참조 무결성을 확인하는 추가 검증:
+
+```typescript
+// evals.json의 id와 eval 디렉토리 매핑 확인
+function validateConsistency(workspacePath: string): string[] {
+  const errors: string[] = [];
+  const evals = require(`${workspacePath}/evals.json`);
+
+  for (const eval of evals.evals) {
+    const evalDir = `${workspacePath}/iteration-1/eval-${eval.id - 1}`;
+
+    // with_skill 디렉토리 존재 확인
+    if (!fs.existsSync(`${evalDir}/with_skill/eval_metadata.json`)) {
+      errors.push(`Missing: ${evalDir}/with_skill/eval_metadata.json`);
+    }
+
+    // without_skill 디렉토리 존재 확인
+    if (!fs.existsSync(`${evalDir}/without_skill/eval_metadata.json`)) {
+      errors.push(`Missing: ${evalDir}/without_skill/eval_metadata.json`);
+    }
+  }
+
+  return errors;
 }
 ```


### PR DESCRIPTION
## Summary

- Add 3 reference documents for the `skill-creator` skill (#741)
- `schemas.md`: 7 JSON schema definitions (evals, eval_metadata, grading, timing, feedback, benchmark, trigger_eval) + workspace directory structure with `with_skill`/`without_skill` layout
- `frontmatter-guide.md`: v2.0 frontmatter field guide with all 11 fields, decision tree, and description writing guide (3rd-person narration, 200-char recommendation)
- `multi-tool-compat.md`: 6-tool compatibility matrix (Claude Code, Cursor, Codex, Amazon Q, Kiro, Antigravity), skill loading flow comparison, and codingbuddy MCP server integration guide

## Test plan

- [x] All 3 files created under `packages/rules/.ai-rules/skills/skill-creator/references/`
- [x] All files exceed 300 lines with TOC included (schemas: 784, frontmatter: 632, compat: 480)
- [x] markdownlint passes with 0 errors
- [x] ajv schema validation passes for all 35 agents
- [x] codingbuddy workspace CI: lint, format, typecheck, test:coverage, circular, build all pass

Closes #741