### PR TITLE
feat(mcp): add session issue tracking to update_context

### DIFF
--- a/apps/mcp-server/src/context/context-document.service.ts
+++ b/apps/mcp-server/src/context/context-document.service.ts
@@ -25,6 +25,7 @@ import {
   createNewContextDocument,
   createPlanSection,
   mergeSection,
+  mergeIssues,
   generateTimestamp,
   estimateDocumentSize,
   cleanupContextDocument,
@@ -172,6 +173,11 @@ export class ContextDocumentService {
       const timestamp = generateTimestamp();
       const limits = await this.getContextLimits();
 
+      // Preserve existing issues across PLAN reset
+      const existingResult = await this.readContext();
+      const existingIssues = existingResult.document?.issues;
+      const mergedIssues = mergeIssues(existingIssues, data.issues);
+
       // Create PLAN section (with DoS protection via truncation)
       const planSection = createPlanSection(
         {
@@ -187,7 +193,12 @@ export class ContextDocumentService {
 
       // Create new document with explicit timestamp (pure function)
       const isoTimestamp = new Date().toISOString();
-      const document = createNewContextDocument(data.title, planSection, isoTimestamp);
+      const document = createNewContextDocument(
+        data.title,
+        planSection,
+        isoTimestamp,
+        mergedIssues,
+      );
 
       // Serialize and write
       const content = serializeContextDocument(document);
@@ -259,6 +270,9 @@ export class ContextDocumentService {
         // Add new section
         document.sections.push(newSection);
       }
+
+      // Merge issues at document level (persist across modes)
+      document.issues = mergeIssues(document.issues, data.issues);
 
       // Update metadata
       document.metadata.lastUpdatedAt = new Date().toISOString();

--- a/apps/mcp-server/src/context/context-document.types.ts
+++ b/apps/mcp-server/src/context/context-document.types.ts
@@ -60,6 +60,21 @@ const MAX_CONTEXT_ARRAY_ITEMS = 100;
 const MAX_CONTEXT_ITEM_LENGTH = 2000;
 
 /**
+ * Issue tracked during a session.
+ * Persists across PLAN→ACT→EVAL mode changes (not reset on mode change).
+ */
+export interface ContextIssue {
+  /** GitHub issue number */
+  number: number;
+  /** Issue title */
+  title: string;
+  /** Issue URL */
+  url: string;
+  /** Issue status (e.g., 'open', 'closed') */
+  status: string;
+}
+
+/**
  * Context document metadata stored in the header.
  */
 export interface ContextMetadata {
@@ -125,6 +140,8 @@ export interface ContextDocument {
   metadata: ContextMetadata;
   /** Mode sections (PLAN, ACT, EVAL) */
   sections: ContextSection[];
+  /** Issues tracked during session (persists across mode changes) */
+  issues?: ContextIssue[];
 }
 
 /**
@@ -145,6 +162,8 @@ export interface ResetContextData {
   decisions?: string[];
   /** Initial notes */
   notes?: string[];
+  /** Issues to track (persists across mode changes) */
+  issues?: ContextIssue[];
   /** Session ID for session-isolated context (optional, omit for legacy behavior) */
   sessionId?: string;
 }
@@ -175,6 +194,8 @@ export interface AppendContextData {
   recommendedActAgentConfidence?: number;
   /** Section status */
   status?: 'in_progress' | 'completed' | 'blocked';
+  /** Issues to track (merged with existing, dedup by number) */
+  issues?: ContextIssue[];
   /** Session ID for session-isolated context (optional, omit for legacy behavior) */
   sessionId?: string;
 }
@@ -236,6 +257,7 @@ export const CONTEXT_MARKDOWN = {
   PROGRESS_HEADER: '### Progress',
   FINDINGS_HEADER: '### Findings',
   RECOMMENDATIONS_HEADER: '### Recommendations',
+  ISSUES_HEADER: '### Issues',
   PRIMARY_AGENT_PREFIX: '**Primary Agent**:',
   RECOMMENDED_ACT_AGENT_PREFIX: '**Recommended ACT Agent**:',
 } as const;

--- a/apps/mcp-server/src/context/context-parser.utils.ts
+++ b/apps/mcp-server/src/context/context-parser.utils.ts
@@ -3,7 +3,12 @@
  * These functions are stateless and have no side effects.
  */
 import type { Mode } from '../keyword/keyword.types';
-import type { ContextDocument, ContextMetadata, ContextSection } from './context-document.types';
+import type {
+  ContextDocument,
+  ContextMetadata,
+  ContextSection,
+  ContextIssue,
+} from './context-document.types';
 import {
   CONTEXT_MARKDOWN,
   CONTEXT_SECTION_HEADER_PATTERN,
@@ -78,6 +83,8 @@ interface ParseContext {
   sections: ContextSection[];
   currentSection: Partial<ContextSection> | null;
   currentListType: SectionListType | null;
+  issues: ContextIssue[];
+  parsingIssues: boolean;
 }
 
 /**
@@ -99,6 +106,8 @@ export function parseContextDocument(content: string): ContextDocument {
     sections: [],
     currentSection: null,
     currentListType: null,
+    issues: [],
+    parsingIssues: false,
   };
 
   for (const line of lines) {
@@ -113,6 +122,7 @@ export function parseContextDocument(content: string): ContextDocument {
   return {
     metadata: ctx.metadata as ContextMetadata,
     sections: ctx.sections,
+    issues: ctx.issues.length > 0 ? ctx.issues : undefined,
   };
 }
 
@@ -120,6 +130,40 @@ export function parseContextDocument(content: string): ContextDocument {
  * Parse a single line and update context.
  */
 function parseLine(line: string, ctx: ParseContext): void {
+  // Check for document-level issues header
+  if (line === CONTEXT_MARKDOWN.ISSUES_HEADER) {
+    // Save current section if any
+    if (ctx.currentSection && ctx.currentSection.mode) {
+      ctx.sections.push(ctx.currentSection as ContextSection);
+      ctx.currentSection = null;
+    }
+    ctx.parsingIssues = true;
+    ctx.currentListType = null;
+    return;
+  }
+
+  // Parse issue items when in issues mode
+  if (ctx.parsingIssues) {
+    if (line.startsWith('- #')) {
+      const issueMatch = line.match(/^- #(\d+): (.+) \(([^)]+)\) - (.+)$/);
+      if (issueMatch) {
+        ctx.issues.push({
+          number: parseInt(issueMatch[1], 10),
+          title: issueMatch[2],
+          status: issueMatch[3],
+          url: issueMatch[4],
+        });
+      }
+      return;
+    }
+    // Non-issue line ends issues parsing
+    if (line.trim().length > 0 && !line.startsWith('- #')) {
+      ctx.parsingIssues = false;
+    } else {
+      return;
+    }
+  }
+
   // Try parsing metadata first (only before sections start)
   if (!ctx.currentSection && parseMetadataLine(line, ctx)) {
     return;

--- a/apps/mcp-server/src/context/context-serializer.utils.ts
+++ b/apps/mcp-server/src/context/context-serializer.utils.ts
@@ -2,7 +2,12 @@
  * Pure serialization functions for context documents.
  * These functions are stateless and have no side effects.
  */
-import type { ContextDocument, ContextMetadata, ContextSection } from './context-document.types';
+import type {
+  ContextDocument,
+  ContextMetadata,
+  ContextSection,
+  ContextIssue,
+} from './context-document.types';
 import { CONTEXT_MARKDOWN } from './context-document.types';
 
 /**
@@ -21,6 +26,15 @@ export function serializeContextDocument(document: ContextDocument): string {
   for (const section of document.sections) {
     lines.push('');
     lines.push(...serializeSection(section));
+  }
+
+  // Serialize document-level issues (persist across mode changes)
+  if (document.issues && document.issues.length > 0) {
+    lines.push('');
+    lines.push(CONTEXT_MARKDOWN.ISSUES_HEADER);
+    for (const issue of document.issues) {
+      lines.push(`- #${issue.number}: ${issue.title} (${issue.status}) - ${issue.url}`);
+    }
   }
 
   return lines.join('\n');
@@ -148,6 +162,7 @@ export function createNewContextDocument(
   title: string,
   planSection: ContextSection,
   isoTimestamp: string,
+  issues?: ContextIssue[],
 ): ContextDocument {
   return {
     metadata: {
@@ -158,6 +173,7 @@ export function createNewContextDocument(
       status: 'active',
     },
     sections: [planSection],
+    issues: issues && issues.length > 0 ? issues : undefined,
   };
 }
 
@@ -240,6 +256,29 @@ export function mergeSection(
     recommendations: mergeArraysUnique(existing.recommendations, newData.recommendations),
     status: newData.status || existing.status,
   };
+}
+
+/**
+ * Merge issues arrays with deduplication by issue number.
+ * Newer issues (from newIssues) take precedence for duplicate numbers.
+ *
+ * @param existing - Existing issues
+ * @param newIssues - New issues to merge
+ * @returns Merged issues without duplicates, or undefined if both empty
+ */
+export function mergeIssues(
+  existing: ContextIssue[] | undefined,
+  newIssues: ContextIssue[] | undefined,
+): ContextIssue[] | undefined {
+  if (!existing && !newIssues) return undefined;
+  if (!existing) return newIssues;
+  if (!newIssues) return existing;
+
+  const map = new Map<number, ContextIssue>();
+  for (const issue of existing) map.set(issue.number, issue);
+  for (const issue of newIssues) map.set(issue.number, issue);
+  const merged = Array.from(map.values());
+  return merged.length > 0 ? merged : undefined;
 }
 
 /**

--- a/apps/mcp-server/src/mcp/handlers/context-document.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/context-document.handler.spec.ts
@@ -398,6 +398,114 @@ describe('ContextDocumentHandler', () => {
     });
   });
 
+  describe('issues tracking', () => {
+    const sampleIssues = [
+      {
+        number: 42,
+        title: 'Fix login bug',
+        url: 'https://github.com/org/repo/issues/42',
+        status: 'open',
+      },
+      {
+        number: 99,
+        title: 'Add search',
+        url: 'https://github.com/org/repo/issues/99',
+        status: 'closed',
+      },
+    ];
+
+    it('should pass issues to resetContext in PLAN mode', async () => {
+      await handler.handle('update_context', {
+        mode: 'PLAN',
+        title: 'Issue Test',
+        issues: sampleIssues,
+      });
+
+      expect(mockContextDocService.resetContext).toHaveBeenCalledWith(
+        expect.objectContaining({ issues: sampleIssues }),
+      );
+    });
+
+    it('should pass issues to appendContext in ACT mode', async () => {
+      await handler.handle('update_context', {
+        mode: 'ACT',
+        issues: sampleIssues,
+      });
+
+      expect(mockContextDocService.appendContext).toHaveBeenCalledWith(
+        expect.objectContaining({ issues: sampleIssues }),
+      );
+    });
+
+    it('should ignore non-array issues', async () => {
+      await handler.handle('update_context', {
+        mode: 'PLAN',
+        title: 'Bad Issues',
+        issues: 'not-an-array',
+      });
+
+      expect(mockContextDocService.resetContext).toHaveBeenCalledWith(
+        expect.objectContaining({ issues: undefined }),
+      );
+    });
+
+    it('should filter out invalid issue objects', async () => {
+      await handler.handle('update_context', {
+        mode: 'PLAN',
+        title: 'Mixed Issues',
+        issues: [
+          { number: 1, title: 'Valid', url: 'https://example.com/1', status: 'open' },
+          { number: 'bad', title: 'Invalid number' },
+          { title: 'Missing number', url: 'https://example.com/2', status: 'open' },
+        ],
+      });
+
+      expect(mockContextDocService.resetContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issues: [{ number: 1, title: 'Valid', url: 'https://example.com/1', status: 'open' }],
+        }),
+      );
+    });
+
+    it('should return undefined issues when all items are invalid', async () => {
+      await handler.handle('update_context', {
+        mode: 'PLAN',
+        title: 'All Bad',
+        issues: [{ bad: true }, 'string-item'],
+      });
+
+      expect(mockContextDocService.resetContext).toHaveBeenCalledWith(
+        expect.objectContaining({ issues: undefined }),
+      );
+    });
+
+    it('should include sessionIssues in read_context response', async () => {
+      const docWithIssues = {
+        exists: true,
+        document: {
+          metadata: mockReadResult.document.metadata,
+          sections: mockReadResult.document.sections,
+          issues: sampleIssues,
+        },
+      };
+      mockContextDocService.readContext = vi.fn().mockResolvedValue(docWithIssues);
+
+      const result = await handler.handle('read_context', {});
+
+      expect(result?.isError).toBeFalsy();
+      const responseData = JSON.parse(result!.content[0].text);
+      expect(responseData.summary.sessionIssues).toEqual(sampleIssues);
+    });
+
+    it('should return empty sessionIssues when no issues exist', async () => {
+      const result = await handler.handle('read_context', {});
+
+      expect(result?.isError).toBeFalsy();
+      const responseData = JSON.parse(result!.content[0].text);
+      expect(responseData.summary.sessionIssues).toEqual([]);
+    });
+  });
+
   describe('getToolDefinitions', () => {
     it('should return tool definitions', () => {
       const definitions = handler.getToolDefinitions();
@@ -420,6 +528,14 @@ describe('ContextDocumentHandler', () => {
       const definitions = handler.getToolDefinitions();
       const readContext = definitions.find(d => d.name === 'read_context');
       expect(readContext?.inputSchema.required).toEqual([]);
+    });
+
+    it('should include issues in update_context schema', () => {
+      const definitions = handler.getToolDefinitions();
+      const updateContext = definitions.find(d => d.name === 'update_context');
+      expect(updateContext?.inputSchema.properties.issues).toBeDefined();
+      const issuesProp = updateContext?.inputSchema.properties.issues as { type: string };
+      expect(issuesProp.type).toBe('array');
     });
 
     it('should include sessionId in update_context schema', () => {

--- a/apps/mcp-server/src/mcp/handlers/context-document.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/context-document.handler.ts
@@ -11,6 +11,7 @@ import {
   getSessionContextFilePath,
 } from '../../context/context-document.types';
 import type { Mode } from '../../keyword/keyword.types';
+import type { ContextIssue } from '../../context/context-document.types';
 import { isValidVerbosity, getVerbosityConfig } from '../../shared/verbosity.types';
 
 /**
@@ -137,6 +138,21 @@ Call this at the end of each mode to persist decisions and notes.`,
               enum: ['in_progress', 'completed', 'blocked'],
               description: 'Status of this mode section',
             },
+            issues: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  number: { type: 'number', description: 'GitHub issue number' },
+                  title: { type: 'string', description: 'Issue title' },
+                  url: { type: 'string', description: 'Issue URL' },
+                  status: { type: 'string', description: 'Issue status (open, closed)' },
+                },
+                required: ['number', 'title', 'url', 'status'],
+              },
+              description:
+                'Issues created/referenced during session. Persists across PLAN→ACT→EVAL modes.',
+            },
             sessionId: {
               type: 'string',
               description:
@@ -197,6 +213,35 @@ Call this at the end of each mode to persist decisions and notes.`,
    */
   private getFilePath(sessionId?: string): string {
     return sessionId ? getSessionContextFilePath(sessionId) : CONTEXT_FILE_PATH;
+  }
+
+  /**
+   * Extract and validate issues from args.
+   * Filters out items that don't match the ContextIssue shape.
+   */
+  private extractIssues(args: Record<string, unknown> | undefined): ContextIssue[] | undefined {
+    if (!Array.isArray(args?.issues)) return undefined;
+
+    const issues: ContextIssue[] = [];
+    for (const item of args.issues) {
+      if (
+        typeof item === 'object' &&
+        item !== null &&
+        typeof (item as Record<string, unknown>).number === 'number' &&
+        typeof (item as Record<string, unknown>).title === 'string' &&
+        typeof (item as Record<string, unknown>).url === 'string' &&
+        typeof (item as Record<string, unknown>).status === 'string'
+      ) {
+        issues.push({
+          number: (item as Record<string, unknown>).number as number,
+          title: (item as Record<string, unknown>).title as string,
+          url: (item as Record<string, unknown>).url as string,
+          status: (item as Record<string, unknown>).status as string,
+        });
+      }
+    }
+
+    return issues.length > 0 ? issues : undefined;
   }
 
   private async handleReadContext(
@@ -269,6 +314,7 @@ Call this at the end of each mode to persist decisions and notes.`,
           : null,
         allDecisions,
         allNotes,
+        sessionIssues: document.issues || [],
       },
     });
   }
@@ -292,6 +338,9 @@ Call this at the end of each mode to persist decisions and notes.`,
     const typedMode = mode as Mode;
     const filePath = this.getFilePath(sessionId);
 
+    // Extract validated issues
+    const issues = this.extractIssues(args);
+
     // For PLAN mode, title is required
     if (typedMode === 'PLAN') {
       const title = extractOptionalString(args, 'title') || 'Untitled Task';
@@ -306,6 +355,7 @@ Call this at the end of each mode to persist decisions and notes.`,
             : undefined,
         decisions: Array.isArray(args?.decisions) ? (args.decisions as string[]) : undefined,
         notes: Array.isArray(args?.notes) ? (args.notes as string[]) : undefined,
+        issues,
         sessionId,
       });
 
@@ -341,6 +391,7 @@ Call this at the end of each mode to persist decisions and notes.`,
       status:
         (extractOptionalString(args, 'status') as 'in_progress' | 'completed' | 'blocked') ??
         undefined,
+      issues,
       sessionId,
     });
 


### PR DESCRIPTION
## Summary
- Add `issues` field to `update_context` tool: array of `{number, title, url, status}`
- Issues persist across PLAN→ACT→EVAL modes (not reset on mode change)
- Issues deduplicated by number on merge
- `read_context` response includes `sessionIssues` in summary
- 8 new tests covering validation, persistence, and response format

## Changed Files
- `context-document.types.ts` — `ContextIssue` interface, updated `ContextDocument`/`ResetContextData`/`AppendContextData`
- `context-document.handler.ts` — Schema, extraction/validation, `sessionIssues` response
- `context-document.service.ts` — Preserve issues on PLAN reset, merge on append
- `context-serializer.utils.ts` — `mergeIssues()` utility, issues serialization
- `context-parser.utils.ts` — Issues parsing from markdown
- `context-document.handler.spec.ts` — 8 new tests

## Test plan
- [x] All 4912 tests pass (0 regressions)
- [x] Lint, format, typecheck, circular, build all pass
- [x] Issues passed to service in PLAN and ACT modes
- [x] Invalid issues filtered out gracefully
- [x] sessionIssues included in read_context response
- [x] Empty sessionIssues returned when no issues exist
- [x] Schema includes issues property

Closes #842