### PR TITLE
chore(repo): add gitignore patterns and test:hooks script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ docs/codingbuddy/*
 .taskmaestro/
 RESULT.json
 TASK.md
+
+# Runtime artifacts
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "wiki:generate": "npx tsx scripts/wiki/generate-wiki.ts",
     "test:wiki": "yarn workspace codingbuddy exec vitest run --config ../../scripts/wiki/vitest.config.ts --root ../../scripts/wiki",
     "sync:settings": "npx tsx scripts/sync-settings/index.ts",
-    "test:sync": "node apps/mcp-server/node_modules/.bin/vitest run --config scripts/sync-settings/vitest.config.ts --root ."
+    "test:sync": "node apps/mcp-server/node_modules/.bin/vitest run --config scripts/sync-settings/vitest.config.ts --root .",
+    "test:hooks": "cd packages/claude-code-plugin && python3 -m pytest tests/ -v"
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",

--- a/packages/claude-code-plugin/.gitignore
+++ b/packages/claude-code-plugin/.gitignore
@@ -15,3 +15,10 @@ node_modules/
 __pycache__/
 *.pyc
 *.pyo
+.pytest_cache/
+
+# Coverage
+coverage/
+
+# Runtime
+.omc/


### PR DESCRIPTION
## Summary
- Add `__pycache__/`, `*.pyc`, `.pytest_cache/` patterns to root `.gitignore`
- Add `coverage/`, `.omc/`, `.pytest_cache/` patterns to `packages/claude-code-plugin/.gitignore`
- Add `test:hooks` script to root `package.json` for CI pytest integration

## Test plan
- [x] `python3 -m pytest tests/ -v` — 140 passed
- [x] `git status` confirms only intended files changed
- [x] No tracked build artifacts remain in git

Closes #934