### PR TITLE
feat(agents): add unique color identifiers to agent definitions

### DIFF
--- a/packages/rules/.ai-rules/agents/README.md
+++ b/packages/rules/.ai-rules/agents/README.md
@@ -1631,6 +1631,8 @@ Some specialist agents define **delegation rules** to clarify when work should b
 Each agent JSON contains:
 
 - **name**: Agent identifier
+- **description**: Brief description of the agent
+- **color**: Unique hex color code for visual identification (e.g., `#61DAFB`)
 - **role**: Title and expertise areas
 - **context_files**: Rules to reference
 - **modes**: Planning, implementation, and evaluation frameworks (for unified specialists)
@@ -1641,6 +1643,52 @@ Each agent JSON contains:
 - **commit_rules**: Structural vs behavioral changes
 - **design_system**: UI component guidelines
 - **communication**: Response language and style
+
+### Color Reference
+
+Each agent has a unique `color` field (hex code) for visual identification in UIs and dashboards.
+
+| Agent | Color | Hex |
+|-------|-------|-----|
+| **Mode Agents** | | |
+| Plan Mode | ![#6C8EBF](https://via.placeholder.com/12/6C8EBF/6C8EBF.png) Steel Blue | `#6C8EBF` |
+| Act Mode | ![#82B366](https://via.placeholder.com/12/82B366/82B366.png) Sage Green | `#82B366` |
+| Eval Mode | ![#D4A843](https://via.placeholder.com/12/D4A843/D4A843.png) Golden | `#D4A843` |
+| Auto Mode | ![#B85450](https://via.placeholder.com/12/B85450/B85450.png) Rust Red | `#B85450` |
+| **Primary Agents** | | |
+| Solution Architect | ![#4A90D9](https://via.placeholder.com/12/4A90D9/4A90D9.png) Royal Blue | `#4A90D9` |
+| Technical Planner | ![#7B68EE](https://via.placeholder.com/12/7B68EE/7B68EE.png) Slate Blue | `#7B68EE` |
+| Frontend Developer | ![#61DAFB](https://via.placeholder.com/12/61DAFB/61DAFB.png) React Cyan | `#61DAFB` |
+| Backend Developer | ![#68A063](https://via.placeholder.com/12/68A063/68A063.png) Node Green | `#68A063` |
+| Mobile Developer | ![#A4C639](https://via.placeholder.com/12/A4C639/A4C639.png) Android Green | `#A4C639` |
+| Data Engineer | ![#E97451](https://via.placeholder.com/12/E97451/E97451.png) Burnt Sienna | `#E97451` |
+| Agent Architect | ![#9B59B6](https://via.placeholder.com/12/9B59B6/9B59B6.png) Amethyst | `#9B59B6` |
+| Platform Engineer | ![#3498DB](https://via.placeholder.com/12/3498DB/3498DB.png) Dodger Blue | `#3498DB` |
+| Tooling Engineer | ![#95A5A6](https://via.placeholder.com/12/95A5A6/95A5A6.png) Concrete | `#95A5A6` |
+| AI/ML Engineer | ![#FF6F61](https://via.placeholder.com/12/FF6F61/FF6F61.png) Coral | `#FF6F61` |
+| DevOps Engineer | ![#2ECC71](https://via.placeholder.com/12/2ECC71/2ECC71.png) Emerald | `#2ECC71` |
+| Test Engineer | ![#F39C12](https://via.placeholder.com/12/F39C12/F39C12.png) Orange | `#F39C12` |
+| Security Engineer | ![#E74C3C](https://via.placeholder.com/12/E74C3C/E74C3C.png) Alizarin | `#E74C3C` |
+| Software Engineer | ![#1ABC9C](https://via.placeholder.com/12/1ABC9C/1ABC9C.png) Turquoise | `#1ABC9C` |
+| Data Scientist | ![#8E44AD](https://via.placeholder.com/12/8E44AD/8E44AD.png) Wisteria | `#8E44AD` |
+| Systems Developer | ![#D35400](https://via.placeholder.com/12/D35400/D35400.png) Pumpkin | `#D35400` |
+| **Domain Specialists** | | |
+| Architecture | ![#2C3E80](https://via.placeholder.com/12/2C3E80/2C3E80.png) Navy | `#2C3E80` |
+| Test Strategy | ![#F1C40F](https://via.placeholder.com/12/F1C40F/F1C40F.png) Sunflower | `#F1C40F` |
+| Performance | ![#E67E22](https://via.placeholder.com/12/E67E22/E67E22.png) Carrot | `#E67E22` |
+| Security | ![#C0392B](https://via.placeholder.com/12/C0392B/C0392B.png) Pomegranate | `#C0392B` |
+| Accessibility | ![#27AE60](https://via.placeholder.com/12/27AE60/27AE60.png) Nephritis | `#27AE60` |
+| SEO | ![#16A085](https://via.placeholder.com/12/16A085/16A085.png) Green Sea | `#16A085` |
+| UI/UX Designer | ![#E91E63](https://via.placeholder.com/12/E91E63/E91E63.png) Pink | `#E91E63` |
+| Documentation | ![#607D8B](https://via.placeholder.com/12/607D8B/607D8B.png) Blue Gray | `#607D8B` |
+| Integration | ![#00BCD4](https://via.placeholder.com/12/00BCD4/00BCD4.png) Cyan | `#00BCD4` |
+| Event Architecture | ![#FF5722](https://via.placeholder.com/12/FF5722/FF5722.png) Deep Orange | `#FF5722` |
+| Observability | ![#795548](https://via.placeholder.com/12/795548/795548.png) Brown | `#795548` |
+| Migration | ![#FF9800](https://via.placeholder.com/12/FF9800/FF9800.png) Amber | `#FF9800` |
+| i18n | ![#009688](https://via.placeholder.com/12/009688/009688.png) Teal | `#009688` |
+| **Utility Agents** | | |
+| Code Quality | ![#8BC34A](https://via.placeholder.com/12/8BC34A/8BC34A.png) Light Green | `#8BC34A` |
+| Code Reviewer | ![#673AB7](https://via.placeholder.com/12/673AB7/673AB7.png) Deep Purple | `#673AB7` |
 
 ---
 
@@ -1667,6 +1715,7 @@ Create a new JSON file following this structure:
 {
   "name": "Agent Name",
   "description": "Brief description",
+  "color": "#HEXCOD",
   "role": {
     "title": "Role Title",
     "expertise": [],

--- a/packages/rules/.ai-rules/agents/accessibility-specialist.json
+++ b/packages/rules/.ai-rules/agents/accessibility-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Accessibility Specialist",
   "description": "Accessibility expert for Planning, Implementation, and Evaluation modes - unified specialist for WCAG 2.1 AA compliance, ARIA attributes, and keyboard navigation",
+  "color": "#27AE60",
   "role": {
     "title": "Accessibility Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/act-mode.json
+++ b/packages/rules/.ai-rules/agents/act-mode.json
@@ -1,6 +1,7 @@
 {
   "name": "Act Mode Agent",
   "description": "ACT mode agent - specialized for actual implementation execution",
+  "color": "#82B366",
   "role": {
     "title": "Act Mode Agent",
     "mode": "ACT",

--- a/packages/rules/.ai-rules/agents/agent-architect.json
+++ b/packages/rules/.ai-rules/agents/agent-architect.json
@@ -1,6 +1,7 @@
 {
   "name": "Agent Architect",
   "description": "Primary Agent for creating, validating, and managing AI agent configurations",
+  "color": "#9B59B6",
   "role": {
     "title": "AI Agent Framework Architect",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/ai-ml-engineer.json
+++ b/packages/rules/.ai-rules/agents/ai-ml-engineer.json
@@ -1,6 +1,7 @@
 {
   "name": "AI/ML Engineer",
   "description": "AI/ML expert for Planning, Implementation, and Evaluation modes - unified specialist for LLM integration, prompt engineering, RAG architecture, AI safety, and testing non-deterministic systems",
+  "color": "#FF6F61",
   "role": {
     "title": "Senior AI/ML Engineer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/architecture-specialist.json
+++ b/packages/rules/.ai-rules/agents/architecture-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Architecture Specialist",
   "description": "Architecture expert for Planning, Implementation, and Evaluation modes - unified specialist for layer placement, dependency direction, and type safety",
+  "color": "#2C3E80",
   "role": {
     "title": "Architecture Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/auto-mode.json
+++ b/packages/rules/.ai-rules/agents/auto-mode.json
@@ -1,6 +1,7 @@
 {
   "name": "Auto Mode Agent",
   "description": "AUTO mode agent - autonomous PLAN → ACT → EVAL cycle until quality targets met",
+  "color": "#B85450",
   "role": {
     "title": "Auto Mode Agent",
     "mode": "AUTO",

--- a/packages/rules/.ai-rules/agents/backend-developer.json
+++ b/packages/rules/.ai-rules/agents/backend-developer.json
@@ -1,6 +1,7 @@
 {
   "name": "Backend Developer",
   "description": "Language-agnostic backend specialist with Clean Architecture, TDD, and security focus. Supports Node.js, Python, Go, Java, and other backend stacks.",
+  "color": "#68A063",
   "role": {
     "title": "Senior Backend Developer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/code-quality-specialist.json
+++ b/packages/rules/.ai-rules/agents/code-quality-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Code Quality Specialist",
   "description": "Code quality expert for Planning, Implementation, and Evaluation modes - unified specialist for SOLID principles, DRY, complexity analysis, and design patterns",
+  "color": "#8BC34A",
   "role": {
     "title": "Code Quality Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/code-reviewer.json
+++ b/packages/rules/.ai-rules/agents/code-reviewer.json
@@ -1,6 +1,7 @@
 {
   "name": "Code Reviewer",
   "description": "Senior software engineer specializing in comprehensive code quality evaluation and improvement recommendations",
+  "color": "#673AB7",
   "role": {
     "title": "Senior Code Reviewer / Quality Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/data-engineer.json
+++ b/packages/rules/.ai-rules/agents/data-engineer.json
@@ -1,6 +1,7 @@
 {
   "name": "Data Engineer",
   "description": "Data specialist focused on database design, schema optimization, migrations, and analytics query optimization. Handles data modeling, ETL patterns, and reporting data structures.",
+  "color": "#E97451",
   "role": {
     "title": "Senior Data Engineer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/data-scientist.json
+++ b/packages/rules/.ai-rules/agents/data-scientist.json
@@ -1,6 +1,7 @@
 {
   "name": "Data Scientist",
   "description": "Data science specialist for exploratory data analysis, statistical modeling, ML model development, and data visualization. Handles EDA, feature engineering, model training, and Jupyter notebook development.",
+  "color": "#8E44AD",
   "role": {
     "title": "Senior Data Scientist",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/devops-engineer.json
+++ b/packages/rules/.ai-rules/agents/devops-engineer.json
@@ -1,6 +1,7 @@
 {
   "name": "DevOps Engineer",
   "description": "Docker, Datadog monitoring, and Next.js deployment specialist",
+  "color": "#2ECC71",
   "role": {
     "title": "DevOps Engineer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/documentation-specialist.json
+++ b/packages/rules/.ai-rules/agents/documentation-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Documentation Specialist",
   "description": "Documentation expert for Planning, Implementation, and Evaluation modes - unified specialist for documentation planning, code comments, type definitions, and documentation quality assessment",
+  "color": "#607D8B",
   "role": {
     "title": "Documentation Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/eval-mode.json
+++ b/packages/rules/.ai-rules/agents/eval-mode.json
@@ -1,6 +1,7 @@
 {
   "name": "Eval Mode Agent",
   "description": "EVAL mode agent - specialized for code quality evaluation and improvement suggestions",
+  "color": "#D4A843",
   "role": {
     "title": "Eval Mode Agent",
     "mode": "EVAL",

--- a/packages/rules/.ai-rules/agents/event-architecture-specialist.json
+++ b/packages/rules/.ai-rules/agents/event-architecture-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Event Architecture Specialist",
   "description": "Event-driven architecture specialist for Planning, Implementation, and Evaluation modes - unified specialist for message queues, event sourcing, CQRS, real-time communication, distributed transactions, and event schema management",
+  "color": "#FF5722",
   "role": {
     "title": "Event Architecture Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/frontend-developer.json
+++ b/packages/rules/.ai-rules/agents/frontend-developer.json
@@ -1,6 +1,7 @@
 {
   "name": "Frontend Developer",
   "description": "Modern React/Next.js specialist with Server Components/Actions, TDD, and accessibility focus",
+  "color": "#61DAFB",
   "role": {
     "title": "Senior Frontend Developer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/i18n-specialist.json
+++ b/packages/rules/.ai-rules/agents/i18n-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "i18n Specialist",
   "description": "Internationalization expert for Planning, Implementation, and Evaluation modes - unified specialist for i18n library setup, translation key structure, formatting, and RTL support",
+  "color": "#009688",
   "role": {
     "title": "Internationalization Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/integration-specialist.json
+++ b/packages/rules/.ai-rules/agents/integration-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Integration Specialist",
   "description": "External service integration specialist for Planning, Implementation, and Evaluation modes - unified specialist for API integrations, webhooks, OAuth flows, and failure isolation patterns",
+  "color": "#00BCD4",
   "role": {
     "title": "Integration Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/migration-specialist.json
+++ b/packages/rules/.ai-rules/agents/migration-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Migration Specialist",
   "description": "Cross-cutting migration coordinator for legacy system modernization, framework upgrades, database migrations, and API versioning - unified specialist for Strangler Fig, Branch by Abstraction, and zero-downtime migration patterns",
+  "color": "#FF9800",
   "role": {
     "title": "Migration Engineer",
     "type": "specialist",

--- a/packages/rules/.ai-rules/agents/mobile-developer.json
+++ b/packages/rules/.ai-rules/agents/mobile-developer.json
@@ -1,6 +1,7 @@
 {
   "name": "Mobile Developer",
   "description": "Cross-platform and native mobile specialist supporting React Native, Flutter, iOS (Swift/SwiftUI), and Android (Kotlin/Compose). Focuses on mobile-specific patterns, performance, and platform guidelines.",
+  "color": "#A4C639",
   "role": {
     "title": "Senior Mobile Developer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/observability-specialist.json
+++ b/packages/rules/.ai-rules/agents/observability-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Observability Specialist",
   "description": "Observability expert for Planning, Implementation, and Evaluation modes - unified specialist for vendor-neutral monitoring, distributed tracing, structured logging, SLI/SLO frameworks, and alerting patterns",
+  "color": "#795548",
   "role": {
     "title": "Observability Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/performance-specialist.json
+++ b/packages/rules/.ai-rules/agents/performance-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Performance Specialist",
   "description": "Performance expert for Planning, Implementation, and Evaluation modes - unified specialist for bundle size optimization, rendering optimization, and Core Web Vitals",
+  "color": "#E67E22",
   "role": {
     "title": "Performance Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/plan-mode.json
+++ b/packages/rules/.ai-rules/agents/plan-mode.json
@@ -1,6 +1,7 @@
 {
   "name": "Plan Mode Agent",
   "description": "PLAN mode agent - specialized for work planning and design",
+  "color": "#6C8EBF",
   "role": {
     "title": "Plan Mode Agent",
     "mode": "PLAN",

--- a/packages/rules/.ai-rules/agents/platform-engineer.json
+++ b/packages/rules/.ai-rules/agents/platform-engineer.json
@@ -1,6 +1,7 @@
 {
   "name": "Platform Engineer",
   "description": "Cloud-native infrastructure expert for Planning, Implementation, and Evaluation modes - unified specialist for Infrastructure as Code, Kubernetes orchestration, multi-cloud strategy, GitOps workflows, cost optimization, and disaster recovery",
+  "color": "#3498DB",
   "related_agents": {
     "complementary": [
       {

--- a/packages/rules/.ai-rules/agents/security-engineer.json
+++ b/packages/rules/.ai-rules/agents/security-engineer.json
@@ -1,6 +1,7 @@
 {
   "name": "Security Engineer",
   "description": "Primary Agent for implementing security features, fixing vulnerabilities, and applying security best practices in code",
+  "color": "#E74C3C",
   "role": {
     "title": "Security Engineer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/security-specialist.json
+++ b/packages/rules/.ai-rules/agents/security-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Security Specialist",
   "description": "Security expert for Planning, Implementation, and Evaluation modes - unified specialist for authentication, authorization, and security vulnerability prevention",
+  "color": "#C0392B",
   "role": {
     "title": "Security Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/seo-specialist.json
+++ b/packages/rules/.ai-rules/agents/seo-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "SEO Specialist",
   "description": "SEO expert for Planning, Implementation, and Evaluation modes - unified specialist for metadata, structured data, and search engine optimization",
+  "color": "#16A085",
   "role": {
     "title": "SEO Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/software-engineer.json
+++ b/packages/rules/.ai-rules/agents/software-engineer.json
@@ -1,6 +1,7 @@
 {
   "name": "Software Engineer",
   "description": "General-purpose implementation engineer — any language, any domain, TDD-first",
+  "color": "#1ABC9C",
   "role": {
     "title": "Senior Software Engineer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/solution-architect.json
+++ b/packages/rules/.ai-rules/agents/solution-architect.json
@@ -1,6 +1,7 @@
 {
   "name": "Solution Architect",
   "description": "High-level system design and architecture planning specialist",
+  "color": "#4A90D9",
   "role": {
     "title": "Solution Architect",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/systems-developer.json
+++ b/packages/rules/.ai-rules/agents/systems-developer.json
@@ -1,6 +1,7 @@
 {
   "name": "Systems Developer",
   "description": "Primary Agent for systems programming, low-level optimization, native code development, and performance-critical implementations",
+  "color": "#D35400",
   "role": {
     "title": "Systems Developer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/technical-planner.json
+++ b/packages/rules/.ai-rules/agents/technical-planner.json
@@ -1,6 +1,7 @@
 {
   "name": "Technical Planner",
   "description": "Low-level implementation planning with TDD and bite-sized tasks",
+  "color": "#7B68EE",
   "role": {
     "title": "Technical Planner",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/test-engineer.json
+++ b/packages/rules/.ai-rules/agents/test-engineer.json
@@ -1,6 +1,7 @@
 {
   "name": "Test Engineer",
   "description": "Primary Agent for TDD cycle execution, test writing, and coverage improvement across all test types",
+  "color": "#F39C12",
   "role": {
     "title": "Test Engineer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/test-strategy-specialist.json
+++ b/packages/rules/.ai-rules/agents/test-strategy-specialist.json
@@ -1,6 +1,7 @@
 {
   "name": "Test Strategy Specialist",
   "description": "Test strategy expert for Planning, Implementation, and Evaluation modes - unified specialist for TDD vs Test-After decisions, test coverage planning, and test quality assessment",
+  "color": "#F1C40F",
   "role": {
     "title": "Test Strategy Engineer",
     "expertise": [

--- a/packages/rules/.ai-rules/agents/tooling-engineer.json
+++ b/packages/rules/.ai-rules/agents/tooling-engineer.json
@@ -1,6 +1,7 @@
 {
   "name": "Tooling Engineer",
   "description": "Project configuration, build tools, and development environment specialist",
+  "color": "#95A5A6",
   "role": {
     "title": "Tooling Engineer",
     "type": "primary",

--- a/packages/rules/.ai-rules/agents/ui-ux-designer.json
+++ b/packages/rules/.ai-rules/agents/ui-ux-designer.json
@@ -1,6 +1,7 @@
 {
   "name": "UI/UX Designer",
   "description": "UI/UX design specialist based on universal design principles and UX best practices - focuses on aesthetics, usability, and user experience rather than specific design system implementations",
+  "color": "#E91E63",
   "role": {
     "title": "UI/UX Design Specialist",
     "expertise": [


### PR DESCRIPTION
## Summary
- Add unique `color` hex code field to all 35 agent JSON files for visual identification
- Colors are semantically meaningful per domain (e.g., `#61DAFB` React cyan for Frontend Developer)
- Document `color` field in agents/README.md with full color reference table
- MCP `get_agent_details` auto-exposes color via existing spread operator (no server code changes)

## Test plan
- [x] All 35 agent JSONs have unique color field verified
- [x] All 172 test files passed (4841 tests)
- [x] Schema validation passed (ajv-cli)
- [x] Markdown lint passed
- [x] TypeScript typecheck passed
- [x] Build succeeded
- [x] No circular dependencies

Closes #760