### PR TITLE
feat(mcp): add validate_parallel_issues tool for file-overlap detection

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/index.ts
+++ b/apps/mcp-server/src/mcp/handlers/index.ts
@@ -91,6 +91,12 @@ export { ContextDocumentHandler } from './context-document.handler';
 export { TuiHandler } from './tui.handler';
 
 /**
+ * Handler for parallel validation tools (validate_parallel_issues)
+ * @see {@link ParallelValidationHandler}
+ */
+export { ParallelValidationHandler } from '../../parallel-validation/parallel-validation.handler';
+
+/**
  * Injection token for the array of all tool handlers.
  *
  * Use this token to inject all handlers into a service that needs to

--- a/apps/mcp-server/src/mcp/mcp.module.ts
+++ b/apps/mcp-server/src/mcp/mcp.module.ts
@@ -27,6 +27,7 @@ import {
   ConventionsHandler,
   ContextDocumentHandler,
   TuiHandler,
+  ParallelValidationHandler,
 } from './handlers';
 
 const handlers = [
@@ -39,6 +40,7 @@ const handlers = [
   ConventionsHandler,
   ContextDocumentHandler,
   TuiHandler,
+  ParallelValidationHandler,
 ];
 
 @Module({

--- a/apps/mcp-server/src/parallel-validation/extract-file-paths.spec.ts
+++ b/apps/mcp-server/src/parallel-validation/extract-file-paths.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { extractFilePaths } from './extract-file-paths';
+
+describe('extractFilePaths', () => {
+  it('should return empty array for empty string', () => {
+    expect(extractFilePaths('')).toEqual([]);
+  });
+
+  it('should extract paths from markdown code blocks', () => {
+    const body = `
+## Changes
+\`\`\`yaml
+apps/mcp-server/src/config/config.schema.ts
+packages/rules/.ai-rules/agents/README.md
+\`\`\`
+    `;
+    const result = extractFilePaths(body);
+    expect(result).toContain('apps/mcp-server/src/config/config.schema.ts');
+    expect(result).toContain('packages/rules/.ai-rules/agents/README.md');
+  });
+
+  it('should extract paths with common prefixes (packages/, src/, apps/, .claude/)', () => {
+    const body = `
+This issue modifies packages/rules/index.ts and src/main.ts.
+Also touches .claude/settings.json and apps/mcp-server/src/mcp/mcp.module.ts.
+    `;
+    const result = extractFilePaths(body);
+    expect(result).toContain('packages/rules/index.ts');
+    expect(result).toContain('src/main.ts');
+    expect(result).toContain('.claude/settings.json');
+    expect(result).toContain('apps/mcp-server/src/mcp/mcp.module.ts');
+  });
+
+  it('should extract paths from "대상 파일" section', () => {
+    const body = `
+## 대상 파일
+- apps/mcp-server/src/mcp/handlers/mode.handler.ts
+- apps/mcp-server/src/keyword/keyword.service.ts
+    `;
+    const result = extractFilePaths(body);
+    expect(result).toContain('apps/mcp-server/src/mcp/handlers/mode.handler.ts');
+    expect(result).toContain('apps/mcp-server/src/keyword/keyword.service.ts');
+  });
+
+  it('should extract paths from "Target Files" section', () => {
+    const body = `
+## Target Files
+- packages/rules/.ai-rules/rules/core.md
+- .cursor/rules/custom-instructions.md
+    `;
+    const result = extractFilePaths(body);
+    expect(result).toContain('packages/rules/.ai-rules/rules/core.md');
+    expect(result).toContain('.cursor/rules/custom-instructions.md');
+  });
+
+  it('should deduplicate paths', () => {
+    const body = `
+Modify packages/rules/index.ts for the feature.
+Also see packages/rules/index.ts for reference.
+    `;
+    const result = extractFilePaths(body);
+    const count = result.filter(p => p === 'packages/rules/index.ts').length;
+    expect(count).toBe(1);
+  });
+
+  it('should ignore URLs and non-file paths', () => {
+    const body = `
+See https://github.com/example/repo/blob/main/src/index.ts
+and http://example.com/packages/foo for reference.
+    `;
+    const result = extractFilePaths(body);
+    expect(result).toEqual([]);
+  });
+
+  it('should extract inline code paths', () => {
+    const body = 'Modify `apps/mcp-server/src/main.ts` and `packages/rules/index.ts`';
+    const result = extractFilePaths(body);
+    expect(result).toContain('apps/mcp-server/src/main.ts');
+    expect(result).toContain('packages/rules/index.ts');
+  });
+
+  it('should handle paths with various extensions', () => {
+    const body = `
+- apps/mcp-server/src/config.yaml
+- packages/rules/.ai-rules/agents/architect.json
+- .kiro/settings.toml
+    `;
+    const result = extractFilePaths(body);
+    expect(result).toContain('apps/mcp-server/src/config.yaml');
+    expect(result).toContain('packages/rules/.ai-rules/agents/architect.json');
+    expect(result).toContain('.kiro/settings.toml');
+  });
+});

--- a/apps/mcp-server/src/parallel-validation/extract-file-paths.ts
+++ b/apps/mcp-server/src/parallel-validation/extract-file-paths.ts
@@ -1,0 +1,39 @@
+/**
+ * Regex for file paths with known prefixes.
+ * Captures: prefix + path segments + file extension.
+ */
+const FILE_PATH_PATTERN =
+  /(?<![/\w])(?:(?:packages|src|apps|\.claude|\.cursor|\.kiro|\.q|\.antigravity|\.codex)\/[\w./@-]+\.\w+)/g;
+
+/**
+ * Matches URLs to filter them out (http:// or https://).
+ */
+const URL_PATTERN = /https?:\/\/\S+/g;
+
+/**
+ * Extracts file paths from a GitHub issue body markdown text.
+ *
+ * Recognizes:
+ * - Paths with common prefixes (packages/, src/, apps/, .claude/, .cursor/, .kiro/, .q/, .antigravity/, .codex/)
+ * - Filters out URLs
+ * - Deduplicates results
+ */
+export function extractFilePaths(issueBody: string): string[] {
+  if (!issueBody.trim()) {
+    return [];
+  }
+
+  // Remove URLs first to avoid false matches
+  const withoutUrls = issueBody.replace(URL_PATTERN, '');
+
+  const paths = new Set<string>();
+
+  // Extract paths matching known prefixes
+  const matches = withoutUrls.matchAll(FILE_PATH_PATTERN);
+  for (const match of matches) {
+    const path = match[0].replace(/[,;:)}\]]+$/, ''); // strip trailing punctuation
+    paths.add(path);
+  }
+
+  return [...paths];
+}

--- a/apps/mcp-server/src/parallel-validation/index.ts
+++ b/apps/mcp-server/src/parallel-validation/index.ts
@@ -1,0 +1,5 @@
+export { extractFilePaths } from './extract-file-paths';
+export { buildOverlapMatrix, type IssueFiles, type OverlapEntry } from './overlap-matrix';
+export { splitIntoWaves } from './wave-splitter';
+export { ParallelValidationHandler } from './parallel-validation.handler';
+export type { ValidationResult } from './parallel-validation.types';

--- a/apps/mcp-server/src/parallel-validation/overlap-matrix.spec.ts
+++ b/apps/mcp-server/src/parallel-validation/overlap-matrix.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { buildOverlapMatrix, type IssueFiles } from './overlap-matrix';
+
+describe('buildOverlapMatrix', () => {
+  it('should return empty matrix for empty input', () => {
+    expect(buildOverlapMatrix([])).toEqual([]);
+  });
+
+  it('should return empty matrix for single issue', () => {
+    const issues: IssueFiles[] = [{ issue: 732, files: ['src/main.ts'] }];
+    expect(buildOverlapMatrix(issues)).toEqual([]);
+  });
+
+  it('should return empty matrix when no files overlap', () => {
+    const issues: IssueFiles[] = [
+      { issue: 732, files: ['src/main.ts'] },
+      { issue: 733, files: ['src/config.ts'] },
+      { issue: 734, files: ['src/utils.ts'] },
+    ];
+    expect(buildOverlapMatrix(issues)).toEqual([]);
+  });
+
+  it('should detect overlap between two issues', () => {
+    const issues: IssueFiles[] = [
+      { issue: 733, files: ['apps/mcp-server/src/config.yaml', 'src/main.ts'] },
+      { issue: 734, files: ['apps/mcp-server/src/config.yaml', 'src/other.ts'] },
+    ];
+    const result = buildOverlapMatrix(issues);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      issueA: 733,
+      issueB: 734,
+      overlappingFiles: ['apps/mcp-server/src/config.yaml'],
+    });
+  });
+
+  it('should detect multiple overlapping files', () => {
+    const issues: IssueFiles[] = [
+      { issue: 733, files: ['src/a.ts', 'src/b.ts', 'src/c.ts'] },
+      { issue: 734, files: ['src/b.ts', 'src/c.ts', 'src/d.ts'] },
+    ];
+    const result = buildOverlapMatrix(issues);
+    expect(result).toHaveLength(1);
+    expect(result[0].overlappingFiles).toEqual(['src/b.ts', 'src/c.ts']);
+  });
+
+  it('should detect overlaps across multiple issue pairs', () => {
+    const issues: IssueFiles[] = [
+      { issue: 732, files: ['src/a.ts', 'src/shared.ts'] },
+      { issue: 733, files: ['src/b.ts', 'src/shared.ts'] },
+      { issue: 734, files: ['src/a.ts', 'src/c.ts'] },
+    ];
+    const result = buildOverlapMatrix(issues);
+    expect(result).toHaveLength(2);
+
+    const pair732_733 = result.find(e => e.issueA === 732 && e.issueB === 733);
+    expect(pair732_733?.overlappingFiles).toEqual(['src/shared.ts']);
+
+    const pair732_734 = result.find(e => e.issueA === 732 && e.issueB === 734);
+    expect(pair732_734?.overlappingFiles).toEqual(['src/a.ts']);
+  });
+
+  it('should sort overlapping files alphabetically', () => {
+    const issues: IssueFiles[] = [
+      { issue: 1, files: ['src/z.ts', 'src/a.ts', 'src/m.ts'] },
+      { issue: 2, files: ['src/m.ts', 'src/z.ts'] },
+    ];
+    const result = buildOverlapMatrix(issues);
+    expect(result[0].overlappingFiles).toEqual(['src/m.ts', 'src/z.ts']);
+  });
+
+  it('should always have issueA < issueB', () => {
+    const issues: IssueFiles[] = [
+      { issue: 999, files: ['src/shared.ts'] },
+      { issue: 100, files: ['src/shared.ts'] },
+    ];
+    const result = buildOverlapMatrix(issues);
+    expect(result[0].issueA).toBe(100);
+    expect(result[0].issueB).toBe(999);
+  });
+});

--- a/apps/mcp-server/src/parallel-validation/overlap-matrix.ts
+++ b/apps/mcp-server/src/parallel-validation/overlap-matrix.ts
@@ -1,0 +1,42 @@
+export interface IssueFiles {
+  issue: number;
+  files: string[];
+}
+
+export interface OverlapEntry {
+  issueA: number;
+  issueB: number;
+  overlappingFiles: string[];
+}
+
+/**
+ * Builds an overlap matrix from issue-file mappings.
+ * For each pair of issues, checks if they share any files.
+ * Returns entries only for pairs that have overlapping files.
+ * issueA is always < issueB. overlappingFiles are sorted alphabetically.
+ */
+export function buildOverlapMatrix(issues: IssueFiles[]): OverlapEntry[] {
+  if (issues.length < 2) {
+    return [];
+  }
+
+  const entries: OverlapEntry[] = [];
+
+  for (let i = 0; i < issues.length; i++) {
+    const filesA = new Set(issues[i].files);
+    for (let j = i + 1; j < issues.length; j++) {
+      const overlapping = issues[j].files.filter(f => filesA.has(f)).sort();
+
+      if (overlapping.length > 0) {
+        const [issueA, issueB] =
+          issues[i].issue < issues[j].issue
+            ? [issues[i].issue, issues[j].issue]
+            : [issues[j].issue, issues[i].issue];
+
+        entries.push({ issueA, issueB, overlappingFiles: overlapping });
+      }
+    }
+  }
+
+  return entries;
+}

--- a/apps/mcp-server/src/parallel-validation/parallel-validation.handler.spec.ts
+++ b/apps/mcp-server/src/parallel-validation/parallel-validation.handler.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ParallelValidationHandler } from './parallel-validation.handler';
+
+describe('ParallelValidationHandler', () => {
+  let handler: ParallelValidationHandler;
+
+  beforeEach(() => {
+    handler = new ParallelValidationHandler();
+  });
+
+  describe('getToolDefinitions', () => {
+    it('should return validate_parallel_issues tool definition', () => {
+      const defs = handler.getToolDefinitions();
+      expect(defs).toHaveLength(1);
+      expect(defs[0].name).toBe('validate_parallel_issues');
+      expect(defs[0].inputSchema.properties).toHaveProperty('issues');
+      expect(defs[0].inputSchema.properties).toHaveProperty('issueContents');
+      expect(defs[0].inputSchema.required).toContain('issues');
+    });
+  });
+
+  describe('handle', () => {
+    it('should return null for unhandled tools', async () => {
+      const result = await handler.handle('unknown_tool', {});
+      expect(result).toBeNull();
+    });
+
+    it('should return error when issues param is missing', async () => {
+      const result = await handler.handle('validate_parallel_issues', {});
+      expect(result?.isError).toBe(true);
+    });
+
+    it('should return error when issues is not an array', async () => {
+      const result = await handler.handle('validate_parallel_issues', {
+        issues: 'not-array',
+      });
+      expect(result?.isError).toBe(true);
+    });
+
+    it('should return OK when no overlaps exist', async () => {
+      const result = await handler.handle('validate_parallel_issues', {
+        issues: [732, 733],
+        issueContents: {
+          '732': '## Target Files\n- src/a.ts',
+          '733': '## Target Files\n- src/b.ts',
+        },
+      });
+      expect(result?.isError).toBeFalsy();
+      const content = JSON.parse(
+        (result?.content as Array<{ type: string; text: string }>)[0].text,
+      );
+      expect(content.hasOverlap).toBe(false);
+      expect(content.severity).toBe('OK');
+      expect(content.suggestedWaves).toHaveLength(1);
+    });
+
+    it('should return WARNING when overlaps exist', async () => {
+      const result = await handler.handle('validate_parallel_issues', {
+        issues: [733, 734],
+        issueContents: {
+          '733': '## Target Files\n- apps/mcp-server/src/config.yaml\n- src/a.ts',
+          '734': '## Target Files\n- apps/mcp-server/src/config.yaml\n- src/b.ts',
+        },
+      });
+      expect(result?.isError).toBeFalsy();
+      const content = JSON.parse(
+        (result?.content as Array<{ type: string; text: string }>)[0].text,
+      );
+      expect(content.hasOverlap).toBe(true);
+      expect(content.severity).toBe('WARNING');
+      expect(content.overlapMatrix).toHaveLength(1);
+      expect(content.overlapMatrix[0].overlappingFiles).toContain(
+        'apps/mcp-server/src/config.yaml',
+      );
+      expect(content.suggestedWaves.length).toBeGreaterThanOrEqual(2);
+      expect(content.message).toContain('WARNING');
+    });
+
+    it('should handle issueContents with multiple issues', async () => {
+      const result = await handler.handle('validate_parallel_issues', {
+        issues: [1, 2, 3],
+        issueContents: {
+          '1': 'Modify src/shared.ts and src/a.ts',
+          '2': 'Change src/b.ts only',
+          '3': 'Update src/shared.ts and src/c.ts',
+        },
+      });
+      const content = JSON.parse(
+        (result?.content as Array<{ type: string; text: string }>)[0].text,
+      );
+      expect(content.hasOverlap).toBe(true);
+      expect(content.suggestedWaves.length).toBeGreaterThanOrEqual(2);
+      // Issue 2 should be in same wave as 1 or 3 (no overlap with either)
+      const waveWith2 = content.suggestedWaves.find((w: number[]) => w.includes(2));
+      expect(waveWith2).toBeDefined();
+    });
+  });
+});

--- a/apps/mcp-server/src/parallel-validation/parallel-validation.handler.ts
+++ b/apps/mcp-server/src/parallel-validation/parallel-validation.handler.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@nestjs/common';
+import type { ToolDefinition } from '../mcp/handlers/base.handler';
+import type { ToolResponse } from '../mcp/response.utils';
+import { AbstractHandler } from '../mcp/handlers/abstract-handler';
+import { createJsonResponse, createErrorResponse } from '../mcp/response.utils';
+import { extractFilePaths } from './extract-file-paths';
+import { buildOverlapMatrix, type IssueFiles } from './overlap-matrix';
+import { splitIntoWaves } from './wave-splitter';
+import type { ValidationResult } from './parallel-validation.types';
+
+@Injectable()
+export class ParallelValidationHandler extends AbstractHandler {
+  protected getHandledTools(): string[] {
+    return ['validate_parallel_issues'];
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'validate_parallel_issues',
+        description:
+          'Validate whether GitHub issues can be safely executed in parallel by checking file overlap. ' +
+          'Returns overlap matrix, severity (OK/WARNING), and zero-conflict wave suggestions. ' +
+          'Iron Rule: Issues modifying the same file MUST NOT run in the same wave.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            issues: {
+              type: 'array',
+              items: { type: 'number' },
+              description: 'List of GitHub issue numbers to validate for parallel execution',
+            },
+            issueContents: {
+              type: 'object',
+              additionalProperties: { type: 'string' },
+              description:
+                'Map of issue number to issue body content. Key is issue number as string, value is the issue body markdown text.',
+            },
+          },
+          required: ['issues'],
+        },
+      },
+    ];
+  }
+
+  protected async handleTool(
+    _toolName: string,
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    const rawIssues = args?.issues;
+    if (!Array.isArray(rawIssues)) {
+      return createErrorResponse(
+        'Missing or invalid required parameter: issues (must be an array of numbers)',
+      );
+    }
+
+    const issueNumbers = rawIssues.map(Number).filter(n => !isNaN(n));
+    const issueContents = (args?.issueContents ?? {}) as Record<string, string>;
+
+    // Extract file paths from each issue's content
+    const issueFiles: IssueFiles[] = issueNumbers.map(issue => ({
+      issue,
+      files: extractFilePaths(issueContents[String(issue)] ?? ''),
+    }));
+
+    // Build overlap matrix
+    const overlapMatrix = buildOverlapMatrix(issueFiles);
+    const hasOverlap = overlapMatrix.length > 0;
+
+    // Suggest zero-conflict waves
+    const suggestedWaves = splitIntoWaves(issueFiles);
+
+    // Build result
+    const overlappingPairs = overlapMatrix
+      .map(e => `#${e.issueA} ↔ #${e.issueB}: ${e.overlappingFiles.join(', ')}`)
+      .join('\n');
+
+    const message = hasOverlap
+      ? `⚠️ WARNING: File overlap detected! ${overlapMatrix.length} conflicting pair(s) found.\n` +
+        `Iron Rule: Issues modifying the same file MUST NOT run in the same Wave.\n\n` +
+        `Conflicts:\n${overlappingPairs}\n\n` +
+        `Suggested waves: ${suggestedWaves.map((w, i) => `Wave ${i + 1}: [${w.map(n => '#' + n).join(', ')}]`).join(' → ')}`
+      : `✅ OK: No file overlap detected. All ${issueNumbers.length} issues can run in parallel.`;
+
+    const result: ValidationResult = {
+      issues: issueFiles,
+      overlapMatrix,
+      hasOverlap,
+      severity: hasOverlap ? 'WARNING' : 'OK',
+      suggestedWaves,
+      message,
+    };
+
+    return createJsonResponse(result);
+  }
+}

--- a/apps/mcp-server/src/parallel-validation/parallel-validation.types.ts
+++ b/apps/mcp-server/src/parallel-validation/parallel-validation.types.ts
@@ -1,0 +1,13 @@
+import type { OverlapEntry } from './overlap-matrix';
+
+export interface ValidationResult {
+  issues: Array<{
+    issue: number;
+    files: string[];
+  }>;
+  overlapMatrix: OverlapEntry[];
+  hasOverlap: boolean;
+  severity: 'OK' | 'WARNING';
+  suggestedWaves: number[][];
+  message: string;
+}

--- a/apps/mcp-server/src/parallel-validation/wave-splitter.spec.ts
+++ b/apps/mcp-server/src/parallel-validation/wave-splitter.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { splitIntoWaves } from './wave-splitter';
+import type { IssueFiles } from './overlap-matrix';
+
+describe('splitIntoWaves', () => {
+  it('should return empty waves for empty input', () => {
+    expect(splitIntoWaves([])).toEqual([]);
+  });
+
+  it('should put single issue in one wave', () => {
+    const issues: IssueFiles[] = [{ issue: 732, files: ['src/main.ts'] }];
+    expect(splitIntoWaves(issues)).toEqual([[732]]);
+  });
+
+  it('should put non-overlapping issues in the same wave', () => {
+    const issues: IssueFiles[] = [
+      { issue: 732, files: ['src/a.ts'] },
+      { issue: 733, files: ['src/b.ts'] },
+      { issue: 734, files: ['src/c.ts'] },
+    ];
+    const waves = splitIntoWaves(issues);
+    expect(waves).toHaveLength(1);
+    expect(waves[0].sort()).toEqual([732, 733, 734]);
+  });
+
+  it('should separate overlapping issues into different waves', () => {
+    const issues: IssueFiles[] = [
+      { issue: 732, files: ['src/shared.ts', 'src/a.ts'] },
+      { issue: 733, files: ['src/shared.ts', 'src/b.ts'] },
+    ];
+    const waves = splitIntoWaves(issues);
+    expect(waves).toHaveLength(2);
+    // Each wave has exactly one issue
+    expect(waves.map(w => w.length)).toEqual([1, 1]);
+  });
+
+  it('should handle complex overlap graph (3 issues, 2 overlap)', () => {
+    const issues: IssueFiles[] = [
+      { issue: 732, files: ['src/a.ts', 'src/shared.ts'] },
+      { issue: 733, files: ['src/b.ts'] },
+      { issue: 734, files: ['src/c.ts', 'src/shared.ts'] },
+    ];
+    const waves = splitIntoWaves(issues);
+    // 732 and 734 overlap, 733 is independent
+    // Wave 1: [732, 733] or [733, 734], Wave 2: [734] or [732]
+    expect(waves.length).toBeGreaterThanOrEqual(2);
+
+    // Verify no wave has overlapping issues
+    for (const wave of waves) {
+      const waveIssues = issues.filter(i => wave.includes(i.issue));
+      for (let i = 0; i < waveIssues.length; i++) {
+        for (let j = i + 1; j < waveIssues.length; j++) {
+          const filesA = new Set(waveIssues[i].files);
+          const overlap = waveIssues[j].files.filter(f => filesA.has(f));
+          expect(overlap).toEqual([]);
+        }
+      }
+    }
+  });
+
+  it('should handle chain overlap (A-B, B-C but not A-C)', () => {
+    const issues: IssueFiles[] = [
+      { issue: 1, files: ['src/ab.ts'] },
+      { issue: 2, files: ['src/ab.ts', 'src/bc.ts'] },
+      { issue: 3, files: ['src/bc.ts'] },
+    ];
+    const waves = splitIntoWaves(issues);
+    // Issue 2 overlaps with both 1 and 3, but 1 and 3 don't overlap
+    // Minimum: 2 waves. e.g. Wave1: [1, 3], Wave2: [2]
+    expect(waves.length).toBeGreaterThanOrEqual(2);
+
+    // Issue 1 and 3 can be in the same wave
+    const waveWith1 = waves.find(w => w.includes(1));
+    const waveWith3 = waves.find(w => w.includes(3));
+    // They could share a wave since they don't overlap
+    if (waveWith1 === waveWith3) {
+      expect(waveWith1).toContain(1);
+      expect(waveWith1).toContain(3);
+    }
+  });
+
+  it('should ensure every issue appears in exactly one wave', () => {
+    const issues: IssueFiles[] = [
+      { issue: 1, files: ['src/a.ts'] },
+      { issue: 2, files: ['src/a.ts', 'src/b.ts'] },
+      { issue: 3, files: ['src/b.ts', 'src/c.ts'] },
+      { issue: 4, files: ['src/d.ts'] },
+    ];
+    const waves = splitIntoWaves(issues);
+    const allIssues = waves.flat().sort();
+    expect(allIssues).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/apps/mcp-server/src/parallel-validation/wave-splitter.ts
+++ b/apps/mcp-server/src/parallel-validation/wave-splitter.ts
@@ -1,0 +1,49 @@
+import type { IssueFiles } from './overlap-matrix';
+
+/**
+ * Splits issues into zero-conflict waves using greedy graph coloring.
+ * Issues in the same wave have no overlapping files.
+ * Returns array of waves, each wave is an array of issue numbers.
+ */
+export function splitIntoWaves(issues: IssueFiles[]): number[][] {
+  if (issues.length === 0) {
+    return [];
+  }
+
+  // Build adjacency: which issues conflict with each other
+  const conflicts = new Map<number, Set<number>>();
+  for (const issue of issues) {
+    conflicts.set(issue.issue, new Set());
+  }
+
+  for (let i = 0; i < issues.length; i++) {
+    const filesA = new Set(issues[i].files);
+    for (let j = i + 1; j < issues.length; j++) {
+      const hasOverlap = issues[j].files.some(f => filesA.has(f));
+      if (hasOverlap) {
+        conflicts.get(issues[i].issue)!.add(issues[j].issue);
+        conflicts.get(issues[j].issue)!.add(issues[i].issue);
+      }
+    }
+  }
+
+  // Greedy coloring: assign each issue to the first wave where it has no conflicts
+  const waves: number[][] = [];
+
+  for (const issue of issues) {
+    let assigned = false;
+    for (const wave of waves) {
+      const hasConflict = wave.some(id => conflicts.get(issue.issue)!.has(id));
+      if (!hasConflict) {
+        wave.push(issue.issue);
+        assigned = true;
+        break;
+      }
+    }
+    if (!assigned) {
+      waves.push([issue.issue]);
+    }
+  }
+
+  return waves;
+}


### PR DESCRIPTION
## Summary
- Add `validate_parallel_issues` MCP tool that detects file overlap between GitHub issues
- Extract file paths from issue body markdown (code blocks, known prefixes, inline code)
- Build overlap matrix showing which issue pairs share files
- Suggest zero-conflict wave splits using greedy graph coloring
- Enforce Iron Rule: any file overlap → WARNING + sequential execution advice
- 31 new tests across 4 spec files, all passing (4872 total)

## Test plan
- [x] `yarn workspace codingbuddy lint` — 0 errors
- [x] `yarn workspace codingbuddy format:check` — passed
- [x] `yarn workspace codingbuddy typecheck` — passed
- [x] `yarn workspace codingbuddy test:coverage` — 176 files, 4872 passed
- [x] `yarn workspace codingbuddy circular` — no circular deps
- [x] `yarn workspace codingbuddy build` — success

Closes #768