### PR TITLE
feat(tui): add collaboration data flow pipeline (EVAL → TUI)

### DIFF
--- a/apps/mcp-server/src/collaboration/index.ts
+++ b/apps/mcp-server/src/collaboration/index.ts
@@ -25,3 +25,11 @@ export {
   formatConsensus,
   formatDiscussionRound,
 } from './terminal-formatter';
+export {
+  mapSeverityToStance,
+  convertSpecialistResult,
+  convertSpecialistResults,
+  type FindingSeverity,
+  type SpecialistFinding,
+  type SpecialistResult,
+} from './opinion-adapter';

--- a/apps/mcp-server/src/collaboration/opinion-adapter.spec.ts
+++ b/apps/mcp-server/src/collaboration/opinion-adapter.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mapSeverityToStance,
+  convertSpecialistResult,
+  convertSpecialistResults,
+  type SpecialistResult,
+} from './opinion-adapter';
+
+describe('opinion-adapter', () => {
+  describe('mapSeverityToStance', () => {
+    it('should map "critical" severity to "reject"', () => {
+      expect(mapSeverityToStance('critical')).toBe('reject');
+    });
+
+    it('should map "high" severity to "reject"', () => {
+      expect(mapSeverityToStance('high')).toBe('reject');
+    });
+
+    it('should map "medium" severity to "concern"', () => {
+      expect(mapSeverityToStance('medium')).toBe('concern');
+    });
+
+    it('should map "low" severity to "approve"', () => {
+      expect(mapSeverityToStance('low')).toBe('approve');
+    });
+
+    it('should map "none" severity to "approve"', () => {
+      expect(mapSeverityToStance('none')).toBe('approve');
+    });
+  });
+
+  describe('convertSpecialistResult', () => {
+    it('should convert a specialist result with critical findings to a reject opinion', () => {
+      const result: SpecialistResult = {
+        agentName: 'Security Specialist',
+        findings: [
+          { text: 'SQL injection vulnerability found', severity: 'critical' },
+          { text: 'Missing input validation', severity: 'high' },
+        ],
+        recommendations: ['Use parameterized queries', 'Add input sanitization'],
+      };
+
+      const opinion = convertSpecialistResult(result);
+
+      expect(opinion.agentName).toBe('Security Specialist');
+      expect(opinion.agentId).toBe('specialist:security-specialist');
+      expect(opinion.stance).toBe('reject');
+      expect(opinion.reasoning).toContain('SQL injection vulnerability found');
+      expect(opinion.reasoning).toContain('Missing input validation');
+      expect(opinion.suggestedChanges).toEqual([
+        'Use parameterized queries',
+        'Add input sanitization',
+      ]);
+    });
+
+    it('should convert a specialist result with medium findings to a concern opinion', () => {
+      const result: SpecialistResult = {
+        agentName: 'Code Quality Specialist',
+        findings: [{ text: 'Function complexity is borderline', severity: 'medium' }],
+        recommendations: ['Consider extracting helper functions'],
+      };
+
+      const opinion = convertSpecialistResult(result);
+
+      expect(opinion.stance).toBe('concern');
+      expect(opinion.reasoning).toContain('Function complexity is borderline');
+      expect(opinion.suggestedChanges).toEqual(['Consider extracting helper functions']);
+    });
+
+    it('should convert a specialist result with no findings to an approve opinion', () => {
+      const result: SpecialistResult = {
+        agentName: 'Performance Specialist',
+        findings: [],
+        recommendations: [],
+      };
+
+      const opinion = convertSpecialistResult(result);
+
+      expect(opinion.stance).toBe('approve');
+      expect(opinion.reasoning).toBe('No issues found.');
+      expect(opinion.suggestedChanges).toEqual([]);
+    });
+
+    it('should use the highest severity finding to determine stance', () => {
+      const result: SpecialistResult = {
+        agentName: 'Architecture Specialist',
+        findings: [
+          { text: 'Minor naming inconsistency', severity: 'low' },
+          { text: 'Circular dependency detected', severity: 'high' },
+          { text: 'Consider adding interface', severity: 'medium' },
+        ],
+        recommendations: ['Break circular dependency'],
+      };
+
+      const opinion = convertSpecialistResult(result);
+
+      // highest severity is 'high' → reject
+      expect(opinion.stance).toBe('reject');
+    });
+
+    it('should generate agentId from agentName by slugifying', () => {
+      const result: SpecialistResult = {
+        agentName: 'Test Strategy Specialist',
+        findings: [{ text: 'Missing edge case tests', severity: 'low' }],
+        recommendations: [],
+      };
+
+      const opinion = convertSpecialistResult(result);
+
+      expect(opinion.agentId).toBe('specialist:test-strategy-specialist');
+    });
+  });
+
+  describe('convertSpecialistResults', () => {
+    it('should convert multiple specialist results into a DiscussionRound', () => {
+      const results: SpecialistResult[] = [
+        {
+          agentName: 'Security Specialist',
+          findings: [{ text: 'Auth token exposed', severity: 'critical' }],
+          recommendations: ['Encrypt tokens'],
+        },
+        {
+          agentName: 'Performance Specialist',
+          findings: [],
+          recommendations: [],
+        },
+      ];
+
+      const round = convertSpecialistResults(results, 1);
+
+      expect(round.roundNumber).toBe(1);
+      expect(round.opinions).toHaveLength(2);
+      expect(round.opinions[0].agentName).toBe('Security Specialist');
+      expect(round.opinions[0].stance).toBe('reject');
+      expect(round.opinions[1].agentName).toBe('Performance Specialist');
+      expect(round.opinions[1].stance).toBe('approve');
+      expect(round.crossReviews).toEqual([]);
+    });
+
+    it('should default roundNumber to 1 when not provided', () => {
+      const round = convertSpecialistResults([]);
+
+      expect(round.roundNumber).toBe(1);
+      expect(round.opinions).toHaveLength(0);
+    });
+  });
+});

--- a/apps/mcp-server/src/collaboration/opinion-adapter.ts
+++ b/apps/mcp-server/src/collaboration/opinion-adapter.ts
@@ -1,0 +1,101 @@
+/**
+ * Opinion Adapter — converts specialist agent results to AgentOpinion/DiscussionRound.
+ *
+ * Pure module: no side effects, no I/O.
+ */
+import { createAgentOpinion, createDiscussionRound } from './types';
+import type { AgentOpinion, DiscussionRound, Stance } from './types';
+
+/** Severity levels produced by specialist agents. */
+export type FindingSeverity = 'critical' | 'high' | 'medium' | 'low' | 'none';
+
+/** A single finding from a specialist agent. */
+export interface SpecialistFinding {
+  readonly text: string;
+  readonly severity: FindingSeverity;
+}
+
+/** Aggregated result from a specialist agent. */
+export interface SpecialistResult {
+  readonly agentName: string;
+  readonly findings: readonly SpecialistFinding[];
+  readonly recommendations: readonly string[];
+}
+
+/** Severity rank — higher number = more severe. */
+const SEVERITY_RANK: Record<FindingSeverity, number> = {
+  none: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+/**
+ * Maps a finding severity to a discussion stance.
+ * critical/high → reject, medium → concern, low/none → approve
+ */
+export function mapSeverityToStance(severity: FindingSeverity): Stance {
+  switch (severity) {
+    case 'critical':
+    case 'high':
+      return 'reject';
+    case 'medium':
+      return 'concern';
+    case 'low':
+    case 'none':
+      return 'approve';
+  }
+}
+
+/**
+ * Slugifies an agent name to produce a stable agentId.
+ * "Security Specialist" → "specialist:security-specialist"
+ */
+function slugify(name: string): string {
+  return `specialist:${name.toLowerCase().replace(/\s+/g, '-')}`;
+}
+
+/**
+ * Determines the highest severity across all findings.
+ * Returns 'none' when there are no findings.
+ */
+function highestSeverity(findings: readonly SpecialistFinding[]): FindingSeverity {
+  if (findings.length === 0) return 'none';
+  let max: FindingSeverity = 'none';
+  for (const f of findings) {
+    if (SEVERITY_RANK[f.severity] > SEVERITY_RANK[max]) {
+      max = f.severity;
+    }
+  }
+  return max;
+}
+
+/**
+ * Converts a single specialist result into an AgentOpinion.
+ */
+export function convertSpecialistResult(result: SpecialistResult): AgentOpinion {
+  const severity = highestSeverity(result.findings);
+  const stance = mapSeverityToStance(severity);
+  const reasoning =
+    result.findings.length === 0 ? 'No issues found.' : result.findings.map(f => f.text).join('; ');
+
+  return createAgentOpinion({
+    agentId: slugify(result.agentName),
+    agentName: result.agentName,
+    stance,
+    reasoning,
+    suggestedChanges: [...result.recommendations],
+  });
+}
+
+/**
+ * Converts multiple specialist results into a DiscussionRound.
+ */
+export function convertSpecialistResults(
+  results: readonly SpecialistResult[],
+  roundNumber = 1,
+): DiscussionRound {
+  const opinions = results.map(convertSpecialistResult);
+  return createDiscussionRound(roundNumber, opinions);
+}

--- a/apps/mcp-server/src/tui/events/index.ts
+++ b/apps/mcp-server/src/tui/events/index.ts
@@ -20,6 +20,7 @@ export {
   type ObjectiveSetEvent,
   type SessionResetEvent,
   type ContextUpdatedEvent,
+  type DiscussionRoundAddedEvent,
 } from './types';
 export {
   type AgentMetadata,

--- a/apps/mcp-server/src/tui/events/types.spec.ts
+++ b/apps/mcp-server/src/tui/events/types.spec.ts
@@ -18,7 +18,7 @@ import {
 
 describe('tui/events/types', () => {
   describe('TUI_EVENTS', () => {
-    it('should define all 13 event names', () => {
+    it('should define all 14 event names', () => {
       expect(TUI_EVENTS).toEqual({
         AGENT_ACTIVATED: 'agent:activated',
         AGENT_DEACTIVATED: 'agent:deactivated',
@@ -33,6 +33,7 @@ describe('tui/events/types', () => {
         OBJECTIVE_SET: 'objective:set',
         SESSION_RESET: 'session:reset',
         CONTEXT_UPDATED: 'context:updated',
+        DISCUSSION_ROUND_ADDED: 'discussion:round-added',
       });
     });
 
@@ -187,6 +188,7 @@ describe('tui/events/types', () => {
         'objective:set': { objective: 'implement auth feature' },
         'session:reset': { reason: 'new-plan-session' },
         'context:updated': { decisions: ['Use JWT'], notes: [], mode: null, status: null },
+        'discussion:round-added': { round: { roundNumber: 1, opinions: [], crossReviews: [] } },
       };
       expect(map['agent:activated'].agentId).toBe('a1');
     });

--- a/apps/mcp-server/src/tui/events/types.ts
+++ b/apps/mcp-server/src/tui/events/types.ts
@@ -6,6 +6,7 @@
  */
 import type { Mode } from '../types';
 import type { EdgeType } from '../dashboard-types';
+import type { DiscussionRound } from '../../collaboration/types';
 import type { AgentMetadata } from './agent-metadata.types';
 
 /**
@@ -26,6 +27,7 @@ export const TUI_EVENTS = Object.freeze({
   OBJECTIVE_SET: 'objective:set',
   SESSION_RESET: 'session:reset',
   CONTEXT_UPDATED: 'context:updated',
+  DISCUSSION_ROUND_ADDED: 'discussion:round-added',
 } as const);
 
 export type TuiEventName = (typeof TUI_EVENTS)[keyof typeof TUI_EVENTS];
@@ -113,6 +115,11 @@ export interface ContextUpdatedEvent {
   status: string | null;
 }
 
+/** Payload when a discussion round is added from specialist results */
+export interface DiscussionRoundAddedEvent {
+  round: DiscussionRound;
+}
+
 /**
  * Maps event names to their payload types for type-safe emit/subscribe.
  */
@@ -130,4 +137,5 @@ export interface TuiEventMap {
   [TUI_EVENTS.OBJECTIVE_SET]: ObjectiveSetEvent;
   [TUI_EVENTS.SESSION_RESET]: SessionResetEvent;
   [TUI_EVENTS.CONTEXT_UPDATED]: ContextUpdatedEvent;
+  [TUI_EVENTS.DISCUSSION_ROUND_ADDED]: DiscussionRoundAddedEvent;
 }

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -24,6 +24,7 @@ import {
   type ObjectiveSetEvent,
   type SessionResetEvent,
   type ContextUpdatedEvent,
+  type DiscussionRoundAddedEvent,
 } from '../events';
 import { selectFocusedAgent } from './use-focus-agent';
 
@@ -78,6 +79,7 @@ export type DashboardAction =
   | { type: 'OBJECTIVE_SET'; payload: ObjectiveSetEvent }
   | { type: 'SESSION_RESET'; payload: SessionResetEvent }
   | { type: 'CONTEXT_UPDATED'; payload: ContextUpdatedEvent }
+  | { type: 'ADD_DISCUSSION_ROUND'; payload: DiscussionRoundAddedEvent }
   | { type: 'CLEANUP_STALE_AGENTS'; payload: { now: number; ttlMs: number } };
 
 function cloneAgents(agents: Map<string, DashboardNode>): Map<string, DashboardNode> {
@@ -301,6 +303,13 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
       };
     }
 
+    case 'ADD_DISCUSSION_ROUND': {
+      return {
+        ...state,
+        discussionRounds: [...state.discussionRounds, action.payload.round],
+      };
+    }
+
     case 'SESSION_RESET':
       return createInitialDashboardState();
 
@@ -375,6 +384,8 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
       dispatch({ type: 'SESSION_RESET', payload: p });
     const onContextUpdated = (p: ContextUpdatedEvent) =>
       dispatch({ type: 'CONTEXT_UPDATED', payload: p });
+    const onDiscussionRoundAdded = (p: DiscussionRoundAddedEvent) =>
+      dispatch({ type: 'ADD_DISCUSSION_ROUND', payload: p });
 
     eventBus.on(TUI_EVENTS.AGENT_ACTIVATED, onActivated);
     eventBus.on(TUI_EVENTS.AGENT_DEACTIVATED, onDeactivated);
@@ -389,6 +400,7 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
     eventBus.on(TUI_EVENTS.OBJECTIVE_SET, onObjectiveSet);
     eventBus.on(TUI_EVENTS.SESSION_RESET, onSessionReset);
     eventBus.on(TUI_EVENTS.CONTEXT_UPDATED, onContextUpdated);
+    eventBus.on(TUI_EVENTS.DISCUSSION_ROUND_ADDED, onDiscussionRoundAdded);
 
     return () => {
       eventBus.off(TUI_EVENTS.AGENT_ACTIVATED, onActivated);
@@ -404,6 +416,7 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
       eventBus.off(TUI_EVENTS.OBJECTIVE_SET, onObjectiveSet);
       eventBus.off(TUI_EVENTS.SESSION_RESET, onSessionReset);
       eventBus.off(TUI_EVENTS.CONTEXT_UPDATED, onContextUpdated);
+      eventBus.off(TUI_EVENTS.DISCUSSION_ROUND_ADDED, onDiscussionRoundAdded);
     };
   }, [eventBus]);
 


### PR DESCRIPTION
## Summary
- Add `OpinionAdapter` module that converts specialist agent results into `AgentOpinion` types for the collaboration visualization pipeline
- Map finding severity to discussion stance: critical/high → reject, medium → concern, low/none → approve
- Add `DISCUSSION_ROUND_ADDED` event to TUI EventBus with `ADD_DISCUSSION_ROUND` reducer action in DashboardState
- Wire event subscription in `useDashboardState` hook so `AgentDiscussionPanel` renders real data
- Export all new types and functions from collaboration module public API

## Test plan
- [x] 12 TDD tests for OpinionAdapter (severity mapping, result conversion, round creation)
- [x] All 107 dashboard state reducer tests passing
- [x] All 19 event type tests passing (updated for 14th event)
- [x] Full test suite: 5083 tests passing across 188 files
- [x] Typecheck clean, lint clean, no circular dependencies
- [x] Build succeeds

Closes #932