### PR TITLE
feat(rules): add Output Language rule for English-only artifacts

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -29,7 +29,7 @@ CodingBuddy supports only JSON configuration format:
 
 | Field | Type | Description | Example |
 |-------|------|-------------|---------|
-| `language` | `string` | Response language for AI | `'ko'`, `'en'`, `'ja'` |
+| `language` | `string` | Communication language for AI responses (conversation only — all generated artifacts like code, comments, docs, and commit messages are always in English) | `'ko'`, `'en'`, `'ja'` |
 | `projectName` | `string` | Project name | `'my-app'` |
 | `description` | `string` | Project description | `'E-commerce platform'` |
 | `repository` | `string` | Repository URL | `'https://github.com/...'` |

--- a/packages/rules/.ai-rules/rules/core.md
+++ b/packages/rules/.ai-rules/rules/core.md
@@ -46,6 +46,39 @@ PLAN → (user: ACT) → ACT → PLAN → (user: EVAL) → EVAL → Improved PLA
 
 ---
 
+### Output Language
+
+**Rule:** The `language` setting in `codingbuddy.config.json` controls **communication language only** (conversation, explanations, questions). All generated **artifacts** must always be written in **English**, regardless of the `language` setting.
+
+| Category | Language | Examples |
+|----------|----------|----------|
+| **Communication** | `codingbuddy.config.json` `language` setting | Conversation, explanations, status updates, questions |
+| **Artifacts** | Always English | Code, comments, variable names, documentation, commit messages, PR titles/descriptions, branch names, TODO items, error messages in code, log messages, JSDoc/TSDoc, type names |
+
+**Why:**
+- Code and documentation in English ensures global readability and collaboration
+- Mixed-language codebases create maintenance burden and hinder onboarding
+- Commit history and PR descriptions must be searchable in a common language
+
+**Examples:**
+
+```
+# Communication (follows language setting, e.g., "ko")
+"이 함수는 사용자 인증을 처리합니다. 다음 단계로 넘어가겠습니다."
+
+# Artifacts (always English)
+/** Validates user authentication token and returns session data. */
+function validateAuthToken(token: string): SessionData { ... }
+
+# Commit message (always English)
+feat(auth): add token validation with session management
+
+# Code comments (always English)
+// Check token expiration before proceeding
+```
+
+---
+
 ### Plan Mode
 
 **Important:**


### PR DESCRIPTION
## Summary
- Add `Output Language` section to `packages/rules/.ai-rules/rules/core.md` as a cross-cutting rule after Work Modes
- Separates communication language (follows `codingbuddy.config.json` `language` setting) from artifact language (always English)
- Artifacts include: code, comments, variable names, documentation, commit messages, PR titles/descriptions, branch names, TODO items, JSDoc/TSDoc, type names
- Update `docs/config-schema.md` to clarify that the `language` field controls communication only

## Test plan
- [x] markdownlint passes (0 errors on 78 files)
- [ ] Verify Output Language section is correctly placed between Work Modes and Plan Mode in core.md
- [ ] Verify config-schema.md language field description includes "conversation only" clarification
- [ ] Verify no conflicts with existing `communication.language` references in core.md

Closes #764