### PR TITLE
feat(plugin): wire file_watcher and history_db into hook lifecycle (#823)

### DIFF
--- a/packages/claude-code-plugin/hooks/post-tool-use.py
+++ b/packages/claude-code-plugin/hooks/post-tool-use.py
@@ -36,7 +36,19 @@ def handle_post_tool_use(data: dict):
     except Exception:
         pass  # Never block tool execution
 
-    # TODO: history tracking (#827)
+    # Record tool call in history database (#823)
+    try:
+        from history_db import HistoryDB
+
+        db = HistoryDB()
+        tool_name = data.get("tool_name", "unknown")
+        input_summary = str(data.get("tool_input", {}))[:200]
+        session_id = os.environ.get("CLAUDE_SESSION_ID", "")
+        db.record_tool_call(session_id, tool_name, input_summary, success=True)
+        db.close()
+    except Exception:
+        pass  # Never block tool execution
+
     return None
 
 

--- a/packages/claude-code-plugin/hooks/pre-tool-use.py
+++ b/packages/claude-code-plugin/hooks/pre-tool-use.py
@@ -2,8 +2,10 @@
 """CodingBuddy PreToolUse Hook.
 
 Intercepts Bash tool calls to enforce quality gates on git commit commands.
+Detects .ai-rules/config changes via FileWatcher (#823).
 Uses safe_main decorator to ensure Claude Code is never blocked.
 """
+import json
 import os
 import re
 import sys
@@ -29,11 +31,91 @@ QUALITY_GATE_CONTEXT = (
     "- Commit message follows project convention"
 )
 
+FILE_WATCHER_CONTEXT = (
+    "CodingBuddy: Rules/config changed since last check. Consider reloading."
+)
+
+# Snapshot persistence directory
+_SNAPSHOT_DIR = os.path.join(
+    os.environ.get("CLAUDE_PLUGIN_DATA",
+                   os.path.join(os.path.expanduser("~"), ".codingbuddy")),
+    "snapshots",
+)
+
 
 def _get_hook_config() -> dict:
     """Load config from cwd."""
     cwd = os.environ.get("CLAUDE_CWD", os.getcwd())
     return get_config(cwd)
+
+
+def _get_project_root(data: dict) -> str:
+    """Get project root from hook input data or environment."""
+    return data.get("cwd", os.environ.get("CLAUDE_CWD", os.getcwd()))
+
+
+def _snapshot_path(project_root: str) -> str:
+    """Return the path to the snapshot file for a given project root."""
+    # Use a hash of project root to avoid path separator issues
+    safe_name = project_root.replace(os.sep, "_").strip("_")
+    return os.path.join(_SNAPSHOT_DIR, f"{safe_name}.json")
+
+
+def _load_snapshot(path: str) -> dict:
+    """Load a saved snapshot from disk."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+
+
+def _save_snapshot(path: str, snapshot: dict) -> None:
+    """Persist a snapshot to disk."""
+    try:
+        os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(snapshot, f)
+    except OSError:
+        pass
+
+
+def _check_file_changes(data: dict) -> Optional[str]:
+    """Check for .ai-rules/config changes via FileWatcher.
+
+    Returns additionalContext string if changes detected, else None.
+    """
+    try:
+        from file_watcher import FileWatcher
+
+        project_root = _get_project_root(data)
+        config = _get_hook_config()
+        fw_config = config.get("fileWatcher", {})
+
+        if not fw_config.get("enabled", True):
+            return None
+
+        watcher = FileWatcher(project_root)
+        snap_path = _snapshot_path(project_root)
+        old_snapshot = _load_snapshot(snap_path)
+
+        if old_snapshot:
+            # Restore previous snapshot for comparison
+            watcher._last_snapshot = old_snapshot
+            changes = watcher.detect_changes()
+            # Take new snapshot for next invocation
+            new_snapshot = watcher.snapshot()
+            _save_snapshot(snap_path, new_snapshot)
+            if changes:
+                return FILE_WATCHER_CONTEXT
+        else:
+            # First invocation — just take initial snapshot
+            new_snapshot = watcher.snapshot()
+            _save_snapshot(snap_path, new_snapshot)
+
+        return None
+    except Exception:
+        return None
 
 
 def _is_git_commit(command: str) -> bool:
@@ -56,23 +138,28 @@ def _handle(data: dict) -> Optional[dict]:
     if tool_name != "Bash":
         return None
 
+    contexts = []
+
+    # Check for file changes (#823)
+    file_change_msg = _check_file_changes(data)
+    if file_change_msg:
+        contexts.append(file_change_msg)
+
     command = data.get("tool_input", {}).get("command", "")
 
-    # Only check git commit commands
-    if not _is_git_commit(command):
+    # Check git commit quality gates
+    if _is_git_commit(command):
+        config = _get_hook_config()
+        quality_gates = config.get("qualityGates", {})
+        if quality_gates.get("enabled", False):
+            contexts.append(QUALITY_GATE_CONTEXT)
+
+    if not contexts:
         return None
 
-    # Load config and check quality gates
-    config = _get_hook_config()
-    quality_gates = config.get("qualityGates", {})
-
-    if not quality_gates.get("enabled", False):
-        return None
-
-    # Quality gates enabled — return context reminder
     return {
         "hookSpecificOutput": {
-            "additionalContext": QUALITY_GATE_CONTEXT,
+            "additionalContext": "\n\n".join(contexts),
         }
     }
 

--- a/packages/claude-code-plugin/hooks/session-start.py
+++ b/packages/claude-code-plugin/hooks/session-start.py
@@ -415,6 +415,24 @@ def main():
         except Exception:
             pass  # Never block session start
 
+        # Step 5: Record session in history database (#823)
+        try:
+            _hooks_dir = os.path.dirname(os.path.abspath(__file__))
+            _lib_dir = os.path.join(_hooks_dir, "lib")
+            if _lib_dir not in sys.path:
+                sys.path.insert(0, _lib_dir)
+
+            from history_db import HistoryDB
+
+            session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+            cwd = os.environ.get("CLAUDE_PROJECT_DIR", str(Path.cwd()))
+            model = os.environ.get("CLAUDE_MODEL", "unknown")
+            db = HistoryDB()
+            db.start_session(session_id, cwd, model)
+            db.close()
+        except Exception:
+            pass  # Never block session start
+
         sys.exit(0)
 
     except PermissionError as e:

--- a/packages/claude-code-plugin/hooks/stop.py
+++ b/packages/claude-code-plugin/hooks/stop.py
@@ -30,6 +30,16 @@ def handle_stop(data: dict):
         summary = stats.format_summary()
         stats.finalize()
 
+        # End session in history database (#823)
+        try:
+            from history_db import HistoryDB
+
+            db = HistoryDB()
+            db.end_session(session_id, outcome="completed")
+            db.close()
+        except Exception:
+            pass  # Never block session stop
+
         if summary:
             return {
                 "systemMessage": summary,


### PR DESCRIPTION
## Summary
- Wire `FileWatcher` into `pre-tool-use.py` to detect `.ai-rules`/config file changes via mtime snapshot persistence between hook invocations
- Wire `HistoryDB` into `session-start.py`, `post-tool-use.py`, and `stop.py` for session/tool call tracking
- All new integration code wrapped in `try/except` (crash-safe, never blocks Claude Code)

## Changes
- **pre-tool-use.py**: Import `FileWatcher`, detect changes on every Bash tool invocation, persist snapshots to `~/.codingbuddy/snapshots/`
- **session-start.py**: Call `HistoryDB.start_session()` after stats init using env vars (`CLAUDE_SESSION_ID`, `CLAUDE_PROJECT_DIR`, `CLAUDE_MODEL`)
- **post-tool-use.py**: Call `HistoryDB.record_tool_call()` after stats recording
- **stop.py**: Call `HistoryDB.end_session()` after stats finalize

## Test plan
- [x] All 75 Python tests pass (`pytest tests/ -v`)
- [x] TypeScript typecheck passes
- [x] Lint passes
- [x] Build passes
- [x] All new code crash-safe (try/except wrapping)
- [x] No regressions in existing hook behavior