### PR TITLE
feat(rules): add continuous execution directive to parallel workers

### DIFF
--- a/packages/rules/.ai-rules/agents/auto-mode.json
+++ b/packages/rules/.ai-rules/agents/auto-mode.json
@@ -21,7 +21,8 @@
       "EVAL phase: Multi-dimensional quality evaluation with anti-sycophancy",
       "Iterate until Critical=0 AND High=0 issues remaining",
       "Maintain context continuity across cycle iterations",
-      "Track iteration count and quality metrics progression"
+      "Track iteration count and quality metrics progression",
+      "Execute all tasks continuously without stopping between steps — only pause for RESULT.json at completion"
     ]
   },
   "context_files": [

--- a/packages/rules/.ai-rules/agents/parallel-orchestrator.json
+++ b/packages/rules/.ai-rules/agents/parallel-orchestrator.json
@@ -149,7 +149,8 @@
         "AUTO mode: every prompt includes PLAN→ACT→EVAL iteration methodology",
         "Exit condition: Critical/High=0 before /ship, Medium/Low in PR description",
         "No ambiguity: exact file paths, exact field values, exact commands",
-        "Plan validation: complex workers should use plan-and-review skill to validate plans before ACT"
+        "Plan validation: complex workers should use plan-and-review skill to validate plans before ACT",
+        "Continuous execution: workers MUST complete all tasks in a single uninterrupted flow without stopping for user input. Only stop after writing RESULT.json."
       ]
     },
     "worker_troubleshooting": {

--- a/packages/rules/.ai-rules/rules/parallel-execution.md
+++ b/packages/rules/.ai-rules/rules/parallel-execution.md
@@ -114,6 +114,18 @@ After all workers in a wave complete:
 
 ---
 
+## Continuous Execution Rule
+
+Workers MUST complete all assigned tasks in a single uninterrupted flow.
+Stopping between tasks to wait for user input is a protocol violation.
+
+- DO NOT stop between steps
+- Complete ALL tasks without waiting for user input
+- Only stop after writing RESULT.json
+- Auto-nudge from conductor is a fallback safety net, not the primary mechanism
+
+---
+
 ## AUTO Mode Iteration Methodology
 
 When using AUTO mode with parallel execution:


### PR DESCRIPTION
## Summary
- Add continuous execution principle to `parallel-orchestrator.json` worker_directive.principles
- Add continuous execution responsibility to `auto-mode.json` role.responsibilities
- Add `## Continuous Execution Rule` section to `parallel-execution.md`
- Workers must complete all tasks in a single uninterrupted flow without stopping for user input

## Test plan
- [x] All 5071 tests pass (187 test files)
- [x] Agent JSON schema validation passes (ajv-cli)
- [x] Markdown lint passes (markdownlint-cli2)
- [x] TypeScript typecheck passes
- [x] No circular dependencies
- [x] Build succeeds

Closes #927