### PR TITLE
feat(plugin): add event-driven notification service (#829)

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/notifications.py
+++ b/packages/claude-code-plugin/hooks/lib/notifications.py
@@ -1,0 +1,184 @@
+"""Event-driven notification service for CodingBuddy.
+
+Sends webhook notifications to Slack, Discord, and Telegram on key events.
+Uses only stdlib (urllib.request) — no external dependencies.
+
+Security: Webhook URLs are loaded from secrets_store (never from config).
+Config only controls event toggles and platform selection.
+"""
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+from urllib.request import Request, urlopen, build_opener, HTTPRedirectHandler
+from urllib.error import URLError
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Refuse all HTTP redirects to prevent secret leakage."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_opener = build_opener(_NoRedirectHandler)
+
+# Ensure hooks/lib is on path for secrets_store import
+_lib_dir = os.path.dirname(os.path.abspath(__file__))
+if _lib_dir not in sys.path:
+    sys.path.insert(0, _lib_dir)
+
+from secrets_store import load_secrets, get_webhook_url
+
+WEBHOOK_TIMEOUT = 10  # seconds
+
+
+@dataclass
+class NotificationEvent:
+    """Represents a notification event."""
+
+    event_type: str  # e.g. "pr_created", "session_end", "error"
+    title: str
+    message: str
+    url: Optional[str] = None
+
+
+# --- Payload formatters ---
+
+
+def format_slack_payload(event: NotificationEvent) -> Dict[str, Any]:
+    """Format event as a Slack Block Kit payload."""
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": event.title, "emoji": True},
+        },
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": event.message},
+        },
+    ]
+    if event.url:
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"<{event.url}|View>"},
+            }
+        )
+    return {"text": event.title, "blocks": blocks}
+
+
+def format_discord_payload(event: NotificationEvent) -> Dict[str, Any]:
+    """Format event as a Discord embed payload."""
+    embed: Dict[str, Any] = {
+        "title": event.title,
+        "description": event.message,
+        "color": _discord_color(event.event_type),
+    }
+    if event.url:
+        embed["url"] = event.url
+    return {"embeds": [embed]}
+
+
+def format_telegram_payload(event: NotificationEvent) -> Dict[str, Any]:
+    """Format event as a Telegram sendMessage payload."""
+    text = f"<b>{event.title}</b>\n{event.message}"
+    if event.url:
+        text += f'\n<a href="{event.url}">View</a>'
+    return {"text": text, "parse_mode": "HTML"}
+
+
+# --- Core send logic ---
+
+
+def send_webhook(url: str, payload: Dict[str, Any]) -> bool:
+    """Send JSON payload to webhook URL via POST.
+
+    Returns True on success, False on any error. Never raises.
+    """
+    try:
+        data = json.dumps(payload).encode("utf-8")
+        req = Request(url, data=data, headers={"Content-Type": "application/json"})
+        with _opener.open(req, timeout=WEBHOOK_TIMEOUT) as resp:
+            return 200 <= resp.status < 300
+    except (URLError, TimeoutError, OSError, ValueError):
+        return False
+
+
+def is_event_enabled(config: Dict[str, Any], event_type: str) -> bool:
+    """Check if an event type is enabled in config.
+
+    Config schema:
+        notifications:
+          events:
+            pr_created: true
+            session_end: true
+    """
+    notifications = config.get("notifications", {})
+    events = notifications.get("events", {})
+    return events.get(event_type, False) is True
+
+
+# --- High-level API ---
+
+_FORMATTERS = {
+    "slack": format_slack_payload,
+    "discord": format_discord_payload,
+    "telegram": format_telegram_payload,
+}
+
+
+def notify(
+    event: NotificationEvent,
+    config: Dict[str, Any],
+    secrets_dir: Optional[str] = None,
+) -> Dict[str, bool]:
+    """Send notification to all configured platforms.
+
+    Args:
+        event: The notification event to send.
+        config: Parsed codingbuddy.config.json (event toggles + platform list).
+        secrets_dir: Override secrets directory (default: ~/.codingbuddy).
+
+    Returns:
+        Dict mapping platform name -> success boolean.
+        Empty dict if event is disabled.
+    """
+    if not is_event_enabled(config, event.event_type):
+        return {}
+
+    if secrets_dir is None:
+        secrets_dir = os.path.join(os.path.expanduser("~"), ".codingbuddy")
+
+    secrets = load_secrets(secrets_dir)
+    notifications = config.get("notifications", {})
+    platforms = notifications.get("platforms", [])
+
+    results: Dict[str, bool] = {}
+    for platform in platforms:
+        url = get_webhook_url(secrets, platform)
+        if url is None:
+            continue
+
+        formatter = _FORMATTERS.get(platform)
+        if formatter is None:
+            continue
+
+        payload = formatter(event)
+        results[platform] = send_webhook(url, payload)
+
+    return results
+
+
+# --- Helpers ---
+
+
+def _discord_color(event_type: str) -> int:
+    """Map event type to Discord embed color."""
+    colors = {
+        "pr_created": 0x2ECC71,  # green
+        "session_end": 0x3498DB,  # blue
+        "error": 0xE74C3C,  # red
+    }
+    return colors.get(event_type, 0x95A5A6)  # gray default

--- a/packages/claude-code-plugin/hooks/lib/secrets_store.py
+++ b/packages/claude-code-plugin/hooks/lib/secrets_store.py
@@ -1,0 +1,82 @@
+"""Secure credential loading for CodingBuddy notification webhooks.
+
+Loads webhook secrets from ~/.codingbuddy/secrets.json.
+Security: file MUST have mode 0o600 (owner read/write only).
+Secrets are NEVER stored in codingbuddy.config.json.
+"""
+import json
+import os
+import stat
+import sys
+from typing import Any, Dict, Optional
+from urllib.parse import quote
+
+SECRETS_FILENAME = "secrets.json"
+# Only allow owner read/write (0o600) or owner read-only (0o400)
+ALLOWED_MODES = {0o600, 0o400}
+
+TELEGRAM_API_BASE = "https://api.telegram.org/bot"
+
+
+def load_secrets(secrets_dir: str) -> Dict[str, Any]:
+    """Load secrets from secrets_dir/secrets.json.
+
+    Args:
+        secrets_dir: Path to directory containing secrets.json.
+
+    Returns:
+        Parsed secrets dict, or empty dict if file missing/invalid/insecure.
+    """
+    secrets_path = os.path.join(secrets_dir, SECRETS_FILENAME)
+
+    if not os.path.isfile(secrets_path):
+        return {}
+
+    # Check permissions — only allow 0o600 and 0o400
+    try:
+        file_stat = os.stat(secrets_path)
+        file_mode = stat.S_IMODE(file_stat.st_mode)
+        if file_mode not in ALLOWED_MODES:
+            print(
+                f"WARNING: {secrets_path} has insecure permissions "
+                f"(mode {oct(file_mode)}). "
+                f"Expected 0o600 or 0o400. Refusing to load secrets.",
+                file=sys.stderr,
+            )
+            return {}
+    except OSError:
+        return {}
+
+    try:
+        with open(secrets_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def get_webhook_url(secrets: Dict[str, Any], platform: str) -> Optional[str]:
+    """Extract the webhook URL for the given platform from secrets.
+
+    Args:
+        secrets: Parsed secrets dict (from load_secrets).
+        platform: One of "slack", "discord", "telegram".
+
+    Returns:
+        The webhook URL string, or None if not configured.
+    """
+    webhooks = secrets.get("webhooks")
+    if not webhooks:
+        return None
+
+    if platform == "slack":
+        return webhooks.get("slack")
+    elif platform == "discord":
+        return webhooks.get("discord")
+    elif platform == "telegram":
+        bot_token = webhooks.get("telegram_bot_token")
+        chat_id = webhooks.get("telegram_chat_id")
+        if bot_token and chat_id:
+            return f"{TELEGRAM_API_BASE}{bot_token}/sendMessage?chat_id={quote(str(chat_id))}"
+        return None
+    else:
+        return None

--- a/packages/claude-code-plugin/hooks/post-tool-use.py
+++ b/packages/claude-code-plugin/hooks/post-tool-use.py
@@ -49,7 +49,48 @@ def handle_post_tool_use(data: dict):
     except Exception:
         pass  # Never block tool execution
 
+    # Notify on PR creation (#829)
+    try:
+        _maybe_notify_pr_created(data)
+    except Exception:
+        pass  # Never block tool execution
+
     return None
+
+
+def _maybe_notify_pr_created(data: dict):
+    """Detect PR creation and send notification if configured."""
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+    tool_output = data.get("tool_output", "")
+
+    # Detect: Bash tool running "gh pr create"
+    command = ""
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+    if "gh pr create" not in command:
+        return
+
+    # Extract PR URL from output (gh pr create prints the URL)
+    pr_url = ""
+    if isinstance(tool_output, str):
+        for line in tool_output.strip().splitlines():
+            line = line.strip()
+            if line.startswith("https://github.com/") and "/pull/" in line:
+                pr_url = line
+                break
+
+    from config import get_config
+    from notifications import NotificationEvent, notify
+
+    config = get_config(os.getcwd())
+    event = NotificationEvent(
+        event_type="pr_created",
+        title="PR Created",
+        message=f"New PR created: {pr_url or command}",
+        url=pr_url or None,
+    )
+    notify(event, config)
 
 
 if __name__ == "__main__":

--- a/packages/claude-code-plugin/hooks/stop.py
+++ b/packages/claude-code-plugin/hooks/stop.py
@@ -40,6 +40,12 @@ def handle_stop(data: dict):
         except Exception:
             pass  # Never block session stop
 
+        # Notify on session end (#829)
+        try:
+            _maybe_notify_session_end(summary)
+        except Exception:
+            pass  # Never block session stop
+
         if summary:
             return {
                 "systemMessage": summary,
@@ -48,6 +54,23 @@ def handle_stop(data: dict):
         pass  # Never block session stop
 
     return None
+
+
+def _maybe_notify_session_end(summary: str):
+    """Send session summary notification if configured."""
+    if not summary:
+        return
+
+    from config import get_config
+    from notifications import NotificationEvent, notify
+
+    config = get_config(os.getcwd())
+    event = NotificationEvent(
+        event_type="session_end",
+        title="Session Complete",
+        message=summary[:500],  # Truncate for webhook limits
+    )
+    notify(event, config)
 
 
 if __name__ == "__main__":

--- a/packages/claude-code-plugin/tests/test_notifications.py
+++ b/packages/claude-code-plugin/tests/test_notifications.py
@@ -1,0 +1,277 @@
+"""Tests for hooks/lib/notifications.py — webhook notification sender."""
+import json
+import os
+import sys
+from unittest.mock import patch, MagicMock
+from urllib.error import URLError
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks", "lib"))
+
+from notifications import (
+    NotificationEvent,
+    format_slack_payload,
+    format_discord_payload,
+    format_telegram_payload,
+    send_webhook,
+    notify,
+    is_event_enabled,
+)
+
+
+class TestNotificationEvent:
+    """Tests for NotificationEvent data structure."""
+
+    def test_creates_event(self):
+        """Should create an event with required fields."""
+        event = NotificationEvent(
+            event_type="pr_created",
+            title="PR Created",
+            message="PR #42 opened",
+        )
+        assert event.event_type == "pr_created"
+        assert event.title == "PR Created"
+        assert event.message == "PR #42 opened"
+
+    def test_optional_url(self):
+        """Should support optional URL field."""
+        event = NotificationEvent(
+            event_type="pr_created",
+            title="PR Created",
+            message="PR #42 opened",
+            url="https://github.com/org/repo/pull/42",
+        )
+        assert event.url == "https://github.com/org/repo/pull/42"
+
+
+class TestFormatSlackPayload:
+    """Tests for Slack webhook payload formatting."""
+
+    def test_basic_payload(self):
+        """Should format a simple Slack payload."""
+        event = NotificationEvent(
+            event_type="pr_created",
+            title="PR Created",
+            message="PR #42: Add notifications",
+        )
+        payload = format_slack_payload(event)
+        assert payload["text"] == "PR Created"
+        assert any("PR #42" in str(block) for block in payload.get("blocks", [payload]))
+
+    def test_payload_with_url(self):
+        """Should include URL in Slack payload."""
+        event = NotificationEvent(
+            event_type="pr_created",
+            title="PR Created",
+            message="PR #42: Add notifications",
+            url="https://github.com/org/repo/pull/42",
+        )
+        payload = format_slack_payload(event)
+        body = json.dumps(payload)
+        assert "https://github.com/org/repo/pull/42" in body
+
+
+class TestFormatDiscordPayload:
+    """Tests for Discord webhook payload formatting."""
+
+    def test_basic_payload(self):
+        """Should format a Discord embed payload."""
+        event = NotificationEvent(
+            event_type="session_end",
+            title="Session Summary",
+            message="10 tools called, 3 files changed",
+        )
+        payload = format_discord_payload(event)
+        assert "embeds" in payload
+        embed = payload["embeds"][0]
+        assert embed["title"] == "Session Summary"
+        assert "10 tools called" in embed["description"]
+
+    def test_payload_with_url(self):
+        """Should include URL in Discord embed."""
+        event = NotificationEvent(
+            event_type="pr_created",
+            title="PR Created",
+            message="PR #42",
+            url="https://github.com/org/repo/pull/42",
+        )
+        payload = format_discord_payload(event)
+        embed = payload["embeds"][0]
+        assert embed.get("url") == "https://github.com/org/repo/pull/42"
+
+
+class TestFormatTelegramPayload:
+    """Tests for Telegram payload formatting."""
+
+    def test_basic_payload(self):
+        """Should format a Telegram sendMessage payload."""
+        event = NotificationEvent(
+            event_type="error",
+            title="Error Alert",
+            message="Build failed",
+        )
+        payload = format_telegram_payload(event)
+        assert "text" in payload
+        assert "Error Alert" in payload["text"]
+        assert "Build failed" in payload["text"]
+
+    def test_uses_html_parse_mode(self):
+        """Should use HTML parse mode for Telegram."""
+        event = NotificationEvent(
+            event_type="error",
+            title="Test",
+            message="msg",
+        )
+        payload = format_telegram_payload(event)
+        assert payload.get("parse_mode") == "HTML"
+
+
+class TestSendWebhook:
+    """Tests for send_webhook — HTTP POST to webhook URL."""
+
+    @patch("notifications._opener.open")
+    def test_sends_post_request(self, mock_urlopen):
+        """Should send a POST request with JSON payload."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = b"ok"
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+
+        result = send_webhook("https://hooks.slack.com/test", {"text": "hello"})
+        assert result is True
+        mock_urlopen.assert_called_once()
+
+    @patch("notifications._opener.open")
+    def test_returns_false_on_network_error(self, mock_urlopen):
+        """Should return False and not raise on network errors."""
+        mock_urlopen.side_effect = URLError("Connection refused")
+
+        result = send_webhook("https://hooks.slack.com/test", {"text": "hello"})
+        assert result is False
+
+    @patch("notifications._opener.open")
+    def test_returns_false_on_timeout(self, mock_urlopen):
+        """Should return False on timeout."""
+        mock_urlopen.side_effect = TimeoutError("timed out")
+
+        result = send_webhook("https://hooks.slack.com/test", {"text": "hello"})
+        assert result is False
+
+
+class TestIsEventEnabled:
+    """Tests for is_event_enabled — config-driven event filtering."""
+
+    def test_all_events_disabled_by_default(self):
+        """Should disable events when no notification config exists."""
+        config = {}
+        assert is_event_enabled(config, "pr_created") is False
+
+    def test_event_enabled_in_config(self):
+        """Should enable event when configured."""
+        config = {
+            "notifications": {
+                "events": {
+                    "pr_created": True,
+                    "session_end": True,
+                }
+            }
+        }
+        assert is_event_enabled(config, "pr_created") is True
+
+    def test_event_disabled_in_config(self):
+        """Should disable event when explicitly set to false."""
+        config = {
+            "notifications": {
+                "events": {
+                    "pr_created": False,
+                }
+            }
+        }
+        assert is_event_enabled(config, "pr_created") is False
+
+    def test_unknown_event_disabled(self):
+        """Should disable events not listed in config."""
+        config = {
+            "notifications": {
+                "events": {
+                    "pr_created": True,
+                }
+            }
+        }
+        assert is_event_enabled(config, "some_other_event") is False
+
+
+class TestNotify:
+    """Tests for notify — high-level send to all configured platforms."""
+
+    @patch("notifications.send_webhook")
+    @patch("notifications.load_secrets")
+    def test_sends_to_configured_platforms(self, mock_load_secrets, mock_send):
+        """Should send to all platforms with configured webhooks."""
+        mock_load_secrets.return_value = {
+            "webhooks": {
+                "slack": "https://hooks.slack.com/services/T00/B00/xxx",
+            }
+        }
+        mock_send.return_value = True
+
+        config = {
+            "notifications": {
+                "events": {"pr_created": True},
+                "platforms": ["slack"],
+            }
+        }
+        event = NotificationEvent(
+            event_type="pr_created",
+            title="PR Created",
+            message="PR #42",
+        )
+        results = notify(event, config)
+        assert results["slack"] is True
+
+    @patch("notifications.send_webhook")
+    @patch("notifications.load_secrets")
+    def test_skips_disabled_events(self, mock_load_secrets, mock_send):
+        """Should not send when event is disabled in config."""
+        mock_load_secrets.return_value = {
+            "webhooks": {
+                "slack": "https://hooks.slack.com/services/T00/B00/xxx",
+            }
+        }
+        config = {
+            "notifications": {
+                "events": {"pr_created": False},
+                "platforms": ["slack"],
+            }
+        }
+        event = NotificationEvent(
+            event_type="pr_created",
+            title="PR Created",
+            message="PR #42",
+        )
+        results = notify(event, config)
+        assert results == {}
+        mock_send.assert_not_called()
+
+    @patch("notifications.send_webhook")
+    @patch("notifications.load_secrets")
+    def test_skips_platform_without_webhook(self, mock_load_secrets, mock_send):
+        """Should skip platforms without configured webhooks."""
+        mock_load_secrets.return_value = {"webhooks": {}}
+        config = {
+            "notifications": {
+                "events": {"pr_created": True},
+                "platforms": ["slack"],
+            }
+        }
+        event = NotificationEvent(
+            event_type="pr_created",
+            title="PR Created",
+            message="PR #42",
+        )
+        results = notify(event, config)
+        assert "slack" not in results
+        mock_send.assert_not_called()

--- a/packages/claude-code-plugin/tests/test_post_tool_use.py
+++ b/packages/claude-code-plugin/tests/test_post_tool_use.py
@@ -1,10 +1,11 @@
-"""Tests for hooks/post-tool-use.py — PostToolUse hook skeleton."""
+"""Tests for hooks/post-tool-use.py — PostToolUse hook with notification wiring."""
 import importlib
 import importlib.util
 import json
 import os
 import sys
 import io
+from unittest.mock import patch, MagicMock
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks", "lib"))
@@ -76,3 +77,61 @@ class TestPostToolUseSkeleton:
         with pytest.raises(SystemExit) as exc_info:
             ptu.handle_post_tool_use()
         assert exc_info.value.code == 0
+
+
+class TestPrCreatedNotification:
+    """Tests for PR creation detection and notification (#829)."""
+
+    @patch("notifications.notify")
+    @patch("config.get_config")
+    def test_detects_gh_pr_create(self, mock_config, mock_notify, monkeypatch, capsys):
+        """Should call notify when gh pr create is detected."""
+        mock_config.return_value = {
+            "notifications": {
+                "events": {"pr_created": True},
+                "platforms": ["slack"],
+            }
+        }
+        mock_notify.return_value = {"slack": True}
+
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": 'gh pr create --title "test" --body "body"'},
+                "tool_output": "https://github.com/org/repo/pull/42\n",
+            },
+            monkeypatch, capsys,
+        )
+        assert result is None
+        mock_notify.assert_called_once()
+        event = mock_notify.call_args[0][0]
+        assert event.event_type == "pr_created"
+        assert event.url == "https://github.com/org/repo/pull/42"
+
+    @patch("notifications.notify")
+    @patch("config.get_config")
+    def test_ignores_non_pr_commands(self, mock_config, mock_notify, monkeypatch, capsys):
+        """Should not notify for non-PR Bash commands."""
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git status"},
+            },
+            monkeypatch, capsys,
+        )
+        assert result is None
+        mock_notify.assert_not_called()
+
+    @patch("notifications.notify")
+    @patch("config.get_config")
+    def test_ignores_non_bash_tools(self, mock_config, mock_notify, monkeypatch, capsys):
+        """Should not notify for non-Bash tool calls."""
+        result = _run_hook(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/some/file"},
+            },
+            monkeypatch, capsys,
+        )
+        assert result is None
+        mock_notify.assert_not_called()

--- a/packages/claude-code-plugin/tests/test_secrets.py
+++ b/packages/claude-code-plugin/tests/test_secrets.py
@@ -1,0 +1,117 @@
+"""Tests for hooks/lib/secrets.py — secure credential loading."""
+import json
+import os
+import stat
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks", "lib"))
+
+from secrets_store import load_secrets, get_webhook_url
+
+
+@pytest.fixture
+def secrets_dir(tmp_path):
+    """Create a temp .codingbuddy directory with proper permissions."""
+    d = tmp_path / ".codingbuddy"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def secrets_file(secrets_dir):
+    """Create a valid secrets.json with correct permissions (0o600)."""
+    data = {
+        "webhooks": {
+            "slack": "https://hooks.slack.com/services/T00/B00/xxx",
+            "discord": "https://discord.com/api/webhooks/123/abc",
+            "telegram_bot_token": "123456:ABC-DEF",
+            "telegram_chat_id": "-100123456",
+        }
+    }
+    f = secrets_dir / "secrets.json"
+    f.write_text(json.dumps(data))
+    os.chmod(str(f), 0o600)
+    return f
+
+
+class TestLoadSecrets:
+    """Tests for load_secrets — read and validate secrets.json."""
+
+    def test_loads_valid_secrets(self, secrets_file, secrets_dir):
+        """Should load secrets from a valid file with correct permissions."""
+        result = load_secrets(str(secrets_dir))
+        assert result["webhooks"]["slack"] == "https://hooks.slack.com/services/T00/B00/xxx"
+
+    def test_returns_empty_when_file_missing(self, tmp_path):
+        """Should return empty dict when secrets.json does not exist."""
+        d = tmp_path / ".codingbuddy"
+        d.mkdir()
+        result = load_secrets(str(d))
+        assert result == {}
+
+    def test_returns_empty_when_dir_missing(self, tmp_path):
+        """Should return empty dict when .codingbuddy dir does not exist."""
+        result = load_secrets(str(tmp_path / "nonexistent"))
+        assert result == {}
+
+    def test_returns_empty_on_invalid_json(self, secrets_dir):
+        """Should return empty dict when secrets.json has invalid JSON."""
+        f = secrets_dir / "secrets.json"
+        f.write_text("not valid json{")
+        os.chmod(str(f), 0o600)
+        result = load_secrets(str(secrets_dir))
+        assert result == {}
+
+    def test_warns_on_loose_permissions(self, secrets_dir, capsys):
+        """Should return empty dict and warn when file permissions are too open."""
+        data = {"webhooks": {"slack": "https://hooks.slack.com/services/T00/B00/xxx"}}
+        f = secrets_dir / "secrets.json"
+        f.write_text(json.dumps(data))
+        os.chmod(str(f), 0o644)  # Too permissive
+        result = load_secrets(str(secrets_dir))
+        assert result == {}
+        assert "insecure permissions" in capsys.readouterr().err
+
+    def test_rejects_owner_execute_permissions(self, secrets_dir):
+        """Should reject 0o700 (owner-execute) even though group/other are zero."""
+        data = {"webhooks": {"slack": "https://hooks.slack.com/services/T00/B00/xxx"}}
+        f = secrets_dir / "secrets.json"
+        f.write_text(json.dumps(data))
+        os.chmod(str(f), 0o700)
+        result = load_secrets(str(secrets_dir))
+        assert result == {}
+
+
+class TestGetWebhookUrl:
+    """Tests for get_webhook_url — extract platform-specific webhook URLs."""
+
+    def test_returns_slack_url(self, secrets_file, secrets_dir):
+        """Should return Slack webhook URL."""
+        secrets = load_secrets(str(secrets_dir))
+        url = get_webhook_url(secrets, "slack")
+        assert url == "https://hooks.slack.com/services/T00/B00/xxx"
+
+    def test_returns_discord_url(self, secrets_file, secrets_dir):
+        """Should return Discord webhook URL."""
+        secrets = load_secrets(str(secrets_dir))
+        url = get_webhook_url(secrets, "discord")
+        assert url == "https://discord.com/api/webhooks/123/abc"
+
+    def test_returns_none_for_unknown_platform(self, secrets_file, secrets_dir):
+        """Should return None for an unrecognized platform."""
+        secrets = load_secrets(str(secrets_dir))
+        url = get_webhook_url(secrets, "unknown_platform")
+        assert url is None
+
+    def test_returns_none_when_no_webhooks(self):
+        """Should return None when secrets have no webhooks key."""
+        url = get_webhook_url({}, "slack")
+        assert url is None
+
+    def test_returns_telegram_bot_token(self, secrets_file, secrets_dir):
+        """Should return Telegram bot token."""
+        secrets = load_secrets(str(secrets_dir))
+        url = get_webhook_url(secrets, "telegram")
+        assert "123456:ABC-DEF" in url

--- a/packages/claude-code-plugin/tests/test_stop.py
+++ b/packages/claude-code-plugin/tests/test_stop.py
@@ -1,0 +1,105 @@
+"""Tests for hooks/stop.py — Stop hook with notification wiring (#829)."""
+import importlib
+import importlib.util
+import json
+import os
+import sys
+import io
+from unittest.mock import patch, MagicMock
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks", "lib"))
+
+_HOOK_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "hooks", "stop.py"
+)
+
+
+def _load_module():
+    """Load stop.py as a module."""
+    for mod_name in list(sys.modules.keys()):
+        if "stop_hook" in mod_name:
+            del sys.modules[mod_name]
+
+    spec = importlib.util.spec_from_file_location("stop_hook", _HOOK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["stop_hook"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_hook(input_data, monkeypatch, capsys):
+    """Run stop hook and return parsed output or None."""
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(input_data)))
+    mod = _load_module()
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.handle_stop()
+    assert exc_info.value.code == 0
+
+    out = capsys.readouterr().out
+    return json.loads(out) if out.strip() else None
+
+
+class TestStopHook:
+    """Tests for the Stop hook basic behavior."""
+
+    def test_exits_zero_always(self, monkeypatch):
+        """Should always exit(0) to never block Claude Code."""
+        monkeypatch.setattr("sys.stdin", io.StringIO("{}"))
+        mod = _load_module()
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.handle_stop()
+        assert exc_info.value.code == 0
+
+    def test_exits_zero_on_empty_stdin(self, monkeypatch):
+        """Should handle empty stdin gracefully."""
+        monkeypatch.setattr("sys.stdin", io.StringIO(""))
+        mod = _load_module()
+
+        with pytest.raises(SystemExit) as exc_info:
+            mod.handle_stop()
+        assert exc_info.value.code == 0
+
+
+class TestSessionEndNotification:
+    """Tests for session end notification wiring (#829)."""
+
+    @patch("notifications.notify")
+    @patch("config.get_config")
+    @patch("stats.SessionStats")
+    def test_notifies_on_session_end(self, mock_stats_cls, mock_config, mock_notify, monkeypatch, capsys):
+        """Should send notification with session summary."""
+        mock_stats = MagicMock()
+        mock_stats.format_summary.return_value = "Session: 5 tools, 2 files"
+        mock_stats_cls.return_value = mock_stats
+        mock_config.return_value = {
+            "notifications": {
+                "events": {"session_end": True},
+                "platforms": ["slack"],
+            }
+        }
+        mock_notify.return_value = {"slack": True}
+
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "test-session")
+        result = _run_hook({"stop_hook_active": True}, monkeypatch, capsys)
+
+        mock_notify.assert_called_once()
+        event = mock_notify.call_args[0][0]
+        assert event.event_type == "session_end"
+        assert "5 tools" in event.message
+
+    @patch("notifications.notify")
+    @patch("config.get_config")
+    @patch("stats.SessionStats")
+    def test_no_notification_when_no_summary(self, mock_stats_cls, mock_config, mock_notify, monkeypatch, capsys):
+        """Should not notify when there's no session summary."""
+        mock_stats = MagicMock()
+        mock_stats.format_summary.return_value = ""
+        mock_stats_cls.return_value = mock_stats
+
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "test-session")
+        _run_hook({"stop_hook_active": True}, monkeypatch, capsys)
+
+        mock_notify.assert_not_called()


### PR DESCRIPTION
## Summary
- Add event-driven notification service supporting Slack, Discord, and Telegram webhooks
- Secure credential loading from `~/.codingbuddy/secrets.json` (mode 0o600 enforced)
- Config-driven event toggles in `codingbuddy.config.json` (no secrets in config)
- PR creation detection via PostToolUse hook (`gh pr create` command)
- Session end summary via Stop hook
- Security hardening: no HTTP redirect following, URL-encoded Telegram chat_id, strict permission allowlist
- stdlib only (urllib.request) — zero external dependencies
- 35 new tests (140 total Python hook tests passing)

## Test plan
- [x] `python3 -m pytest tests/ -v --tb=short` — 140/140 passed
- [x] `yarn workspace codingbuddy-claude-plugin lint` — passed
- [x] `yarn workspace codingbuddy-claude-plugin format:check` — passed
- [x] `yarn workspace codingbuddy-claude-plugin typecheck` — passed
- [x] `yarn workspace codingbuddy-claude-plugin test:coverage` — 71 TS tests passed
- [x] `yarn workspace codingbuddy-claude-plugin circular` — no circular deps
- [x] `yarn workspace codingbuddy-claude-plugin build` — passed
- [x] Security review: 0 Critical, 0 High (all fixed)
- [x] Quality review: crash-safe, graceful network failure, proper decoupling

Closes #829