### PR TITLE
chore(rules): add auto-dispatch enforcement rule for specialists

### DIFF
--- a/.claude/rules/custom-instructions.md
+++ b/.claude/rules/custom-instructions.md
@@ -156,6 +156,67 @@ Examples:
 
 </PARALLEL_EXECUTION_MANDATORY_RULE>
 
+## 🔴 MANDATORY: Auto-Dispatch Enforcement
+
+<AUTO_DISPATCH_ENFORCEMENT_RULE>
+
+**When `parse_mode` returns `dispatch="auto"`, you MUST dispatch all recommended specialists. No exceptions.**
+
+### Core Rule
+
+If the `parse_mode` response contains `dispatch="auto"` or `dispatchReady` with specialist agents:
+1. **MUST** dispatch every listed specialist — skipping any is a protocol violation
+2. **Teams preferred** over Agent tool for specialist dispatch (use `TeamCreate` + `SendMessage`)
+3. **Report results** via `SendMessage` back to team lead, not just text output
+
+### Teams-Based Dispatch Workflow
+
+```
+parse_mode returns dispatch="auto"
+     ↓
+TeamCreate({ team_name: "<task>-specialists" })
+     ↓
+Spawn each specialist as teammate via Agent tool (team_name, name)
+     ↓
+Assign tasks via TaskCreate + TaskUpdate (owner)
+     ↓
+Specialists report findings via SendMessage
+     ↓
+Team lead collects and summarizes all findings
+     ↓
+Shutdown teammates via SendMessage({ type: "shutdown_request" })
+```
+
+### SendMessage-Based Reporting
+
+Specialists MUST report findings through `SendMessage`, not just tool output:
+
+```
+SendMessage({
+  to: "team-lead",
+  message: "## [Specialist] Findings\n- Finding 1\n- Finding 2\n...",
+  summary: "[specialist-name] analysis complete"
+})
+```
+
+The team lead collects all specialist messages and presents a consolidated summary.
+
+### Red Flags (STOP if you think these)
+
+| Thought | Reality |
+|---------|---------|
+| "I can handle this analysis myself" | NO. Specialists have domain expertise you lack. Dispatch them. |
+| "It's just a small change, no need for specialists" | NO. dispatch="auto" means the system determined specialists are needed. |
+| "I'll save time by skipping dispatch" | NO. Skipping specialists causes missed issues that cost more time later. |
+| "The specialists will just repeat what I already know" | NO. Specialists catch domain-specific issues you would miss. |
+| "I'll dispatch them later after I look at the code" | NO. Dispatch IMMEDIATELY when dispatch="auto" is returned. |
+
+### Fallback
+
+If Teams-based dispatch fails (e.g., team creation error), fall back to Agent tool with `run_in_background: true` for each specialist. Document the fallback in your response.
+
+</AUTO_DISPATCH_ENFORCEMENT_RULE>
+
 ## 🔴 MANDATORY: Context Document Management
 
 <CONTEXT_DOCUMENT_RULE>

--- a/packages/rules/.ai-rules/adapters/claude-code.md
+++ b/packages/rules/.ai-rules/adapters/claude-code.md
@@ -523,6 +523,70 @@ Each workflow mode activates different specialist agents:
 
 **Important:** Specialists from one mode do NOT carry over to the next mode. Each mode has its own recommended specialist set.
 
+### Auto-Dispatch Enforcement
+
+When `parse_mode` returns `dispatch="auto"` or `dispatchReady` with specialist agents, dispatching is **mandatory** — not optional.
+
+**Rule:** Every listed specialist MUST be dispatched. Skipping any specialist is a protocol violation.
+
+#### Teams-Based Specialist Dispatch (Preferred)
+
+Teams are preferred over the Agent tool for specialist dispatch because they enable structured coordination and message-based reporting:
+
+```
+1. TeamCreate({ team_name: "<task>-specialists" })
+2. Spawn specialists as teammates:
+   Agent({ team_name, name: "security-specialist", subagent_type: "general-purpose", prompt: ... })
+   Agent({ team_name, name: "code-quality-specialist", subagent_type: "general-purpose", prompt: ... })
+3. Create and assign tasks:
+   TaskCreate({ subject: "Security review of auth module" })
+   TaskUpdate({ taskId, owner: "security-specialist" })
+4. Specialists work autonomously, report via SendMessage:
+   SendMessage({ to: "team-lead", message: "## Security Findings\n- ...", summary: "Security review done" })
+5. Team lead collects all findings
+6. Shutdown: SendMessage({ to: "security-specialist", message: { type: "shutdown_request" } })
+```
+
+#### SendMessage-Based Reporting
+
+Specialists report findings through `SendMessage` to the team lead. This enables:
+- Structured collection of all specialist outputs
+- Consolidated summary for the user
+- Clear audit trail of what each specialist found
+
+**Report format:**
+```markdown
+## [Specialist Name] Findings
+
+### Critical
+- [finding]
+
+### High
+- [finding]
+
+### Medium
+- [finding]
+
+### Recommendations
+- [recommendation]
+```
+
+#### Fallback: Agent Tool
+
+If Teams-based dispatch fails, fall back to the Agent tool:
+- Use `run_in_background: true` for each specialist
+- Collect results via `TaskOutput`
+- Document the fallback reason in your response
+
+#### Red Flags
+
+| Thought | Reality |
+|---------|---------|
+| "I can handle this analysis myself" | Specialists have domain expertise. Dispatch them. |
+| "It's just a small change" | dispatch="auto" means the system determined specialists are needed. |
+| "I'll save time by skipping" | Skipping causes missed issues that cost more later. |
+| "I'll dispatch later" | Dispatch IMMEDIATELY when dispatch="auto" is returned. |
+
 ### Execution Strategy Selection (MANDATORY)
 
 When `parse_mode` returns `availableStrategies`:


### PR DESCRIPTION
## Summary
- Add MANDATORY Auto-Dispatch Enforcement section to `.claude/rules/custom-instructions.md` with Teams-based workflow, SendMessage reporting, and Red Flags table
- Document Teams-Based Specialist Dispatch in `packages/rules/.ai-rules/adapters/claude-code.md` with step-by-step workflow, report format, fallback strategy, and Red Flags

## Test plan
- [x] `ajv-cli validate` — all 36 agent schemas valid
- [x] `markdownlint-cli2` — 87 markdown files, 0 errors
- [x] Verified new sections integrate correctly with existing document structure

Closes #809