### PR TITLE
feat(skills): add dependency verification to /ship skill

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -47,6 +47,27 @@ Run `git diff --name-only` (include both staged and unstaged changes) and classi
 
 If changed files don't match any pattern (e.g., docs-only, root config), skip CI checks entirely and proceed to Step 5.
 
+## Step 3.5: Verify Dependencies
+
+Before running CI checks, ensure project dependencies are available:
+
+```bash
+# Check if node_modules exists
+if [ ! -d "node_modules" ]; then
+  echo "node_modules missing, installing dependencies..."
+  yarn install --frozen-lockfile
+fi
+
+# Verify npx is available
+npx --version
+```
+
+- If `node_modules` does not exist, run `yarn install --frozen-lockfile`
+- If install fails → **STOP**. Do NOT proceed to CI checks or PR creation.
+- Verify `npx` is available by running `npx --version`
+
+**Iron Law:** Never skip CI checks due to missing dependencies.
+
 ## Step 4: Run Local CI Checks
 
 Run checks **only for affected workspaces**. Execute checks sequentially within each workspace. Stop at first failure.


### PR DESCRIPTION
## Summary

- Add Step 3.5: Verify Dependencies to `/ship` skill between Step 3 (Detect Affected Workspaces) and Step 4 (Run Local CI Checks)
- Checks if `node_modules` exists; runs `yarn install --frozen-lockfile` if missing
- Stops shipping if dependency installation fails — no PR creation without CI
- Verifies `npx` availability before proceeding to CI checks
- Un-gitignores `.claude/skills/ship/` to track the skill file in git

## Test plan

- [ ] Run `/ship` in a fresh git worktree (no `node_modules`) — should auto-install deps then run CI
- [ ] Run `/ship` in main repo (with `node_modules`) — should skip install, zero overhead
- [ ] Simulate `yarn install` failure — should STOP before CI checks
- [ ] Verify Step 3.5 appears between Step 3 and Step 4 in SKILL.md

Closes #880