### PR TITLE
feat(sync): add multi-tool settings sync automation

### DIFF
--- a/.antigravity/rules/instructions.md
+++ b/.antigravity/rules/instructions.md
@@ -8,7 +8,7 @@ This project follows shared AI coding rules from `packages/rules/.ai-rules/` for
 
 **Source**: `packages/rules/.ai-rules/rules/core.md`
 
-#### Work Modes
+### Work Modes
 
 You have four modes of operation:
 
@@ -74,19 +74,45 @@ See full augmented coding guide in [packages/rules/.ai-rules/rules/augmented-cod
 
 **Source**: `packages/rules/.ai-rules/agents/`
 
-Available specialist agents:
-- **Frontend Developer** - React/Next.js, TDD, design system
-- **Code Reviewer** - Quality evaluation, architecture analysis
-- **Architecture Specialist** - Layer boundaries, dependency direction
-- **Test Strategy Specialist** - Test coverage, TDD workflow
-- **Performance Specialist** - Bundle size, rendering optimization
-- **Security Specialist** - OAuth 2.0, JWT, XSS/CSRF protection
-- **Accessibility Specialist** - WCAG 2.1 AA compliance
-- **SEO Specialist** - Metadata API, structured data
-- **Design System Specialist** - Design system usage
-- **Documentation Specialist** - Documentation quality
-- **Code Quality Specialist** - SOLID, DRY, complexity
-- **DevOps Engineer** - Docker, Datadog, deployment
+| Agent | Description | Expertise |
+|-------|-------------|-----------|
+| Accessibility Specialist | Accessibility expert for Planning, Implementation, and Evaluation modes - unified specialist for WCAG 2.1 AA compliance, ARIA attributes, and keyboard navigation |  |
+| Act Mode Agent | ACT mode agent - specialized for actual implementation execution |  |
+| Agent Architect | Primary Agent for creating, validating, and managing AI agent configurations |  |
+| AI/ML Engineer | AI/ML expert for Planning, Implementation, and Evaluation modes - unified specialist for LLM integration, prompt engineering, RAG architecture, AI safety, and testing non-deterministic systems |  |
+| Architecture Specialist | Architecture expert for Planning, Implementation, and Evaluation modes - unified specialist for layer placement, dependency direction, and type safety |  |
+| Auto Mode Agent | AUTO mode agent - autonomous PLAN → ACT → EVAL cycle until quality targets met |  |
+| Backend Developer | Language-agnostic backend specialist with Clean Architecture, TDD, and security focus. Supports Node.js, Python, Go, Java, and other backend stacks. |  |
+| Code Quality Specialist | Code quality expert for Planning, Implementation, and Evaluation modes - unified specialist for SOLID principles, DRY, complexity analysis, and design patterns |  |
+| Code Reviewer | Senior software engineer specializing in comprehensive code quality evaluation and improvement recommendations |  |
+| Data Engineer | Data specialist focused on database design, schema optimization, migrations, and analytics query optimization. Handles data modeling, ETL patterns, and reporting data structures. |  |
+| Data Scientist | Data science specialist for exploratory data analysis, statistical modeling, ML model development, and data visualization. Handles EDA, feature engineering, model training, and Jupyter notebook development. |  |
+| DevOps Engineer | Docker, Datadog monitoring, and Next.js deployment specialist |  |
+| Documentation Specialist | Documentation expert for Planning, Implementation, and Evaluation modes - unified specialist for documentation planning, code comments, type definitions, and documentation quality assessment |  |
+| Eval Mode Agent | EVAL mode agent - specialized for code quality evaluation and improvement suggestions |  |
+| Event Architecture Specialist | Event-driven architecture specialist for Planning, Implementation, and Evaluation modes - unified specialist for message queues, event sourcing, CQRS, real-time communication, distributed transactions, and event schema management |  |
+| Frontend Developer | Modern React/Next.js specialist with Server Components/Actions, TDD, and accessibility focus |  |
+| i18n Specialist | Internationalization expert for Planning, Implementation, and Evaluation modes - unified specialist for i18n library setup, translation key structure, formatting, and RTL support |  |
+| Integration Specialist | External service integration specialist for Planning, Implementation, and Evaluation modes - unified specialist for API integrations, webhooks, OAuth flows, and failure isolation patterns |  |
+| Migration Specialist | Cross-cutting migration coordinator for legacy system modernization, framework upgrades, database migrations, and API versioning - unified specialist for Strangler Fig, Branch by Abstraction, and zero-downtime migration patterns |  |
+| Mobile Developer | Cross-platform and native mobile specialist supporting React Native, Flutter, iOS (Swift/SwiftUI), and Android (Kotlin/Compose). Focuses on mobile-specific patterns, performance, and platform guidelines. |  |
+| Observability Specialist | Observability expert for Planning, Implementation, and Evaluation modes - unified specialist for vendor-neutral monitoring, distributed tracing, structured logging, SLI/SLO frameworks, and alerting patterns |  |
+| Parallel Orchestrator | Orchestrates parallel execution of multiple GitHub issues using taskMaestro with file-overlap validation, Wave grouping, and AUTO mode workers |  |
+| Performance Specialist | Performance expert for Planning, Implementation, and Evaluation modes - unified specialist for bundle size optimization, rendering optimization, and Core Web Vitals |  |
+| Plan Mode Agent | PLAN mode agent - specialized for work planning and design |  |
+| Plan Reviewer | Reviews implementation plans for quality, completeness, and feasibility before execution |  |
+| Platform Engineer | Cloud-native infrastructure expert for Planning, Implementation, and Evaluation modes - unified specialist for Infrastructure as Code, Kubernetes orchestration, multi-cloud strategy, GitOps workflows, cost optimization, and disaster recovery |  |
+| Security Engineer | Primary Agent for implementing security features, fixing vulnerabilities, and applying security best practices in code |  |
+| Security Specialist | Security expert for Planning, Implementation, and Evaluation modes - unified specialist for authentication, authorization, and security vulnerability prevention |  |
+| SEO Specialist | SEO expert for Planning, Implementation, and Evaluation modes - unified specialist for metadata, structured data, and search engine optimization |  |
+| Software Engineer | General-purpose implementation engineer — any language, any domain, TDD-first |  |
+| Solution Architect | High-level system design and architecture planning specialist |  |
+| Systems Developer | Primary Agent for systems programming, low-level optimization, native code development, and performance-critical implementations |  |
+| Technical Planner | Low-level implementation planning with TDD and bite-sized tasks |  |
+| Test Engineer | Primary Agent for TDD cycle execution, test writing, and coverage improvement across all test types |  |
+| Test Strategy Specialist | Test strategy expert for Planning, Implementation, and Evaluation modes - unified specialist for TDD vs Test-After decisions, test coverage planning, and test quality assessment |  |
+| Tooling Engineer | Project configuration, build tools, and development environment specialist |  |
+| UI/UX Designer | UI/UX design specialist based on universal design principles and UX best practices - focuses on aesthetics, usability, and user experience rather than specific design system implementations |  |
 
 See agent details in [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md)
 
@@ -100,21 +126,20 @@ See agent details in [packages/rules/.ai-rules/agents/README.md](../../packages/
 2. Follow the returned `instructions` **EXACTLY**
 3. Apply the returned `rules` as context
 4. If `warnings` are present, inform the user
-5. **Fallback** (MCP unavailable): Follow mode-specific rules from `packages/rules/.ai-rules/rules/core.md`
 
 **This is MANDATORY, not optional.**
 
-Failure to follow mode rules when these keywords are present will result in:
+Failure to call `parse_mode` when these keywords are present will result in:
 - Missed critical checklists (Devil's Advocate Analysis, Impact Radius Analysis)
 - Incomplete evaluations
 - Quality issues not caught before deployment
 
 **Red Flags** (STOP if you think these):
-
 | Thought | Reality |
 |---------|---------|
-| "I can handle EVAL myself" | NO. Follow mode rules FIRST. |
+| "I can handle EVAL myself" | NO. Call parse_mode FIRST. |
 | "The rules are similar anyway" | NO. Each mode has specific checklists. |
+| "I'll save a tool call" | NO. parse_mode MUST be called FIRST. |
 | "I already know what to do" | NO. Rules may have been updated. |
 
 </CODINGBUDDY_CRITICAL_RULE>
@@ -137,8 +162,6 @@ If the codingbuddy MCP server is configured, use these tools:
 | `recommend_skills` | Recommend skills based on prompt → then call `get_skill` |
 | `get_skill` | Load full skill content |
 | `update_context` | Update context document (decisions, notes, progress) |
-
-> For the full list of tools (18 total, including 1 deprecated), see [antigravity.md](../../packages/rules/.ai-rules/adapters/antigravity.md#mcp-tools).
 
 ### Configuration
 
@@ -193,14 +216,6 @@ Persists decisions across mode transitions in `docs/codingbuddy/context.md`:
 **When completing each mode**, execute two calls in strict order:
 1. **`update_context`** — Persist decisions, notes, findings to `docs/codingbuddy/context.md` (first)
 2. **`task_boundary`** — Signal mode boundary to Antigravity (second)
-
-> `update_context` must be called first to preserve cross-mode context even if the session is interrupted.
-
-`task_boundary` parameters:
-- Mode: `PLANNING`, `EXECUTION`, `VERIFICATION`, or `AUTO_ITERATION`
-- TaskName: Current work area
-- TaskStatus: Next steps
-- TaskSummary: Summary of completed work
 
 ### Communication
 

--- a/.claude/rules/custom-instructions.md
+++ b/.claude/rules/custom-instructions.md
@@ -46,10 +46,47 @@ Follow the common rules defined in `packages/rules/.ai-rules/` for consistency a
 
 **Source**: `packages/rules/.ai-rules/agents/`
 
-**Available Agents** (31 agents + 4 mode agents):
-- **Primary**: Solution Architect, Technical Planner, Frontend Developer, Backend Developer, Mobile Developer, Data Engineer, Agent Architect, Platform Engineer, Tooling Engineer, AI/ML Engineer, DevOps Engineer, Test Engineer, Security Engineer, Software Engineer, Data Scientist, Systems Developer
-- **Domain**: Architecture, Test Strategy, Performance, Security, Accessibility, SEO, UI/UX Design, Documentation, Integration, Event Architecture, Observability, Migration, i18n
-- **Core/Utility**: Code Reviewer, Code Quality
+**Available Agents**:
+
+| Agent | Description | Expertise |
+|-------|-------------|-----------|
+| Accessibility Specialist | Accessibility expert for Planning, Implementation, and Evaluation modes - unified specialist for WCAG 2.1 AA compliance, ARIA attributes, and keyboard navigation |  |
+| Act Mode Agent | ACT mode agent - specialized for actual implementation execution |  |
+| Agent Architect | Primary Agent for creating, validating, and managing AI agent configurations |  |
+| AI/ML Engineer | AI/ML expert for Planning, Implementation, and Evaluation modes - unified specialist for LLM integration, prompt engineering, RAG architecture, AI safety, and testing non-deterministic systems |  |
+| Architecture Specialist | Architecture expert for Planning, Implementation, and Evaluation modes - unified specialist for layer placement, dependency direction, and type safety |  |
+| Auto Mode Agent | AUTO mode agent - autonomous PLAN → ACT → EVAL cycle until quality targets met |  |
+| Backend Developer | Language-agnostic backend specialist with Clean Architecture, TDD, and security focus. Supports Node.js, Python, Go, Java, and other backend stacks. |  |
+| Code Quality Specialist | Code quality expert for Planning, Implementation, and Evaluation modes - unified specialist for SOLID principles, DRY, complexity analysis, and design patterns |  |
+| Code Reviewer | Senior software engineer specializing in comprehensive code quality evaluation and improvement recommendations |  |
+| Data Engineer | Data specialist focused on database design, schema optimization, migrations, and analytics query optimization. Handles data modeling, ETL patterns, and reporting data structures. |  |
+| Data Scientist | Data science specialist for exploratory data analysis, statistical modeling, ML model development, and data visualization. Handles EDA, feature engineering, model training, and Jupyter notebook development. |  |
+| DevOps Engineer | Docker, Datadog monitoring, and Next.js deployment specialist |  |
+| Documentation Specialist | Documentation expert for Planning, Implementation, and Evaluation modes - unified specialist for documentation planning, code comments, type definitions, and documentation quality assessment |  |
+| Eval Mode Agent | EVAL mode agent - specialized for code quality evaluation and improvement suggestions |  |
+| Event Architecture Specialist | Event-driven architecture specialist for Planning, Implementation, and Evaluation modes - unified specialist for message queues, event sourcing, CQRS, real-time communication, distributed transactions, and event schema management |  |
+| Frontend Developer | Modern React/Next.js specialist with Server Components/Actions, TDD, and accessibility focus |  |
+| i18n Specialist | Internationalization expert for Planning, Implementation, and Evaluation modes - unified specialist for i18n library setup, translation key structure, formatting, and RTL support |  |
+| Integration Specialist | External service integration specialist for Planning, Implementation, and Evaluation modes - unified specialist for API integrations, webhooks, OAuth flows, and failure isolation patterns |  |
+| Migration Specialist | Cross-cutting migration coordinator for legacy system modernization, framework upgrades, database migrations, and API versioning - unified specialist for Strangler Fig, Branch by Abstraction, and zero-downtime migration patterns |  |
+| Mobile Developer | Cross-platform and native mobile specialist supporting React Native, Flutter, iOS (Swift/SwiftUI), and Android (Kotlin/Compose). Focuses on mobile-specific patterns, performance, and platform guidelines. |  |
+| Observability Specialist | Observability expert for Planning, Implementation, and Evaluation modes - unified specialist for vendor-neutral monitoring, distributed tracing, structured logging, SLI/SLO frameworks, and alerting patterns |  |
+| Parallel Orchestrator | Orchestrates parallel execution of multiple GitHub issues using taskMaestro with file-overlap validation, Wave grouping, and AUTO mode workers |  |
+| Performance Specialist | Performance expert for Planning, Implementation, and Evaluation modes - unified specialist for bundle size optimization, rendering optimization, and Core Web Vitals |  |
+| Plan Mode Agent | PLAN mode agent - specialized for work planning and design |  |
+| Plan Reviewer | Reviews implementation plans for quality, completeness, and feasibility before execution |  |
+| Platform Engineer | Cloud-native infrastructure expert for Planning, Implementation, and Evaluation modes - unified specialist for Infrastructure as Code, Kubernetes orchestration, multi-cloud strategy, GitOps workflows, cost optimization, and disaster recovery |  |
+| Security Engineer | Primary Agent for implementing security features, fixing vulnerabilities, and applying security best practices in code |  |
+| Security Specialist | Security expert for Planning, Implementation, and Evaluation modes - unified specialist for authentication, authorization, and security vulnerability prevention |  |
+| SEO Specialist | SEO expert for Planning, Implementation, and Evaluation modes - unified specialist for metadata, structured data, and search engine optimization |  |
+| Software Engineer | General-purpose implementation engineer — any language, any domain, TDD-first |  |
+| Solution Architect | High-level system design and architecture planning specialist |  |
+| Systems Developer | Primary Agent for systems programming, low-level optimization, native code development, and performance-critical implementations |  |
+| Technical Planner | Low-level implementation planning with TDD and bite-sized tasks |  |
+| Test Engineer | Primary Agent for TDD cycle execution, test writing, and coverage improvement across all test types |  |
+| Test Strategy Specialist | Test strategy expert for Planning, Implementation, and Evaluation modes - unified specialist for TDD vs Test-After decisions, test coverage planning, and test quality assessment |  |
+| Tooling Engineer | Project configuration, build tools, and development environment specialist |  |
+| UI/UX Designer | UI/UX design specialist based on universal design principles and UX best practices - focuses on aesthetics, usability, and user experience rather than specific design system implementations |  |
 
 See [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md) for details.
 
@@ -88,7 +125,7 @@ Even if plan separates TDD into individual steps (e.g., Step 1: Write test, Step
 
 **When user message starts with PLAN, ACT, EVAL, or AUTO keyword (or localized: Korean 계획/실행/평가/자동, Japanese 計画/実行/評価/自動, Chinese 计划/执行/评估/自动, Spanish PLANIFICAR/ACTUAR/EVALUAR/AUTOMÁTICO):**
 
-1. **IMMEDIATELY** call `mcp__codingbuddy__parse_mode` with the user's prompt
+1. **IMMEDIATELY** call `parse_mode` MCP tool with the user's prompt
 2. Follow the returned `instructions` **EXACTLY**
 3. Apply the returned `rules` as context
 4. If `warnings` are present, inform the user
@@ -169,38 +206,6 @@ If the `parse_mode` response contains `dispatch="auto"` or `dispatchReady` with 
 2. **Teams preferred** over Agent tool for specialist dispatch (use `TeamCreate` + `SendMessage`)
 3. **Report results** via `SendMessage` back to team lead, not just text output
 
-### Teams-Based Dispatch Workflow
-
-```
-parse_mode returns dispatch="auto"
-     ↓
-TeamCreate({ team_name: "<task>-specialists" })
-     ↓
-Spawn each specialist as teammate via Agent tool (team_name, name)
-     ↓
-Assign tasks via TaskCreate + TaskUpdate (owner)
-     ↓
-Specialists report findings via SendMessage
-     ↓
-Team lead collects and summarizes all findings
-     ↓
-Shutdown teammates via SendMessage({ type: "shutdown_request" })
-```
-
-### SendMessage-Based Reporting
-
-Specialists MUST report findings through `SendMessage`, not just tool output:
-
-```
-SendMessage({
-  to: "team-lead",
-  message: "## [Specialist] Findings\n- Finding 1\n- Finding 2\n...",
-  summary: "[specialist-name] analysis complete"
-})
-```
-
-The team lead collects all specialist messages and presents a consolidated summary.
-
 ### Red Flags (STOP if you think these)
 
 | Thought | Reality |
@@ -210,10 +215,6 @@ The team lead collects all specialist messages and presents a consolidated summa
 | "I'll save time by skipping dispatch" | NO. Skipping specialists causes missed issues that cost more time later. |
 | "The specialists will just repeat what I already know" | NO. Specialists catch domain-specific issues you would miss. |
 | "I'll dispatch them later after I look at the code" | NO. Dispatch IMMEDIATELY when dispatch="auto" is returned. |
-
-### Fallback
-
-If Teams-based dispatch fails (e.g., team creation error), fall back to Agent tool with `run_in_background: true` for each specialist. Document the fallback in your response.
 
 </AUTO_DISPATCH_ENFORCEMENT_RULE>
 
@@ -230,44 +231,12 @@ If Teams-based dispatch fails (e.g., team creation error), fall back to Agent to
 - **PLAN/AUTO mode**: Resets (deletes and recreates) the context document
 - **ACT/EVAL mode**: Appends a new section to the existing document
 
-### Key Fields in parse_mode Response
-
-| Field | Description |
-|-------|-------------|
-| `contextFilePath` | Always `docs/codingbuddy/context.md` |
-| `contextExists` | Whether document was found/created |
-| `contextDocument` | Full parsed document with all sections |
-| `mandatoryAction` | Required action before completing the mode |
-
 ### Required Workflow
 
 **In ALL modes:**
 1. `parse_mode` automatically reads/creates context
 2. Review `contextDocument` for previous decisions and notes
 3. Before completing: `update_context` to persist current work
-
-**update_context parameters:**
-- `decisions[]` - Key decisions made
-- `notes[]` - Implementation notes
-- `progress[]` - (ACT) Progress items
-- `findings[]` - (EVAL) Review findings
-- `recommendations[]` - (EVAL) Improvement recommendations
-- `status` - `in_progress` | `completed` | `blocked`
-
-### Why This Matters
-
-- **Single fixed path** - No dynamic filenames, always `docs/codingbuddy/context.md`
-- **Automatic integration** - `parse_mode` handles reset/append logic
-- **Survives compaction** - Context persists even when conversation is summarized
-- **Cross-mode continuity** - ACT mode sees PLAN decisions, EVAL sees ACT progress
-
-### Red Flags (STOP if you think these):
-
-| Thought | Reality |
-|---------|---------|
-| "I'll remember the context" | NO. Context compaction erases memory. |
-| "parse_mode handles everything" | NO. You must call `update_context` before completing. |
-| "The file doesn't exist" | `parse_mode` creates it automatically in PLAN mode. |
 
 </CONTEXT_DOCUMENT_RULE>
 
@@ -283,9 +252,12 @@ If Teams-based dispatch fails (e.g., team creation error), fall back to Agent to
 ## Full Documentation
 
 For comprehensive guides:
-- **Core Rules**: [packages/rules/.ai-rules/rules/core.md](../../packages/rules/.ai-rules/rules/core.md)
-- **Project Setup**: [packages/rules/.ai-rules/rules/project.md](../../packages/rules/.ai-rules/rules/project.md)
-- **Augmented Coding**: [packages/rules/.ai-rules/rules/augmented-coding.md](../../packages/rules/.ai-rules/rules/augmented-coding.md)
+- **augmented-coding**: [packages/rules/.ai-rules/rules/augmented-coding.md](../../packages/rules/.ai-rules/rules/augmented-coding.md)
+- **clarification-guide**: [packages/rules/.ai-rules/rules/clarification-guide.md](../../packages/rules/.ai-rules/rules/clarification-guide.md)
+- **core**: [packages/rules/.ai-rules/rules/core.md](../../packages/rules/.ai-rules/rules/core.md)
+- **parallel-execution**: [packages/rules/.ai-rules/rules/parallel-execution.md](../../packages/rules/.ai-rules/rules/parallel-execution.md)
+- **project**: [packages/rules/.ai-rules/rules/project.md](../../packages/rules/.ai-rules/rules/project.md)
+- **structured-reasoning-guide**: [packages/rules/.ai-rules/rules/structured-reasoning-guide.md](../../packages/rules/.ai-rules/rules/structured-reasoning-guide.md)
 - **Agents System**: [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md)
 - **Claude Integration**: [packages/rules/.ai-rules/adapters/claude-code.md](../../packages/rules/.ai-rules/adapters/claude-code.md)
 

--- a/.codex/rules/system-prompt.md
+++ b/.codex/rules/system-prompt.md
@@ -34,10 +34,47 @@ You have four modes of operation:
 - **Frontend Developer** (`packages/rules/.ai-rules/agents/frontend-developer.json`): PLAN/ACT modes
 - **Code Reviewer** (`packages/rules/.ai-rules/agents/code-reviewer.json`): EVAL mode
 
-**Specialist Agents** (35 available):
-- Architecture, Test Strategy, Performance, Security
-- Accessibility, SEO, i18n, Documentation
-- Code Quality, and more
+**Specialist Agents** (37 available):
+
+| Agent | Description | Expertise |
+|-------|-------------|-----------|
+| Accessibility Specialist | Accessibility expert for Planning, Implementation, and Evaluation modes - unified specialist for WCAG 2.1 AA compliance, ARIA attributes, and keyboard navigation |  |
+| Act Mode Agent | ACT mode agent - specialized for actual implementation execution |  |
+| Agent Architect | Primary Agent for creating, validating, and managing AI agent configurations |  |
+| AI/ML Engineer | AI/ML expert for Planning, Implementation, and Evaluation modes - unified specialist for LLM integration, prompt engineering, RAG architecture, AI safety, and testing non-deterministic systems |  |
+| Architecture Specialist | Architecture expert for Planning, Implementation, and Evaluation modes - unified specialist for layer placement, dependency direction, and type safety |  |
+| Auto Mode Agent | AUTO mode agent - autonomous PLAN → ACT → EVAL cycle until quality targets met |  |
+| Backend Developer | Language-agnostic backend specialist with Clean Architecture, TDD, and security focus. Supports Node.js, Python, Go, Java, and other backend stacks. |  |
+| Code Quality Specialist | Code quality expert for Planning, Implementation, and Evaluation modes - unified specialist for SOLID principles, DRY, complexity analysis, and design patterns |  |
+| Code Reviewer | Senior software engineer specializing in comprehensive code quality evaluation and improvement recommendations |  |
+| Data Engineer | Data specialist focused on database design, schema optimization, migrations, and analytics query optimization. Handles data modeling, ETL patterns, and reporting data structures. |  |
+| Data Scientist | Data science specialist for exploratory data analysis, statistical modeling, ML model development, and data visualization. Handles EDA, feature engineering, model training, and Jupyter notebook development. |  |
+| DevOps Engineer | Docker, Datadog monitoring, and Next.js deployment specialist |  |
+| Documentation Specialist | Documentation expert for Planning, Implementation, and Evaluation modes - unified specialist for documentation planning, code comments, type definitions, and documentation quality assessment |  |
+| Eval Mode Agent | EVAL mode agent - specialized for code quality evaluation and improvement suggestions |  |
+| Event Architecture Specialist | Event-driven architecture specialist for Planning, Implementation, and Evaluation modes - unified specialist for message queues, event sourcing, CQRS, real-time communication, distributed transactions, and event schema management |  |
+| Frontend Developer | Modern React/Next.js specialist with Server Components/Actions, TDD, and accessibility focus |  |
+| i18n Specialist | Internationalization expert for Planning, Implementation, and Evaluation modes - unified specialist for i18n library setup, translation key structure, formatting, and RTL support |  |
+| Integration Specialist | External service integration specialist for Planning, Implementation, and Evaluation modes - unified specialist for API integrations, webhooks, OAuth flows, and failure isolation patterns |  |
+| Migration Specialist | Cross-cutting migration coordinator for legacy system modernization, framework upgrades, database migrations, and API versioning - unified specialist for Strangler Fig, Branch by Abstraction, and zero-downtime migration patterns |  |
+| Mobile Developer | Cross-platform and native mobile specialist supporting React Native, Flutter, iOS (Swift/SwiftUI), and Android (Kotlin/Compose). Focuses on mobile-specific patterns, performance, and platform guidelines. |  |
+| Observability Specialist | Observability expert for Planning, Implementation, and Evaluation modes - unified specialist for vendor-neutral monitoring, distributed tracing, structured logging, SLI/SLO frameworks, and alerting patterns |  |
+| Parallel Orchestrator | Orchestrates parallel execution of multiple GitHub issues using taskMaestro with file-overlap validation, Wave grouping, and AUTO mode workers |  |
+| Performance Specialist | Performance expert for Planning, Implementation, and Evaluation modes - unified specialist for bundle size optimization, rendering optimization, and Core Web Vitals |  |
+| Plan Mode Agent | PLAN mode agent - specialized for work planning and design |  |
+| Plan Reviewer | Reviews implementation plans for quality, completeness, and feasibility before execution |  |
+| Platform Engineer | Cloud-native infrastructure expert for Planning, Implementation, and Evaluation modes - unified specialist for Infrastructure as Code, Kubernetes orchestration, multi-cloud strategy, GitOps workflows, cost optimization, and disaster recovery |  |
+| Security Engineer | Primary Agent for implementing security features, fixing vulnerabilities, and applying security best practices in code |  |
+| Security Specialist | Security expert for Planning, Implementation, and Evaluation modes - unified specialist for authentication, authorization, and security vulnerability prevention |  |
+| SEO Specialist | SEO expert for Planning, Implementation, and Evaluation modes - unified specialist for metadata, structured data, and search engine optimization |  |
+| Software Engineer | General-purpose implementation engineer — any language, any domain, TDD-first |  |
+| Solution Architect | High-level system design and architecture planning specialist |  |
+| Systems Developer | Primary Agent for systems programming, low-level optimization, native code development, and performance-critical implementations |  |
+| Technical Planner | Low-level implementation planning with TDD and bite-sized tasks |  |
+| Test Engineer | Primary Agent for TDD cycle execution, test writing, and coverage improvement across all test types |  |
+| Test Strategy Specialist | Test strategy expert for Planning, Implementation, and Evaluation modes - unified specialist for TDD vs Test-After decisions, test coverage planning, and test quality assessment |  |
+| Tooling Engineer | Project configuration, build tools, and development environment specialist |  |
+| UI/UX Designer | UI/UX design specialist based on universal design principles and UX best practices - focuses on aesthetics, usability, and user experience rather than specific design system implementations |  |
 
 For complete workflow details, see [packages/rules/.ai-rules/rules/core.md](../../packages/rules/.ai-rules/rules/core.md)
 
@@ -95,7 +132,6 @@ Follow the **Red → Green → Refactor** cycle:
 - DRY (Don't Repeat Yourself)
 - Keep methods small (10-20 lines max)
 - Minimize state, prefer pure functions
-- Tidy First: Separate structural vs behavioral changes
 
 For complete augmented coding guide, see [packages/rules/.ai-rules/rules/augmented-coding.md](../../packages/rules/.ai-rules/rules/augmented-coding.md)
 
@@ -105,19 +141,6 @@ For complete augmented coding guide, see [packages/rules/.ai-rules/rules/augment
 
 **Source**: [packages/rules/.ai-rules/agents/](../../packages/rules/.ai-rules/agents/)
 
-All specialist agents are defined in `packages/rules/.ai-rules/agents/` directory:
-
-| Agent | Expertise | Use Cases |
-|-------|-----------|-----------|
-| Frontend Developer | React/Next.js, TDD, design system | Component implementation, Server Actions |
-| Code Reviewer | Quality evaluation, architecture | Code review, production readiness |
-| Security Specialist | OAuth 2.0, JWT, XSS/CSRF | Authentication, security audit |
-| Accessibility Specialist | WCAG 2.1 AA, ARIA | A11y compliance, screen readers |
-| Performance Specialist | Bundle size, Core Web Vitals | Performance tuning, optimization |
-| +7 more specialists | Various domains | See agents README |
-
-For complete agent documentation, see [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md)
-
 ### Specialist Execution
 
 When `parse_mode` returns `parallelAgentsRecommendation` or `dispatchReady`, execute specialists **sequentially**:
@@ -125,12 +148,6 @@ When `parse_mode` returns `parallelAgentsRecommendation` or `dispatchReady`, exe
 1. Announce specialists being analyzed
 2. For each specialist: apply its system prompt as analysis context, analyze, record findings
 3. Consolidate all findings into a unified summary
-
-**Preferred workflow:**
-- If `dispatchReady.parallelAgents[]` exists: use `dispatchParams.prompt` directly
-- Otherwise: call `prepare_parallel_agents` MCP tool to get system prompts
-
-**Note:** `subagent_type` and `run_in_background` are Claude Code-specific parameters — ignore them in Codex.
 
 See [packages/rules/.ai-rules/adapters/codex.md](../../packages/rules/.ai-rules/adapters/codex.md#specialist-agents-execution) for the full workflow.
 
@@ -199,14 +216,6 @@ codingbuddy MCP 서버 사용 시 `CODINGBUDDY_PROJECT_ROOT` 환경변수를 프
 }
 ```
 
-**Project root resolution priority:**
-1. `CODINGBUDDY_PROJECT_ROOT` environment variable (highest priority)
-2. `roots/list` MCP capability (support unconfirmed in Codex)
-3. `findProjectRoot()` automatic detection (fallback)
-
-> `CODINGBUDDY_PROJECT_ROOT` 없이는 서버가 프로젝트의 `codingbuddy.config.json`을 찾지 못하여
-> `language` 등 설정이 기본값으로 동작합니다.
-
 자세한 설정 방법: [packages/rules/.ai-rules/adapters/codex.md](../../packages/rules/.ai-rules/adapters/codex.md)
 
 ---
@@ -228,73 +237,28 @@ codingbuddy MCP 서버 사용 시 `CODINGBUDDY_PROJECT_ROOT` 환경변수를 프
 | `get_agent_details` | Get detailed profile of a specific AI agent | Need agent expertise info |
 | `get_agent_system_prompt` | Get complete system prompt for a specialist agent | Before specialist analysis |
 | `prepare_parallel_agents` | Prepare specialist agents for sequential execution | EVAL mode specialist analysis |
-| `dispatch_agents` | Get dispatch params (Claude Code optimized — use `prepare_parallel_agents` instead) | Not recommended for Codex |
-| `analyze_task` | Task risk assessment, specialist recommendations, and workflow suggestions | Start of PLAN mode |
+| `dispatch_agents` | Get dispatch params (Claude Code optimized) | Not recommended for Codex |
+| `analyze_task` | Task risk assessment, specialist recommendations | Start of PLAN mode |
 | `generate_checklist` | Contextual checklists (security, accessibility, performance, testing, code-quality, SEO) | Before completing ACT/EVAL |
 | `get_project_config` | Get project tech stack, architecture, conventions, and language settings | Need project context |
 | `get_code_conventions` | Get project code conventions from tsconfig, eslint, prettier, editorconfig | Before implementing code changes |
-| `suggest_config_updates` | Analyze project and suggest config updates based on detected changes | After project setup changes |
-| `recommend_skills` | Recommend skills based on user prompt with multi-language support | Detect skill-worthy intent |
-| `get_skill` | Get full skill content by name (definition + instructions) | After recommend_skills or slash-command |
-| `list_skills` | List all available skills with optional priority filtering | Browse skill catalog |
-| `read_context` | Read context document (docs/codingbuddy/context.md) with verbosity control | Check previous mode decisions |
+| `recommend_skills` | Recommend skills based on user prompt | Detect skill-worthy intent |
+| `get_skill` | Get full skill content by name | After recommend_skills or slash-command |
+| `list_skills` | List all available skills | Browse skill catalog |
+| `read_context` | Read context document | Check previous mode decisions |
 | `update_context` | Persist decisions, notes, progress to context document | **MANDATORY** before completing each mode |
-| `cleanup_context` | Summarize older context sections to reduce document size | Context document too large |
-| `set_project_root` | ~~Set project root~~ **(deprecated — will be removed in v2.0.0)** | Use `CODINGBUDDY_PROJECT_ROOT` env var |
-| `restart_tui` | Restart TUI client when unresponsive (Claude Code only) | Not applicable in Codex |
 
 ---
 
-## 🛠️ Skills
-
-> **Note:** For the complete MCP tools reference, see the [Available MCP Tools](#-available-mcp-tools) section above. This section focuses on skill usage patterns.
-
-Skills are structured AI instructions for specialized tasks (brainstorming, TDD, debugging, planning, etc.).
-
-### Skill Access Methods
-
-**Primary (MCP Tool — works with npm install):**
-
-| Tool | Description |
-|------|-------------|
-| `recommend_skills` | Recommend skills based on user prompt with multi-language support |
-| `get_skill` | Load full skill content by name |
-| `list_skills` | List all available skills with optional filtering |
-
-**Usage pattern:**
-```
-User prompt → recommend_skills(prompt) → get_skill(recommended skillName) → follow instructions
-```
-
-**Fallback (Monorepo contributors only):**
-```bash
-cat .ai-rules/skills/<skill-name>/SKILL.md
-```
-
-> **Note:** `parse_mode` already embeds matched skill content in `included_skills` — no separate `get_skill` call needed when using mode keywords (PLAN/ACT/EVAL/AUTO).
-
-### Available Skills
-
-Highlighted skills (use `list_skills()` for the complete list):
-
-- `brainstorming` - Explore requirements before implementation
-- `test-driven-development` - TDD workflow
-- `systematic-debugging` - Debug methodically
-- `writing-plans` - Create implementation plans
-- `executing-plans` - Execute plans with checkpoints
-- `subagent-driven-development` - In-session plan execution
-- `dispatching-parallel-agents` - Handle parallel tasks
-- `frontend-design` - Build production-grade UI
-- `pr-all-in-one` - Unified commit and PR workflow
-
----
-
-## 📖 Full Documentation
+## Full Documentation
 
 For comprehensive guides:
-- **Core Rules**: [packages/rules/.ai-rules/rules/core.md](../../packages/rules/.ai-rules/rules/core.md)
-- **Project Setup**: [packages/rules/.ai-rules/rules/project.md](../../packages/rules/.ai-rules/rules/project.md)
-- **Augmented Coding**: [packages/rules/.ai-rules/rules/augmented-coding.md](../../packages/rules/.ai-rules/rules/augmented-coding.md)
+- **augmented-coding**: [packages/rules/.ai-rules/rules/augmented-coding.md](../../packages/rules/.ai-rules/rules/augmented-coding.md)
+- **clarification-guide**: [packages/rules/.ai-rules/rules/clarification-guide.md](../../packages/rules/.ai-rules/rules/clarification-guide.md)
+- **core**: [packages/rules/.ai-rules/rules/core.md](../../packages/rules/.ai-rules/rules/core.md)
+- **parallel-execution**: [packages/rules/.ai-rules/rules/parallel-execution.md](../../packages/rules/.ai-rules/rules/parallel-execution.md)
+- **project**: [packages/rules/.ai-rules/rules/project.md](../../packages/rules/.ai-rules/rules/project.md)
+- **structured-reasoning-guide**: [packages/rules/.ai-rules/rules/structured-reasoning-guide.md](../../packages/rules/.ai-rules/rules/structured-reasoning-guide.md)
 - **Agents System**: [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md)
 - **Integration Guide**: [packages/rules/.ai-rules/adapters/codex.md](../../packages/rules/.ai-rules/adapters/codex.md)
 

--- a/.cursor/rules/auto-agent.mdc
+++ b/.cursor/rules/auto-agent.mdc
@@ -60,6 +60,48 @@ When `parse_mode` returns `parallelAgentsRecommendation`:
 
 See `packages/rules/.ai-rules/adapters/cursor.md` for full details.
 
+## Available Agents
+
+| Agent | Description | Expertise |
+|-------|-------------|-----------|
+| Accessibility Specialist | Accessibility expert for Planning, Implementation, and Evaluation modes - unified specialist for WCAG 2.1 AA compliance, ARIA attributes, and keyboard navigation |  |
+| Act Mode Agent | ACT mode agent - specialized for actual implementation execution |  |
+| Agent Architect | Primary Agent for creating, validating, and managing AI agent configurations |  |
+| AI/ML Engineer | AI/ML expert for Planning, Implementation, and Evaluation modes - unified specialist for LLM integration, prompt engineering, RAG architecture, AI safety, and testing non-deterministic systems |  |
+| Architecture Specialist | Architecture expert for Planning, Implementation, and Evaluation modes - unified specialist for layer placement, dependency direction, and type safety |  |
+| Auto Mode Agent | AUTO mode agent - autonomous PLAN → ACT → EVAL cycle until quality targets met |  |
+| Backend Developer | Language-agnostic backend specialist with Clean Architecture, TDD, and security focus. Supports Node.js, Python, Go, Java, and other backend stacks. |  |
+| Code Quality Specialist | Code quality expert for Planning, Implementation, and Evaluation modes - unified specialist for SOLID principles, DRY, complexity analysis, and design patterns |  |
+| Code Reviewer | Senior software engineer specializing in comprehensive code quality evaluation and improvement recommendations |  |
+| Data Engineer | Data specialist focused on database design, schema optimization, migrations, and analytics query optimization. Handles data modeling, ETL patterns, and reporting data structures. |  |
+| Data Scientist | Data science specialist for exploratory data analysis, statistical modeling, ML model development, and data visualization. Handles EDA, feature engineering, model training, and Jupyter notebook development. |  |
+| DevOps Engineer | Docker, Datadog monitoring, and Next.js deployment specialist |  |
+| Documentation Specialist | Documentation expert for Planning, Implementation, and Evaluation modes - unified specialist for documentation planning, code comments, type definitions, and documentation quality assessment |  |
+| Eval Mode Agent | EVAL mode agent - specialized for code quality evaluation and improvement suggestions |  |
+| Event Architecture Specialist | Event-driven architecture specialist for Planning, Implementation, and Evaluation modes - unified specialist for message queues, event sourcing, CQRS, real-time communication, distributed transactions, and event schema management |  |
+| Frontend Developer | Modern React/Next.js specialist with Server Components/Actions, TDD, and accessibility focus |  |
+| i18n Specialist | Internationalization expert for Planning, Implementation, and Evaluation modes - unified specialist for i18n library setup, translation key structure, formatting, and RTL support |  |
+| Integration Specialist | External service integration specialist for Planning, Implementation, and Evaluation modes - unified specialist for API integrations, webhooks, OAuth flows, and failure isolation patterns |  |
+| Migration Specialist | Cross-cutting migration coordinator for legacy system modernization, framework upgrades, database migrations, and API versioning - unified specialist for Strangler Fig, Branch by Abstraction, and zero-downtime migration patterns |  |
+| Mobile Developer | Cross-platform and native mobile specialist supporting React Native, Flutter, iOS (Swift/SwiftUI), and Android (Kotlin/Compose). Focuses on mobile-specific patterns, performance, and platform guidelines. |  |
+| Observability Specialist | Observability expert for Planning, Implementation, and Evaluation modes - unified specialist for vendor-neutral monitoring, distributed tracing, structured logging, SLI/SLO frameworks, and alerting patterns |  |
+| Parallel Orchestrator | Orchestrates parallel execution of multiple GitHub issues using taskMaestro with file-overlap validation, Wave grouping, and AUTO mode workers |  |
+| Performance Specialist | Performance expert for Planning, Implementation, and Evaluation modes - unified specialist for bundle size optimization, rendering optimization, and Core Web Vitals |  |
+| Plan Mode Agent | PLAN mode agent - specialized for work planning and design |  |
+| Plan Reviewer | Reviews implementation plans for quality, completeness, and feasibility before execution |  |
+| Platform Engineer | Cloud-native infrastructure expert for Planning, Implementation, and Evaluation modes - unified specialist for Infrastructure as Code, Kubernetes orchestration, multi-cloud strategy, GitOps workflows, cost optimization, and disaster recovery |  |
+| Security Engineer | Primary Agent for implementing security features, fixing vulnerabilities, and applying security best practices in code |  |
+| Security Specialist | Security expert for Planning, Implementation, and Evaluation modes - unified specialist for authentication, authorization, and security vulnerability prevention |  |
+| SEO Specialist | SEO expert for Planning, Implementation, and Evaluation modes - unified specialist for metadata, structured data, and search engine optimization |  |
+| Software Engineer | General-purpose implementation engineer — any language, any domain, TDD-first |  |
+| Solution Architect | High-level system design and architecture planning specialist |  |
+| Systems Developer | Primary Agent for systems programming, low-level optimization, native code development, and performance-critical implementations |  |
+| Technical Planner | Low-level implementation planning with TDD and bite-sized tasks |  |
+| Test Engineer | Primary Agent for TDD cycle execution, test writing, and coverage improvement across all test types |  |
+| Test Strategy Specialist | Test strategy expert for Planning, Implementation, and Evaluation modes - unified specialist for TDD vs Test-After decisions, test coverage planning, and test quality assessment |  |
+| Tooling Engineer | Project configuration, build tools, and development environment specialist |  |
+| UI/UX Designer | UI/UX design specialist based on universal design principles and UX best practices - focuses on aesthetics, usability, and user experience rather than specific design system implementations |  |
+
 ## Reference
 
 Agent definitions: `packages/rules/.ai-rules/agents/README.md`

--- a/.cursor/rules/imports.mdc
+++ b/.cursor/rules/imports.mdc
@@ -55,6 +55,10 @@ Key skill triggers:
 
 All details in Single Source of Truth:
 
-- [`packages/rules/.ai-rules/rules/core.md`](../../packages/rules/.ai-rules/rules/core.md)
 - [`packages/rules/.ai-rules/rules/augmented-coding.md`](../../packages/rules/.ai-rules/rules/augmented-coding.md)
+- [`packages/rules/.ai-rules/rules/clarification-guide.md`](../../packages/rules/.ai-rules/rules/clarification-guide.md)
+- [`packages/rules/.ai-rules/rules/core.md`](../../packages/rules/.ai-rules/rules/core.md)
+- [`packages/rules/.ai-rules/rules/parallel-execution.md`](../../packages/rules/.ai-rules/rules/parallel-execution.md)
+- [`packages/rules/.ai-rules/rules/project.md`](../../packages/rules/.ai-rules/rules/project.md)
+- [`packages/rules/.ai-rules/rules/structured-reasoning-guide.md`](../../packages/rules/.ai-rules/rules/structured-reasoning-guide.md)
 - [`packages/rules/.ai-rules/agents/README.md`](../../packages/rules/.ai-rules/agents/README.md)

--- a/.kiro/rules/guidelines.md
+++ b/.kiro/rules/guidelines.md
@@ -30,12 +30,46 @@ See `packages/rules/.ai-rules/rules/augmented-coding.md`:
 ### Specialist Knowledge
 
 See `packages/rules/.ai-rules/agents/`:
-- Frontend Development (React/Next.js, TDD, design system)
-- Code Review (quality evaluation, architecture analysis)
-- Security (OAuth 2.0, JWT, XSS/CSRF protection)
-- Performance (bundle optimization, rendering)
-- Accessibility (WCAG 2.1 AA compliance)
-- SEO, Architecture, Test Strategy, Design System, Documentation, Code Quality, DevOps
+
+| Agent | Description | Expertise |
+|-------|-------------|-----------|
+| Accessibility Specialist | Accessibility expert for Planning, Implementation, and Evaluation modes - unified specialist for WCAG 2.1 AA compliance, ARIA attributes, and keyboard navigation |  |
+| Act Mode Agent | ACT mode agent - specialized for actual implementation execution |  |
+| Agent Architect | Primary Agent for creating, validating, and managing AI agent configurations |  |
+| AI/ML Engineer | AI/ML expert for Planning, Implementation, and Evaluation modes - unified specialist for LLM integration, prompt engineering, RAG architecture, AI safety, and testing non-deterministic systems |  |
+| Architecture Specialist | Architecture expert for Planning, Implementation, and Evaluation modes - unified specialist for layer placement, dependency direction, and type safety |  |
+| Auto Mode Agent | AUTO mode agent - autonomous PLAN → ACT → EVAL cycle until quality targets met |  |
+| Backend Developer | Language-agnostic backend specialist with Clean Architecture, TDD, and security focus. Supports Node.js, Python, Go, Java, and other backend stacks. |  |
+| Code Quality Specialist | Code quality expert for Planning, Implementation, and Evaluation modes - unified specialist for SOLID principles, DRY, complexity analysis, and design patterns |  |
+| Code Reviewer | Senior software engineer specializing in comprehensive code quality evaluation and improvement recommendations |  |
+| Data Engineer | Data specialist focused on database design, schema optimization, migrations, and analytics query optimization. Handles data modeling, ETL patterns, and reporting data structures. |  |
+| Data Scientist | Data science specialist for exploratory data analysis, statistical modeling, ML model development, and data visualization. Handles EDA, feature engineering, model training, and Jupyter notebook development. |  |
+| DevOps Engineer | Docker, Datadog monitoring, and Next.js deployment specialist |  |
+| Documentation Specialist | Documentation expert for Planning, Implementation, and Evaluation modes - unified specialist for documentation planning, code comments, type definitions, and documentation quality assessment |  |
+| Eval Mode Agent | EVAL mode agent - specialized for code quality evaluation and improvement suggestions |  |
+| Event Architecture Specialist | Event-driven architecture specialist for Planning, Implementation, and Evaluation modes - unified specialist for message queues, event sourcing, CQRS, real-time communication, distributed transactions, and event schema management |  |
+| Frontend Developer | Modern React/Next.js specialist with Server Components/Actions, TDD, and accessibility focus |  |
+| i18n Specialist | Internationalization expert for Planning, Implementation, and Evaluation modes - unified specialist for i18n library setup, translation key structure, formatting, and RTL support |  |
+| Integration Specialist | External service integration specialist for Planning, Implementation, and Evaluation modes - unified specialist for API integrations, webhooks, OAuth flows, and failure isolation patterns |  |
+| Migration Specialist | Cross-cutting migration coordinator for legacy system modernization, framework upgrades, database migrations, and API versioning - unified specialist for Strangler Fig, Branch by Abstraction, and zero-downtime migration patterns |  |
+| Mobile Developer | Cross-platform and native mobile specialist supporting React Native, Flutter, iOS (Swift/SwiftUI), and Android (Kotlin/Compose). Focuses on mobile-specific patterns, performance, and platform guidelines. |  |
+| Observability Specialist | Observability expert for Planning, Implementation, and Evaluation modes - unified specialist for vendor-neutral monitoring, distributed tracing, structured logging, SLI/SLO frameworks, and alerting patterns |  |
+| Parallel Orchestrator | Orchestrates parallel execution of multiple GitHub issues using taskMaestro with file-overlap validation, Wave grouping, and AUTO mode workers |  |
+| Performance Specialist | Performance expert for Planning, Implementation, and Evaluation modes - unified specialist for bundle size optimization, rendering optimization, and Core Web Vitals |  |
+| Plan Mode Agent | PLAN mode agent - specialized for work planning and design |  |
+| Plan Reviewer | Reviews implementation plans for quality, completeness, and feasibility before execution |  |
+| Platform Engineer | Cloud-native infrastructure expert for Planning, Implementation, and Evaluation modes - unified specialist for Infrastructure as Code, Kubernetes orchestration, multi-cloud strategy, GitOps workflows, cost optimization, and disaster recovery |  |
+| Security Engineer | Primary Agent for implementing security features, fixing vulnerabilities, and applying security best practices in code |  |
+| Security Specialist | Security expert for Planning, Implementation, and Evaluation modes - unified specialist for authentication, authorization, and security vulnerability prevention |  |
+| SEO Specialist | SEO expert for Planning, Implementation, and Evaluation modes - unified specialist for metadata, structured data, and search engine optimization |  |
+| Software Engineer | General-purpose implementation engineer — any language, any domain, TDD-first |  |
+| Solution Architect | High-level system design and architecture planning specialist |  |
+| Systems Developer | Primary Agent for systems programming, low-level optimization, native code development, and performance-critical implementations |  |
+| Technical Planner | Low-level implementation planning with TDD and bite-sized tasks |  |
+| Test Engineer | Primary Agent for TDD cycle execution, test writing, and coverage improvement across all test types |  |
+| Test Strategy Specialist | Test strategy expert for Planning, Implementation, and Evaluation modes - unified specialist for TDD vs Test-After decisions, test coverage planning, and test quality assessment |  |
+| Tooling Engineer | Project configuration, build tools, and development environment specialist |  |
+| UI/UX Designer | UI/UX design specialist based on universal design principles and UX best practices - focuses on aesthetics, usability, and user experience rather than specific design system implementations |  |
 
 ### MCP Server Integration
 
@@ -56,14 +90,6 @@ When the codingbuddy MCP server is configured (`.kiro/settings/mcp.json`), use M
 - `recommend_skills` → `get_skill` — Discover and load relevant skills
 - `prepare_parallel_agents` — Get specialist prompts for sequential execution
 
-**Slash-Command Handling:**
-- When user types `/<command>` (e.g., `/debug`, `/tdd`), call `get_skill("<skill-name>")` to load the skill
-- See `packages/rules/.ai-rules/adapters/kiro.md` for the full mapping table
-
-**Proactive Skill Activation:**
-- When user intent matches skill patterns (bugs, planning, TDD), call `recommend_skills` proactively — before any other action
-- `recommend_skills` is the authoritative source of truth for intent-to-skill matching
-
 **Configuration Tools:**
 - `get_project_config` — Get project configuration (language, tech stack)
 - `get_code_conventions` — Get project code conventions
@@ -76,23 +102,24 @@ When the codingbuddy MCP server is configured (`.kiro/settings/mcp.json`), use M
 
 **When user message starts with PLAN, ACT, EVAL, or AUTO keyword (or localized: Korean 계획/실행/평가/자동, Japanese 計画/実行/評価/自動, Chinese 计划/执行/评估/自动, Spanish PLANIFICAR/ACTUAR/EVALUAR/AUTOMÁTICO):**
 
-1. **IMMEDIATELY** call `parse_mode` MCP tool (if available) or follow the mode-specific rules from `packages/rules/.ai-rules/rules/core.md`
-2. Apply the mode's workflow **EXACTLY**
-3. Do NOT proceed with your own interpretation
+1. **IMMEDIATELY** call `parse_mode` MCP tool with the user's prompt
+2. Follow the returned `instructions` **EXACTLY**
+3. Apply the returned `rules` as context
+4. If `warnings` are present, inform the user
 
 **This is MANDATORY, not optional.**
 
-Failure to follow mode rules when these keywords are present will result in:
+Failure to call `parse_mode` when these keywords are present will result in:
 - Missed critical checklists (Devil's Advocate Analysis, Impact Radius Analysis)
 - Incomplete evaluations
 - Quality issues not caught before deployment
 
 **Red Flags** (STOP if you think these):
-
 | Thought | Reality |
 |---------|---------|
-| "I can handle EVAL myself" | NO. Follow mode rules FIRST. |
+| "I can handle EVAL myself" | NO. Call parse_mode FIRST. |
 | "The rules are similar anyway" | NO. Each mode has specific checklists. |
+| "I'll save a tool call" | NO. parse_mode MUST be called FIRST. |
 | "I already know what to do" | NO. Rules may have been updated. |
 
 </CODINGBUDDY_CRITICAL_RULE>

--- a/.q/rules/customizations.md
+++ b/.q/rules/customizations.md
@@ -28,11 +28,45 @@ Refer to `packages/rules/.ai-rules/rules/augmented-coding.md`:
 
 ### Specialist Expertise
 
-Refer to `packages/rules/.ai-rules/agents/*.json`:
-- Frontend development patterns
-- Security best practices
-- Performance optimization
-- Accessibility guidelines
+| Agent | Description | Expertise |
+|-------|-------------|-----------|
+| Accessibility Specialist | Accessibility expert for Planning, Implementation, and Evaluation modes - unified specialist for WCAG 2.1 AA compliance, ARIA attributes, and keyboard navigation |  |
+| Act Mode Agent | ACT mode agent - specialized for actual implementation execution |  |
+| Agent Architect | Primary Agent for creating, validating, and managing AI agent configurations |  |
+| AI/ML Engineer | AI/ML expert for Planning, Implementation, and Evaluation modes - unified specialist for LLM integration, prompt engineering, RAG architecture, AI safety, and testing non-deterministic systems |  |
+| Architecture Specialist | Architecture expert for Planning, Implementation, and Evaluation modes - unified specialist for layer placement, dependency direction, and type safety |  |
+| Auto Mode Agent | AUTO mode agent - autonomous PLAN → ACT → EVAL cycle until quality targets met |  |
+| Backend Developer | Language-agnostic backend specialist with Clean Architecture, TDD, and security focus. Supports Node.js, Python, Go, Java, and other backend stacks. |  |
+| Code Quality Specialist | Code quality expert for Planning, Implementation, and Evaluation modes - unified specialist for SOLID principles, DRY, complexity analysis, and design patterns |  |
+| Code Reviewer | Senior software engineer specializing in comprehensive code quality evaluation and improvement recommendations |  |
+| Data Engineer | Data specialist focused on database design, schema optimization, migrations, and analytics query optimization. Handles data modeling, ETL patterns, and reporting data structures. |  |
+| Data Scientist | Data science specialist for exploratory data analysis, statistical modeling, ML model development, and data visualization. Handles EDA, feature engineering, model training, and Jupyter notebook development. |  |
+| DevOps Engineer | Docker, Datadog monitoring, and Next.js deployment specialist |  |
+| Documentation Specialist | Documentation expert for Planning, Implementation, and Evaluation modes - unified specialist for documentation planning, code comments, type definitions, and documentation quality assessment |  |
+| Eval Mode Agent | EVAL mode agent - specialized for code quality evaluation and improvement suggestions |  |
+| Event Architecture Specialist | Event-driven architecture specialist for Planning, Implementation, and Evaluation modes - unified specialist for message queues, event sourcing, CQRS, real-time communication, distributed transactions, and event schema management |  |
+| Frontend Developer | Modern React/Next.js specialist with Server Components/Actions, TDD, and accessibility focus |  |
+| i18n Specialist | Internationalization expert for Planning, Implementation, and Evaluation modes - unified specialist for i18n library setup, translation key structure, formatting, and RTL support |  |
+| Integration Specialist | External service integration specialist for Planning, Implementation, and Evaluation modes - unified specialist for API integrations, webhooks, OAuth flows, and failure isolation patterns |  |
+| Migration Specialist | Cross-cutting migration coordinator for legacy system modernization, framework upgrades, database migrations, and API versioning - unified specialist for Strangler Fig, Branch by Abstraction, and zero-downtime migration patterns |  |
+| Mobile Developer | Cross-platform and native mobile specialist supporting React Native, Flutter, iOS (Swift/SwiftUI), and Android (Kotlin/Compose). Focuses on mobile-specific patterns, performance, and platform guidelines. |  |
+| Observability Specialist | Observability expert for Planning, Implementation, and Evaluation modes - unified specialist for vendor-neutral monitoring, distributed tracing, structured logging, SLI/SLO frameworks, and alerting patterns |  |
+| Parallel Orchestrator | Orchestrates parallel execution of multiple GitHub issues using taskMaestro with file-overlap validation, Wave grouping, and AUTO mode workers |  |
+| Performance Specialist | Performance expert for Planning, Implementation, and Evaluation modes - unified specialist for bundle size optimization, rendering optimization, and Core Web Vitals |  |
+| Plan Mode Agent | PLAN mode agent - specialized for work planning and design |  |
+| Plan Reviewer | Reviews implementation plans for quality, completeness, and feasibility before execution |  |
+| Platform Engineer | Cloud-native infrastructure expert for Planning, Implementation, and Evaluation modes - unified specialist for Infrastructure as Code, Kubernetes orchestration, multi-cloud strategy, GitOps workflows, cost optimization, and disaster recovery |  |
+| Security Engineer | Primary Agent for implementing security features, fixing vulnerabilities, and applying security best practices in code |  |
+| Security Specialist | Security expert for Planning, Implementation, and Evaluation modes - unified specialist for authentication, authorization, and security vulnerability prevention |  |
+| SEO Specialist | SEO expert for Planning, Implementation, and Evaluation modes - unified specialist for metadata, structured data, and search engine optimization |  |
+| Software Engineer | General-purpose implementation engineer — any language, any domain, TDD-first |  |
+| Solution Architect | High-level system design and architecture planning specialist |  |
+| Systems Developer | Primary Agent for systems programming, low-level optimization, native code development, and performance-critical implementations |  |
+| Technical Planner | Low-level implementation planning with TDD and bite-sized tasks |  |
+| Test Engineer | Primary Agent for TDD cycle execution, test writing, and coverage improvement across all test types |  |
+| Test Strategy Specialist | Test strategy expert for Planning, Implementation, and Evaluation modes - unified specialist for TDD vs Test-After decisions, test coverage planning, and test quality assessment |  |
+| Tooling Engineer | Project configuration, build tools, and development environment specialist |  |
+| UI/UX Designer | UI/UX design specialist based on universal design principles and UX best practices - focuses on aesthetics, usability, and user experience rather than specific design system implementations |  |
 
 ## 🔴 MANDATORY: Keyword Mode Detection
 
@@ -40,13 +74,14 @@ Refer to `packages/rules/.ai-rules/agents/*.json`:
 
 **When user message starts with PLAN, ACT, EVAL, or AUTO keyword (or localized: Korean 계획/실행/평가/자동, Japanese 計画/実行/評価/自動, Chinese 计划/执行/评估/自动, Spanish PLANIFICAR/ACTUAR/EVALUAR/AUTOMÁTICO):**
 
-1. **IMMEDIATELY** follow the mode-specific rules from `packages/rules/.ai-rules/rules/core.md`
-2. Apply the mode's workflow **EXACTLY**
-3. Do NOT proceed with your own interpretation
+1. **IMMEDIATELY** call `parse_mode` MCP tool with the user's prompt
+2. Follow the returned `instructions` **EXACTLY**
+3. Apply the returned `rules` as context
+4. If `warnings` are present, inform the user
 
 **This is MANDATORY, not optional.**
 
-Failure to follow mode rules when these keywords are present will result in:
+Failure to call `parse_mode` when these keywords are present will result in:
 - Missed critical checklists (Devil's Advocate Analysis, Impact Radius Analysis)
 - Incomplete evaluations
 - Quality issues not caught before deployment
@@ -54,8 +89,9 @@ Failure to follow mode rules when these keywords are present will result in:
 **Red Flags** (STOP if you think these):
 | Thought | Reality |
 |---------|---------|
-| "I can handle EVAL myself" | NO. Follow mode rules FIRST. |
+| "I can handle EVAL myself" | NO. Call parse_mode FIRST. |
 | "The rules are similar anyway" | NO. Each mode has specific checklists. |
+| "I'll save a tool call" | NO. parse_mode MUST be called FIRST. |
 | "I already know what to do" | NO. Rules may have been updated. |
 
 </CODINGBUDDY_CRITICAL_RULE>

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "wiki:generate": "npx tsx scripts/wiki/generate-wiki.ts",
-    "test:wiki": "yarn workspace codingbuddy exec vitest run --config ../../scripts/wiki/vitest.config.ts --root ../../scripts/wiki"
+    "test:wiki": "yarn workspace codingbuddy exec vitest run --config ../../scripts/wiki/vitest.config.ts --root ../../scripts/wiki",
+    "sync:settings": "npx tsx scripts/sync-settings/index.ts",
+    "test:sync": "node apps/mcp-server/node_modules/.bin/vitest run --config scripts/sync-settings/vitest.config.ts --root ."
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",

--- a/scripts/sync-settings/__tests__/fixtures/.ai-rules/agents/README.md
+++ b/scripts/sync-settings/__tests__/fixtures/.ai-rules/agents/README.md
@@ -1,0 +1,1 @@
+# Agent README - should be skipped by readAgents

--- a/scripts/sync-settings/__tests__/fixtures/.ai-rules/agents/backend-developer.json
+++ b/scripts/sync-settings/__tests__/fixtures/.ai-rules/agents/backend-developer.json
@@ -1,0 +1,6 @@
+{
+  "name": "Backend Developer",
+  "description": "Backend development specialist",
+  "expertise": ["Node.js", "REST APIs"],
+  "activation": { "mode": ["PLAN", "ACT"] }
+}

--- a/scripts/sync-settings/__tests__/fixtures/.ai-rules/agents/frontend-developer.json
+++ b/scripts/sync-settings/__tests__/fixtures/.ai-rules/agents/frontend-developer.json
@@ -1,0 +1,6 @@
+{
+  "name": "Frontend Developer",
+  "description": "Frontend development specialist",
+  "expertise": ["React", "TypeScript"],
+  "activation": { "mode": ["PLAN", "ACT"] }
+}

--- a/scripts/sync-settings/__tests__/fixtures/.ai-rules/rules/augmented-coding.md
+++ b/scripts/sync-settings/__tests__/fixtures/.ai-rules/rules/augmented-coding.md
@@ -1,0 +1,5 @@
+# Augmented Coding Principles
+
+## TDD Cycle
+
+Red, Green, Refactor

--- a/scripts/sync-settings/__tests__/fixtures/.ai-rules/rules/core.md
+++ b/scripts/sync-settings/__tests__/fixtures/.ai-rules/rules/core.md
@@ -1,0 +1,5 @@
+# Core Rules
+
+## Work Modes
+
+PLAN, ACT, EVAL, AUTO

--- a/scripts/sync-settings/__tests__/generators.spec.ts
+++ b/scripts/sync-settings/__tests__/generators.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { generateAll, generateForTool } from '../generators';
+import type { SourceData } from '../types';
+
+const FIXTURE_DATA: SourceData = {
+  agents: [
+    {
+      name: 'backend-developer',
+      displayName: 'Backend Developer',
+      description: 'Backend development specialist',
+      expertise: ['Node.js', 'REST APIs'],
+    },
+    {
+      name: 'frontend-developer',
+      displayName: 'Frontend Developer',
+      description: 'Frontend development specialist',
+      expertise: ['React', 'TypeScript'],
+    },
+    {
+      name: 'security-specialist',
+      displayName: 'Security Specialist',
+      description: 'Security audit and hardening',
+      expertise: ['OWASP', 'JWT'],
+    },
+  ],
+  rules: [
+    {
+      name: 'augmented-coding',
+      relativePath: 'packages/rules/.ai-rules/rules/augmented-coding.md',
+    },
+    { name: 'core', relativePath: 'packages/rules/.ai-rules/rules/core.md' },
+    { name: 'project', relativePath: 'packages/rules/.ai-rules/rules/project.md' },
+  ],
+};
+
+describe('generateForTool', () => {
+  describe('cursor', () => {
+    it('generates .mdc file with YAML frontmatter', () => {
+      const files = generateForTool('cursor', FIXTURE_DATA);
+      const autoAgent = files.find(f => f.relativePath === '.cursor/rules/auto-agent.mdc');
+      expect(autoAgent).toBeDefined();
+      expect(autoAgent!.content).toMatch(/^---\n/);
+      expect(autoAgent!.content).toContain('alwaysApply:');
+    });
+
+    it('includes agent mapping table', () => {
+      const files = generateForTool('cursor', FIXTURE_DATA);
+      const autoAgent = files.find(f => f.relativePath === '.cursor/rules/auto-agent.mdc')!;
+      expect(autoAgent.content).toContain('frontend-developer');
+      expect(autoAgent.content).toContain('backend-developer');
+    });
+
+    it('generates imports.mdc', () => {
+      const files = generateForTool('cursor', FIXTURE_DATA);
+      const imports = files.find(f => f.relativePath === '.cursor/rules/imports.mdc');
+      expect(imports).toBeDefined();
+      expect(imports!.content).toContain('parse_mode');
+    });
+  });
+
+  describe('claude', () => {
+    it('generates custom-instructions.md', () => {
+      const files = generateForTool('claude', FIXTURE_DATA);
+      const ci = files.find(f => f.relativePath === '.claude/rules/custom-instructions.md');
+      expect(ci).toBeDefined();
+      expect(ci!.content).toContain('# Custom Instructions for Claude Code');
+    });
+
+    it('includes agent list', () => {
+      const files = generateForTool('claude', FIXTURE_DATA);
+      const ci = files.find(f => f.relativePath === '.claude/rules/custom-instructions.md')!;
+      expect(ci.content).toContain('Frontend Developer');
+      expect(ci.content).toContain('Security Specialist');
+    });
+
+    it('includes CODINGBUDDY_CRITICAL_RULE', () => {
+      const files = generateForTool('claude', FIXTURE_DATA);
+      const ci = files.find(f => f.relativePath === '.claude/rules/custom-instructions.md')!;
+      expect(ci.content).toContain('CODINGBUDDY_CRITICAL_RULE');
+    });
+
+    it('references source rule files', () => {
+      const files = generateForTool('claude', FIXTURE_DATA);
+      const ci = files.find(f => f.relativePath === '.claude/rules/custom-instructions.md')!;
+      expect(ci.content).toContain('packages/rules/.ai-rules/rules/core.md');
+      expect(ci.content).toContain('packages/rules/.ai-rules/rules/augmented-coding.md');
+    });
+  });
+
+  describe('antigravity', () => {
+    it('generates instructions.md', () => {
+      const files = generateForTool('antigravity', FIXTURE_DATA);
+      const instr = files.find(f => f.relativePath === '.antigravity/rules/instructions.md');
+      expect(instr).toBeDefined();
+      expect(instr!.content).toContain('# Antigravity Instructions');
+    });
+
+    it('includes agent list', () => {
+      const files = generateForTool('antigravity', FIXTURE_DATA);
+      const instr = files.find(f => f.relativePath === '.antigravity/rules/instructions.md')!;
+      expect(instr.content).toContain('Backend Developer');
+    });
+  });
+
+  describe('codex', () => {
+    it('generates system-prompt.md', () => {
+      const files = generateForTool('codex', FIXTURE_DATA);
+      const sp = files.find(f => f.relativePath === '.codex/rules/system-prompt.md');
+      expect(sp).toBeDefined();
+      expect(sp!.content).toContain('# Codex System Prompt');
+    });
+  });
+
+  describe('q', () => {
+    it('generates customizations.md', () => {
+      const files = generateForTool('q', FIXTURE_DATA);
+      const cust = files.find(f => f.relativePath === '.q/rules/customizations.md');
+      expect(cust).toBeDefined();
+      expect(cust!.content).toContain('# Amazon Q Customizations');
+    });
+  });
+
+  describe('kiro', () => {
+    it('generates guidelines.md', () => {
+      const files = generateForTool('kiro', FIXTURE_DATA);
+      const gl = files.find(f => f.relativePath === '.kiro/rules/guidelines.md');
+      expect(gl).toBeDefined();
+      expect(gl!.content).toContain('# Kiro Guidelines');
+    });
+  });
+});
+
+describe('generateAll', () => {
+  it('generates files for all 6 tools', () => {
+    const files = generateAll(FIXTURE_DATA);
+    const paths = files.map(f => f.relativePath);
+
+    expect(paths).toContain('.cursor/rules/auto-agent.mdc');
+    expect(paths).toContain('.cursor/rules/imports.mdc');
+    expect(paths).toContain('.claude/rules/custom-instructions.md');
+    expect(paths).toContain('.antigravity/rules/instructions.md');
+    expect(paths).toContain('.codex/rules/system-prompt.md');
+    expect(paths).toContain('.q/rules/customizations.md');
+    expect(paths).toContain('.kiro/rules/guidelines.md');
+  });
+
+  it('is idempotent — same input produces identical output', () => {
+    const first = generateAll(FIXTURE_DATA);
+    const second = generateAll(FIXTURE_DATA);
+    expect(first).toEqual(second);
+  });
+});

--- a/scripts/sync-settings/__tests__/readers.spec.ts
+++ b/scripts/sync-settings/__tests__/readers.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readAgents, readRules } from '../readers';
+import path from 'node:path';
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+const AI_RULES_DIR = path.join(FIXTURES_DIR, '.ai-rules');
+
+describe('readAgents', () => {
+  it('reads agent JSON files and returns AgentInfo[]', async () => {
+    const agents = await readAgents(path.join(AI_RULES_DIR, 'agents'));
+
+    expect(agents).toHaveLength(2);
+    expect(agents[0]).toEqual({
+      name: 'backend-developer',
+      displayName: 'Backend Developer',
+      description: 'Backend development specialist',
+      expertise: ['Node.js', 'REST APIs'],
+    });
+    expect(agents[1]).toEqual({
+      name: 'frontend-developer',
+      displayName: 'Frontend Developer',
+      description: 'Frontend development specialist',
+      expertise: ['React', 'TypeScript'],
+    });
+  });
+
+  it('sorts agents alphabetically by name', async () => {
+    const agents = await readAgents(path.join(AI_RULES_DIR, 'agents'));
+    const names = agents.map(a => a.name);
+    expect(names).toEqual([...names].sort());
+  });
+
+  it('skips non-JSON files', async () => {
+    const agents = await readAgents(path.join(AI_RULES_DIR, 'agents'));
+    // README.md in agents dir should be ignored
+    expect(agents.every(a => !a.name.includes('README'))).toBe(true);
+  });
+});
+
+describe('readRules', () => {
+  it('reads rule markdown files and returns RuleInfo[]', async () => {
+    const rules = await readRules(
+      path.join(AI_RULES_DIR, 'rules'),
+      'packages/rules/.ai-rules/rules',
+    );
+
+    expect(rules).toHaveLength(2);
+    expect(rules[0]).toEqual({
+      name: 'augmented-coding',
+      relativePath: 'packages/rules/.ai-rules/rules/augmented-coding.md',
+    });
+    expect(rules[1]).toEqual({
+      name: 'core',
+      relativePath: 'packages/rules/.ai-rules/rules/core.md',
+    });
+  });
+
+  it('sorts rules alphabetically by name', async () => {
+    const rules = await readRules(
+      path.join(AI_RULES_DIR, 'rules'),
+      'packages/rules/.ai-rules/rules',
+    );
+    const names = rules.map(r => r.name);
+    expect(names).toEqual([...names].sort());
+  });
+});

--- a/scripts/sync-settings/__tests__/sync.spec.ts
+++ b/scripts/sync-settings/__tests__/sync.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { syncSettings } from '../sync';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('syncSettings', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sync-test-'));
+
+    // Create .ai-rules source structure
+    const agentsDir = path.join(tmpDir, 'packages/rules/.ai-rules/agents');
+    const rulesDir = path.join(tmpDir, 'packages/rules/.ai-rules/rules');
+    await fs.mkdir(agentsDir, { recursive: true });
+    await fs.mkdir(rulesDir, { recursive: true });
+
+    // Create agent fixtures
+    await fs.writeFile(
+      path.join(agentsDir, 'frontend-developer.json'),
+      JSON.stringify({
+        name: 'Frontend Developer',
+        description: 'Frontend specialist',
+        expertise: ['React'],
+      }),
+    );
+
+    // Create rule fixtures
+    await fs.writeFile(path.join(rulesDir, 'core.md'), '# Core Rules\n');
+
+    // Create target directories
+    for (const dir of [
+      '.cursor/rules',
+      '.claude/rules',
+      '.antigravity/rules',
+      '.codex/rules',
+      '.q/rules',
+      '.kiro/rules',
+    ]) {
+      await fs.mkdir(path.join(tmpDir, dir), { recursive: true });
+    }
+  });
+
+  it('generates all tool config files', async () => {
+    const result = await syncSettings(tmpDir);
+
+    expect(result.filesWritten).toBeGreaterThanOrEqual(7);
+
+    // Verify key files exist
+    const cursorAgent = await fs.readFile(
+      path.join(tmpDir, '.cursor/rules/auto-agent.mdc'),
+      'utf-8',
+    );
+    expect(cursorAgent).toContain('frontend-developer');
+
+    const claudeCI = await fs.readFile(
+      path.join(tmpDir, '.claude/rules/custom-instructions.md'),
+      'utf-8',
+    );
+    expect(claudeCI).toContain('Frontend Developer');
+  });
+
+  it('is idempotent — running twice produces same files', async () => {
+    await syncSettings(tmpDir);
+    const firstContent = await fs.readFile(
+      path.join(tmpDir, '.cursor/rules/auto-agent.mdc'),
+      'utf-8',
+    );
+
+    await syncSettings(tmpDir);
+    const secondContent = await fs.readFile(
+      path.join(tmpDir, '.cursor/rules/auto-agent.mdc'),
+      'utf-8',
+    );
+
+    expect(firstContent).toBe(secondContent);
+  });
+
+  it('can sync a single tool independently', async () => {
+    const result = await syncSettings(tmpDir, { tools: ['cursor'] });
+
+    expect(result.filesWritten).toBe(2); // auto-agent.mdc + imports.mdc
+
+    // Claude file should NOT be generated
+    await expect(
+      fs.access(path.join(tmpDir, '.claude/rules/custom-instructions.md')),
+    ).rejects.toThrow();
+  });
+
+  it('returns summary of what was written', async () => {
+    const result = await syncSettings(tmpDir);
+
+    expect(result.filesWritten).toBeGreaterThan(0);
+    expect(result.files).toBeInstanceOf(Array);
+    expect(result.files.length).toBe(result.filesWritten);
+    expect(result.files[0]).toMatch(/^\./); // starts with .
+  });
+});

--- a/scripts/sync-settings/generators.ts
+++ b/scripts/sync-settings/generators.ts
@@ -1,0 +1,950 @@
+/**
+ * Generators — pure functions that produce tool-specific config file content
+ * from SourceData extracted from .ai-rules.
+ */
+
+import type { GeneratedFile, SourceData, ToolName } from './types';
+
+// ---------------------------------------------------------------------------
+// Shared sections
+// ---------------------------------------------------------------------------
+
+function agentTable(data: SourceData): string {
+  const lines = ['| Agent | Description | Expertise |', '|-------|-------------|-----------|'];
+  for (const a of data.agents) {
+    lines.push(`| ${a.displayName} | ${a.description} | ${a.expertise.join(', ')} |`);
+  }
+  return lines.join('\n');
+}
+
+function ruleRefs(data: SourceData, prefix: string): string {
+  return data.rules
+    .map(r => `- **${r.name}**: [${r.relativePath}](${prefix}${r.relativePath})`)
+    .join('\n');
+}
+
+function mandatoryKeywordRule(): string {
+  return `## 🔴 MANDATORY: Keyword Mode Detection
+
+<CODINGBUDDY_CRITICAL_RULE>
+
+**When user message starts with PLAN, ACT, EVAL, or AUTO keyword (or localized: Korean 계획/실행/평가/자동, Japanese 計画/実行/評価/自動, Chinese 计划/执行/评估/自动, Spanish PLANIFICAR/ACTUAR/EVALUAR/AUTOMÁTICO):**
+
+1. **IMMEDIATELY** call \`parse_mode\` MCP tool with the user's prompt
+2. Follow the returned \`instructions\` **EXACTLY**
+3. Apply the returned \`rules\` as context
+4. If \`warnings\` are present, inform the user
+
+**This is MANDATORY, not optional.**
+
+Failure to call \`parse_mode\` when these keywords are present will result in:
+- Missed critical checklists (Devil's Advocate Analysis, Impact Radius Analysis)
+- Incomplete evaluations
+- Quality issues not caught before deployment
+
+**Red Flags** (STOP if you think these):
+| Thought | Reality |
+|---------|---------|
+| "I can handle EVAL myself" | NO. Call parse_mode FIRST. |
+| "The rules are similar anyway" | NO. Each mode has specific checklists. |
+| "I'll save a tool call" | NO. parse_mode MUST be called FIRST. |
+| "I already know what to do" | NO. Rules may have been updated. |
+
+</CODINGBUDDY_CRITICAL_RULE>`;
+}
+
+function workflowSection(): string {
+  return `### Work Modes
+
+You have four modes of operation:
+
+1. **PLAN mode** - Define a plan without making changes
+2. **ACT mode** - Execute the plan and make changes
+3. **EVAL mode** - Analyze results and propose improvements
+4. **AUTO mode** - Autonomous PLAN → ACT → EVAL cycle until quality achieved
+
+**Mode Flow**:
+- Start in PLAN mode by default
+- Move to ACT when user types \`ACT\`
+- Return to PLAN after ACT completes (automatic)
+- Move to EVAL only when user explicitly types \`EVAL\`
+- Move to AUTO when user types \`AUTO\` (autonomous cycle)
+
+**Mode Indicators**:
+- Print \`# Mode: PLAN\` in plan mode
+- Print \`# Mode: ACT\` in act mode
+- Print \`# Mode: EVAL\` in eval mode
+- Print \`# Mode: AUTO\` in auto mode (with iteration number)`;
+}
+
+function tddSection(): string {
+  return `### TDD Cycle (Strict Adherence)
+
+Follow the **Red → Green → Refactor** cycle:
+
+1. **Red**: Write a failing test that defines functionality
+2. **Green**: Implement minimum code needed to pass
+3. **Refactor**: Improve structure only after tests pass
+
+### Core Principles
+- **TDD for core logic** (entities, shared/utils, shared/hooks)
+- **Test-after for UI** (features, widgets)
+- **SOLID principles** and code quality standards
+- **90%+ test coverage** goal
+- **No mocking** - test real behavior with actual implementations
+
+### Code Quality Standards
+- TypeScript strict mode (no \`any\`)
+- DRY (Don't Repeat Yourself)
+- Keep methods small (10-20 lines max)
+- Minimize state, prefer pure functions`;
+}
+
+function contextDocSection(): string {
+  return `## 🔴 MANDATORY: Context Document Persistence
+
+Before completing any mode (PLAN/ACT/EVAL), you **MUST** call \`update_context\` to persist:
+- \`decisions[]\` — Key decisions made
+- \`notes[]\` — Implementation notes
+- \`progress[]\` — (ACT mode) Progress items
+- \`findings[]\` / \`recommendations[]\` — (EVAL mode) Review results
+- \`status\` — \`in_progress\`, \`completed\`, or \`blocked\`
+
+Without this call, decisions and progress will be lost across sessions or context compaction.`;
+}
+
+// ---------------------------------------------------------------------------
+// Per-tool generators
+// ---------------------------------------------------------------------------
+
+function generateCursor(data: SourceData): GeneratedFile[] {
+  const autoAgent = `---
+description: codingbuddy Agent auto-activation based on file patterns
+globs:
+  - "**/*.tsx"
+  - "**/*.ts"
+  - "**/*.go"
+  - "**/*.py"
+  - "**/*.java"
+  - "**/*.rs"
+  - "**/Dockerfile"
+  - "**/*.yml"
+  - "**/*.yaml"
+alwaysApply: false
+---
+
+# codingbuddy Agent System
+
+## Required: Mode Keyword Detection
+
+When user message starts with \`PLAN\`, \`ACT\`, \`EVAL\`, \`AUTO\` (or localized variants: 자동, 自動, 自动, AUTOMÁTICO):
+
+→ **Immediately** call \`parse_mode\` MCP tool
+
+## File Context → Agent Mapping
+
+| File Pattern | Recommended Agent | MCP Call |
+|--------------|-------------------|----------|
+| \`*.tsx\`, \`*.ts\` | frontend-developer | \`get_agent_details("frontend-developer")\` |
+| \`*.go\`, \`*.py\`, \`*.java\`, \`*.rs\` | backend-developer | \`get_agent_details("backend-developer")\` |
+| \`Dockerfile\`, \`*.yml\` | devops-engineer | \`get_agent_details("devops-engineer")\` |
+| \`*.json\` (agents/) | agent-architect | \`get_agent_details("agent-architect")\` |
+
+## Specialist Auto-Recommendation
+
+| Detected Topic | Recommended Specialist |
+|----------------|------------------------|
+| Security, auth, XSS, CSRF | security-specialist |
+| Accessibility, ARIA, a11y, WCAG | accessibility-specialist |
+| Performance, bundle, optimization | performance-specialist |
+| Testing, TDD, coverage | test-strategy-specialist |
+| Architecture, layers, dependencies | architecture-specialist |
+
+## Pre-Analysis
+
+Before starting specialist analysis, optionally call \`analyze_task\` MCP tool for:
+- Risk assessment of the current task
+- Recommended specialists (may differ from file-pattern defaults)
+- Contextual checklists
+
+## Specialist Execution Pattern
+
+When \`parse_mode\` returns \`parallelAgentsRecommendation\`:
+
+1. Call \`prepare_parallel_agents\` MCP tool with the recommended specialists
+2. Execute each specialist **sequentially** (one at a time):
+   - Announce: "🔍 Analyzing from [icon] [specialist-name] perspective..."
+   - Apply specialist system prompt to analyze target code
+   - Record findings
+3. Present consolidated findings summary
+
+See \`packages/rules/.ai-rules/adapters/cursor.md\` for full details.
+
+## Available Agents
+
+${agentTable(data)}
+
+## Reference
+
+Agent definitions: \`packages/rules/.ai-rules/agents/README.md\`
+`;
+
+  const imports = `---
+description: codingbuddy common rules - applied to all conversations
+globs:
+alwaysApply: true
+---
+
+# codingbuddy Rules
+
+## Workflow
+
+- **PLAN** → **ACT** → **PLAN** (default flow)
+- **EVAL** only on explicit request
+- **AUTO** for autonomous PLAN → ACT → EVAL cycle until quality achieved
+
+## Required Actions
+
+When \`PLAN\`, \`ACT\`, \`EVAL\`, \`AUTO\` keywords detected → **Immediately** call \`parse_mode\` MCP tool
+
+## Context Persistence
+
+After completing work in any mode → call \`update_context\` MCP tool to persist decisions and notes.
+
+## Quality Tools
+
+- \`analyze_task\` — Pre-planning task analysis with risk assessment
+- \`generate_checklist\` — Contextual checklists for security, accessibility, performance
+- \`search_rules\` — Search project rules and guidelines
+- \`get_code_conventions\` — Get code conventions and style guide
+
+## Core Principles
+
+- TDD: Red → Green → Refactor
+- Test coverage 90%+
+- TypeScript strict (no \`any\`)
+- Server Components first
+
+## Project Config
+
+Use \`get_project_config\` MCP tool to retrieve project-specific settings (language, tech stack, conventions).
+
+## Skills
+
+When a skill might apply to the user's task:
+1. Call \`recommend_skills\` with the user's prompt
+2. If recommendations returned, call \`get_skill\` with the top skillName
+3. Follow the loaded skill instructions
+
+Key skill triggers:
+- Bug/error/debug → \`systematic-debugging\`
+- New feature/build → \`brainstorming\` → \`writing-plans\`
+- TDD/test → \`test-driven-development\`
+- Plan execution → \`executing-plans\`
+
+## Detailed Rules
+
+All details in Single Source of Truth:
+
+${data.rules.map(r => `- [\`${r.relativePath}\`](../../${r.relativePath})`).join('\n')}
+- [\`packages/rules/.ai-rules/agents/README.md\`](../../packages/rules/.ai-rules/agents/README.md)
+`;
+
+  return [
+    { relativePath: '.cursor/rules/auto-agent.mdc', content: autoAgent },
+    { relativePath: '.cursor/rules/imports.mdc', content: imports },
+  ];
+}
+
+function generateClaude(data: SourceData): GeneratedFile[] {
+  const content = `# Custom Instructions for Claude Code
+
+## Project Rules
+
+Follow the common rules defined in \`packages/rules/.ai-rules/\` for consistency across all AI coding assistants.
+
+### 📚 Core Workflow
+
+**Source**: \`packages/rules/.ai-rules/rules/core.md\`
+
+**Work Modes**:
+- **PLAN mode**: Create implementation plans with TDD approach
+- **ACT mode**: Execute changes following quality standards
+- **EVAL mode**: Evaluate code quality and suggest improvements
+- **AUTO mode**: Autonomous PLAN → ACT → EVAL cycle until quality achieved
+
+**Mode Flow**: PLAN (default) → ACT (user types "ACT") → PLAN (automatic) → EVAL (user types "EVAL") | AUTO (autonomous cycle)
+
+**Mode Indicators**: Display \`activation_message.formatted\` from the \`parse_mode\` response (e.g., \`🤖 agent-name [Primary Agent]\`), then print \`# Mode: PLAN|ACT|EVAL|AUTO\` and \`## Agent : [Agent Name]\` at the start of responses
+
+### 🏗️ Project Context
+
+**Source**: \`packages/rules/.ai-rules/rules/project.md\`
+
+**Tech Stack**: See project's \`package.json\`
+
+**Architecture**:
+- Layered structure: app → widgets → features → entities → shared
+- Pure/impure function separation required
+- Server Components as default
+
+### 🎯 Code Quality
+
+**Source**: \`packages/rules/.ai-rules/rules/augmented-coding.md\`
+
+**TDD Cycle**: Red (failing test) → Green (minimal code) → Refactor
+
+**Principles**:
+- TDD for core logic (entities, shared/utils, hooks)
+- Test-after for UI (features, widgets)
+- SOLID principles, DRY, 90%+ test coverage
+- No mocking - test real behavior
+- TypeScript strict mode (no \`any\`)
+
+### 🤖 Specialist Agents
+
+**Source**: \`packages/rules/.ai-rules/agents/\`
+
+**Available Agents**:
+
+${agentTable(data)}
+
+See [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md) for details.
+
+## 🔴 MANDATORY: TDD Execution Continuity
+
+<TDD_CONTINUITY_RULE>
+
+**TDD RED phase test failures are expected results and are NOT a reason to halt implementation.**
+
+### Test Failure Classification
+
+| Type | Description | Action |
+|------|-------------|--------|
+| **Expected RED** | Intentional test failure in TDD RED phase | Proceed to GREEN phase immediately |
+| **Unexpected Failure** | Test that should pass but doesn't | Stop and analyze root cause |
+
+### RED-GREEN-REFACTOR is an Atomic Operation
+
+1. **RED**: Write failing test -> Run to confirm failure -> **DO NOT STOP**
+2. **GREEN**: Write minimal implementation -> Run to confirm pass
+3. **REFACTOR**: Refactor -> Confirm tests still pass
+
+**Do not wait for user input until all three phases are complete.**
+
+### TDD Step Handling During Plan Execution
+
+Even if plan separates TDD into individual steps (e.g., Step 1: Write test, Step 2: Verify fails, Step 3: Implement):
+- When a step containing **"Expected: FAIL" or "verify it fails"** results in test failure -> Proceed to next step immediately
+- This **takes precedence** over the executing-plans skill's "STOP on test fail" rule
+
+</TDD_CONTINUITY_RULE>
+
+${mandatoryKeywordRule()}
+
+Examples:
+- \`PLAN design auth feature\` → **immediately** call parse_mode → work in PLAN mode
+- \`AUTO implement user dashboard\` → **immediately** call parse_mode → autonomous PLAN→ACT→EVAL cycle
+
+## 🔴 MANDATORY: Parallel Specialist Agent Execution
+
+<PARALLEL_EXECUTION_MANDATORY_RULE>
+
+**When \`parse_mode\` returns \`dispatchReady\`, use it directly with the Task tool — no extra calls needed.**
+
+**Strategy Selection (before dispatch):**
+- [ ] Check \`availableStrategies\` in \`parse_mode\` response
+- [ ] If \`["subagent", "taskmaestro"]\` → AskUserQuestion to choose
+- [ ] If \`taskmaestroInstallHint\` present and user wants taskmaestro → guide installation
+- [ ] Pass chosen strategy to \`dispatch_agents(executionStrategy: ...)\`
+
+**Quick Checklist (Auto-Dispatch - Preferred):**
+- [ ] Check \`dispatchReady\` in \`parse_mode\` response
+- [ ] Use \`dispatchReady.primaryAgent.dispatchParams\` with Task tool
+- [ ] Use \`dispatchReady.parallelAgents[].dispatchParams\` with Task tool (\`run_in_background: true\`)
+- [ ] Collect results with \`TaskOutput\`
+- [ ] Summarize all findings
+
+**Fallback (if \`dispatchReady\` is not present):**
+- [ ] Call \`dispatch_agents\` or \`prepare_parallel_agents\` with recommended specialists
+- [ ] Execute each agent via Task tool (\`subagent_type: "general-purpose"\`, \`run_in_background: true\`)
+- [ ] Display activation status
+- [ ] Collect results with \`TaskOutput\`
+- [ ] Summarize all findings
+
+**Mode-specific Specialists:**
+
+| Mode | Specialists |
+|------|-------------|
+| **PLAN** | 🏛️ architecture, 🧪 test-strategy, 📨 event-architecture, 🔗 integration, 📊 observability, 🔄 migration |
+| **ACT** | 📏 code-quality, 🧪 test-strategy, 📨 event-architecture, 🔗 integration |
+| **EVAL** | 🔒 security, ♿ accessibility, ⚡ performance, 📏 code-quality, 📨 event-architecture, 🔗 integration, 📊 observability, 🔄 migration |
+| **AUTO** | 🏛️ architecture, 🧪 test-strategy, 🔒 security, 📏 code-quality, 📨 event-architecture, 🔗 integration, 📊 observability, 🔄 migration |
+
+> **Note:** All modes support both SubAgent and TaskMaestro execution strategies.
+> The strategy is selected per-invocation via user choice.
+
+**📖 Full Guide:** [Parallel Specialist Agents Execution](../../packages/rules/.ai-rules/adapters/claude-code.md#parallel-specialist-agents-execution)
+
+</PARALLEL_EXECUTION_MANDATORY_RULE>
+
+## 🔴 MANDATORY: Auto-Dispatch Enforcement
+
+<AUTO_DISPATCH_ENFORCEMENT_RULE>
+
+**When \`parse_mode\` returns \`dispatch="auto"\`, you MUST dispatch all recommended specialists. No exceptions.**
+
+### Core Rule
+
+If the \`parse_mode\` response contains \`dispatch="auto"\` or \`dispatchReady\` with specialist agents:
+1. **MUST** dispatch every listed specialist — skipping any is a protocol violation
+2. **Teams preferred** over Agent tool for specialist dispatch (use \`TeamCreate\` + \`SendMessage\`)
+3. **Report results** via \`SendMessage\` back to team lead, not just text output
+
+### Red Flags (STOP if you think these)
+
+| Thought | Reality |
+|---------|---------|
+| "I can handle this analysis myself" | NO. Specialists have domain expertise you lack. Dispatch them. |
+| "It's just a small change, no need for specialists" | NO. dispatch="auto" means the system determined specialists are needed. |
+| "I'll save time by skipping dispatch" | NO. Skipping specialists causes missed issues that cost more time later. |
+| "The specialists will just repeat what I already know" | NO. Specialists catch domain-specific issues you would miss. |
+| "I'll dispatch them later after I look at the code" | NO. Dispatch IMMEDIATELY when dispatch="auto" is returned. |
+
+</AUTO_DISPATCH_ENFORCEMENT_RULE>
+
+## 🔴 MANDATORY: Context Document Management
+
+<CONTEXT_DOCUMENT_RULE>
+
+**Fixed file \`docs/codingbuddy/context.md\` persists PLAN → ACT → EVAL context across context compaction.**
+
+### How It Works
+
+\`parse_mode\` **automatically** manages the context document:
+
+- **PLAN/AUTO mode**: Resets (deletes and recreates) the context document
+- **ACT/EVAL mode**: Appends a new section to the existing document
+
+### Required Workflow
+
+**In ALL modes:**
+1. \`parse_mode\` automatically reads/creates context
+2. Review \`contextDocument\` for previous decisions and notes
+3. Before completing: \`update_context\` to persist current work
+
+</CONTEXT_DOCUMENT_RULE>
+
+## Claude Code Specific
+
+- Follow project's configured language setting
+- Use structured markdown formatting
+- Provide clear, actionable feedback
+- Reference project context from \`packages/rules/.ai-rules/rules/project.md\`
+- Follow PLAN → ACT → EVAL workflow when appropriate
+- Use AUTO mode for autonomous quality-driven development cycles
+
+## Full Documentation
+
+For comprehensive guides:
+${data.rules.map(r => `- **${r.name}**: [${r.relativePath}](../../${r.relativePath})`).join('\n')}
+- **Agents System**: [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md)
+- **Claude Integration**: [packages/rules/.ai-rules/adapters/claude-code.md](../../packages/rules/.ai-rules/adapters/claude-code.md)
+
+---
+
+**Note**: These instructions reference common AI rules from \`packages/rules/.ai-rules/\` directory shared across all AI assistants (Cursor, Claude Code, Antigravity, Codex, Q, Kiro) for consistency.
+`;
+
+  return [{ relativePath: '.claude/rules/custom-instructions.md', content }];
+}
+
+function generateAntigravity(data: SourceData): GeneratedFile[] {
+  const content = `# Antigravity Instructions
+
+## Common AI Rules Reference
+
+This project follows shared AI coding rules from \`packages/rules/.ai-rules/\` for consistency across all AI assistants (Cursor, Claude Code, Antigravity, Codex, Q, Kiro).
+
+### 📚 Core Workflow (PLAN/ACT/EVAL)
+
+**Source**: \`packages/rules/.ai-rules/rules/core.md\`
+
+${workflowSection()}
+
+See full workflow details in [packages/rules/.ai-rules/rules/core.md](../../packages/rules/.ai-rules/rules/core.md)
+
+### 🏗️ Project Context
+
+**Source**: \`packages/rules/.ai-rules/rules/project.md\`
+
+#### Tech Stack
+
+Refer to the project's \`package.json\`.
+
+#### Project Structure
+\`\`\`
+src/
+├── app/          # Next.js App Router
+├── entities/     # Domain entities (business logic)
+├── features/     # Feature-specific UI components
+├── widgets/      # Composite widgets
+└── shared/       # Common modules
+\`\`\`
+
+See full project setup in [packages/rules/.ai-rules/rules/project.md](../../packages/rules/.ai-rules/rules/project.md)
+
+### 🎯 Augmented Coding Principles
+
+**Source**: \`packages/rules/.ai-rules/rules/augmented-coding.md\`
+
+#### TDD Cycle
+1. **Red**: Write a failing test
+2. **Green**: Implement minimum code to pass
+3. **Refactor**: Improve structure after tests pass
+
+#### Core Principles
+- **TDD for core logic** (entities, shared/utils, hooks)
+- **Test-after for UI** (features, widgets)
+- **SOLID principles** and code quality standards
+- **90%+ test coverage** goal
+- **No mocking** - test real behavior
+
+See full augmented coding guide in [packages/rules/.ai-rules/rules/augmented-coding.md](../../packages/rules/.ai-rules/rules/augmented-coding.md)
+
+### 🤖 Specialist Agents
+
+**Source**: \`packages/rules/.ai-rules/agents/\`
+
+${agentTable(data)}
+
+See agent details in [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md)
+
+${mandatoryKeywordRule()}
+
+Example: \`EVAL\` → **immediately** apply EVAL mode rules → perform Devil's Advocate Analysis
+
+---
+
+## MCP Server Integration
+
+If the codingbuddy MCP server is configured, use these tools:
+
+### Key Tools
+
+| Tool | Purpose |
+|------|---------|
+| \`parse_mode\` | Parse PLAN/ACT/EVAL/AUTO mode keywords + load Agent/rules |
+| \`search_rules\` | Search rules and guidelines |
+| \`get_agent_details\` | Get specialist Agent profile and expertise |
+| \`recommend_skills\` | Recommend skills based on prompt → then call \`get_skill\` |
+| \`get_skill\` | Load full skill content |
+| \`update_context\` | Update context document (decisions, notes, progress) |
+
+### Configuration
+
+Add MCP server configuration to \`.antigravity/config.json\`:
+
+\`\`\`json
+{
+  "mcpServers": {
+    "codingbuddy": {
+      "command": "npx",
+      "args": ["-y", "codingbuddy"],
+      "env": {
+        "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+      }
+    }
+  }
+}
+\`\`\`
+
+Full configuration guide: [packages/rules/.ai-rules/adapters/antigravity.md](../../packages/rules/.ai-rules/adapters/antigravity.md)
+
+---
+
+## Skills
+
+codingbuddy skills are accessed through the MCP tool chain:
+
+1. **Auto-recommend**: \`recommend_skills({ prompt: "user message" })\` → AI recommends matching skills
+2. **Browse and select**: \`list_skills()\` → \`get_skill("skill-name")\` → load skill content
+3. **Slash-command**: When user types \`/<command>\` → call \`get_skill\`
+
+> **Note:** \`parse_mode\` automatically embeds matched skills in \`included_skills\`.
+> No separate \`recommend_skills\` call is needed when using mode keywords (PLAN/ACT/EVAL/AUTO).
+
+---
+
+## Context Document
+
+Persists decisions across mode transitions in \`docs/codingbuddy/context.md\`:
+
+- \`parse_mode\` automatically reads/creates the context document
+- **Before completing each mode**: call \`update_context\` (mandatory)
+- PLAN/AUTO mode: resets existing content and starts fresh
+- ACT/EVAL mode: appends new section to existing content
+
+---
+
+## Antigravity-Specific Features
+
+### Task Boundaries & Completion Ordering
+
+**When completing each mode**, execute two calls in strict order:
+1. **\`update_context\`** — Persist decisions, notes, findings to \`docs/codingbuddy/context.md\` (first)
+2. **\`task_boundary\`** — Signal mode boundary to Antigravity (second)
+
+### Communication
+
+- **Follow project's configured language setting** — use \`get_project_config\` MCP tool to retrieve current language setting
+- Use structured markdown formatting
+- Provide clear, actionable feedback
+
+---
+
+For full integration guide, see [packages/rules/.ai-rules/adapters/antigravity.md](../../packages/rules/.ai-rules/adapters/antigravity.md)
+`;
+
+  return [{ relativePath: '.antigravity/rules/instructions.md', content }];
+}
+
+function generateCodex(data: SourceData): GeneratedFile[] {
+  const content = `# Codex System Prompt
+
+This project uses shared AI coding rules from \`packages/rules/.ai-rules/\` directory for consistency across all AI assistants (Cursor, Claude Code, Antigravity, Codex, Q, Kiro).
+
+## 📚 Core Workflow Rules
+
+**Source**: [packages/rules/.ai-rules/rules/core.md](../../packages/rules/.ai-rules/rules/core.md)
+
+${workflowSection()}
+
+### Agent System
+
+**Auto-activated Agents**:
+- **Frontend Developer** (\`packages/rules/.ai-rules/agents/frontend-developer.json\`): PLAN/ACT modes
+- **Code Reviewer** (\`packages/rules/.ai-rules/agents/code-reviewer.json\`): EVAL mode
+
+**Specialist Agents** (${data.agents.length} available):
+
+${agentTable(data)}
+
+For complete workflow details, see [packages/rules/.ai-rules/rules/core.md](../../packages/rules/.ai-rules/rules/core.md)
+
+---
+
+## 🏗️ Project Setup
+
+**Source**: [packages/rules/.ai-rules/rules/project.md](../../packages/rules/.ai-rules/rules/project.md)
+
+### Tech Stack
+
+Refer to project's \`package.json\`.
+
+### Project Structure
+\`\`\`
+src/
+├── app/          # Next.js App Router
+├── entities/     # Domain entities (business logic)
+├── features/     # Feature-specific UI components
+├── widgets/      # Composite widgets
+└── shared/       # Common modules
+\`\`\`
+
+### Development Rules
+- **Layer dependency**: app → widgets → features → entities → shared
+- **Pure/impure separation**: Separate files for pure and impure functions
+- **Server Components**: Default, Client Components only when necessary
+- **Test coverage**: 90%+ goal
+
+For complete project setup, see [packages/rules/.ai-rules/rules/project.md](../../packages/rules/.ai-rules/rules/project.md)
+
+---
+
+## 🎯 Augmented Coding Principles
+
+**Source**: [packages/rules/.ai-rules/rules/augmented-coding.md](../../packages/rules/.ai-rules/rules/augmented-coding.md)
+
+${tddSection()}
+
+For complete augmented coding guide, see [packages/rules/.ai-rules/rules/augmented-coding.md](../../packages/rules/.ai-rules/rules/augmented-coding.md)
+
+---
+
+## 🤖 Specialist Agents
+
+**Source**: [packages/rules/.ai-rules/agents/](../../packages/rules/.ai-rules/agents/)
+
+### Specialist Execution
+
+When \`parse_mode\` returns \`parallelAgentsRecommendation\` or \`dispatchReady\`, execute specialists **sequentially**:
+
+1. Announce specialists being analyzed
+2. For each specialist: apply its system prompt as analysis context, analyze, record findings
+3. Consolidate all findings into a unified summary
+
+See [packages/rules/.ai-rules/adapters/codex.md](../../packages/rules/.ai-rules/adapters/codex.md#specialist-agents-execution) for the full workflow.
+
+---
+
+${mandatoryKeywordRule()}
+
+Example: \`PLAN design auth feature\` → **즉시** parse_mode 호출 → PLAN 모드로 작업
+
+---
+
+${contextDocSection()}
+
+---
+
+## 🔧 MCP Server Configuration
+
+codingbuddy MCP 서버 사용 시 \`CODINGBUDDY_PROJECT_ROOT\` 환경변수를 프로젝트의 절대 경로로 설정하세요.
+
+\`\`\`json
+{
+  "mcpServers": {
+    "codingbuddy": {
+      "command": "npx",
+      "args": ["-y", "codingbuddy"],
+      "env": {
+        "CODINGBUDDY_PROJECT_ROOT": "/absolute/path/to/your/project"
+      }
+    }
+  }
+}
+\`\`\`
+
+자세한 설정 방법: [packages/rules/.ai-rules/adapters/codex.md](../../packages/rules/.ai-rules/adapters/codex.md)
+
+---
+
+## 💬 Communication
+
+- **Always respond in Korean**
+- User frequently modifies code directly, so **always read code and refresh information** instead of relying on memory
+- **Start by understanding current code state** for every question
+
+---
+
+## 🔧 Available MCP Tools
+
+| Tool | Description | When to Use |
+|------|-------------|-------------|
+| \`parse_mode\` | Parse PLAN/ACT/EVAL/AUTO keywords and return mode-specific rules | Message starts with mode keyword |
+| \`search_rules\` | Search for rules and guidelines | Need project rules context |
+| \`get_agent_details\` | Get detailed profile of a specific AI agent | Need agent expertise info |
+| \`get_agent_system_prompt\` | Get complete system prompt for a specialist agent | Before specialist analysis |
+| \`prepare_parallel_agents\` | Prepare specialist agents for sequential execution | EVAL mode specialist analysis |
+| \`dispatch_agents\` | Get dispatch params (Claude Code optimized) | Not recommended for Codex |
+| \`analyze_task\` | Task risk assessment, specialist recommendations | Start of PLAN mode |
+| \`generate_checklist\` | Contextual checklists (security, accessibility, performance, testing, code-quality, SEO) | Before completing ACT/EVAL |
+| \`get_project_config\` | Get project tech stack, architecture, conventions, and language settings | Need project context |
+| \`get_code_conventions\` | Get project code conventions from tsconfig, eslint, prettier, editorconfig | Before implementing code changes |
+| \`recommend_skills\` | Recommend skills based on user prompt | Detect skill-worthy intent |
+| \`get_skill\` | Get full skill content by name | After recommend_skills or slash-command |
+| \`list_skills\` | List all available skills | Browse skill catalog |
+| \`read_context\` | Read context document | Check previous mode decisions |
+| \`update_context\` | Persist decisions, notes, progress to context document | **MANDATORY** before completing each mode |
+
+---
+
+## Full Documentation
+
+For comprehensive guides:
+${data.rules.map(r => `- **${r.name}**: [${r.relativePath}](../../${r.relativePath})`).join('\n')}
+- **Agents System**: [packages/rules/.ai-rules/agents/README.md](../../packages/rules/.ai-rules/agents/README.md)
+- **Integration Guide**: [packages/rules/.ai-rules/adapters/codex.md](../../packages/rules/.ai-rules/adapters/codex.md)
+
+---
+
+**Note**: This file references common AI rules from \`packages/rules/.ai-rules/\` directory. All AI assistants (Cursor, Claude Code, Antigravity, Codex, Q, Kiro) share the same rules for consistency.
+`;
+
+  return [{ relativePath: '.codex/rules/system-prompt.md', content }];
+}
+
+function generateQ(data: SourceData): GeneratedFile[] {
+  const content = `# Amazon Q Customizations
+
+## Common AI Rules
+
+This project follows shared coding rules from \`packages/rules/.ai-rules/\` for consistency across all AI assistants.
+
+### Workflow Modes (PLAN/ACT/EVAL/AUTO)
+
+Refer to \`packages/rules/.ai-rules/rules/core.md\`:
+- **PLAN**: Create implementation plans
+- **ACT**: Execute code changes
+- **EVAL**: Quality assessment and improvements
+- **AUTO**: Autonomous PLAN → ACT → EVAL cycle until quality achieved
+
+### Project Setup
+
+Refer to \`packages/rules/.ai-rules/rules/project.md\`:
+- **Tech Stack**: 프로젝트의 package.json 참조
+- **Architecture**: Layered structure (app → widgets → features → entities → shared)
+- **Development Rules**: File naming, import/export conventions
+
+### Coding Standards
+
+Refer to \`packages/rules/.ai-rules/rules/augmented-coding.md\`:
+- **TDD Workflow**: Red → Green → Refactor
+- **Code Quality**: SOLID principles, DRY, 90%+ coverage
+- **Testing**: No mocking, test real behavior
+
+### Specialist Expertise
+
+${agentTable(data)}
+
+${mandatoryKeywordRule()}
+
+Example: \`EVAL\` → **즉시** EVAL 모드 규칙 적용 → Devil's Advocate Analysis 수행
+
+---
+
+## Amazon Q Specific Features
+
+### AWS Integration
+- Leverage Q's AWS knowledge for deployment
+- Use Q's security scanning with our security rules
+- Apply Q's cost optimization suggestions
+
+### Language Support
+- Respond in Korean (한국어) as per project standard
+- Use technical Korean terminology
+
+## Full Documentation
+
+- Core Workflow: \`packages/rules/.ai-rules/rules/core.md\`
+- Project Setup: \`packages/rules/.ai-rules/rules/project.md\`
+- Coding Principles: \`packages/rules/.ai-rules/rules/augmented-coding.md\`
+- Specialist Agents: \`packages/rules/.ai-rules/agents/README.md\`
+- Integration Guide: \`packages/rules/.ai-rules/adapters/q.md\`
+`;
+
+  return [{ relativePath: '.q/rules/customizations.md', content }];
+}
+
+function generateKiro(data: SourceData): GeneratedFile[] {
+  const content = `# Kiro Guidelines
+
+## Common AI Rules
+
+This project uses shared coding rules from \`packages/rules/.ai-rules/\` for consistency across all AI coding assistants.
+
+### Workflow Reference
+
+See \`packages/rules/.ai-rules/rules/core.md\`:
+- **PLAN mode**: Create implementation plans with TDD approach
+- **ACT mode**: Execute changes following quality standards
+- **EVAL mode**: Evaluate code quality and suggest improvements
+- **AUTO mode**: Autonomous PLAN → ACT → EVAL cycle until quality achieved
+
+### Project Context
+
+See \`packages/rules/.ai-rules/rules/project.md\`:
+- **Tech Stack**: 프로젝트의 package.json 참조
+- **Architecture**: Layered structure (app → widgets → features → entities → shared)
+- **Conventions**: File naming, import/export rules, pure/impure function separation
+
+### Coding Principles
+
+See \`packages/rules/.ai-rules/rules/augmented-coding.md\`:
+- **TDD Cycle**: Red (failing test) → Green (minimal code) → Refactor
+- **Quality Standards**: SOLID principles, DRY, code complexity management
+- **Testing**: 90%+ coverage goal, no mocking, real behavior testing
+- **Commit Discipline**: Separate structural and behavioral changes
+
+### Specialist Knowledge
+
+See \`packages/rules/.ai-rules/agents/\`:
+
+${agentTable(data)}
+
+### MCP Server Integration
+
+When the codingbuddy MCP server is configured (\`.kiro/settings/mcp.json\`), use MCP tools for enhanced workflow:
+
+**Core Workflow Tools:**
+- \`parse_mode\` — Parse PLAN/ACT/EVAL/AUTO keywords and load appropriate Agent/rules
+- \`update_context\` — Persist decisions and notes to \`docs/codingbuddy/context.md\` (mandatory at mode completion)
+- \`read_context\` — Read current context document
+
+**Analysis Tools:**
+- \`search_rules\` — Search rules and guidelines by query
+- \`analyze_task\` — Pre-planning task analysis with risk assessment
+- \`generate_checklist\` — Contextual checklists (security, a11y, performance)
+
+**Agent & Skills Tools:**
+- \`get_agent_details\` — Get specialist agent profile
+- \`recommend_skills\` → \`get_skill\` — Discover and load relevant skills
+- \`prepare_parallel_agents\` — Get specialist prompts for sequential execution
+
+**Configuration Tools:**
+- \`get_project_config\` — Get project configuration (language, tech stack)
+- \`get_code_conventions\` — Get project code conventions
+
+> **Note:** MCP 서버가 설정되어 있지 않은 경우, \`.ai-rules/\` 디렉토리의 파일을 직접 참조하여 동일한 규칙을 적용할 수 있습니다.
+
+${mandatoryKeywordRule()}
+
+Example: \`EVAL\` → **즉시** EVAL 모드 규칙 적용 → Devil's Advocate Analysis 수행
+
+---
+
+## Kiro-Specific Features
+
+### Communication
+- Follow the \`languageInstruction\` from \`parse_mode\` response (or the project's \`codingbuddy.config.json\` language setting)
+- Use clear, structured markdown formatting
+- Provide actionable, specific feedback
+
+### Workflow
+Apply PLAN → ACT → EVAL (or AUTO for autonomous cycle) workflow as defined in \`packages/rules/.ai-rules/rules/core.md\`
+
+## Full Documentation
+
+For comprehensive guides:
+- **Core Rules**: \`packages/rules/.ai-rules/rules/core.md\`
+- **Project Setup**: \`packages/rules/.ai-rules/rules/project.md\`
+- **Augmented Coding**: \`packages/rules/.ai-rules/rules/augmented-coding.md\`
+- **Agents System**: \`packages/rules/.ai-rules/agents/README.md\`
+- **Integration Guide**: \`packages/rules/.ai-rules/adapters/kiro.md\`
+
+---
+
+**Note**: These guidelines reference common AI rules from \`packages/rules/.ai-rules/\` directory shared across all AI assistants for consistency.
+`;
+
+  return [{ relativePath: '.kiro/rules/guidelines.md', content }];
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+const GENERATORS: Record<ToolName, (data: SourceData) => GeneratedFile[]> = {
+  cursor: generateCursor,
+  claude: generateClaude,
+  antigravity: generateAntigravity,
+  codex: generateCodex,
+  q: generateQ,
+  kiro: generateKiro,
+};
+
+/**
+ * Generate config files for a single tool.
+ */
+export function generateForTool(tool: ToolName, data: SourceData): GeneratedFile[] {
+  return GENERATORS[tool](data);
+}
+
+/**
+ * Generate config files for ALL tools. Idempotent — same input always produces same output.
+ */
+export function generateAll(data: SourceData): GeneratedFile[] {
+  const tools: ToolName[] = ['cursor', 'claude', 'antigravity', 'codex', 'q', 'kiro'];
+  return tools.flatMap(t => GENERATORS[t](data));
+}

--- a/scripts/sync-settings/index.ts
+++ b/scripts/sync-settings/index.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env npx tsx
+/**
+ * CLI entry point for sync-settings.
+ *
+ * Usage:
+ *   npx tsx scripts/sync-settings/index.ts            # sync all tools
+ *   npx tsx scripts/sync-settings/index.ts cursor      # sync single tool
+ *   npx tsx scripts/sync-settings/index.ts cursor kiro # sync multiple tools
+ */
+
+import path from 'node:path';
+import { syncSettings } from './sync';
+import type { ToolName } from './types';
+
+const VALID_TOOLS: ToolName[] = ['cursor', 'claude', 'antigravity', 'codex', 'q', 'kiro'];
+
+async function main(): Promise<void> {
+  const projectRoot = path.resolve(__dirname, '../..');
+  const args = process.argv.slice(2);
+
+  // Validate tool names if provided
+  const tools: ToolName[] | undefined =
+    args.length > 0
+      ? args.map(arg => {
+          if (!VALID_TOOLS.includes(arg as ToolName)) {
+            console.error(`Unknown tool: ${arg}. Valid tools: ${VALID_TOOLS.join(', ')}`);
+            process.exit(1);
+          }
+          return arg as ToolName;
+        })
+      : undefined;
+
+  console.log(
+    tools ? `Syncing settings for: ${tools.join(', ')}` : 'Syncing settings for all tools...',
+  );
+
+  const result = await syncSettings(projectRoot, tools ? { tools } : undefined);
+
+  console.log(`\nDone! ${result.filesWritten} file(s) written:`);
+  for (const f of result.files) {
+    console.log(`  ✓ ${f}`);
+  }
+}
+
+main().catch(err => {
+  console.error('Sync failed:', err);
+  process.exit(1);
+});

--- a/scripts/sync-settings/readers.ts
+++ b/scripts/sync-settings/readers.ts
@@ -1,0 +1,47 @@
+/**
+ * Readers — pure-ish functions that extract SourceData from .ai-rules.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { AgentInfo, RuleInfo } from './types';
+
+/**
+ * Read all agent JSON files from the given directory.
+ * Returns AgentInfo[] sorted alphabetically by name.
+ */
+export async function readAgents(agentsDir: string): Promise<AgentInfo[]> {
+  const entries = await fs.readdir(agentsDir);
+  const jsonFiles = entries.filter(f => f.endsWith('.json')).sort();
+
+  const agents: AgentInfo[] = [];
+
+  for (const file of jsonFiles) {
+    const raw = await fs.readFile(path.join(agentsDir, file), 'utf-8');
+    const data = JSON.parse(raw);
+    agents.push({
+      name: path.basename(file, '.json'),
+      displayName: data.name ?? path.basename(file, '.json'),
+      description: data.description ?? '',
+      expertise: Array.isArray(data.expertise) ? data.expertise : [],
+    });
+  }
+
+  return agents;
+}
+
+/**
+ * Read all rule markdown files from the given directory.
+ * Returns RuleInfo[] sorted alphabetically by name.
+ * @param rulesDir  Absolute path to the rules directory on disk.
+ * @param relativeBase  Relative path prefix from project root (e.g. "packages/rules/.ai-rules/rules").
+ */
+export async function readRules(rulesDir: string, relativeBase: string): Promise<RuleInfo[]> {
+  const entries = await fs.readdir(rulesDir);
+  const mdFiles = entries.filter(f => f.endsWith('.md')).sort();
+
+  return mdFiles.map(file => ({
+    name: path.basename(file, '.md'),
+    relativePath: `${relativeBase}/${file}`,
+  }));
+}

--- a/scripts/sync-settings/sync.ts
+++ b/scripts/sync-settings/sync.ts
@@ -1,0 +1,54 @@
+/**
+ * Sync orchestrator — reads .ai-rules, generates configs, writes files.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { readAgents, readRules } from './readers';
+import { generateAll, generateForTool } from './generators';
+import type { SourceData, ToolName } from './types';
+
+export interface SyncOptions {
+  /** Sync only these tools. If omitted, syncs all. */
+  tools?: ToolName[];
+}
+
+export interface SyncResult {
+  filesWritten: number;
+  files: string[];
+}
+
+/**
+ * Run the settings sync.
+ * @param projectRoot  Absolute path to the project root.
+ * @param options      Optional filtering.
+ */
+export async function syncSettings(
+  projectRoot: string,
+  options?: SyncOptions,
+): Promise<SyncResult> {
+  const aiRulesBase = path.join(projectRoot, 'packages/rules/.ai-rules');
+
+  const data: SourceData = {
+    agents: await readAgents(path.join(aiRulesBase, 'agents')),
+    rules: await readRules(path.join(aiRulesBase, 'rules'), 'packages/rules/.ai-rules/rules'),
+  };
+
+  const files = options?.tools
+    ? options.tools.flatMap(t => generateForTool(t, data))
+    : generateAll(data);
+
+  const writtenPaths: string[] = [];
+
+  for (const file of files) {
+    const absPath = path.join(projectRoot, file.relativePath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, file.content, 'utf-8');
+    writtenPaths.push(file.relativePath);
+  }
+
+  return {
+    filesWritten: writtenPaths.length,
+    files: writtenPaths,
+  };
+}

--- a/scripts/sync-settings/types.ts
+++ b/scripts/sync-settings/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Sync-settings types — shared interfaces for reading .ai-rules
+ * and generating tool-specific configuration files.
+ */
+
+/** Minimal agent metadata extracted from an agent JSON file. */
+export interface AgentInfo {
+  /** File-stem name, e.g. "frontend-developer" */
+  name: string;
+  /** Human-readable display name */
+  displayName: string;
+  /** One-line description */
+  description: string;
+  /** Expertise tags */
+  expertise: string[];
+}
+
+/** Metadata for a single rule markdown file. */
+export interface RuleInfo {
+  /** File-stem name, e.g. "core" */
+  name: string;
+  /** Relative path from project root, e.g. "packages/rules/.ai-rules/rules/core.md" */
+  relativePath: string;
+}
+
+/** Aggregated data read from .ai-rules — the input to every generator. */
+export interface SourceData {
+  agents: AgentInfo[];
+  rules: RuleInfo[];
+}
+
+/** A single file to be written by the sync orchestrator. */
+export interface GeneratedFile {
+  /** Relative path from project root, e.g. ".cursor/rules/auto-agent.mdc" */
+  relativePath: string;
+  /** Full file content */
+  content: string;
+}
+
+/** Supported tool identifiers. */
+export type ToolName = 'cursor' | 'claude' | 'antigravity' | 'codex' | 'q' | 'kiro';

--- a/scripts/sync-settings/vitest.config.ts
+++ b/scripts/sync-settings/vitest.config.ts
@@ -1,0 +1,7 @@
+export default {
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['scripts/sync-settings/__tests__/**/*.spec.ts'],
+  },
+};


### PR DESCRIPTION
## Summary
- Add `scripts/sync-settings/` engine that reads `.ai-rules/` source data (agents, rules) and generates tool-specific config files for all 6 supported tools
- Template-based generators produce idempotent, format-correct output for Cursor (`.mdc`), Claude Code (`.md`), Antigravity, Codex, Amazon Q, and Kiro
- CLI supports syncing all tools (`yarn sync:settings`) or specific tools (`yarn sync:settings cursor kiro`)
- 23 tests covering readers, generators, and sync orchestrator with fixture-based testing
- Regenerate all 7 tool config files from `.ai-rules` single source of truth

## Test plan
- [x] `yarn test:sync` — 23/23 tests pass (readers, generators, sync orchestrator)
- [x] `yarn sync:settings` — generates all 7 files successfully
- [x] `yarn sync:settings cursor` — generates only Cursor files (2 files)
- [x] Idempotency verified — running twice produces identical output
- [x] Agent JSON schema validation — 37/37 valid
- [x] Markdown lint — 94 files, 0 errors
- [x] Prettier formatting — all sync-settings files pass

Closes #821