### PR TITLE
feat(mcp): add real-time specialist execution visibility via Teams messaging

### DIFF
--- a/apps/mcp-server/src/agent/agent.types.ts
+++ b/apps/mcp-server/src/agent/agent.types.ts
@@ -111,6 +111,25 @@ export interface TeamsDispatch {
 }
 
 /**
+ * SendMessage-based progress reporting instructions for specialist visibility
+ */
+export interface VisibilityMessages {
+  onStart: string;
+  onFinding: string;
+  onComplete: string;
+}
+
+/**
+ * Configuration for real-time specialist execution visibility via Teams messaging
+ */
+export interface VisibilityConfig {
+  reportTo: string;
+  format: string;
+  includeProgress: boolean;
+  messages?: VisibilityMessages;
+}
+
+/**
  * Result of dispatching agents for execution
  */
 export interface DispatchResult {
@@ -125,6 +144,8 @@ export interface DispatchResult {
   teams?: TeamsDispatch;
   /** Execution strategy used for this dispatch */
   executionStrategy?: string;
+  /** Real-time specialist execution visibility configuration */
+  visibility?: VisibilityConfig;
 }
 
 /**

--- a/apps/mcp-server/src/mcp/handlers/agent.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/agent.handler.spec.ts
@@ -537,6 +537,112 @@ describe('AgentHandler', () => {
           );
         });
       });
+
+      describe('visibility field', () => {
+        it('should include visibility in dispatch response', async () => {
+          const dispatchResultWithVisibility = {
+            ...mockDispatchResult,
+            visibility: {
+              reportTo: 'team-lead',
+              format: 'structured',
+              includeProgress: true,
+            },
+          };
+          mockAgentService.dispatchAgents = vi.fn().mockResolvedValue(dispatchResultWithVisibility);
+
+          const result = await handler.handle('dispatch_agents', {
+            mode: 'EVAL',
+            primaryAgent: 'security-specialist',
+          });
+
+          expect(result?.isError).toBeFalsy();
+          const content = JSON.parse(result?.content[0]?.text as string);
+          expect(content.visibility).toBeDefined();
+          expect(content.visibility.reportTo).toBe('team-lead');
+          expect(content.visibility.format).toBe('structured');
+          expect(content.visibility.includeProgress).toBe(true);
+        });
+
+        it('should add visibility with SendMessage instructions when specialists are dispatched', async () => {
+          const resultWithSpecialists = {
+            primaryAgent: mockDispatchResult.primaryAgent,
+            parallelAgents: [
+              {
+                name: 'accessibility-specialist',
+                displayName: 'Accessibility Specialist',
+                description: 'Accessibility review',
+                dispatchParams: {
+                  subagent_type: 'general-purpose' as const,
+                  prompt: 'You are an accessibility specialist...',
+                  description: 'Accessibility review',
+                  run_in_background: true as const,
+                },
+              },
+            ],
+            executionHint: 'Use Task tool...',
+          };
+          mockAgentService.dispatchAgents = vi.fn().mockResolvedValue(resultWithSpecialists);
+
+          const result = await handler.handle('dispatch_agents', {
+            mode: 'EVAL',
+            primaryAgent: 'security-specialist',
+            specialists: ['accessibility-specialist'],
+            includeParallel: true,
+          });
+
+          expect(result?.isError).toBeFalsy();
+          const content = JSON.parse(result?.content[0]?.text as string);
+          expect(content.visibility).toBeDefined();
+          expect(content.visibility.reportTo).toBe('team-lead');
+          expect(content.visibility.format).toBe('structured');
+          expect(content.visibility.includeProgress).toBe(true);
+        });
+
+        it('should include visibility with messaging instructions for each specialist', async () => {
+          const resultWithVisibility = {
+            ...mockDispatchResult,
+            visibility: {
+              reportTo: 'team-lead',
+              format: 'structured',
+              includeProgress: true,
+              messages: {
+                onStart: 'Report start via SendMessage to team-lead',
+                onFinding: 'Report each finding via SendMessage to team-lead',
+                onComplete: 'Report completion summary via SendMessage to team-lead',
+              },
+            },
+          };
+          mockAgentService.dispatchAgents = vi.fn().mockResolvedValue(resultWithVisibility);
+
+          const result = await handler.handle('dispatch_agents', {
+            mode: 'EVAL',
+            primaryAgent: 'security-specialist',
+          });
+
+          expect(result?.isError).toBeFalsy();
+          const content = JSON.parse(result?.content[0]?.text as string);
+          expect(content.visibility.messages).toBeDefined();
+          expect(content.visibility.messages.onStart).toContain('SendMessage');
+          expect(content.visibility.messages.onFinding).toContain('SendMessage');
+          expect(content.visibility.messages.onComplete).toContain('SendMessage');
+        });
+
+        it('should include visibility even when no specialists are dispatched', async () => {
+          const resultMinimal = {
+            executionHint: 'Use Task tool...',
+          };
+          mockAgentService.dispatchAgents = vi.fn().mockResolvedValue(resultMinimal);
+
+          const result = await handler.handle('dispatch_agents', {
+            mode: 'EVAL',
+          });
+
+          expect(result?.isError).toBeFalsy();
+          const content = JSON.parse(result?.content[0]?.text as string);
+          expect(content.visibility).toBeDefined();
+          expect(content.visibility.reportTo).toBe('team-lead');
+        });
+      });
     });
   });
 

--- a/apps/mcp-server/src/mcp/handlers/agent.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/agent.handler.ts
@@ -201,6 +201,24 @@ export class AgentHandler extends AbstractHandler {
         includeParallel,
         executionStrategy,
       });
+
+      // Ensure visibility is always present for real-time specialist execution tracking
+      if (!result.visibility) {
+        result.visibility = {
+          reportTo: 'team-lead',
+          format: 'structured',
+          includeProgress: true,
+          messages: {
+            onStart:
+              'Report start via SendMessage to team-lead with specialist name and task scope',
+            onFinding:
+              'Report each finding via SendMessage to team-lead with severity and description',
+            onComplete:
+              'Report completion summary via SendMessage to team-lead with total findings count',
+          },
+        };
+      }
+
       return createJsonResponse(result);
     } catch (error) {
       return createErrorResponse(


### PR DESCRIPTION
## Summary
- Add `VisibilityConfig` and `VisibilityMessages` types to `agent.types.ts`
- Add `visibility` field to `DispatchResult` interface for SendMessage-based progress reporting
- `AgentHandler.handleDispatchAgents` injects default visibility config (reportTo, format, includeProgress, messages) when service doesn't provide one
- Each specialist reports: start, findings, completion via structured SendMessage to team-lead
- 4 new tests covering visibility field behavior in `agent.handler.spec.ts`

## Test plan
- [x] All 4922 existing tests pass
- [x] 4 new visibility tests pass (service-provided visibility, handler-injected visibility, messaging instructions, minimal dispatch)
- [x] lint, format, typecheck, coverage, circular, build all pass

Closes #810