### PR TITLE
feat(mcp): unified agent registry in dispatch_agents

### DIFF
--- a/apps/mcp-server/src/agent/agent.module.ts
+++ b/apps/mcp-server/src/agent/agent.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AgentService } from './agent.service';
 import { RulesModule } from '../rules/rules.module';
+import { CustomModule } from '../custom';
+import { CodingBuddyConfigModule } from '../config/config.module';
 
 @Module({
-  imports: [RulesModule],
+  imports: [RulesModule, CustomModule, CodingBuddyConfigModule],
   providers: [AgentService],
   exports: [AgentService],
 })

--- a/apps/mcp-server/src/agent/agent.service.spec.ts
+++ b/apps/mcp-server/src/agent/agent.service.spec.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AgentService } from './agent.service';
 import type { RulesService } from '../rules/rules.service';
+import type { CustomService } from '../custom';
+import type { ConfigService } from '../config/config.service';
 import type { AgentProfile } from '../rules/rules.types';
 import type { AgentContext, DispatchResult } from './agent.types';
 
 describe('AgentService', () => {
   let service: AgentService;
   let mockRulesService: Partial<RulesService>;
+  let mockCustomService: Partial<CustomService>;
+  let mockConfigService: Partial<ConfigService>;
 
   const mockSecurityAgent: AgentProfile = {
     name: 'Security Specialist',
@@ -42,8 +46,18 @@ describe('AgentService', () => {
     mockRulesService = {
       getAgent: vi.fn(),
     };
+    mockCustomService = {
+      listCustomAgents: vi.fn().mockResolvedValue([]),
+    };
+    mockConfigService = {
+      getProjectRoot: vi.fn().mockReturnValue('/test/project'),
+    };
 
-    service = new AgentService(mockRulesService as RulesService);
+    service = new AgentService(
+      mockRulesService as RulesService,
+      mockCustomService as CustomService,
+      mockConfigService as ConfigService,
+    );
   });
 
   describe('getAgentSystemPrompt', () => {

--- a/apps/mcp-server/src/agent/agent.service.ts
+++ b/apps/mcp-server/src/agent/agent.service.ts
@@ -1,9 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { RulesService } from '../rules/rules.service';
+import { CustomService } from '../custom';
+import { ConfigService } from '../config/config.service';
 import type { Mode } from '../keyword/keyword.types';
+import type { AgentProfile } from '../rules/rules.types';
 import type {
   AgentContext,
   AgentSystemPrompt,
+  InlineAgentDefinition,
   ParallelAgentSet,
   PreparedAgent,
   FailedAgent,
@@ -27,13 +31,21 @@ import { getVerbosityConfig } from '../shared/verbosity.types';
 export class AgentService {
   private readonly logger = new Logger(AgentService.name);
 
-  constructor(private readonly rulesService: RulesService) {}
+  constructor(
+    private readonly rulesService: RulesService,
+    private readonly customService: CustomService,
+    private readonly configService: ConfigService,
+  ) {}
 
   /**
    * Get complete system prompt for a single agent to be executed as subagent
    */
-  async getAgentSystemPrompt(agentName: string, context: AgentContext): Promise<AgentSystemPrompt> {
-    const agentProfile = await this.rulesService.getAgent(agentName);
+  async getAgentSystemPrompt(
+    agentName: string,
+    context: AgentContext,
+    inlineAgents?: Record<string, InlineAgentDefinition>,
+  ): Promise<AgentSystemPrompt> {
+    const agentProfile = await this.resolveAgent(agentName, inlineAgents);
 
     const systemPrompt = buildAgentSystemPrompt(agentProfile, context);
     const description = buildTaskDescription(agentProfile, context);
@@ -61,6 +73,7 @@ export class AgentService {
     targetFiles?: string[],
     sharedContext?: string,
     verbosity?: VerbosityLevel,
+    inlineAgents?: Record<string, InlineAgentDefinition>,
   ): Promise<ParallelAgentSet> {
     const uniqueSpecialists = Array.from(new Set(specialists));
     const context: AgentContext = {
@@ -75,6 +88,7 @@ export class AgentService {
       uniqueSpecialists,
       context,
       verbosityConfig.includeAgentPrompt,
+      inlineAgents,
     );
 
     return this.buildParallelAgentSet(agents, failedAgents);
@@ -84,9 +98,10 @@ export class AgentService {
     specialists: string[],
     context: AgentContext,
     includeFullPrompt: boolean,
+    inlineAgents?: Record<string, InlineAgentDefinition>,
   ): Promise<{ agents: PreparedAgent[]; failedAgents: FailedAgent[] }> {
     const results = await Promise.all(
-      specialists.map(name => this.tryLoadAgent(name, context, includeFullPrompt)),
+      specialists.map(name => this.tryLoadAgent(name, context, includeFullPrompt, inlineAgents)),
     );
 
     const agents: PreparedAgent[] = [];
@@ -116,9 +131,10 @@ export class AgentService {
     specialistName: string,
     context: AgentContext,
     includeFullPrompt: boolean,
+    inlineAgents?: Record<string, InlineAgentDefinition>,
   ): Promise<{ success: true; agent: PreparedAgent } | { success: false; error: FailedAgent }> {
     try {
-      const profile = await this.rulesService.getAgent(specialistName);
+      const profile = await this.resolveAgent(specialistName, inlineAgents);
       const agent: PreparedAgent = {
         id: specialistName,
         displayName: profile.name,
@@ -206,7 +222,11 @@ export class AgentService {
     // Dispatch primary agent
     if (input.primaryAgent) {
       try {
-        const agentPrompt = await this.getAgentSystemPrompt(input.primaryAgent, context);
+        const agentPrompt = await this.getAgentSystemPrompt(
+          input.primaryAgent,
+          context,
+          input.inlineAgents,
+        );
         result.primaryAgent = {
           name: input.primaryAgent,
           displayName: agentPrompt.displayName,
@@ -227,7 +247,12 @@ export class AgentService {
     // Dispatch taskmaestro strategy
     if (input.executionStrategy === 'taskmaestro' && input.specialists?.length) {
       const uniqueSpecialists = Array.from(new Set(input.specialists));
-      const { agents, failedAgents } = await this.loadAgents(uniqueSpecialists, context, true);
+      const { agents, failedAgents } = await this.loadAgents(
+        uniqueSpecialists,
+        context,
+        true,
+        input.inlineAgents,
+      );
 
       const assignments: TaskmaestroAssignment[] = agents.map(agent => ({
         name: agent.id,
@@ -252,7 +277,12 @@ export class AgentService {
     if (input.executionStrategy === 'teams' && input.specialists?.length) {
       const uniqueSpecialists = Array.from(new Set(input.specialists));
       const teamName = `${(input.mode ?? 'eval').toLowerCase()}-specialists`;
-      const { agents, failedAgents } = await this.loadAgents(uniqueSpecialists, context, true);
+      const { agents, failedAgents } = await this.loadAgents(
+        uniqueSpecialists,
+        context,
+        true,
+        input.inlineAgents,
+      );
 
       const teammates: TeamsTeammate[] = agents.map(agent => ({
         name: agent.id,
@@ -281,6 +311,7 @@ export class AgentService {
         uniqueSpecialists,
         context,
         true, // always include full prompt for dispatch
+        input.inlineAgents,
       );
 
       result.parallelAgents = agents.map(
@@ -342,5 +373,50 @@ When done, provide a summary of all findings.`;
 4. Monitor via TaskList — teammates coordinate via shared task list
 5. Collect results when all teammates go idle
 6. Shutdown teammates via SendMessage with shutdown_request`;
+  }
+
+  /**
+   * Resolve an agent by name using the unified registry.
+   * Resolution order: inline > custom local > primary (override chain).
+   */
+  async resolveAgent(
+    agentName: string,
+    inlineAgents?: Record<string, InlineAgentDefinition>,
+  ): Promise<AgentProfile> {
+    // 1. Highest priority: inline agent definitions
+    if (inlineAgents?.[agentName]) {
+      const inline = inlineAgents[agentName];
+      this.logger.debug(`Resolved agent '${agentName}' from inline definition`);
+      return {
+        name: inline.name,
+        description: inline.description,
+        role: inline.role,
+        communication: inline.communication,
+        source: 'custom',
+      };
+    }
+
+    // 2. Medium priority: custom local agents (.codingbuddy/agents/)
+    try {
+      const projectRoot = this.configService.getProjectRoot();
+      const customAgents = await this.customService.listCustomAgents(projectRoot);
+      const customAgent = customAgents.find(a => a.name === `${agentName}.json`);
+      if (customAgent) {
+        this.logger.debug(`Resolved agent '${agentName}' from custom local`);
+        return {
+          name: customAgent.parsed.name,
+          description: customAgent.parsed.description,
+          role: customAgent.parsed.role,
+          source: 'custom',
+        };
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Failed to check custom agents for '${agentName}': ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+
+    // 3. Lowest priority: primary agents (packages/rules/.ai-rules/agents/)
+    return this.rulesService.getAgent(agentName);
   }
 }

--- a/apps/mcp-server/src/agent/agent.types.ts
+++ b/apps/mcp-server/src/agent/agent.types.ts
@@ -149,6 +149,26 @@ export interface DispatchResult {
 }
 
 /**
+ * Inline agent definition passed directly in dispatch params.
+ * Compatible with AgentProfile for unified resolution.
+ */
+export interface InlineAgentDefinition {
+  name: string;
+  description: string;
+  role: {
+    title: string;
+    expertise: string[];
+    responsibilities?: string[];
+  };
+  communication?: {
+    language?: string;
+    style?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/**
  * Input parameters for the dispatch_agents tool
  */
 export interface DispatchAgentsInput {
@@ -160,6 +180,8 @@ export interface DispatchAgentsInput {
   primaryAgent?: string;
   /** Execution strategy: 'subagent' (default), 'taskmaestro', or 'teams' */
   executionStrategy?: 'subagent' | 'taskmaestro' | 'teams';
+  /** Inline agent definitions keyed by agent ID, highest priority in resolution */
+  inlineAgents?: Record<string, InlineAgentDefinition>;
 }
 
 /**

--- a/apps/mcp-server/src/mcp/handlers/agent.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/agent.handler.spec.ts
@@ -42,6 +42,7 @@ describe('AgentHandler', () => {
         expect(mockAgentService.getAgentSystemPrompt).toHaveBeenCalledWith(
           'security-specialist',
           expect.objectContaining({ mode: 'EVAL' }),
+          undefined,
         );
       });
 
@@ -110,6 +111,7 @@ describe('AgentHandler', () => {
             targetFiles: ['src/app.ts'],
             taskDescription: 'Review security',
           }),
+          undefined,
         );
       });
 
@@ -181,6 +183,7 @@ describe('AgentHandler', () => {
           undefined,
           undefined,
           undefined,
+          undefined,
         );
       });
 
@@ -245,6 +248,7 @@ describe('AgentHandler', () => {
           ['src/app.ts'],
           'Review code',
           undefined,
+          undefined,
         );
       });
 
@@ -279,6 +283,7 @@ describe('AgentHandler', () => {
           undefined,
           undefined,
           'minimal',
+          undefined,
         );
       });
 
@@ -296,6 +301,7 @@ describe('AgentHandler', () => {
           undefined,
           undefined,
           'standard',
+          undefined,
         );
       });
 
@@ -309,6 +315,7 @@ describe('AgentHandler', () => {
         expect(mockAgentService.prepareParallelAgents).toHaveBeenCalledWith(
           'EVAL',
           ['security-specialist'],
+          undefined,
           undefined,
           undefined,
           undefined,
@@ -331,6 +338,7 @@ describe('AgentHandler', () => {
           ['src/app.ts'],
           'Review code',
           'full',
+          undefined,
         );
       });
     });
@@ -680,6 +688,181 @@ describe('AgentHandler', () => {
 
       const dispatchAgents = definitions.find(d => d.name === 'dispatch_agents');
       expect(dispatchAgents?.inputSchema.required).toEqual(['mode']);
+    });
+
+    it('should include inlineAgents in dispatch_agents schema', () => {
+      const definitions = handler.getToolDefinitions();
+      const dispatchAgents = definitions.find(d => d.name === 'dispatch_agents');
+      const properties = dispatchAgents?.inputSchema.properties as Record<string, unknown>;
+      expect(properties).toHaveProperty('inlineAgents');
+    });
+  });
+
+  describe('unified agent registry (inlineAgents)', () => {
+    const inlineAgent = {
+      name: 'My Custom Agent',
+      description: 'A custom inline agent',
+      role: {
+        title: 'Custom Specialist',
+        expertise: ['custom-domain'],
+      },
+    };
+
+    const mockDispatchResult = {
+      primaryAgent: {
+        name: 'my-inline-agent',
+        displayName: 'My Custom Agent',
+        description: 'A custom inline agent',
+        dispatchParams: {
+          subagent_type: 'general-purpose' as const,
+          prompt: 'You are a custom specialist...',
+          description: 'A custom inline agent',
+        },
+      },
+      executionHint: 'Use Task tool...',
+    };
+
+    beforeEach(() => {
+      mockAgentService.dispatchAgents = vi.fn().mockResolvedValue(mockDispatchResult);
+    });
+
+    describe('dispatch_agents with inlineAgents', () => {
+      it('should pass inlineAgents to service', async () => {
+        const inlineAgents = { 'my-inline-agent': inlineAgent };
+
+        await handler.handle('dispatch_agents', {
+          mode: 'EVAL',
+          primaryAgent: 'my-inline-agent',
+          inlineAgents,
+        });
+
+        expect(mockAgentService.dispatchAgents).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mode: 'EVAL',
+            primaryAgent: 'my-inline-agent',
+            inlineAgents,
+          }),
+        );
+      });
+
+      it('should work without inlineAgents (backwards compatible)', async () => {
+        await handler.handle('dispatch_agents', {
+          mode: 'EVAL',
+          primaryAgent: 'security-specialist',
+        });
+
+        expect(mockAgentService.dispatchAgents).toHaveBeenCalledWith(
+          expect.objectContaining({
+            mode: 'EVAL',
+            primaryAgent: 'security-specialist',
+          }),
+        );
+
+        const callArgs = (mockAgentService.dispatchAgents as ReturnType<typeof vi.fn>).mock
+          .calls[0][0];
+        expect(callArgs.inlineAgents).toBeUndefined();
+      });
+
+      it('should pass inlineAgents with multiple agents', async () => {
+        const multipleInline = {
+          'agent-a': inlineAgent,
+          'agent-b': { ...inlineAgent, name: 'Agent B', description: 'Second agent' },
+        };
+
+        await handler.handle('dispatch_agents', {
+          mode: 'PLAN',
+          primaryAgent: 'agent-a',
+          specialists: ['agent-b'],
+          inlineAgents: multipleInline,
+          includeParallel: true,
+        });
+
+        expect(mockAgentService.dispatchAgents).toHaveBeenCalledWith(
+          expect.objectContaining({
+            inlineAgents: multipleInline,
+          }),
+        );
+      });
+
+      it('should ignore non-object inlineAgents', async () => {
+        await handler.handle('dispatch_agents', {
+          mode: 'EVAL',
+          primaryAgent: 'security-specialist',
+          inlineAgents: 'not-an-object',
+        });
+
+        const callArgs = (mockAgentService.dispatchAgents as ReturnType<typeof vi.fn>).mock
+          .calls[0][0];
+        expect(callArgs.inlineAgents).toBeUndefined();
+      });
+    });
+
+    describe('get_agent_system_prompt with inlineAgents', () => {
+      it('should pass inlineAgents to service', async () => {
+        const inlineAgents = { 'my-inline-agent': inlineAgent };
+
+        await handler.handle('get_agent_system_prompt', {
+          agentName: 'my-inline-agent',
+          context: { mode: 'EVAL' },
+          inlineAgents,
+        });
+
+        expect(mockAgentService.getAgentSystemPrompt).toHaveBeenCalledWith(
+          'my-inline-agent',
+          expect.objectContaining({ mode: 'EVAL' }),
+          inlineAgents,
+        );
+      });
+
+      it('should work without inlineAgents (backwards compatible)', async () => {
+        await handler.handle('get_agent_system_prompt', {
+          agentName: 'security-specialist',
+          context: { mode: 'EVAL' },
+        });
+
+        expect(mockAgentService.getAgentSystemPrompt).toHaveBeenCalledWith(
+          'security-specialist',
+          expect.objectContaining({ mode: 'EVAL' }),
+          undefined,
+        );
+      });
+    });
+
+    describe('prepare_parallel_agents with inlineAgents', () => {
+      it('should pass inlineAgents to service', async () => {
+        const inlineAgents = { 'my-inline-agent': inlineAgent };
+
+        await handler.handle('prepare_parallel_agents', {
+          mode: 'EVAL',
+          specialists: ['my-inline-agent'],
+          inlineAgents,
+        });
+
+        expect(mockAgentService.prepareParallelAgents).toHaveBeenCalledWith(
+          'EVAL',
+          ['my-inline-agent'],
+          undefined,
+          undefined,
+          undefined,
+          inlineAgents,
+        );
+      });
+
+      it('should work without inlineAgents (backwards compatible)', async () => {
+        await handler.handle('prepare_parallel_agents', {
+          mode: 'EVAL',
+          specialists: ['security-specialist'],
+        });
+
+        expect(mockAgentService.prepareParallelAgents).toHaveBeenCalledWith(
+          'EVAL',
+          ['security-specialist'],
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+        );
+      });
     });
   });
 });

--- a/apps/mcp-server/src/mcp/handlers/agent.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/agent.handler.ts
@@ -3,6 +3,7 @@ import type { ToolDefinition } from './base.handler';
 import type { ToolResponse } from '../response.utils';
 import { AbstractHandler } from './abstract-handler';
 import { AgentService } from '../../agent/agent.service';
+import type { InlineAgentDefinition } from '../../agent/agent.types';
 import type { Mode } from '../../keyword/keyword.types';
 import { isValidVerbosity } from '../../shared/verbosity.types';
 import { createJsonResponse, createErrorResponse } from '../response.utils';
@@ -164,6 +165,27 @@ export class AgentHandler extends AbstractHandler {
               description:
                 'Execution strategy for specialist agents. "subagent" (default) uses Claude Code Agent tool with run_in_background. "taskmaestro" returns tmux pane assignments for /taskmaestro skill. "teams" uses Claude Code native teams with shared TaskList coordination.',
             },
+            inlineAgents: {
+              type: 'object',
+              description:
+                'Inline agent definitions keyed by agent ID. These take highest priority in resolution (inline > custom local > primary). Each value must have name, description, and role fields.',
+              additionalProperties: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  description: { type: 'string' },
+                  role: {
+                    type: 'object',
+                    properties: {
+                      title: { type: 'string' },
+                      expertise: { type: 'array', items: { type: 'string' } },
+                    },
+                    required: ['title', 'expertise'],
+                  },
+                },
+                required: ['name', 'description', 'role'],
+              },
+            },
           },
           required: ['mode'],
         },
@@ -190,6 +212,7 @@ export class AgentHandler extends AbstractHandler {
     const includeParallel = args?.includeParallel === true;
     const executionStrategy =
       (args?.executionStrategy as 'subagent' | 'taskmaestro' | 'teams' | undefined) ?? 'subagent';
+    const inlineAgents = this.extractInlineAgents(args);
 
     try {
       const result = await this.agentService.dispatchAgents({
@@ -200,6 +223,7 @@ export class AgentHandler extends AbstractHandler {
         taskDescription,
         includeParallel,
         executionStrategy,
+        inlineAgents,
       });
 
       // Ensure visibility is always present for real-time specialist execution tracking
@@ -254,13 +278,18 @@ export class AgentHandler extends AbstractHandler {
 
     const targetFiles = extractStringArray(context, 'targetFiles');
     const taskDescription = extractOptionalString(context, 'taskDescription');
+    const inlineAgents = this.extractInlineAgents(args);
 
     try {
-      const result = await this.agentService.getAgentSystemPrompt(agentName, {
-        mode: mode as Mode,
-        targetFiles,
-        taskDescription,
-      });
+      const result = await this.agentService.getAgentSystemPrompt(
+        agentName,
+        {
+          mode: mode as Mode,
+          targetFiles,
+          taskDescription,
+        },
+        inlineAgents,
+      );
       return createJsonResponse(result);
     } catch (error) {
       return createErrorResponse(
@@ -295,6 +324,7 @@ export class AgentHandler extends AbstractHandler {
         : isValidVerbosity(verbosityStr)
           ? verbosityStr
           : 'standard';
+    const inlineAgents = this.extractInlineAgents(args);
 
     try {
       const result = await this.agentService.prepareParallelAgents(
@@ -303,6 +333,7 @@ export class AgentHandler extends AbstractHandler {
         targetFiles,
         sharedContext,
         verbosity,
+        inlineAgents,
       );
       return createJsonResponse(result);
     } catch (error) {
@@ -310,5 +341,17 @@ export class AgentHandler extends AbstractHandler {
         `Failed to prepare parallel agents: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
     }
+  }
+
+  /**
+   * Extract and validate inlineAgents from tool args.
+   * Returns undefined if not present or not a valid object.
+   */
+  private extractInlineAgents(
+    args: Record<string, unknown> | undefined,
+  ): Record<string, InlineAgentDefinition> | undefined {
+    const raw = args?.inlineAgents;
+    if (!isRecordObject(raw)) return undefined;
+    return raw as Record<string, InlineAgentDefinition>;
   }
 }

--- a/apps/mcp-server/src/mcp/mcp.service.spec.ts
+++ b/apps/mcp-server/src/mcp/mcp.service.spec.ts
@@ -2315,9 +2315,11 @@ describe('McpService', () => {
         expect(parsed.displayName).toBe('Security Specialist');
         expect(parsed.systemPrompt).toContain('Security Specialist');
         expect(parsed.description).toBeDefined();
-        expect(mockAgentService.getAgentSystemPrompt).toHaveBeenCalledWith('security-specialist', {
-          mode: 'PLAN',
-        });
+        expect(mockAgentService.getAgentSystemPrompt).toHaveBeenCalledWith(
+          'security-specialist',
+          { mode: 'PLAN' },
+          undefined,
+        );
       });
 
       it('should pass targetFiles and taskDescription to service', async () => {
@@ -2345,6 +2347,7 @@ describe('McpService', () => {
             targetFiles: ['src/components/Button.tsx'],
             taskDescription: 'Review component accessibility',
           },
+          undefined,
         );
       });
     });
@@ -2501,6 +2504,7 @@ describe('McpService', () => {
           undefined,
           undefined,
           undefined,
+          undefined,
         );
       });
 
@@ -2525,6 +2529,7 @@ describe('McpService', () => {
           ['security-specialist'],
           ['src/api/auth.ts', 'src/api/login.ts'],
           'Review authentication implementation',
+          undefined,
           undefined,
         );
       });


### PR DESCRIPTION
## Summary
- Add unified agent registry to `dispatch_agents` supporting 3 agent sources with override chain: **inline > custom local > primary**
- Add `InlineAgentDefinition` type and `inlineAgents` parameter to `dispatch_agents`, `get_agent_system_prompt`, and `prepare_parallel_agents`
- Implement `resolveAgent` method in `AgentService` that checks inline definitions first, then `.codingbuddy/agents/` custom local agents, then falls back to primary builtin agents
- Inject `CustomService` and `ConfigService` into `AgentService` via `AgentModule`
- Full backwards compatibility maintained — all existing tests pass unchanged

## Test plan
- [x] TDD: 7 new tests for inlineAgents passthrough and backwards compatibility
- [x] All 4947 tests pass (177 test files)
- [x] Build succeeds
- [x] Lint, format, typecheck, circular checks pass
- [x] Coverage maintained

Closes #811