### PR TITLE
feat(mcp): integrate agent discussion config with EVAL mode

### DIFF
--- a/apps/mcp-server/src/config/config.schema.ts
+++ b/apps/mcp-server/src/config/config.schema.ts
@@ -125,6 +125,13 @@ const AIConfigSchema = z.object({
    * ```
    */
   planReviewGate: z.boolean().optional(),
+  /**
+   * Enable/disable agent discussion integration in EVAL mode.
+   * When enabled, parse_mode EVAL response includes agentDiscussion config
+   * for structuring specialist findings as AgentOpinion protocol.
+   * Default: true (enabled)
+   */
+  agentDiscussion: z.boolean().optional(),
 });
 
 const AutoConfigSchema = z.object({

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
@@ -1113,4 +1113,87 @@ describe('ModeHandler', () => {
       expect(parsed.planReviewGate.dispatch).toBe('recommend');
     });
   });
+
+  describe('agentDiscussion in EVAL mode', () => {
+    it('should include agentDiscussion in EVAL mode response', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'EVAL',
+        originalPrompt: 'evaluate implementation',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'EVAL evaluate implementation',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text as string);
+      expect(parsed.agentDiscussion).toBeDefined();
+      expect(parsed.agentDiscussion.enabled).toBe(true);
+      expect(parsed.agentDiscussion.format).toBe('structured');
+      expect(parsed.agentDiscussion.includeConsensus).toBe(true);
+    });
+
+    it('should disable agentDiscussion when config sets it to false', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'EVAL',
+        originalPrompt: 'evaluate implementation',
+      });
+      (mockConfigService.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ai: { agentDiscussion: false },
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'EVAL evaluate implementation',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text as string);
+      expect(parsed.agentDiscussion).toBeDefined();
+      expect(parsed.agentDiscussion.enabled).toBe(false);
+    });
+
+    it('should NOT include agentDiscussion in PLAN mode', async () => {
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN design feature',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text as string);
+      expect(parsed.agentDiscussion).toBeUndefined();
+    });
+
+    it('should NOT include agentDiscussion in ACT mode', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'ACT',
+        originalPrompt: 'implement feature',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'ACT implement feature',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text as string);
+      expect(parsed.agentDiscussion).toBeUndefined();
+    });
+
+    it('should NOT include agentDiscussion in AUTO mode', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'AUTO',
+        originalPrompt: 'implement dashboard',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'AUTO implement dashboard',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text as string);
+      expect(parsed.agentDiscussion).toBeUndefined();
+    });
+  });
 });

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.ts
@@ -48,6 +48,16 @@ interface DeepThinkingInstructions {
   detailLevel: string;
 }
 
+/** Agent discussion configuration for EVAL mode responses */
+interface AgentDiscussionConfig {
+  /** Whether agent discussion is enabled */
+  enabled: boolean;
+  /** Format for structuring specialist findings */
+  format: 'structured';
+  /** Whether to include consensus analysis */
+  includeConsensus: boolean;
+}
+
 /** Plan review gate recommendation included in PLAN/AUTO mode responses */
 interface PlanReviewGate {
   /** Whether the plan review gate is enabled */
@@ -253,6 +263,12 @@ export class ModeHandler extends AbstractHandler {
         settings?.ai?.planReviewGate,
       );
 
+      // Build agent discussion config for EVAL mode
+      const agentDiscussion = this.buildAgentDiscussion(
+        result.mode as Mode,
+        settings?.ai?.agentDiscussion,
+      );
+
       return createJsonResponse({
         ...result,
         language,
@@ -264,6 +280,8 @@ export class ModeHandler extends AbstractHandler {
         ...(deepThinkingInstructions && { deepThinkingInstructions }),
         // Include plan review gate for PLAN/AUTO modes
         ...(planReviewGate && { planReviewGate }),
+        // Include agent discussion config for EVAL mode
+        ...(agentDiscussion && { agentDiscussion }),
         // Include context document info (mandatory)
         ...contextResult,
         // Include project root warning when auto-detected and config missing
@@ -478,6 +496,27 @@ export class ModeHandler extends AbstractHandler {
       enabled,
       agent: 'plan-reviewer',
       dispatch: 'recommend',
+    };
+  }
+
+  /**
+   * Build agent discussion config for EVAL mode.
+   * Returns undefined for PLAN/ACT/AUTO modes (not applicable).
+   */
+  private buildAgentDiscussion(
+    mode: Mode,
+    configValue?: boolean,
+  ): AgentDiscussionConfig | undefined {
+    if (mode !== 'EVAL') {
+      return undefined;
+    }
+
+    const enabled = configValue !== false;
+
+    return {
+      enabled,
+      format: 'structured',
+      includeConsensus: true,
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `agentDiscussion` field to `parse_mode` EVAL mode response (`{ enabled: true, format: "structured", includeConsensus: true }`)
- Add `agentDiscussion` boolean config to `AIConfigSchema` (configurable via `codingbuddy.config.json`, default: enabled)
- Add `AgentDiscussionConfig` interface and `buildAgentDiscussion` builder method following existing patterns (`buildPlanReviewGate`)
- TDD: 5 tests added covering EVAL inclusion, config disable, and PLAN/ACT/AUTO exclusion

## Test plan
- [x] EVAL mode response includes `agentDiscussion` with correct shape
- [x] Setting `ai.agentDiscussion: false` in config disables it
- [x] PLAN, ACT, AUTO modes do NOT include `agentDiscussion`
- [x] All 4952 tests passing, 177 test files
- [x] Lint, format, typecheck, circular, build all pass

Closes #835