### PR TITLE
feat(pipeline): add sequential task pipeline engine with data passing

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/index.ts
+++ b/apps/mcp-server/src/mcp/handlers/index.ts
@@ -103,6 +103,12 @@ export { DiscussionHandler } from './discussion.handler';
 export { ParallelValidationHandler } from '../../parallel-validation/parallel-validation.handler';
 
 /**
+ * Handler for pipeline tools (run_pipeline, pipeline_status, resume_pipeline)
+ * @see {@link PipelineHandler}
+ */
+export { PipelineHandler } from './pipeline.handler';
+
+/**
  * Injection token for the array of all tool handlers.
  *
  * Use this token to inject all handlers into a service that needs to

--- a/apps/mcp-server/src/mcp/handlers/pipeline.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/pipeline.handler.spec.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PipelineHandler } from './pipeline.handler';
+import { PipelineService } from '../../pipeline/pipeline.service';
+import type { PipelineExecution } from '../../pipeline/pipeline.types';
+
+describe('PipelineHandler', () => {
+  let handler: PipelineHandler;
+  let mockService: PipelineService;
+
+  const mockExecution: PipelineExecution = {
+    id: 'exec-1',
+    pipelineId: 'pipeline-1',
+    status: 'completed',
+    currentStageIndex: 1,
+    stageResults: [
+      {
+        stageId: 's1',
+        status: 'completed',
+        output: 'done',
+        startedAt: '2026-03-25T00:00:00Z',
+        completedAt: '2026-03-25T00:00:01Z',
+        durationMs: 1000,
+      },
+    ],
+    startedAt: '2026-03-25T00:00:00Z',
+    completedAt: '2026-03-25T00:00:01Z',
+  };
+
+  beforeEach(() => {
+    mockService = {
+      runPipeline: vi.fn().mockResolvedValue(mockExecution),
+      getStatus: vi.fn().mockReturnValue(mockExecution),
+      resumePipeline: vi.fn().mockResolvedValue(mockExecution),
+    } as unknown as PipelineService;
+
+    handler = new PipelineHandler(mockService);
+  });
+
+  describe('handle', () => {
+    it('should return null for unhandled tools', async () => {
+      const result = await handler.handle('unknown_tool', {});
+      expect(result).toBeNull();
+    });
+
+    describe('run_pipeline', () => {
+      it('should run pipeline with valid definition', async () => {
+        const args = {
+          pipeline: {
+            id: 'p1',
+            name: 'Test',
+            stages: [{ id: 's1', name: 'Build', type: 'command', config: { command: 'echo ok' } }],
+          },
+        };
+
+        const result = await handler.handle('run_pipeline', args);
+
+        expect(result?.isError).toBeFalsy();
+        expect(mockService.runPipeline).toHaveBeenCalled();
+      });
+
+      it('should return error for missing pipeline field', async () => {
+        const result = await handler.handle('run_pipeline', {});
+
+        expect(result?.isError).toBe(true);
+        expect(result?.content[0].text).toContain('Missing required parameter: pipeline');
+      });
+
+      it('should return error for invalid pipeline definition', async () => {
+        const result = await handler.handle('run_pipeline', {
+          pipeline: { id: '', name: '', stages: [] },
+        });
+
+        expect(result?.isError).toBe(true);
+        expect(result?.content[0].text).toContain('Invalid pipeline definition');
+      });
+    });
+
+    describe('pipeline_status', () => {
+      it('should return status for valid execution ID', async () => {
+        const result = await handler.handle('pipeline_status', {
+          executionId: 'exec-1',
+        });
+
+        expect(result?.isError).toBeFalsy();
+        expect(mockService.getStatus).toHaveBeenCalledWith('exec-1');
+      });
+
+      it('should return error for missing executionId', async () => {
+        const result = await handler.handle('pipeline_status', {});
+
+        expect(result?.isError).toBe(true);
+        expect(result?.content[0].text).toContain('Missing required parameter: executionId');
+      });
+
+      it('should return error when execution not found', async () => {
+        mockService.getStatus = vi.fn().mockReturnValue(undefined);
+
+        const result = await handler.handle('pipeline_status', {
+          executionId: 'nonexistent',
+        });
+
+        expect(result?.isError).toBe(true);
+        expect(result?.content[0].text).toContain('not found');
+      });
+    });
+
+    describe('resume_pipeline', () => {
+      it('should resume pipeline with valid args', async () => {
+        const args = {
+          executionId: 'exec-1',
+          pipeline: {
+            id: 'p1',
+            name: 'Test',
+            stages: [{ id: 's1', name: 'Build', type: 'command', config: { command: 'echo ok' } }],
+          },
+        };
+
+        const result = await handler.handle('resume_pipeline', args);
+
+        expect(result?.isError).toBeFalsy();
+        expect(mockService.resumePipeline).toHaveBeenCalled();
+      });
+
+      it('should return error for missing executionId', async () => {
+        const result = await handler.handle('resume_pipeline', {
+          pipeline: { id: 'p1', name: 'Test', stages: [] },
+        });
+
+        expect(result?.isError).toBe(true);
+        expect(result?.content[0].text).toContain('Missing required parameter: executionId');
+      });
+
+      it('should return error when resume fails', async () => {
+        mockService.resumePipeline = vi
+          .fn()
+          .mockRejectedValue(new Error('Pipeline is not in a failed state'));
+
+        const result = await handler.handle('resume_pipeline', {
+          executionId: 'exec-1',
+          pipeline: {
+            id: 'p1',
+            name: 'Test',
+            stages: [{ id: 's1', name: 'Build', type: 'command', config: { command: 'echo ok' } }],
+          },
+        });
+
+        expect(result?.isError).toBe(true);
+        expect(result?.content[0].text).toContain('Pipeline is not in a failed state');
+      });
+    });
+  });
+
+  describe('getToolDefinitions', () => {
+    it('should return tool definitions for all pipeline tools', () => {
+      const definitions = handler.getToolDefinitions();
+
+      expect(definitions).toHaveLength(3);
+      expect(definitions.map(d => d.name)).toEqual([
+        'run_pipeline',
+        'pipeline_status',
+        'resume_pipeline',
+      ]);
+    });
+
+    it('should have correct required parameters', () => {
+      const definitions = handler.getToolDefinitions();
+
+      const runPipeline = definitions.find(d => d.name === 'run_pipeline');
+      expect(runPipeline?.inputSchema.required).toContain('pipeline');
+
+      const status = definitions.find(d => d.name === 'pipeline_status');
+      expect(status?.inputSchema.required).toContain('executionId');
+
+      const resume = definitions.find(d => d.name === 'resume_pipeline');
+      expect(resume?.inputSchema.required).toContain('executionId');
+      expect(resume?.inputSchema.required).toContain('pipeline');
+    });
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/pipeline.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/pipeline.handler.ts
@@ -1,0 +1,159 @@
+/**
+ * Pipeline Handler — MCP Tool Handler for Pipeline Operations
+ *
+ * Provides run_pipeline, pipeline_status, and resume_pipeline tools
+ * for the Sequential Task Pipeline Engine.
+ */
+
+import { Injectable } from '@nestjs/common';
+import { AbstractHandler } from './abstract-handler';
+import type { ToolDefinition } from './base.handler';
+import type { ToolResponse } from '../response.utils';
+import { createJsonResponse, createErrorResponse } from '../response.utils';
+import { PipelineService } from '../../pipeline/pipeline.service';
+import { isValidPipelineDefinition } from '../../pipeline/pipeline.types';
+import type { PipelineDefinition } from '../../pipeline/pipeline.types';
+import { extractRequiredString } from '../../shared/validation.constants';
+
+@Injectable()
+export class PipelineHandler extends AbstractHandler {
+  constructor(private readonly pipelineService: PipelineService) {
+    super();
+  }
+
+  protected getHandledTools(): string[] {
+    return ['run_pipeline', 'pipeline_status', 'resume_pipeline'];
+  }
+
+  protected async handleTool(
+    toolName: string,
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    switch (toolName) {
+      case 'run_pipeline':
+        return this.handleRunPipeline(args);
+      case 'pipeline_status':
+        return this.handlePipelineStatus(args);
+      case 'resume_pipeline':
+        return this.handleResumePipeline(args);
+      default:
+        return createErrorResponse(`Unknown tool: ${toolName}`);
+    }
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'run_pipeline',
+        description:
+          'Run a sequential task pipeline. Stages execute in order, with each stage receiving the previous stage output as input.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            pipeline: {
+              type: 'object',
+              description:
+                'Pipeline definition with id, name, and stages array. Each stage has id, name, type (command|agent|skill), and config.',
+            },
+          },
+          required: ['pipeline'],
+        },
+      },
+      {
+        name: 'pipeline_status',
+        description: 'Get the status of a pipeline execution including stage results and progress.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            executionId: {
+              type: 'string',
+              description: 'The execution ID returned from run_pipeline.',
+            },
+          },
+          required: ['executionId'],
+        },
+      },
+      {
+        name: 'resume_pipeline',
+        description:
+          'Resume a failed pipeline from the failed stage. Preserves completed stage results and re-executes from the failure point.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            executionId: {
+              type: 'string',
+              description: 'The execution ID of the failed pipeline.',
+            },
+            pipeline: {
+              type: 'object',
+              description: 'Updated pipeline definition (may have fixed stages).',
+            },
+          },
+          required: ['executionId', 'pipeline'],
+        },
+      },
+    ];
+  }
+
+  private async handleRunPipeline(
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    const pipeline = args?.pipeline;
+    if (!pipeline || typeof pipeline !== 'object') {
+      return createErrorResponse('Missing required parameter: pipeline');
+    }
+
+    if (!isValidPipelineDefinition(pipeline)) {
+      return createErrorResponse(
+        'Invalid pipeline definition: must have non-empty id, name, and valid stages',
+      );
+    }
+
+    const execution = await this.pipelineService.runPipeline(pipeline as PipelineDefinition);
+    return createJsonResponse(execution);
+  }
+
+  private async handlePipelineStatus(
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    const executionId = extractRequiredString(args, 'executionId');
+    if (executionId === null) {
+      return createErrorResponse('Missing required parameter: executionId');
+    }
+
+    const status = this.pipelineService.getStatus(executionId);
+    if (!status) {
+      return createErrorResponse(`Execution '${executionId}' not found`);
+    }
+
+    return createJsonResponse(status);
+  }
+
+  private async handleResumePipeline(
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    const executionId = extractRequiredString(args, 'executionId');
+    if (executionId === null) {
+      return createErrorResponse('Missing required parameter: executionId');
+    }
+
+    const pipeline = args?.pipeline;
+    if (!pipeline || typeof pipeline !== 'object') {
+      return createErrorResponse('Missing required parameter: pipeline');
+    }
+
+    if (!isValidPipelineDefinition(pipeline)) {
+      return createErrorResponse('Invalid pipeline definition');
+    }
+
+    try {
+      const execution = await this.pipelineService.resumePipeline(
+        executionId,
+        pipeline as PipelineDefinition,
+      );
+      return createJsonResponse(execution);
+    } catch (error) {
+      return createErrorResponse(error instanceof Error ? error.message : String(error));
+    }
+  }
+}

--- a/apps/mcp-server/src/mcp/mcp.module.ts
+++ b/apps/mcp-server/src/mcp/mcp.module.ts
@@ -11,6 +11,7 @@ import { ContextModule } from '../context/context.module';
 import { StateModule } from '../state/state.module';
 import { DiagnosticModule } from '../diagnostic/diagnostic.module';
 import { TuiEventsModule } from '../tui/events';
+import { PipelineModule } from '../pipeline/pipeline.module';
 import { SkillRecommendationService } from '../skill/skill-recommendation.service';
 import { LanguageService } from '../shared/language.service';
 import { ModelResolverService } from '../model';
@@ -29,6 +30,7 @@ import {
   TuiHandler,
   DiscussionHandler,
   ParallelValidationHandler,
+  PipelineHandler,
 } from './handlers';
 
 const handlers = [
@@ -43,6 +45,7 @@ const handlers = [
   TuiHandler,
   DiscussionHandler,
   ParallelValidationHandler,
+  PipelineHandler,
 ];
 
 @Module({
@@ -57,6 +60,7 @@ const handlers = [
     StateModule,
     DiagnosticModule,
     TuiEventsModule,
+    PipelineModule,
   ],
   controllers: [McpController],
   providers: [

--- a/apps/mcp-server/src/pipeline/index.ts
+++ b/apps/mcp-server/src/pipeline/index.ts
@@ -1,0 +1,21 @@
+export { PipelineModule } from './pipeline.module';
+export { PipelineService } from './pipeline.service';
+export { executeStage } from './pipeline.executors';
+export type {
+  PipelineStageType,
+  PipelineStageConfig,
+  CommandStageConfig,
+  AgentStageConfig,
+  SkillStageConfig,
+  PipelineStage,
+  PipelineDefinition,
+  PipelineStageStatus,
+  PipelineStageResult,
+  PipelineExecutionStatus,
+  PipelineExecution,
+} from './pipeline.types';
+export {
+  isValidStageType,
+  isValidPipelineStage,
+  isValidPipelineDefinition,
+} from './pipeline.types';

--- a/apps/mcp-server/src/pipeline/pipeline.executors.spec.ts
+++ b/apps/mcp-server/src/pipeline/pipeline.executors.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { executeStage } from './pipeline.executors';
+import type { PipelineStage } from './pipeline.types';
+
+describe('Pipeline Stage Executors', () => {
+  describe('command stage', () => {
+    it('should execute a shell command and return stdout', async () => {
+      const stage: PipelineStage = {
+        id: 'cmd-1',
+        name: 'Echo',
+        type: 'command',
+        config: { command: 'echo "hello world"' },
+      };
+      const result = await executeStage(stage, undefined);
+      expect(result.status).toBe('completed');
+      expect(result.output?.trim()).toBe('hello world');
+    });
+
+    it('should pass previous output as PIPELINE_INPUT env var', async () => {
+      const stage: PipelineStage = {
+        id: 'cmd-2',
+        name: 'Read Input',
+        type: 'command',
+        config: { command: 'echo "received: $PIPELINE_INPUT"' },
+      };
+      const result = await executeStage(stage, 'previous-output');
+      expect(result.status).toBe('completed');
+      expect(result.output?.trim()).toBe('received: previous-output');
+    });
+
+    it('should return failed status when command fails', async () => {
+      const stage: PipelineStage = {
+        id: 'cmd-3',
+        name: 'Fail',
+        type: 'command',
+        config: { command: 'exit 1' },
+      };
+      const result = await executeStage(stage, undefined);
+      expect(result.status).toBe('failed');
+      expect(result.error).toBeDefined();
+    });
+
+    it('should include timing information', async () => {
+      const stage: PipelineStage = {
+        id: 'cmd-4',
+        name: 'Timed',
+        type: 'command',
+        config: { command: 'echo "done"' },
+      };
+      const result = await executeStage(stage);
+      expect(result.startedAt).toBeDefined();
+      expect(result.completedAt).toBeDefined();
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('agent stage', () => {
+    it('should return formatted agent prompt with input context', async () => {
+      const stage: PipelineStage = {
+        id: 'agent-1',
+        name: 'Review',
+        type: 'agent',
+        config: { agentName: 'code-reviewer', prompt: 'Review this code' },
+      };
+      const result = await executeStage(stage, 'function foo() {}');
+      expect(result.status).toBe('completed');
+      expect(result.output).toContain('code-reviewer');
+      expect(result.output).toContain('Review this code');
+      expect(result.output).toContain('function foo() {}');
+    });
+
+    it('should work without previous input', async () => {
+      const stage: PipelineStage = {
+        id: 'agent-2',
+        name: 'Plan',
+        type: 'agent',
+        config: { agentName: 'architect', prompt: 'Design system' },
+      };
+      const result = await executeStage(stage);
+      expect(result.status).toBe('completed');
+      expect(result.output).toContain('architect');
+      expect(result.output).toContain('Design system');
+    });
+  });
+
+  describe('skill stage', () => {
+    it('should return formatted skill invocation with input context', async () => {
+      const stage: PipelineStage = {
+        id: 'skill-1',
+        name: 'TDD',
+        type: 'skill',
+        config: { skillName: 'tdd', args: '--strict' },
+      };
+      const result = await executeStage(stage, 'test context');
+      expect(result.status).toBe('completed');
+      expect(result.output).toContain('tdd');
+      expect(result.output).toContain('--strict');
+      expect(result.output).toContain('test context');
+    });
+
+    it('should work without args', async () => {
+      const stage: PipelineStage = {
+        id: 'skill-2',
+        name: 'Review',
+        type: 'skill',
+        config: { skillName: 'code-review' },
+      };
+      const result = await executeStage(stage);
+      expect(result.status).toBe('completed');
+      expect(result.output).toContain('code-review');
+    });
+  });
+
+  describe('unknown stage type', () => {
+    it('should return failed for unknown stage type', async () => {
+      const stage = {
+        id: 'unknown-1',
+        name: 'Unknown',
+        type: 'unknown' as 'command',
+        config: {},
+      } as PipelineStage;
+      const result = await executeStage(stage);
+      expect(result.status).toBe('failed');
+      expect(result.error).toContain('Unknown stage type');
+    });
+  });
+});

--- a/apps/mcp-server/src/pipeline/pipeline.executors.ts
+++ b/apps/mcp-server/src/pipeline/pipeline.executors.ts
@@ -1,0 +1,117 @@
+/**
+ * Pipeline Stage Executors — Pure Functions
+ *
+ * Each executor handles a specific stage type and returns a PipelineStageResult.
+ * Output from one stage becomes input to the next stage in the pipeline.
+ */
+
+import { execSync } from 'child_process';
+import type {
+  PipelineStage,
+  PipelineStageResult,
+  CommandStageConfig,
+  AgentStageConfig,
+  SkillStageConfig,
+} from './pipeline.types';
+
+/**
+ * Execute a single pipeline stage and return the result.
+ *
+ * @param stage - The stage definition to execute
+ * @param input - Optional output from the previous stage
+ * @returns The stage execution result with status, output, timing
+ */
+export async function executeStage(
+  stage: PipelineStage,
+  input?: string,
+): Promise<PipelineStageResult> {
+  const startedAt = new Date().toISOString();
+  const startTime = Date.now();
+
+  try {
+    let output: string;
+
+    switch (stage.type) {
+      case 'command':
+        output = executeCommandStage(stage.config as CommandStageConfig, input);
+        break;
+      case 'agent':
+        output = executeAgentStage(stage.config as AgentStageConfig, input);
+        break;
+      case 'skill':
+        output = executeSkillStage(stage.config as SkillStageConfig, input);
+        break;
+      default:
+        return {
+          stageId: stage.id,
+          status: 'failed',
+          error: `Unknown stage type: ${(stage as { type: string }).type}`,
+          startedAt,
+          completedAt: new Date().toISOString(),
+          durationMs: Date.now() - startTime,
+        };
+    }
+
+    return {
+      stageId: stage.id,
+      status: 'completed',
+      output,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      durationMs: Date.now() - startTime,
+    };
+  } catch (error) {
+    return {
+      stageId: stage.id,
+      status: 'failed',
+      error: error instanceof Error ? error.message : String(error),
+      startedAt,
+      completedAt: new Date().toISOString(),
+      durationMs: Date.now() - startTime,
+    };
+  }
+}
+
+/**
+ * Execute a shell command stage.
+ * Previous stage output is available via PIPELINE_INPUT env var.
+ */
+function executeCommandStage(config: CommandStageConfig, input?: string): string {
+  const env = { ...process.env };
+  if (input !== undefined) {
+    env.PIPELINE_INPUT = input;
+  }
+  const result = execSync(config.command, {
+    encoding: 'utf-8',
+    env,
+    timeout: 60_000,
+  });
+  return result;
+}
+
+/**
+ * Format an agent stage invocation.
+ * Returns a structured prompt string with agent name, prompt, and input context.
+ */
+function executeAgentStage(config: AgentStageConfig, input?: string): string {
+  const parts = [`[Agent: ${config.agentName}]`, `[Prompt: ${config.prompt}]`];
+  if (input !== undefined) {
+    parts.push(`[Input: ${input}]`);
+  }
+  return parts.join('\n');
+}
+
+/**
+ * Format a skill stage invocation.
+ * Returns a structured skill invocation string with name, args, and input context.
+ */
+function executeSkillStage(config: SkillStageConfig, input?: string): string {
+  const parts = [`[Skill: ${config.skillName}]`];
+  if (config.args) {
+    parts.push(`[Args: ${config.args}]`);
+  }
+  if (input !== undefined) {
+    parts.push(`[Input: ${input}]`);
+  }
+  return parts.join('\n');
+}

--- a/apps/mcp-server/src/pipeline/pipeline.module.ts
+++ b/apps/mcp-server/src/pipeline/pipeline.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PipelineService } from './pipeline.service';
+
+@Module({
+  providers: [PipelineService],
+  exports: [PipelineService],
+})
+export class PipelineModule {}

--- a/apps/mcp-server/src/pipeline/pipeline.service.spec.ts
+++ b/apps/mcp-server/src/pipeline/pipeline.service.spec.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PipelineService } from './pipeline.service';
+import type { PipelineDefinition } from './pipeline.types';
+
+describe('PipelineService', () => {
+  let service: PipelineService;
+
+  beforeEach(() => {
+    service = new PipelineService();
+  });
+
+  const createPipeline = (stages: PipelineDefinition['stages'] = []): PipelineDefinition => ({
+    id: 'test-pipeline',
+    name: 'Test Pipeline',
+    stages,
+  });
+
+  describe('runPipeline', () => {
+    it('should run all stages sequentially and return completed status', async () => {
+      const pipeline = createPipeline([
+        { id: 's1', name: 'Step 1', type: 'command', config: { command: 'echo "step1"' } },
+        { id: 's2', name: 'Step 2', type: 'command', config: { command: 'echo "step2"' } },
+      ]);
+
+      const execution = await service.runPipeline(pipeline);
+
+      expect(execution.status).toBe('completed');
+      expect(execution.stageResults).toHaveLength(2);
+      expect(execution.stageResults[0].status).toBe('completed');
+      expect(execution.stageResults[1].status).toBe('completed');
+    });
+
+    it('should stop on stage failure and mark pipeline as failed', async () => {
+      const pipeline = createPipeline([
+        { id: 's1', name: 'Pass', type: 'command', config: { command: 'echo "ok"' } },
+        { id: 's2', name: 'Fail', type: 'command', config: { command: 'exit 1' } },
+        { id: 's3', name: 'Skip', type: 'command', config: { command: 'echo "skip"' } },
+      ]);
+
+      const execution = await service.runPipeline(pipeline);
+
+      expect(execution.status).toBe('failed');
+      expect(execution.stageResults).toHaveLength(2);
+      expect(execution.stageResults[0].status).toBe('completed');
+      expect(execution.stageResults[1].status).toBe('failed');
+    });
+
+    it('should handle empty pipeline', async () => {
+      const pipeline = createPipeline([]);
+
+      const execution = await service.runPipeline(pipeline);
+
+      expect(execution.status).toBe('completed');
+      expect(execution.stageResults).toHaveLength(0);
+    });
+
+    it('should handle single stage pipeline', async () => {
+      const pipeline = createPipeline([
+        { id: 's1', name: 'Only', type: 'command', config: { command: 'echo "only"' } },
+      ]);
+
+      const execution = await service.runPipeline(pipeline);
+
+      expect(execution.status).toBe('completed');
+      expect(execution.stageResults).toHaveLength(1);
+    });
+
+    it('should pass output from stage N as input to stage N+1', async () => {
+      const pipeline = createPipeline([
+        { id: 's1', name: 'Produce', type: 'command', config: { command: 'echo "data-from-s1"' } },
+        {
+          id: 's2',
+          name: 'Consume',
+          type: 'command',
+          config: { command: 'echo "received: $PIPELINE_INPUT"' },
+        },
+      ]);
+
+      const execution = await service.runPipeline(pipeline);
+
+      expect(execution.status).toBe('completed');
+      expect(execution.stageResults[1].output?.trim()).toBe('received: data-from-s1');
+    });
+
+    it('should generate unique execution IDs', async () => {
+      const pipeline = createPipeline([]);
+
+      const exec1 = await service.runPipeline(pipeline);
+      const exec2 = await service.runPipeline(pipeline);
+
+      expect(exec1.id).not.toBe(exec2.id);
+    });
+
+    it('should set timing fields', async () => {
+      const pipeline = createPipeline([
+        { id: 's1', name: 'Step', type: 'command', config: { command: 'echo "done"' } },
+      ]);
+
+      const execution = await service.runPipeline(pipeline);
+
+      expect(execution.startedAt).toBeDefined();
+      expect(execution.completedAt).toBeDefined();
+    });
+  });
+
+  describe('getStatus', () => {
+    it('should return execution status by ID', async () => {
+      const pipeline = createPipeline([]);
+      const execution = await service.runPipeline(pipeline);
+
+      const status = service.getStatus(execution.id);
+
+      expect(status).toBeDefined();
+      expect(status?.id).toBe(execution.id);
+    });
+
+    it('should return undefined for unknown ID', () => {
+      const status = service.getStatus('nonexistent');
+
+      expect(status).toBeUndefined();
+    });
+  });
+
+  describe('resumePipeline', () => {
+    it('should resume from failed stage', async () => {
+      const pipeline = createPipeline([
+        { id: 's1', name: 'Pass', type: 'command', config: { command: 'echo "ok"' } },
+        { id: 's2', name: 'Fail', type: 'command', config: { command: 'exit 1' } },
+        { id: 's3', name: 'After', type: 'command', config: { command: 'echo "after"' } },
+      ]);
+
+      // First run — s2 fails
+      const firstRun = await service.runPipeline(pipeline);
+      expect(firstRun.status).toBe('failed');
+
+      // Fix the pipeline definition with a passing command for s2
+      const fixedPipeline = createPipeline([
+        { id: 's1', name: 'Pass', type: 'command', config: { command: 'echo "ok"' } },
+        { id: 's2', name: 'Fixed', type: 'command', config: { command: 'echo "fixed"' } },
+        { id: 's3', name: 'After', type: 'command', config: { command: 'echo "after"' } },
+      ]);
+
+      const resumed = await service.resumePipeline(firstRun.id, fixedPipeline);
+
+      expect(resumed.status).toBe('completed');
+      // s1 result preserved from first run, s2 and s3 re-executed
+      expect(resumed.stageResults).toHaveLength(3);
+      expect(resumed.stageResults[0].output?.trim()).toBe('ok');
+      expect(resumed.stageResults[1].output?.trim()).toBe('fixed');
+      expect(resumed.stageResults[2].output?.trim()).toBe('after');
+    });
+
+    it('should throw for unknown execution ID', async () => {
+      const pipeline = createPipeline([]);
+
+      await expect(service.resumePipeline('nonexistent', pipeline)).rejects.toThrow(
+        'Execution not found',
+      );
+    });
+
+    it('should throw for already completed pipeline', async () => {
+      const pipeline = createPipeline([
+        { id: 's1', name: 'Done', type: 'command', config: { command: 'echo "done"' } },
+      ]);
+
+      const execution = await service.runPipeline(pipeline);
+
+      await expect(service.resumePipeline(execution.id, pipeline)).rejects.toThrow(
+        'Pipeline is not in a failed state',
+      );
+    });
+  });
+});

--- a/apps/mcp-server/src/pipeline/pipeline.service.ts
+++ b/apps/mcp-server/src/pipeline/pipeline.service.ts
@@ -1,0 +1,133 @@
+/**
+ * Pipeline Service — Sequential Task Pipeline Execution Engine
+ *
+ * Runs pipeline stages sequentially, passing output from stage N as input to stage N+1.
+ * Supports resume-on-failure: resumes from the failed stage, not from the beginning.
+ */
+
+import { Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import type { PipelineDefinition, PipelineExecution, PipelineStageResult } from './pipeline.types';
+import { executeStage } from './pipeline.executors';
+
+@Injectable()
+export class PipelineService {
+  private readonly executions = new Map<string, PipelineExecution>();
+
+  /**
+   * Run a pipeline from the beginning.
+   * Executes stages sequentially, passing output between stages.
+   * Stops on first stage failure.
+   */
+  async runPipeline(definition: PipelineDefinition): Promise<PipelineExecution> {
+    const executionId = randomUUID();
+    const startedAt = new Date().toISOString();
+
+    const execution = await this.executeFromStage(executionId, definition, 0, [], startedAt);
+    this.executions.set(executionId, execution);
+    return execution;
+  }
+
+  /**
+   * Get the status of a pipeline execution.
+   */
+  getStatus(executionId: string): PipelineExecution | undefined {
+    return this.executions.get(executionId);
+  }
+
+  /**
+   * Resume a failed pipeline from the failed stage.
+   * Preserves results from completed stages and re-executes from the failure point.
+   *
+   * @param executionId - ID of the failed execution
+   * @param updatedDefinition - Updated pipeline definition (may have fixed stages)
+   */
+  async resumePipeline(
+    executionId: string,
+    updatedDefinition: PipelineDefinition,
+  ): Promise<PipelineExecution> {
+    const existing = this.executions.get(executionId);
+    if (!existing) {
+      throw new Error('Execution not found');
+    }
+    if (existing.status !== 'failed') {
+      throw new Error('Pipeline is not in a failed state');
+    }
+
+    // Find the index of the failed stage
+    const failedIndex = existing.stageResults.findIndex(r => r.status === 'failed');
+    const preservedResults = existing.stageResults.slice(0, failedIndex);
+
+    const execution = await this.executeFromStage(
+      executionId,
+      updatedDefinition,
+      failedIndex,
+      [...preservedResults],
+      existing.startedAt,
+    );
+    this.executions.set(executionId, execution);
+    return execution;
+  }
+
+  /**
+   * Execute pipeline stages starting from a given index.
+   */
+  private async executeFromStage(
+    executionId: string,
+    definition: PipelineDefinition,
+    startIndex: number,
+    previousResults: PipelineStageResult[],
+    startedAt: string,
+  ): Promise<PipelineExecution> {
+    const stageResults: PipelineStageResult[] = [...previousResults];
+
+    // Get last output from previous results for data passing
+    let lastOutput: string | undefined;
+    if (previousResults.length > 0) {
+      const lastResult = previousResults[previousResults.length - 1];
+      lastOutput = lastResult.output?.trim();
+    }
+
+    for (let i = startIndex; i < definition.stages.length; i++) {
+      const stage = definition.stages[i];
+
+      // Update in-progress execution state
+      const inProgress: PipelineExecution = {
+        id: executionId,
+        pipelineId: definition.id,
+        status: 'running',
+        currentStageIndex: i,
+        stageResults: [...stageResults],
+        startedAt,
+      };
+      this.executions.set(executionId, inProgress);
+
+      const result = await executeStage(stage, lastOutput);
+      stageResults.push(result);
+
+      if (result.status === 'failed') {
+        return {
+          id: executionId,
+          pipelineId: definition.id,
+          status: 'failed',
+          currentStageIndex: i,
+          stageResults,
+          startedAt,
+          completedAt: new Date().toISOString(),
+        };
+      }
+
+      lastOutput = result.output?.trim();
+    }
+
+    return {
+      id: executionId,
+      pipelineId: definition.id,
+      status: 'completed',
+      currentStageIndex: definition.stages.length - 1,
+      stageResults,
+      startedAt,
+      completedAt: new Date().toISOString(),
+    };
+  }
+}

--- a/apps/mcp-server/src/pipeline/pipeline.types.spec.ts
+++ b/apps/mcp-server/src/pipeline/pipeline.types.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isValidStageType,
+  isValidPipelineStage,
+  isValidPipelineDefinition,
+} from './pipeline.types';
+
+describe('Pipeline Type Guards', () => {
+  describe('isValidStageType', () => {
+    it('should return true for "command"', () => {
+      expect(isValidStageType('command')).toBe(true);
+    });
+
+    it('should return true for "agent"', () => {
+      expect(isValidStageType('agent')).toBe(true);
+    });
+
+    it('should return true for "skill"', () => {
+      expect(isValidStageType('skill')).toBe(true);
+    });
+
+    it('should return false for invalid string', () => {
+      expect(isValidStageType('invalid')).toBe(false);
+    });
+
+    it('should return false for non-string', () => {
+      expect(isValidStageType(123)).toBe(false);
+      expect(isValidStageType(null)).toBe(false);
+      expect(isValidStageType(undefined)).toBe(false);
+    });
+  });
+
+  describe('isValidPipelineStage', () => {
+    const validStage = {
+      id: 'stage-1',
+      name: 'Build',
+      type: 'command',
+      config: { command: 'yarn build' },
+    };
+
+    it('should return true for valid stage', () => {
+      expect(isValidPipelineStage(validStage)).toBe(true);
+    });
+
+    it('should return false for missing id', () => {
+      expect(isValidPipelineStage({ ...validStage, id: '' })).toBe(false);
+    });
+
+    it('should return false for missing name', () => {
+      expect(isValidPipelineStage({ ...validStage, name: '' })).toBe(false);
+    });
+
+    it('should return false for invalid type', () => {
+      expect(isValidPipelineStage({ ...validStage, type: 'invalid' })).toBe(false);
+    });
+
+    it('should return false for null config', () => {
+      expect(isValidPipelineStage({ ...validStage, config: null })).toBe(false);
+    });
+
+    it('should return false for non-object', () => {
+      expect(isValidPipelineStage(null)).toBe(false);
+      expect(isValidPipelineStage('string')).toBe(false);
+      expect(isValidPipelineStage(42)).toBe(false);
+    });
+  });
+
+  describe('isValidPipelineDefinition', () => {
+    const validDefinition = {
+      id: 'pipeline-1',
+      name: 'Deploy Pipeline',
+      stages: [
+        { id: 's1', name: 'Build', type: 'command', config: { command: 'yarn build' } },
+        { id: 's2', name: 'Test', type: 'command', config: { command: 'yarn test' } },
+      ],
+    };
+
+    it('should return true for valid definition', () => {
+      expect(isValidPipelineDefinition(validDefinition)).toBe(true);
+    });
+
+    it('should return true for empty stages array', () => {
+      expect(isValidPipelineDefinition({ ...validDefinition, stages: [] })).toBe(true);
+    });
+
+    it('should return false for missing id', () => {
+      expect(isValidPipelineDefinition({ ...validDefinition, id: '' })).toBe(false);
+    });
+
+    it('should return false for missing name', () => {
+      expect(isValidPipelineDefinition({ ...validDefinition, name: '' })).toBe(false);
+    });
+
+    it('should return false for non-array stages', () => {
+      expect(isValidPipelineDefinition({ ...validDefinition, stages: 'not-array' })).toBe(false);
+    });
+
+    it('should return false if any stage is invalid', () => {
+      const invalid = {
+        ...validDefinition,
+        stages: [{ id: '', name: 'Bad', type: 'command', config: {} }],
+      };
+      expect(isValidPipelineDefinition(invalid)).toBe(false);
+    });
+
+    it('should return false for non-object', () => {
+      expect(isValidPipelineDefinition(null)).toBe(false);
+      expect(isValidPipelineDefinition(undefined)).toBe(false);
+    });
+  });
+});

--- a/apps/mcp-server/src/pipeline/pipeline.types.ts
+++ b/apps/mcp-server/src/pipeline/pipeline.types.ts
@@ -1,0 +1,158 @@
+/**
+ * Sequential Task Pipeline Engine — Type Definitions
+ *
+ * Defines the core types for pipeline definition, execution, and status tracking.
+ * Pipelines chain stages sequentially, passing output from stage N as input to stage N+1.
+ */
+
+// ============================================================================
+// Stage Types
+// ============================================================================
+
+/**
+ * Types of pipeline stages.
+ * - 'command': Execute a shell command
+ * - 'agent': Execute an agent prompt
+ * - 'skill': Execute a skill invocation
+ */
+export type PipelineStageType = 'command' | 'agent' | 'skill';
+
+/**
+ * Configuration for a command stage.
+ * Executes a shell command with the previous stage's output available as PIPELINE_INPUT env var.
+ */
+export interface CommandStageConfig {
+  readonly command: string;
+}
+
+/**
+ * Configuration for an agent stage.
+ * Sends a prompt to an agent with the previous stage's output as context.
+ */
+export interface AgentStageConfig {
+  readonly agentName: string;
+  readonly prompt: string;
+}
+
+/**
+ * Configuration for a skill stage.
+ * Invokes a skill with the previous stage's output as context.
+ */
+export interface SkillStageConfig {
+  readonly skillName: string;
+  readonly args?: string;
+}
+
+/**
+ * Union type for stage-specific configuration.
+ */
+export type PipelineStageConfig = CommandStageConfig | AgentStageConfig | SkillStageConfig;
+
+// ============================================================================
+// Pipeline Definition
+// ============================================================================
+
+/**
+ * A single stage in a pipeline definition.
+ */
+export interface PipelineStage {
+  readonly id: string;
+  readonly name: string;
+  readonly type: PipelineStageType;
+  readonly config: PipelineStageConfig;
+}
+
+/**
+ * Complete pipeline definition with ordered stages.
+ */
+export interface PipelineDefinition {
+  readonly id: string;
+  readonly name: string;
+  readonly stages: readonly PipelineStage[];
+}
+
+// ============================================================================
+// Execution Status
+// ============================================================================
+
+/**
+ * Status of an individual pipeline stage execution.
+ */
+export type PipelineStageStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+
+/**
+ * Result of executing a single pipeline stage.
+ */
+export interface PipelineStageResult {
+  readonly stageId: string;
+  readonly status: PipelineStageStatus;
+  readonly output?: string;
+  readonly error?: string;
+  readonly startedAt: string;
+  readonly completedAt?: string;
+  readonly durationMs?: number;
+}
+
+/**
+ * Overall pipeline execution status.
+ */
+export type PipelineExecutionStatus = 'running' | 'completed' | 'failed' | 'paused';
+
+/**
+ * Tracks the state of a pipeline execution.
+ */
+export interface PipelineExecution {
+  readonly id: string;
+  readonly pipelineId: string;
+  readonly status: PipelineExecutionStatus;
+  readonly currentStageIndex: number;
+  readonly stageResults: readonly PipelineStageResult[];
+  readonly startedAt: string;
+  readonly completedAt?: string;
+}
+
+// ============================================================================
+// Type Guards
+// ============================================================================
+
+const VALID_STAGE_TYPES: readonly PipelineStageType[] = ['command', 'agent', 'skill'];
+
+/**
+ * Check if a value is a valid pipeline stage type.
+ */
+export function isValidStageType(value: unknown): value is PipelineStageType {
+  return typeof value === 'string' && VALID_STAGE_TYPES.includes(value as PipelineStageType);
+}
+
+/**
+ * Check if a value is a valid pipeline stage.
+ */
+export function isValidPipelineStage(value: unknown): value is PipelineStage {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.id === 'string' &&
+    obj.id.length > 0 &&
+    typeof obj.name === 'string' &&
+    obj.name.length > 0 &&
+    isValidStageType(obj.type) &&
+    typeof obj.config === 'object' &&
+    obj.config !== null
+  );
+}
+
+/**
+ * Check if a value is a valid pipeline definition.
+ */
+export function isValidPipelineDefinition(value: unknown): value is PipelineDefinition {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.id === 'string' &&
+    obj.id.length > 0 &&
+    typeof obj.name === 'string' &&
+    obj.name.length > 0 &&
+    Array.isArray(obj.stages) &&
+    obj.stages.every((stage: unknown) => isValidPipelineStage(stage))
+  );
+}

--- a/docs/plans/2026-03-25-sequential-pipeline-engine.md
+++ b/docs/plans/2026-03-25-sequential-pipeline-engine.md
@@ -1,0 +1,126 @@
+# Sequential Task Pipeline Engine — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a sequential task pipeline engine that chains tasks with data passing — when task A completes, automatically start task B with A's output as context.
+
+**Architecture:** New `pipeline/` module under `apps/mcp-server/src/` following existing NestJS patterns. Pure pipeline execution logic separated from MCP handler. Stage executors handle different stage types (command, agent, skill).
+
+**Tech Stack:** TypeScript, NestJS, Vitest
+
+## Alternatives
+
+### Decision: Pipeline State Storage
+
+| Criteria | Approach A: In-Memory Map | Approach B: File-Based Persistence |
+|---|---|---|
+| Performance | Fast, no I/O | Slower, disk I/O |
+| Complexity | Low | Medium (serialization) |
+| Maintainability | Simple | More code to maintain |
+| Resilience | Lost on restart | Survives restart |
+
+**Decision:** In-Memory Map — Pipeline executions are short-lived; persistence can be added later if needed. YAGNI.
+
+### Decision: Stage Executor Pattern
+
+| Criteria | Approach A: Strategy Pattern (classes) | Approach B: Pure Function Map |
+|---|---|---|
+| Performance | Same | Same |
+| Complexity | Higher (class hierarchy) | Lower (simple functions) |
+| Testability | Good | Better (no mocking needed) |
+| Maintainability | More boilerplate | Less code |
+
+**Decision:** Pure Function Map — Simpler, more testable, follows project's pure/impure separation principle.
+
+---
+
+## Tasks
+
+### Task 1: Define Pipeline Types
+**File:** `apps/mcp-server/src/pipeline/pipeline.types.ts`
+
+1. Create the file with these interfaces:
+   - `PipelineStageType = 'command' | 'agent' | 'skill'`
+   - `PipelineStageConfig` — union type per stage type
+   - `PipelineStage` — `{ id, name, type, config }`
+   - `PipelineDefinition` — `{ id, name, stages[] }`
+   - `PipelineStageStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped'`
+   - `PipelineStageResult` — `{ stageId, status, output?, error?, startedAt, completedAt, durationMs }`
+   - `PipelineExecutionStatus = 'running' | 'completed' | 'failed' | 'paused'`
+   - `PipelineExecution` — `{ id, pipelineId, status, currentStageIndex, stageResults[], startedAt, completedAt? }`
+2. Run `yarn workspace codingbuddy build` to verify types compile
+
+### Task 2: Write Failing Tests for Pipeline Types Validation
+**File:** `apps/mcp-server/src/pipeline/pipeline.types.spec.ts`
+
+1. Write tests for type guard functions:
+   - `isValidStageType(value)` — validates 'command' | 'agent' | 'skill'
+   - `isValidPipelineDefinition(value)` — validates definition structure
+   - `isValidPipelineStage(value)` — validates stage structure
+2. Run tests — Expected: FAIL (functions don't exist yet)
+3. Implement the type guards in `pipeline.types.ts`
+4. Run tests — Expected: PASS
+
+### Task 3: Write Failing Tests for Stage Executors
+**File:** `apps/mcp-server/src/pipeline/pipeline.executors.spec.ts`
+
+1. Write tests for `executeStage(stage, input)`:
+   - Command stage: executes shell command with input as env var, returns stdout
+   - Agent stage: returns formatted agent prompt with input context
+   - Skill stage: returns formatted skill invocation with input context
+   - Unknown stage type: throws error
+   - Command stage failure: returns error result
+2. Run tests — Expected: FAIL
+3. Implement `pipeline.executors.ts` with `executeStage()` pure function
+4. Run tests — Expected: PASS
+
+### Task 4: Write Failing Tests for Pipeline Service
+**File:** `apps/mcp-server/src/pipeline/pipeline.service.spec.ts`
+
+1. Write tests for `PipelineService`:
+   - `runPipeline()` — runs all stages sequentially, passes output between stages
+   - `runPipeline()` — stops on stage failure, marks pipeline as 'failed'
+   - `runPipeline()` — handles empty pipeline (no stages)
+   - `runPipeline()` — handles single stage pipeline
+   - `getStatus()` — returns execution status by ID
+   - `getStatus()` — returns undefined for unknown ID
+   - `resumePipeline()` — resumes from failed stage (not restart)
+   - `resumePipeline()` — throws for unknown execution ID
+   - `resumePipeline()` — throws for already completed pipeline
+   - Data passing: output of stage N is input to stage N+1
+   - Progress tracking: currentStageIndex updates during execution
+2. Run tests — Expected: FAIL
+3. Implement `pipeline.service.ts`
+4. Run tests — Expected: PASS
+
+### Task 5: Write Failing Tests for Pipeline Handler
+**File:** `apps/mcp-server/src/mcp/handlers/pipeline.handler.spec.ts`
+
+1. Write tests for `PipelineHandler`:
+   - `handle('run_pipeline', ...)` — valid pipeline definition
+   - `handle('run_pipeline', ...)` — missing required fields
+   - `handle('pipeline_status', ...)` — valid execution ID
+   - `handle('pipeline_status', ...)` — missing execution ID
+   - `handle('pipeline_status', ...)` — unknown execution ID
+   - `handle('unknown_tool', ...)` — returns null
+   - `getToolDefinitions()` — returns correct definitions
+2. Run tests — Expected: FAIL
+3. Implement `pipeline.handler.ts` extending `AbstractHandler`
+4. Run tests — Expected: PASS
+
+### Task 6: Create Pipeline Module and Register
+**Files:** `apps/mcp-server/src/pipeline/pipeline.module.ts`, `apps/mcp-server/src/pipeline/index.ts`
+
+1. Create `PipelineModule` NestJS module
+2. Export `PipelineService` from module
+3. Create `index.ts` barrel export
+4. Add `PipelineHandler` to `apps/mcp-server/src/mcp/handlers/index.ts`
+5. Add `PipelineModule` to `McpModule` imports
+6. Add `PipelineHandler` to handlers array in `mcp.module.ts`
+7. Run `yarn workspace codingbuddy build` — verify compilation
+8. Run `yarn workspace codingbuddy test` — verify all tests pass
+
+### Task 7: Final CI Verification
+1. Run `yarn workspace codingbuddy build` — zero errors
+2. Run `yarn workspace codingbuddy test` — all tests pass
+3. Verify no lint errors


### PR DESCRIPTION
## Summary
- Add sequential task pipeline engine that chains stages with data passing (A→B→C)
- Each stage can be a shell command, agent prompt, or skill invocation
- Output from stage N is automatically passed as input to stage N+1
- Pipeline resumes from failed stage (not restart from beginning)
- Status tracking with per-stage results, timing, and progress
- 3 MCP tools: `run_pipeline`, `pipeline_status`, `resume_pipeline`
- New `pipeline/` module following existing NestJS + AbstractHandler patterns
- 51 new tests (types, executors, service, handler), all passing

## Test plan
- [x] 18 type guard tests (isValidStageType, isValidPipelineStage, isValidPipelineDefinition)
- [x] 9 executor tests (command/agent/skill stages, error handling, timing)
- [x] 12 service tests (sequential execution, data passing, resume, edge cases)
- [x] 12 handler tests (MCP tool validation, error responses, tool definitions)
- [x] Full CI: lint, format, typecheck, test:coverage (5023 pass), circular, build

Closes #814