### PR TITLE
fix(dashboard): add PRAGMA busy_timeout and schema integration tests

### DIFF
--- a/apps/dashboard/src/lib/__tests__/data-loader.test.ts
+++ b/apps/dashboard/src/lib/__tests__/data-loader.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdtempSync, unlinkSync, rmdirSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   loadSessions,
   loadCostEntries,
@@ -9,6 +12,7 @@ import {
   aggregateCostEntries,
   aggregateAgentActivity,
   aggregateSkillUsage,
+  openDatabase,
 } from '../data-loader';
 import type { Session } from '../types';
 
@@ -108,20 +112,38 @@ describe('data-loader', () => {
   describe('aggregateAgentActivity', () => {
     it('counts tool calls by agent prefix', () => {
       const toolCalls = [
-        { sessionId: 's1', timestamp: 0, toolName: 'Agent(software-engineer)', inputSummary: null, success: true },
-        { sessionId: 's1', timestamp: 0, toolName: 'Agent(software-engineer)', inputSummary: null, success: true },
-        { sessionId: 's1', timestamp: 0, toolName: 'Agent(test-engineer)', inputSummary: null, success: false },
+        {
+          sessionId: 's1',
+          timestamp: 0,
+          toolName: 'Agent(software-engineer)',
+          inputSummary: null,
+          success: true,
+        },
+        {
+          sessionId: 's1',
+          timestamp: 0,
+          toolName: 'Agent(software-engineer)',
+          inputSummary: null,
+          success: true,
+        },
+        {
+          sessionId: 's1',
+          timestamp: 0,
+          toolName: 'Agent(test-engineer)',
+          inputSummary: null,
+          success: false,
+        },
         { sessionId: 's1', timestamp: 0, toolName: 'Bash', inputSummary: null, success: true },
       ];
 
       const result = aggregateAgentActivity(toolCalls);
 
       expect(result).toHaveLength(2);
-      const se = result.find((a) => a.agent === 'software-engineer');
+      const se = result.find(a => a.agent === 'software-engineer');
       expect(se?.count).toBe(2);
       expect(se?.successRate).toBe(1);
 
-      const te = result.find((a) => a.agent === 'test-engineer');
+      const te = result.find(a => a.agent === 'test-engineer');
       expect(te?.count).toBe(1);
       expect(te?.successRate).toBe(0);
     });
@@ -137,20 +159,44 @@ describe('data-loader', () => {
   describe('aggregateSkillUsage', () => {
     it('counts skill invocations from tool calls', () => {
       const toolCalls = [
-        { sessionId: 's1', timestamp: 0, toolName: 'Skill(commit)', inputSummary: null, success: true },
-        { sessionId: 's1', timestamp: 0, toolName: 'Skill(commit)', inputSummary: null, success: true },
-        { sessionId: 's1', timestamp: 0, toolName: 'Skill(ship)', inputSummary: null, success: true },
-        { sessionId: 's1', timestamp: 0, toolName: 'mcp__codingbuddy__parse_mode', inputSummary: null, success: true },
+        {
+          sessionId: 's1',
+          timestamp: 0,
+          toolName: 'Skill(commit)',
+          inputSummary: null,
+          success: true,
+        },
+        {
+          sessionId: 's1',
+          timestamp: 0,
+          toolName: 'Skill(commit)',
+          inputSummary: null,
+          success: true,
+        },
+        {
+          sessionId: 's1',
+          timestamp: 0,
+          toolName: 'Skill(ship)',
+          inputSummary: null,
+          success: true,
+        },
+        {
+          sessionId: 's1',
+          timestamp: 0,
+          toolName: 'mcp__codingbuddy__parse_mode',
+          inputSummary: null,
+          success: true,
+        },
         { sessionId: 's1', timestamp: 0, toolName: 'Bash', inputSummary: null, success: true },
       ];
 
       const result = aggregateSkillUsage(toolCalls);
 
       expect(result).toHaveLength(3);
-      const commit = result.find((s) => s.skill === 'commit');
+      const commit = result.find(s => s.skill === 'commit');
       expect(commit?.count).toBe(2);
 
-      const parseMode = result.find((s) => s.skill === 'parse_mode');
+      const parseMode = result.find(s => s.skill === 'parse_mode');
       expect(parseMode?.count).toBe(1);
     });
 
@@ -205,6 +251,154 @@ describe('data-loader', () => {
       expect(result[0]).toHaveProperty('date');
       expect(result[0]).toHaveProperty('created');
       expect(result[0]).toHaveProperty('merged');
+    });
+  });
+
+  describe('openDatabase', () => {
+    let tmpDir: string;
+    let dbPath: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'dataloader-pragma-'));
+      dbPath = join(tmpDir, 'test.db');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Database = require('better-sqlite3');
+      const db = new Database(dbPath);
+      db.exec('CREATE TABLE sessions (id INTEGER PRIMARY KEY)');
+      db.close();
+    });
+
+    afterEach(() => {
+      try {
+        unlinkSync(dbPath);
+      } catch {}
+      try {
+        unlinkSync(dbPath + '-wal');
+      } catch {}
+      try {
+        unlinkSync(dbPath + '-shm');
+      } catch {}
+      try {
+        rmdirSync(tmpDir);
+      } catch {}
+    });
+
+    it('sets PRAGMA busy_timeout=5000', () => {
+      const db = openDatabase(dbPath);
+      expect(db).not.toBeNull();
+      const result = db!.pragma('busy_timeout', { simple: true });
+      expect(result).toBe(5000);
+      db!.close();
+    });
+
+    it('returns null for nonexistent path', () => {
+      expect(openDatabase('/nonexistent/path.db')).toBeNull();
+    });
+  });
+
+  describe('integration: real SQLite schema', () => {
+    let tmpDir: string;
+    let dbPath: string;
+    const now = Date.now() / 1000;
+
+    const SCHEMA = `
+      CREATE TABLE IF NOT EXISTS sessions (
+        id INTEGER PRIMARY KEY,
+        session_id TEXT UNIQUE NOT NULL,
+        started_at REAL NOT NULL,
+        ended_at REAL,
+        project TEXT,
+        model TEXT,
+        tool_call_count INTEGER DEFAULT 0,
+        error_count INTEGER DEFAULT 0,
+        outcome TEXT
+      );
+      CREATE TABLE IF NOT EXISTS tool_calls (
+        id INTEGER PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        timestamp REAL NOT NULL,
+        tool_name TEXT NOT NULL,
+        input_summary TEXT,
+        success INTEGER DEFAULT 1,
+        FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id);
+      CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at);
+    `;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'dataloader-integration-'));
+      dbPath = join(tmpDir, 'history.db');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const Database = require('better-sqlite3');
+      const db = new Database(dbPath);
+      db.exec(SCHEMA);
+
+      db.prepare(
+        'INSERT INTO sessions (session_id, started_at, ended_at, project, model, tool_call_count, error_count, outcome) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      ).run('test-sess-1', now - 3600, now, 'my-project', 'claude-opus', 42, 3, 'success');
+
+      db.prepare(
+        'INSERT INTO tool_calls (session_id, timestamp, tool_name, input_summary, success) VALUES (?, ?, ?, ?, ?)',
+      ).run('test-sess-1', now - 1800, 'Agent(software-engineer)', 'implement feature', 1);
+      db.prepare(
+        'INSERT INTO tool_calls (session_id, timestamp, tool_name, input_summary, success) VALUES (?, ?, ?, ?, ?)',
+      ).run('test-sess-1', now - 900, 'Skill(commit)', null, 1);
+      db.prepare(
+        'INSERT INTO tool_calls (session_id, timestamp, tool_name, input_summary, success) VALUES (?, ?, ?, ?, ?)',
+      ).run('test-sess-1', now - 600, 'mcp__codingbuddy__parse_mode', null, 1);
+
+      db.close();
+    });
+
+    afterEach(() => {
+      try {
+        unlinkSync(dbPath);
+      } catch {}
+      try {
+        unlinkSync(dbPath + '-wal');
+      } catch {}
+      try {
+        unlinkSync(dbPath + '-shm');
+      } catch {}
+      try {
+        rmdirSync(tmpDir);
+      } catch {}
+    });
+
+    it('loadSessions reads sessions from real DB', async () => {
+      const sessions = await loadSessions(dbPath);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0].sessionId).toBe('test-sess-1');
+      expect(sessions[0].project).toBe('my-project');
+      expect(sessions[0].model).toBe('claude-opus');
+      expect(sessions[0].toolCallCount).toBe(42);
+      expect(sessions[0].errorCount).toBe(3);
+      expect(sessions[0].outcome).toBe('success');
+    });
+
+    it('loadCostEntries aggregates cost from real DB', async () => {
+      const entries = await loadCostEntries(dbPath);
+      expect(entries.length).toBeGreaterThan(0);
+      expect(entries[0].sessions).toBe(1);
+      expect(entries[0].toolCalls).toBe(42);
+      expect(entries[0].cost).toBeGreaterThan(0);
+    });
+
+    it('loadAgentActivity aggregates agents from real DB', async () => {
+      const activity = await loadAgentActivity(dbPath);
+      expect(activity).toHaveLength(1);
+      expect(activity[0].agent).toBe('software-engineer');
+      expect(activity[0].count).toBe(1);
+      expect(activity[0].successRate).toBe(1);
+    });
+
+    it('loadSkillUsage aggregates skills from real DB', async () => {
+      const usage = await loadSkillUsage(dbPath);
+      expect(usage).toHaveLength(2);
+      const skills = usage.map(u => u.skill);
+      expect(skills).toContain('commit');
+      expect(skills).toContain('parse_mode');
     });
   });
 });

--- a/apps/dashboard/src/lib/data-loader.ts
+++ b/apps/dashboard/src/lib/data-loader.ts
@@ -1,13 +1,6 @@
 import { existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
-import type {
-  Session,
-  ToolCall,
-  CostEntry,
-  AgentActivity,
-  SkillUsage,
-  PREntry,
-} from './types';
+import type { Session, ToolCall, CostEntry, AgentActivity, SkillUsage, PREntry } from './types';
 import {
   generateMockSessions,
   generateMockCostEntries,
@@ -39,7 +32,7 @@ interface RawToolCallRow {
 }
 
 export function sessionsFromRows(rows: RawSessionRow[]): Session[] {
-  return rows.map((row) => ({
+  return rows.map(row => ({
     sessionId: row.session_id,
     startedAt: row.started_at,
     endedAt: row.ended_at,
@@ -69,7 +62,7 @@ export function aggregateCostEntries(sessions: Session[]): CostEntry[] {
     .map(([date, data]) => ({
       date,
       cost: parseFloat(
-        (data.toolCalls * COST_PER_TOOL_CALL + data.sessions * COST_PER_SESSION).toFixed(2)
+        (data.toolCalls * COST_PER_TOOL_CALL + data.sessions * COST_PER_SESSION).toFixed(2),
       ),
       sessions: data.sessions,
       toolCalls: data.toolCalls,
@@ -125,12 +118,14 @@ export function aggregateSkillUsage(toolCalls: ToolCall[]): SkillUsage[] {
     .map(([skill, count]) => ({ skill, count }));
 }
 
-function openDatabase(dbPath: string) {
+export function openDatabase(dbPath: string) {
   try {
     if (!existsSync(dbPath)) return null;
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const Database = require('better-sqlite3');
-    return new Database(dbPath, { readonly: true });
+    const db = new Database(dbPath, { readonly: true });
+    db.pragma('busy_timeout = 5000');
+    return db;
   } catch {
     return null;
   }
@@ -138,16 +133,18 @@ function openDatabase(dbPath: string) {
 
 export async function loadSessions(
   dbPath: string = `${process.env.HOME}/.codingbuddy/history.db`,
-  days = 30
+  days = 30,
 ): Promise<Session[]> {
   const db = openDatabase(dbPath);
   if (!db) return generateMockSessions(days);
 
   try {
     const cutoff = Date.now() / 1000 - days * 86400;
-    const rows = db.prepare(
-      'SELECT session_id, started_at, ended_at, project, model, tool_call_count, error_count, outcome FROM sessions WHERE started_at >= ? ORDER BY started_at DESC'
-    ).all(cutoff) as RawSessionRow[];
+    const rows = db
+      .prepare(
+        'SELECT session_id, started_at, ended_at, project, model, tool_call_count, error_count, outcome FROM sessions WHERE started_at >= ? ORDER BY started_at DESC',
+      )
+      .all(cutoff) as RawSessionRow[];
     return sessionsFromRows(rows);
   } catch {
     return generateMockSessions(days);
@@ -158,16 +155,18 @@ export async function loadSessions(
 
 export async function loadCostEntries(
   dbPath: string = `${process.env.HOME}/.codingbuddy/history.db`,
-  days = 30
+  days = 30,
 ): Promise<CostEntry[]> {
   const db = openDatabase(dbPath);
   if (!db) return generateMockCostEntries(days);
 
   try {
     const cutoff = Date.now() / 1000 - days * 86400;
-    const rows = db.prepare(
-      'SELECT session_id, started_at, ended_at, project, model, tool_call_count, error_count, outcome FROM sessions WHERE started_at >= ? ORDER BY started_at'
-    ).all(cutoff) as RawSessionRow[];
+    const rows = db
+      .prepare(
+        'SELECT session_id, started_at, ended_at, project, model, tool_call_count, error_count, outcome FROM sessions WHERE started_at >= ? ORDER BY started_at',
+      )
+      .all(cutoff) as RawSessionRow[];
     const sessions = sessionsFromRows(rows);
     return aggregateCostEntries(sessions);
   } catch {
@@ -178,16 +177,16 @@ export async function loadCostEntries(
 }
 
 export async function loadAgentActivity(
-  dbPath: string = `${process.env.HOME}/.codingbuddy/history.db`
+  dbPath: string = `${process.env.HOME}/.codingbuddy/history.db`,
 ): Promise<AgentActivity[]> {
   const db = openDatabase(dbPath);
   if (!db) return generateMockAgentActivity();
 
   try {
-    const rows = db.prepare(
-      'SELECT session_id, timestamp, tool_name, input_summary, success FROM tool_calls'
-    ).all() as RawToolCallRow[];
-    const toolCalls: ToolCall[] = rows.map((r) => ({
+    const rows = db
+      .prepare('SELECT session_id, timestamp, tool_name, input_summary, success FROM tool_calls')
+      .all() as RawToolCallRow[];
+    const toolCalls: ToolCall[] = rows.map(r => ({
       sessionId: r.session_id,
       timestamp: r.timestamp,
       toolName: r.tool_name,
@@ -203,16 +202,16 @@ export async function loadAgentActivity(
 }
 
 export async function loadSkillUsage(
-  dbPath: string = `${process.env.HOME}/.codingbuddy/history.db`
+  dbPath: string = `${process.env.HOME}/.codingbuddy/history.db`,
 ): Promise<SkillUsage[]> {
   const db = openDatabase(dbPath);
   if (!db) return generateMockSkillUsage();
 
   try {
-    const rows = db.prepare(
-      'SELECT session_id, timestamp, tool_name, input_summary, success FROM tool_calls'
-    ).all() as RawToolCallRow[];
-    const toolCalls: ToolCall[] = rows.map((r) => ({
+    const rows = db
+      .prepare('SELECT session_id, timestamp, tool_name, input_summary, success FROM tool_calls')
+      .all() as RawToolCallRow[];
+    const toolCalls: ToolCall[] = rows.map(r => ({
       sessionId: r.session_id,
       timestamp: r.timestamp,
       toolName: r.tool_name,
@@ -227,18 +226,16 @@ export async function loadSkillUsage(
   }
 }
 
-export async function loadPREntries(
-  repoPath?: string,
-  days = 30
-): Promise<PREntry[]> {
+export async function loadPREntries(repoPath?: string, days = 30): Promise<PREntry[]> {
   try {
     const cwd = repoPath ?? process.cwd();
     const since = new Date(Date.now() - days * 86400000).toISOString().split('T')[0];
 
-    const gitLog = execSync(
-      `git log --since="${since}" --pretty=format:"%ad|%s" --date=short`,
-      { cwd, encoding: 'utf-8', timeout: 5000 }
-    );
+    const gitLog = execSync(`git log --since="${since}" --pretty=format:"%ad|%s" --date=short`, {
+      cwd,
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
 
     if (!gitLog.trim()) return generateMockPREntries(days);
 


### PR DESCRIPTION
## Summary
- Verified Dashboard `data-loader.ts` SELECT queries match Plugin `history_db.py` CREATE TABLE schema (all columns aligned, no mismatches)
- Added `PRAGMA busy_timeout=5000` to `openDatabase()` for WAL concurrent access safety
- Exported `openDatabase` function for testability
- Added 6 new tests: 2 openDatabase unit tests + 4 integration tests with real SQLite schema

## Test plan
- [x] `yarn workspace codingbuddy-dashboard lint` — passed
- [x] `yarn workspace codingbuddy-dashboard format:check` — passed
- [x] `yarn workspace codingbuddy-dashboard typecheck` — passed
- [x] `yarn workspace codingbuddy-dashboard test` — 20/20 passed
- [x] `yarn workspace codingbuddy-dashboard build` — passed

Closes #930