### PR TITLE
feat(plugin): add SQLite execution history database (#827)

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/__init__.py
+++ b/packages/claude-code-plugin/hooks/lib/__init__.py
@@ -1,0 +1,2 @@
+"""CodingBuddy plugin shared library."""
+__version__ = "4.5.0"

--- a/packages/claude-code-plugin/hooks/lib/history_db.py
+++ b/packages/claude-code-plugin/hooks/lib/history_db.py
@@ -1,0 +1,164 @@
+"""Execution history database for tracking sessions and tool calls."""
+import logging
+import os
+import sqlite3
+import stat
+import time
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DB_PATH = os.path.expanduser("~/.codingbuddy/history.db")
+
+
+class HistoryDB:
+    """Persistent SQLite database for execution history."""
+
+    def __init__(self, db_path: str = DEFAULT_DB_PATH):
+        self._db_path = db_path
+        self._ensure_directory()
+        self._conn = sqlite3.connect(db_path, timeout=10)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._set_file_permissions()
+        self._create_tables()
+
+    def _ensure_directory(self):
+        """Create parent directory with 0o700 permissions."""
+        dir_path = os.path.dirname(self._db_path)
+        if not os.path.exists(dir_path):
+            os.makedirs(dir_path, mode=0o700)
+        else:
+            os.chmod(dir_path, 0o700)
+
+    def _set_file_permissions(self):
+        """Set DB file permissions to 0o600."""
+        if os.path.exists(self._db_path):
+            os.chmod(self._db_path, 0o600)
+
+    def _create_tables(self):
+        """Create sessions and tool_calls tables."""
+        try:
+            self._conn.executescript("""
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id INTEGER PRIMARY KEY,
+                    session_id TEXT UNIQUE NOT NULL,
+                    started_at REAL NOT NULL,
+                    ended_at REAL,
+                    project TEXT,
+                    model TEXT,
+                    tool_call_count INTEGER DEFAULT 0,
+                    error_count INTEGER DEFAULT 0,
+                    outcome TEXT
+                );
+                CREATE TABLE IF NOT EXISTS tool_calls (
+                    id INTEGER PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    timestamp REAL NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    input_summary TEXT,
+                    success INTEGER DEFAULT 1,
+                    FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id);
+                CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at);
+            """)
+        except sqlite3.Error as e:
+            logger.error("Failed to create tables: %s", e)
+
+    def start_session(self, session_id: str, project: str, model: str = None):
+        """Record a new session."""
+        try:
+            self._conn.execute(
+                "INSERT INTO sessions (session_id, started_at, project, model) VALUES (?, ?, ?, ?)",
+                (session_id, time.time(), project, model),
+            )
+            self._conn.commit()
+        except sqlite3.Error as e:
+            logger.error("Failed to start session: %s", e)
+
+    def record_tool_call(
+        self,
+        session_id: str,
+        tool_name: str,
+        input_summary: str = None,
+        success: bool = True,
+    ):
+        """Record a tool call and update session counters."""
+        try:
+            self._conn.execute(
+                "INSERT INTO tool_calls (session_id, timestamp, tool_name, input_summary, success) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (session_id, time.time(), tool_name, input_summary, 1 if success else 0),
+            )
+            self._conn.execute(
+                "UPDATE sessions SET tool_call_count = tool_call_count + 1 WHERE session_id = ?",
+                (session_id,),
+            )
+            if not success:
+                self._conn.execute(
+                    "UPDATE sessions SET error_count = error_count + 1 WHERE session_id = ?",
+                    (session_id,),
+                )
+            self._conn.commit()
+        except sqlite3.Error as e:
+            logger.error("Failed to record tool call: %s", e)
+
+    def end_session(self, session_id: str, outcome: str = None):
+        """Mark a session as ended."""
+        try:
+            self._conn.execute(
+                "UPDATE sessions SET ended_at = ?, outcome = ? WHERE session_id = ?",
+                (time.time(), outcome, session_id),
+            )
+            self._conn.commit()
+        except sqlite3.Error as e:
+            logger.error("Failed to end session: %s", e)
+
+    def query_sessions(self, days: int = 30) -> list:
+        """Query sessions from the last N days."""
+        try:
+            cutoff = time.time() - (days * 86400)
+            cursor = self._conn.execute(
+                "SELECT session_id, started_at, ended_at, project, model, "
+                "tool_call_count, error_count, outcome "
+                "FROM sessions WHERE started_at >= ? ORDER BY started_at DESC",
+                (cutoff,),
+            )
+            columns = [desc[0] for desc in cursor.description]
+            return [dict(zip(columns, row)) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            logger.error("Failed to query sessions: %s", e)
+            return []
+
+    def query_tool_stats(self) -> dict:
+        """Get aggregate tool usage counts."""
+        try:
+            cursor = self._conn.execute(
+                "SELECT tool_name, COUNT(*) as count FROM tool_calls GROUP BY tool_name"
+            )
+            return {row[0]: row[1] for row in cursor.fetchall()}
+        except sqlite3.Error as e:
+            logger.error("Failed to query tool stats: %s", e)
+            return {}
+
+    def cleanup(self, retention_days: int = 90):
+        """Delete records older than retention_days."""
+        try:
+            cutoff = time.time() - (retention_days * 86400)
+            self._conn.execute(
+                "DELETE FROM tool_calls WHERE session_id IN "
+                "(SELECT session_id FROM sessions WHERE started_at < ?)",
+                (cutoff,),
+            )
+            self._conn.execute(
+                "DELETE FROM sessions WHERE started_at < ?", (cutoff,)
+            )
+            self._conn.commit()
+        except sqlite3.Error as e:
+            logger.error("Failed to cleanup old records: %s", e)
+
+    def close(self):
+        """Close the database connection."""
+        try:
+            self._conn.close()
+        except sqlite3.Error as e:
+            logger.error("Failed to close database: %s", e)

--- a/packages/claude-code-plugin/tests/test_history_db.py
+++ b/packages/claude-code-plugin/tests/test_history_db.py
@@ -1,0 +1,199 @@
+"""Tests for HistoryDB — execution history SQLite database."""
+import os
+import stat
+import sqlite3
+import tempfile
+import time
+import threading
+
+import pytest
+
+from hooks.lib.history_db import HistoryDB
+
+
+@pytest.fixture
+def db_dir():
+    """Create a temporary directory for test databases."""
+    d = tempfile.mkdtemp()
+    yield d
+    # cleanup handled by OS
+
+
+@pytest.fixture
+def db_path(db_dir):
+    return os.path.join(db_dir, "history.db")
+
+
+@pytest.fixture
+def db(db_path):
+    """Create a HistoryDB instance with a temp path."""
+    instance = HistoryDB(db_path=db_path)
+    yield instance
+    instance.close()
+
+
+class TestDatabaseCreation:
+    def test_create_database_creates_tables(self, db, db_path):
+        """Verify both sessions and tool_calls tables exist."""
+        conn = sqlite3.connect(db_path)
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        )
+        tables = [row[0] for row in cursor.fetchall()]
+        conn.close()
+        assert "sessions" in tables
+        assert "tool_calls" in tables
+
+    def test_directory_permissions_0o700(self, db_dir):
+        """Directory should have 0o700 permissions."""
+        sub = os.path.join(db_dir, "secure")
+        _db = HistoryDB(db_path=os.path.join(sub, "history.db"))
+        mode = stat.S_IMODE(os.stat(sub).st_mode)
+        _db.close()
+        assert mode == 0o700
+
+    def test_db_file_permissions_0o600(self, db_dir):
+        """DB file should have 0o600 permissions."""
+        path = os.path.join(db_dir, "secure", "history.db")
+        _db = HistoryDB(db_path=path)
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        _db.close()
+        assert mode == 0o600
+
+    def test_wal_mode_enabled(self, db, db_path):
+        """PRAGMA journal_mode should return 'wal'."""
+        conn = sqlite3.connect(db_path)
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        conn.close()
+        assert mode == "wal"
+
+
+class TestSessionOperations:
+    def test_start_session(self, db):
+        """start_session should insert a record that can be queried back."""
+        db.start_session("sess-1", project="/my/project", model="opus")
+        sessions = db.query_sessions(days=1)
+        assert len(sessions) == 1
+        assert sessions[0]["session_id"] == "sess-1"
+        assert sessions[0]["project"] == "/my/project"
+        assert sessions[0]["model"] == "opus"
+
+    def test_end_session(self, db):
+        """end_session should set ended_at."""
+        db.start_session("sess-2", project="/proj")
+        db.end_session("sess-2", outcome="success")
+        sessions = db.query_sessions(days=1)
+        assert sessions[0]["ended_at"] is not None
+        assert sessions[0]["outcome"] == "success"
+
+
+class TestToolCallOperations:
+    def test_record_tool_call(self, db):
+        """record_tool_call should insert record and increment tool_call_count."""
+        db.start_session("sess-3", project="/proj")
+        db.record_tool_call("sess-3", "Read", input_summary="file.py")
+        db.record_tool_call("sess-3", "Write", input_summary="out.py")
+        sessions = db.query_sessions(days=1)
+        assert sessions[0]["tool_call_count"] == 2
+
+    def test_record_tool_call_error(self, db):
+        """success=False should increment error_count."""
+        db.start_session("sess-4", project="/proj")
+        db.record_tool_call("sess-4", "Bash", success=True)
+        db.record_tool_call("sess-4", "Bash", success=False)
+        db.record_tool_call("sess-4", "Bash", success=False)
+        sessions = db.query_sessions(days=1)
+        assert sessions[0]["tool_call_count"] == 3
+        assert sessions[0]["error_count"] == 2
+
+
+class TestQueryOperations:
+    def test_query_sessions_by_date(self, db):
+        """query_sessions should filter by days parameter."""
+        db.start_session("recent", project="/proj")
+        # Insert an old session directly
+        import sqlite3 as _sq
+        old_time = time.time() - (60 * 86400)  # 60 days ago
+        db._conn.execute(
+            "INSERT INTO sessions (session_id, started_at, project) VALUES (?, ?, ?)",
+            ("old-sess", old_time, "/old"),
+        )
+        db._conn.commit()
+
+        recent = db.query_sessions(days=7)
+        assert len(recent) == 1
+        assert recent[0]["session_id"] == "recent"
+
+        all_sessions = db.query_sessions(days=90)
+        assert len(all_sessions) == 2
+
+    def test_query_tool_usage_stats(self, db):
+        """query_tool_stats should return aggregate counts per tool."""
+        db.start_session("sess-5", project="/proj")
+        db.record_tool_call("sess-5", "Read")
+        db.record_tool_call("sess-5", "Read")
+        db.record_tool_call("sess-5", "Write")
+        stats = db.query_tool_stats()
+        assert stats["Read"] == 2
+        assert stats["Write"] == 1
+
+
+class TestCleanupAndConcurrency:
+    def test_cleanup_old_records(self, db):
+        """cleanup should remove records older than retention_days."""
+        db.start_session("keep", project="/proj")
+        old_time = time.time() - (100 * 86400)
+        db._conn.execute(
+            "INSERT INTO sessions (session_id, started_at, project) VALUES (?, ?, ?)",
+            ("remove-me", old_time, "/old"),
+        )
+        db._conn.execute(
+            "INSERT INTO tool_calls (session_id, timestamp, tool_name) VALUES (?, ?, ?)",
+            ("remove-me", old_time, "Bash"),
+        )
+        db._conn.commit()
+
+        db.cleanup(retention_days=90)
+        sessions = db.query_sessions(days=365)
+        assert len(sessions) == 1
+        assert sessions[0]["session_id"] == "keep"
+        # tool_calls for removed session should also be gone
+        cursor = db._conn.execute(
+            "SELECT COUNT(*) FROM tool_calls WHERE session_id = ?", ("remove-me",)
+        )
+        assert cursor.fetchone()[0] == 0
+
+    def test_concurrent_access_with_wal(self, db_path):
+        """Two connections with WAL should not deadlock."""
+        db1 = HistoryDB(db_path=db_path)
+        db2 = HistoryDB(db_path=db_path)
+
+        errors = []
+
+        def writer1():
+            try:
+                db1.start_session("concurrent-1", project="/proj1")
+                for i in range(10):
+                    db1.record_tool_call("concurrent-1", f"Tool{i}")
+            except Exception as e:
+                errors.append(e)
+
+        def writer2():
+            try:
+                db2.start_session("concurrent-2", project="/proj2")
+                for i in range(10):
+                    db2.record_tool_call("concurrent-2", f"Tool{i}")
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=writer1)
+        t2 = threading.Thread(target=writer2)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        db1.close()
+        db2.close()
+
+        assert len(errors) == 0, f"Concurrent access errors: {errors}"


### PR DESCRIPTION
## Summary
- Add `HistoryDB` class in `hooks/lib/history_db.py` for persistent execution history tracking
- SQLite database at `~/.codingbuddy/history.db` with WAL mode for concurrent access
- Session tracking (start, end, outcome) and tool call recording with counters
- Query sessions by date range, aggregate tool usage stats, auto-cleanup of old records
- Secure file permissions: directory 0o700, DB file 0o600
- 12 passing tests using temp directories (no real ~/.codingbuddy/ touched)

## Test plan
- [x] 12 unit tests pass (`python3 -m pytest tests/test_history_db.py -v`)
- [x] All workspace CI checks pass (lint, format, typecheck, test:coverage, circular, build)

Closes #827