### PR TITLE
feat(mcp): add dispatch strength to parse_mode specialist recommendations

### DIFF
--- a/apps/mcp-server/src/config/config.schema.ts
+++ b/apps/mcp-server/src/config/config.schema.ts
@@ -71,6 +71,22 @@ const AIConfigSchema = z.object({
   defaultModel: z.string().optional(),
   primaryAgent: z.string().optional(),
   /**
+   * Override default dispatch strength for parallel specialist agents.
+   * - "auto": Always dispatch specialists automatically
+   * - "recommend": Suggest dispatch (default for PLAN/ACT)
+   * - "skip": Do not dispatch specialists
+   *
+   * Default varies by mode: EVAL="auto", PLAN/ACT="recommend"
+   *
+   * @example
+   * ```javascript
+   * ai: {
+   *   dispatchStrength: 'auto',
+   * }
+   * ```
+   */
+  dispatchStrength: z.enum(['auto', 'recommend', 'skip']).optional(),
+  /**
    * List of agent names to exclude from automatic resolution.
    * Useful for project-specific exclusions (e.g., exclude mobile-developer for backend-only projects).
    *

--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -262,9 +262,22 @@ export interface AgentInfo {
   expertise: string[];
 }
 
+/** Dispatch strength for parallel agent execution */
+export type DispatchStrength = 'auto' | 'recommend' | 'skip';
+
+/** Default dispatch strength by mode */
+export const MODE_DISPATCH_DEFAULTS: Record<Mode, DispatchStrength> = {
+  EVAL: 'auto',
+  PLAN: 'recommend',
+  ACT: 'recommend',
+  AUTO: 'recommend',
+};
+
 export interface ParallelAgentRecommendation {
   specialists: string[];
   hint: string;
+  /** Dispatch strength: "auto" (must dispatch), "recommend" (suggested), "skip" (do not dispatch) */
+  dispatch?: DispatchStrength;
 }
 
 /**

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
@@ -43,6 +43,7 @@ describe('ModeHandler', () => {
       getProjectRootSource: vi.fn().mockReturnValue('env'),
       isConfigLoaded: vi.fn().mockReturnValue(true),
       reload: vi.fn().mockResolvedValue({}),
+      getSettings: vi.fn().mockResolvedValue({}),
     } as unknown as ConfigService;
 
     mockLanguageService = {
@@ -840,6 +841,90 @@ describe('ModeHandler', () => {
       const parsed = JSON.parse(result!.content[0].text as string);
       expect(parsed.availableStrategies).toEqual(['subagent']);
       expect(parsed.taskmaestroInstallHint).toContain('TaskMaestro skill not found');
+    });
+  });
+
+  describe('dispatch strength in parallelAgentsRecommendation', () => {
+    it('should set dispatch to "auto" for EVAL mode by default', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'EVAL',
+        originalPrompt: 'evaluate implementation',
+        parallelAgentsRecommendation: {
+          specialists: ['security-specialist'],
+          hint: 'Use Task tool...',
+        },
+      });
+
+      const result = await handler.handle('parse_mode', { prompt: 'EVAL evaluate implementation' });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text as string);
+      expect(parsed.parallelAgentsRecommendation.dispatch).toBe('auto');
+    });
+
+    it('should set dispatch to "recommend" for PLAN mode by default', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        parallelAgentsRecommendation: {
+          specialists: ['architecture-specialist'],
+          hint: 'Use Task tool...',
+        },
+      });
+
+      const result = await handler.handle('parse_mode', { prompt: 'PLAN design feature' });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text as string);
+      expect(parsed.parallelAgentsRecommendation.dispatch).toBe('recommend');
+    });
+
+    it('should set dispatch to "recommend" for ACT mode by default', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'ACT',
+        originalPrompt: 'implement feature',
+        parallelAgentsRecommendation: {
+          specialists: ['code-quality-specialist'],
+          hint: 'Use Task tool...',
+        },
+      });
+
+      const result = await handler.handle('parse_mode', { prompt: 'ACT implement feature' });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text as string);
+      expect(parsed.parallelAgentsRecommendation.dispatch).toBe('recommend');
+    });
+
+    it('should override dispatch with config value when set', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        parallelAgentsRecommendation: {
+          specialists: ['architecture-specialist'],
+          hint: 'Use Task tool...',
+        },
+      });
+      (mockConfigService.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ai: { dispatchStrength: 'skip' },
+      });
+
+      const result = await handler.handle('parse_mode', { prompt: 'PLAN design feature' });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text as string);
+      expect(parsed.parallelAgentsRecommendation.dispatch).toBe('skip');
+    });
+
+    it('should not add dispatch when parallelAgentsRecommendation is absent', async () => {
+      // mockParseModeResult has no parallelAgentsRecommendation
+      const result = await handler.handle('parse_mode', { prompt: 'PLAN test task' });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text as string);
+      expect(parsed.parallelAgentsRecommendation).toBeUndefined();
     });
   });
 });

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.ts
@@ -15,12 +15,14 @@ import { ContextDocumentService } from '../../context/context-document.service';
 import { DiagnosticLogService } from '../../diagnostic/diagnostic-log.service';
 import { CONTEXT_FILE_PATH, type ContextDocument } from '../../context/context-document.types';
 import { LOCALIZED_KEYWORD_MAP } from '../../keyword/keyword.types';
-import type {
-  Mode,
-  DispatchReady,
-  DispatchReadyAgent,
-  IncludedAgent,
-  ParallelAgentRecommendation,
+import {
+  MODE_DISPATCH_DEFAULTS,
+  type Mode,
+  type DispatchReady,
+  type DispatchReadyAgent,
+  type DispatchStrength,
+  type IncludedAgent,
+  type ParallelAgentRecommendation,
 } from '../../keyword/keyword.types';
 import { isValidVerbosity } from '../../shared/verbosity.types';
 import { AgentService } from '../../agent/agent.service';
@@ -194,6 +196,14 @@ export class ModeHandler extends AbstractHandler {
 
       // Persist state for context recovery after compaction
       await this.persistModeState(result.mode);
+
+      // Enrich parallelAgentsRecommendation with dispatch strength
+      if (result.parallelAgentsRecommendation) {
+        const settings = await this.configService.getSettings();
+        const configDispatch = settings.ai?.dispatchStrength as DispatchStrength | undefined;
+        result.parallelAgentsRecommendation.dispatch =
+          configDispatch ?? MODE_DISPATCH_DEFAULTS[result.mode as Mode] ?? 'recommend';
+      }
 
       // Build dispatchReady from included_agent and parallelAgentsRecommendation
       // Only include parallel agent prompts when verbosity is 'full' (token efficiency)


### PR DESCRIPTION
## Summary
- Add `dispatch` field to `parallelAgentsRecommendation` in parse_mode response
- Values: `"auto"` (MUST dispatch), `"recommend"` (suggested), `"skip"` (do not dispatch)
- Default by mode: EVAL → `"auto"`, PLAN/ACT/AUTO → `"recommend"`
- Configurable via `ai.dispatchStrength` in codingbuddy.config.json
- 5 TDD tests covering mode defaults, config override, and field absence

## Test plan
- [x] 48/48 tests pass (5 new dispatch strength tests)
- [x] TypeScript type check clean
- [x] Lint, format, circular dependency, build all pass

Closes #808