### PR TITLE
fix(rules): encode status verification rules into parallel-orchestrator and taskMaestro

### DIFF
--- a/.claude/skills/taskmaestro/SKILL.md
+++ b/.claude/skills/taskmaestro/SKILL.md
@@ -440,6 +440,9 @@ create_worktrees() {
     local wt_dir="${WORKTREE_BASE}/wt-${i}"
     local branch="taskmaestro/$(date +%s)/pane-${i}"
     git worktree add "$wt_dir" -b "$branch" master
+
+    # Artifact cleanup: remove ephemeral files that may exist from previous runs
+    rm -f "${wt_dir}/RESULT.json" "${wt_dir}/TASK.md"
   done
 }
 ```
@@ -508,7 +511,9 @@ assign_tasks() {
   for i in "${!issues[@]}"; do
     local pane="${SESSION}:0.${i}"
     local issue="${issues[$i]}"
-    local prompt="AUTO: Issue #${issue} 구현"
+
+    # Worker prompt includes git add safety rules and artifact commit ban
+    local prompt="Read the file TASK.md in this directory carefully and execute ALL instructions exactly as written. Follow codingbuddy PLAN→ACT→EVAL. Run 'yarn install' first if node_modules missing. NEVER use 'git add -A' — always stage specific files. If errors occur, diagnose and fix yourself. Use /ship to create PR, then write RESULT.json. Start now."
 
     # Verify pane is ready before sending
     if ! tmux capture-pane -t "$pane" -p | grep -qE "$PROMPT_PATTERN"; then
@@ -617,25 +622,75 @@ status_check() {
 
   for pane in $panes; do
     local target="${SESSION}:0.${pane}"
-    local content
-    content=$(tmux capture-pane -t "$target" -p 2>/dev/null | tail -5)
-
-    local state="unknown"
-    if echo "$content" | grep -qE "$PROMPT_PATTERN"; then
-      state="idle"
-    elif echo "$content" | grep -qiE 'error|fail'; then
-      state="error"
-    else
-      state="working"
-    fi
-
     local wt_dir="${WORKTREE_BASE}/wt-$((pane + 1))"
     local branch="none"
     if [ -d "$wt_dir" ]; then
       branch=$(git -C "$wt_dir" branch --show-current 2>/dev/null || echo "detached")
     fi
 
-    echo "pane-${pane}: ${state} | branch: ${branch}"
+    # --- 3-Factor Analysis (30-line scan) ---
+    local content
+    content=$(tmux capture-pane -t "$target" -p 2>/dev/null | tail -30)
+
+    # Factor 1: Error scan (30 lines, not 8)
+    local has_error=false
+    if echo "$content" | grep -qiE 'error|fail|exception|panic|FATAL'; then
+      has_error=true
+    fi
+
+    # Factor 2: Active spinner detection (animating characters)
+    local has_active_spinner=false
+    if echo "$content" | grep -qE '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]'; then
+      has_active_spinner=true
+    fi
+
+    # Factor 3: Completed spinner detection (static ✓ or ✗)
+    local has_completed_spinner=false
+    if echo "$content" | grep -qE '[✓✗✔✘]'; then
+      has_completed_spinner=true
+    fi
+
+    # Determine state from 3 factors
+    local state="unknown"
+    if echo "$content" | grep -qE "$PROMPT_PATTERN"; then
+      state="idle"
+    elif [ "$has_error" = true ] && [ "$has_active_spinner" = false ]; then
+      state="error"
+    elif [ "$has_error" = true ] && [ "$has_active_spinner" = true ]; then
+      state="stuck (errors + thinking)"
+    elif [ "$has_active_spinner" = true ]; then
+      state="working"
+    elif [ "$has_completed_spinner" = true ]; then
+      state="step-complete"
+    else
+      state="unknown"
+    fi
+
+    # --- RESULT.json Validation ---
+    local result_status=""
+    local result_file="${wt_dir}/RESULT.json"
+    if [ -f "$result_file" ]; then
+      local result_issue
+      result_issue=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${result_file}','utf8')).issue||'')}catch(e){console.log('')}" 2>/dev/null)
+
+      # Check if RESULT.json issue matches assigned task
+      # Extract assigned issue from branch name (taskmaestro/<ts>/pane-N)
+      local assigned_issue=""
+      # If result_issue is empty or mismatched, flag as stale
+      if [ -z "$result_issue" ]; then
+        result_status="(no issue field)"
+      else
+        result_status="(issue: ${result_issue})"
+      fi
+
+      # Auto-remove stale RESULT.json if status is not from current task
+      # (conductor should verify issue match against Wave assignment)
+    fi
+
+    echo "pane-${pane}: ${state} | branch: ${branch} ${result_status}"
+    if [ "$has_error" = true ]; then
+      echo "  ⚠ errors detected in 30-line scan"
+    fi
   done
 }
 ```
@@ -806,3 +861,14 @@ cleanup_all() {
 - **Conductor layout requires tmux ≥ 2.3** — uses `-f` flag for full-width `join-pane`
 - **After layout setup, conductor is the last pane** — pane indices shift during `swap-pane` + `break-pane` + `join-pane`
 - **Worker status colors are pane-local** — use `set_worker_status()` to update border colors per pane
+
+## Status Verification Rules
+
+- **RESULT.json is NOT the sole source of truth** — always validate the `issue` field matches the assigned task AND cross-verify with `capture-pane` output
+- **3-factor analysis for status** — every status check must evaluate: (1) error scan across 30 lines, (2) active spinner presence, (3) completed spinner presence
+- **Active vs Completed spinner discrimination** — animating characters (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) = active work; static characters (`✓✗✔✘`) = step complete. Never confuse them.
+- **"thinking" ≠ productive work** when errors are visible — if errors appear alongside thinking/reasoning indicators, the worker is stuck in a retry loop
+- **Stall detection** — duration >5 minutes on the same step with no token/cost change = STALLED. Intervene immediately.
+- **NEVER use `git add -A` or `git add .`** — always stage specific files by name. This applies to both the conductor and all worker prompts.
+- **RESULT.json and TASK.md must NEVER be committed** — these are ephemeral per-worktree artifacts. If found in staged changes, unstage immediately.
+- **Stale RESULT.json auto-removal** — if RESULT.json `issue` field does not match the currently assigned task, remove it (`rm -f RESULT.json`) before the worker starts.

--- a/packages/rules/.ai-rules/agents/parallel-orchestrator.json
+++ b/packages/rules/.ai-rules/agents/parallel-orchestrator.json
@@ -259,5 +259,47 @@
     "ship_skill": ".claude/skills/ship/SKILL.md",
     "parallel_rules": ".ai-rules/rules/parallel-execution.md",
     "feedback_memory": "feedback_no_file_overlap_parallel.md"
+  },
+  "systemPrompt": {
+    "status_verification": {
+      "description": "Rules for verifying worker status during parallel execution",
+      "rules": [
+        {
+          "id": "result_json_not_sole_truth",
+          "rule": "RESULT.json is NOT the sole source of truth. Always validate the issue field matches the assigned task AND cross-verify with capture-pane output.",
+          "rationale": "RESULT.json can be stale from a previous run or contain data from a different issue."
+        },
+        {
+          "id": "spinner_discrimination",
+          "rule": "Discriminate between Active spinner (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏ animating) and Completed spinner (✓ or ✗ static). Active means work in progress; Completed means the step finished. Never confuse a completed spinner for active work.",
+          "rationale": "Misreading a completed spinner as active leads to false 'working' status reports."
+        },
+        {
+          "id": "error_scan_depth",
+          "rule": "Error detection requires scanning at least 30 lines of capture-pane output, not just the last 8. Errors may appear above the visible fold.",
+          "rationale": "Shallow scans miss errors that scrolled up but are still relevant to the current state."
+        },
+        {
+          "id": "thinking_not_productive",
+          "rule": "'thinking' or 'reasoning' indicators do NOT equal productive work when error messages are visible in the same capture-pane output. If errors are present alongside thinking indicators, the worker is likely stuck in a retry loop.",
+          "rationale": "Workers can appear busy while repeatedly failing on the same error."
+        },
+        {
+          "id": "stall_detection",
+          "rule": "Duration >5 minutes on the same step with no token/cost change = STALLED. Intervene immediately — do not wait for the worker to self-recover.",
+          "rationale": "Stalled workers waste time and pane resources. Early detection enables faster recovery."
+        },
+        {
+          "id": "git_add_safety",
+          "rule": "NEVER use `git add -A` or `git add .` — always stage specific files by name. This applies to both the conductor and all worker prompts.",
+          "rationale": "Blanket staging captures RESULT.json, TASK.md, and other artifacts that must not be committed."
+        },
+        {
+          "id": "artifact_commit_ban",
+          "rule": "RESULT.json and TASK.md must NEVER be committed to the repository. These are ephemeral per-worktree artifacts. If found in staged changes, unstage them immediately.",
+          "rationale": "These files are task-specific runtime artifacts that pollute the repository and cause merge conflicts."
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Added `systemPrompt.status_verification` with 7 rules to `parallel-orchestrator.json`: RESULT.json cross-verification, spinner discrimination, 30-line error scan, stall detection, git add safety, artifact commit ban
- Enhanced taskMaestro `status_check` with 3-factor analysis (error scan 30 lines + active spinner + completed spinner) and RESULT.json issue field validation
- Added artifact cleanup (`rm -f RESULT.json TASK.md`) to `create_worktrees` after worktree creation
- Updated `assign_tasks` worker prompt with git add safety rules and artifact commit ban
- Added comprehensive Status Verification Rules section to Important Notes

## Test plan
- [x] JSON schema validation passes (`ajv-cli validate`)
- [x] Markdown lint passes (`markdownlint-cli2`)
- [x] codingbuddy workspace: lint, format, typecheck, test:coverage (4938 passed), circular, build all pass
- [ ] Manual: run `/taskmaestro status` and verify 3-factor analysis output
- [ ] Manual: run `/taskmaestro wave-transition` and verify RESULT.json/TASK.md cleanup

Closes #888