### PR TITLE
fix(landing-page): make #agents-all anchor link functional

### DIFF
--- a/apps/landing-page/__tests__/__helpers__/mock-translations.ts
+++ b/apps/landing-page/__tests__/__helpers__/mock-translations.ts
@@ -29,6 +29,7 @@ export const mockTranslations: Record<string, Record<string, string>> = {
     allCategories: 'All',
     noResults: 'No agents found matching your criteria',
     viewAll: 'View All Agents',
+    showLess: 'Show Less',
     'categories.Planning': 'Planning',
     'categories.Development': 'Development',
     'categories.Review': 'Review',

--- a/apps/landing-page/__tests__/widgets/AgentsShowcase.test.tsx
+++ b/apps/landing-page/__tests__/widgets/AgentsShowcase.test.tsx
@@ -1,10 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@/__tests__/__helpers__/next-intl-mock';
 import { AgentsShowcase } from '@/widgets/AgentsShowcase';
 
 describe('AgentsShowcase', () => {
+  beforeEach(() => {
+    window.location.hash = '';
+  });
+
   it('should render with locale prop', () => {
     render(<AgentsShowcase locale="en" />);
     expect(screen.getByTestId('agents-showcase')).toBeInTheDocument();
@@ -23,6 +27,11 @@ describe('AgentsShowcase', () => {
   it('should have id attribute for anchor navigation', () => {
     render(<AgentsShowcase locale="en" />);
     expect(screen.getByTestId('agents-showcase')).toHaveAttribute('id', 'agents');
+  });
+
+  it('should have agents-all id on the grid for anchor target', () => {
+    render(<AgentsShowcase locale="en" />);
+    expect(document.getElementById('agents-all')).toBeInTheDocument();
   });
 
   it('should have aria-labelledby linking to heading', () => {
@@ -84,5 +93,40 @@ describe('AgentsShowcase', () => {
     await user.click(screen.getByRole('button', { name: 'Security' }));
 
     expect(screen.queryByText('View All Agents')).not.toBeInTheDocument();
+  });
+
+  it('should show all agents when View All is clicked', async () => {
+    const user = userEvent.setup();
+    render(<AgentsShowcase locale="en" />);
+
+    await user.click(screen.getByText('View All Agents'));
+
+    // Should now show more than 8 agents
+    const agentIcons = screen.getAllByRole('img', { hidden: true });
+    expect(agentIcons.length).toBeGreaterThan(8);
+    // View All link should be hidden, Show Less should appear
+    expect(screen.queryByText('View All Agents')).not.toBeInTheDocument();
+    expect(screen.getByText('Show Less')).toBeInTheDocument();
+  });
+
+  it('should collapse agents when Show Less is clicked', async () => {
+    const user = userEvent.setup();
+    render(<AgentsShowcase locale="en" />);
+
+    await user.click(screen.getByText('View All Agents'));
+    await user.click(screen.getByText('Show Less'));
+
+    const agentIcons = screen.getAllByRole('img', { hidden: true });
+    expect(agentIcons.length).toBeLessThanOrEqual(8);
+    expect(screen.getByText('View All Agents')).toBeInTheDocument();
+  });
+
+  it('should auto-expand when URL hash is #agents-all', () => {
+    window.location.hash = '#agents-all';
+    render(<AgentsShowcase locale="en" />);
+
+    const agentIcons = screen.getAllByRole('img', { hidden: true });
+    expect(agentIcons.length).toBeGreaterThan(8);
+    expect(screen.getByText('Show Less')).toBeInTheDocument();
   });
 });

--- a/apps/landing-page/messages/en.json
+++ b/apps/landing-page/messages/en.json
@@ -82,6 +82,7 @@
     "allCategories": "All",
     "noResults": "No agents found matching your criteria",
     "viewAll": "View All Agents",
+    "showLess": "Show Less",
     "categories": {
       "Planning": "Planning",
       "Development": "Development",

--- a/apps/landing-page/messages/es.json
+++ b/apps/landing-page/messages/es.json
@@ -82,6 +82,7 @@
     "allCategories": "Todos",
     "noResults": "No se encontraron agentes que coincidan con los criterios",
     "viewAll": "Ver Todos los Agentes",
+    "showLess": "Mostrar menos",
     "categories": {
       "Planning": "Planificación",
       "Development": "Desarrollo",

--- a/apps/landing-page/messages/ja.json
+++ b/apps/landing-page/messages/ja.json
@@ -82,6 +82,7 @@
     "allCategories": "すべて",
     "noResults": "条件に一致するエージェントが見つかりません",
     "viewAll": "すべてのエージェントを見る",
+    "showLess": "折りたたむ",
     "categories": {
       "Planning": "企画",
       "Development": "開発",

--- a/apps/landing-page/messages/ko.json
+++ b/apps/landing-page/messages/ko.json
@@ -82,6 +82,7 @@
     "allCategories": "전체",
     "noResults": "조건에 맞는 에이전트를 찾을 수 없습니다",
     "viewAll": "모든 에이전트 보기",
+    "showLess": "접기",
     "categories": {
       "Planning": "기획",
       "Development": "개발",

--- a/apps/landing-page/messages/zh-CN.json
+++ b/apps/landing-page/messages/zh-CN.json
@@ -82,6 +82,7 @@
     "allCategories": "全部",
     "noResults": "未找到符合条件的代理",
     "viewAll": "查看所有代理",
+    "showLess": "收起",
     "categories": {
       "Planning": "规划",
       "Development": "开发",

--- a/apps/landing-page/widgets/AgentsShowcase/index.tsx
+++ b/apps/landing-page/widgets/AgentsShowcase/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { ArrowRight } from 'lucide-react';
+import { useCallback, useSyncExternalStore } from 'react';
+import { ArrowRight, ChevronUp } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { AgentCategory, WidgetProps } from '@/types';
 import { agents } from './data/agents';
@@ -9,11 +10,32 @@ import { AgentCard } from './ui/AgentCard';
 import { FilterBar } from './ui/FilterBar';
 
 const MAX_VISIBLE_AGENTS = 8;
+const AGENTS_ALL_HASH = '#agents-all';
+
+const hashSubscribe = (cb: () => void) => {
+  window.addEventListener('hashchange', cb);
+  return () => window.removeEventListener('hashchange', cb);
+};
+const getHashSnapshot = () => window.location.hash;
+const getServerSnapshot = () => '';
 
 export const AgentsShowcase = ({ locale }: WidgetProps) => {
   const t = useTranslations('agents');
+  const hash = useSyncExternalStore(hashSubscribe, getHashSnapshot, getServerSnapshot);
+  const showAllFromHash = hash === AGENTS_ALL_HASH;
 
   const { filteredAgents, category, setCategory } = useAgentFilter(agents);
+
+  const handleViewAll = useCallback((e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    window.location.hash = AGENTS_ALL_HASH;
+  }, []);
+
+  const handleShowLess = useCallback(() => {
+    window.history.replaceState(null, '', window.location.pathname);
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+    document.getElementById('agents')?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
 
   const translations = {
     filter: t('filter'),
@@ -27,8 +49,10 @@ export const AgentsShowcase = ({ locale }: WidgetProps) => {
     } as Record<AgentCategory, string>,
   };
 
-  const visibleAgents = filteredAgents.slice(0, MAX_VISIBLE_AGENTS);
   const hasMore = filteredAgents.length > MAX_VISIBLE_AGENTS;
+  const visibleAgents = showAllFromHash
+    ? filteredAgents
+    : filteredAgents.slice(0, MAX_VISIBLE_AGENTS);
 
   return (
     <section
@@ -54,7 +78,7 @@ export const AgentsShowcase = ({ locale }: WidgetProps) => {
       </p>
 
       {visibleAgents.length > 0 ? (
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div id="agents-all" className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {visibleAgents.map(agent => (
             <AgentCard
               key={agent.id}
@@ -69,15 +93,29 @@ export const AgentsShowcase = ({ locale }: WidgetProps) => {
         </p>
       )}
 
-      {hasMore && (
+      {hasMore && !showAllFromHash && (
         <div className="mt-8 text-center">
           <a
             href="#agents-all"
+            onClick={handleViewAll}
             className="text-primary hover:text-primary/80 inline-flex items-center gap-1 text-sm font-medium transition-colors"
           >
             {t('viewAll')}
             <ArrowRight className="size-4" />
           </a>
+        </div>
+      )}
+
+      {showAllFromHash && hasMore && (
+        <div className="mt-8 text-center">
+          <button
+            type="button"
+            onClick={handleShowLess}
+            className="text-primary hover:text-primary/80 inline-flex items-center gap-1 text-sm font-medium transition-colors"
+          >
+            {t('showLess')}
+            <ChevronUp className="size-4" />
+          </button>
         </div>
       )}
     </section>


### PR DESCRIPTION
## Summary
- Fix broken `#agents-all` anchor on the landing page that produced no visible action or scroll
- Use `useSyncExternalStore` to reactively track URL hash (`#agents-all`) and toggle between showing 8 agents and all agents
- Add `id="agents-all"` anchor target on the agents grid element
- Add `showLess` translation key to all 5 locales (en, ko, ja, zh-CN, es)
- Add 3 new tests: expand on click, collapse on Show Less, auto-expand on hash navigation

## Test plan
- [x] All 239 landing-page tests pass (16 AgentsShowcase tests including 3 new)
- [x] Lint, format, typecheck, circular dependency check all pass
- [x] Next.js build succeeds with static generation for all locales
- [x] Coverage at 97.4%
- [ ] Navigate to `/ko#agents-all` — all agents should be visible
- [ ] Click "View All Agents" — expands to show all 29 agents, URL updates to `#agents-all`
- [ ] Click "Show Less" — collapses back to 8 agents, scrolls to section top

Closes #762