### PR TITLE
perf(plugin): reduce PostToolUse hook per-call I/O

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/history_db.py
+++ b/packages/claude-code-plugin/hooks/lib/history_db.py
@@ -13,6 +13,22 @@ DEFAULT_DB_PATH = os.path.expanduser("~/.codingbuddy/history.db")
 class HistoryDB:
     """Persistent SQLite database for execution history."""
 
+    _instance: "HistoryDB | None" = None
+
+    @classmethod
+    def get_instance(cls, db_path: str = DEFAULT_DB_PATH) -> "HistoryDB":
+        """Return the singleton instance, creating it on first call."""
+        if cls._instance is None:
+            cls._instance = cls(db_path=db_path)
+        return cls._instance
+
+    @classmethod
+    def close_instance(cls) -> None:
+        """Close and clear the singleton instance."""
+        if cls._instance is not None:
+            cls._instance.close()
+            cls._instance = None
+
     def __init__(self, db_path: str = DEFAULT_DB_PATH):
         self._db_path = db_path
         self._ensure_directory()

--- a/packages/claude-code-plugin/hooks/lib/stats.py
+++ b/packages/claude-code-plugin/hooks/lib/stats.py
@@ -20,15 +20,19 @@ DEFAULT_DATA_DIR = os.path.join(os.path.expanduser("~"), ".codingbuddy")
 class SessionStats:
     """Track operational metrics for a Claude Code session."""
 
-    def __init__(self, session_id: str, data_dir: Optional[str] = None):
+    def __init__(self, session_id: str, data_dir: Optional[str] = None, flush_interval: int = 10):
         """Initialize stats tracker.
 
         Args:
             session_id: Unique session identifier.
             data_dir: Directory for stats files.
                       Uses CLAUDE_PLUGIN_DATA env or ~/.codingbuddy.
+            flush_interval: Number of record_tool_call() invocations between
+                           automatic disk flushes. Default 10.
         """
         self.session_id = session_id
+        self._flush_interval = flush_interval
+        self._pending_count = 0
 
         if data_dir is None:
             data_dir = os.environ.get("CLAUDE_PLUGIN_DATA", DEFAULT_DATA_DIR)
@@ -50,24 +54,55 @@ class SessionStats:
                 "tool_names": {},
             })
 
+        # In-memory accumulator — deltas since last flush
+        self._mem_tool_count = 0
+        self._mem_error_count = 0
+        self._mem_tool_names: Dict[str, int] = {}
+
     def record_tool_call(self, tool_name: str, success: bool = True) -> None:
-        """Record a tool call.
+        """Record a tool call in memory. Flushes to disk every flush_interval calls.
 
         Args:
             tool_name: Name of the tool called.
             success: Whether the tool call succeeded.
         """
-        data = self._locked_read()
-        data["tool_count"] = data.get("tool_count", 0) + 1
-
+        self._mem_tool_count += 1
         if not success:
-            data["error_count"] = data.get("error_count", 0) + 1
+            self._mem_error_count += 1
+        self._mem_tool_names[tool_name] = self._mem_tool_names.get(tool_name, 0) + 1
 
+        self._pending_count += 1
+        if self._pending_count >= self._flush_interval:
+            self.flush()
+
+    def flush(self) -> None:
+        """Flush accumulated in-memory stats to disk."""
+        if self._pending_count == 0:
+            return
+        data = self._locked_read()
+        data["tool_count"] = data.get("tool_count", 0) + self._mem_tool_count
+        data["error_count"] = data.get("error_count", 0) + self._mem_error_count
         tool_names = data.get("tool_names", {})
-        tool_names[tool_name] = tool_names.get(tool_name, 0) + 1
+        for name, count in self._mem_tool_names.items():
+            tool_names[name] = tool_names.get(name, 0) + count
         data["tool_names"] = tool_names
-
         self._locked_write(data)
+        # Reset in-memory accumulators
+        self._mem_tool_count = 0
+        self._mem_error_count = 0
+        self._mem_tool_names = {}
+        self._pending_count = 0
+
+    def _merged_data(self) -> Dict[str, Any]:
+        """Return disk data merged with in-memory deltas (read-only)."""
+        data = self._locked_read()
+        data["tool_count"] = data.get("tool_count", 0) + self._mem_tool_count
+        data["error_count"] = data.get("error_count", 0) + self._mem_error_count
+        tool_names = dict(data.get("tool_names", {}))
+        for name, count in self._mem_tool_names.items():
+            tool_names[name] = tool_names.get(name, 0) + count
+        data["tool_names"] = tool_names
+        return data
 
     def format_summary(self) -> str:
         """Format a human-readable summary.
@@ -75,7 +110,7 @@ class SessionStats:
         Returns:
             String like '[CB] Xm | Y tools | Z errors | Bash:N Edit:M'
         """
-        data = self._locked_read()
+        data = self._merged_data()
         duration = time.time() - data.get("started_at", time.time())
         minutes = int(duration // 60)
         tool_count = data.get("tool_count", 0)
@@ -96,6 +131,7 @@ class SessionStats:
         Returns:
             Dict with session stats.
         """
+        self.flush()
         data = self._locked_read()
         duration = time.time() - data.get("started_at", time.time())
         data["duration_seconds"] = duration

--- a/packages/claude-code-plugin/hooks/post-tool-use.py
+++ b/packages/claude-code-plugin/hooks/post-tool-use.py
@@ -36,16 +36,15 @@ def handle_post_tool_use(data: dict):
     except Exception:
         pass  # Never block tool execution
 
-    # Record tool call in history database (#823)
+    # Record tool call in history database (#823) — singleton reuse (#931)
     try:
         from history_db import HistoryDB
 
-        db = HistoryDB()
+        db = HistoryDB.get_instance()
         tool_name = data.get("tool_name", "unknown")
         input_summary = str(data.get("tool_input", {}))[:200]
         session_id = os.environ.get("CLAUDE_SESSION_ID", "")
         db.record_tool_call(session_id, tool_name, input_summary, success=True)
-        db.close()
     except Exception:
         pass  # Never block tool execution
 
@@ -71,6 +70,14 @@ def _maybe_notify_pr_created(data: dict):
     if "gh pr create" not in command:
         return
 
+    # Check config before importing notification modules (#931)
+    from config import get_config
+
+    config = get_config(os.getcwd())
+    notifications_config = config.get("notifications", {})
+    if not notifications_config.get("enabled", True):
+        return
+
     # Extract PR URL from output (gh pr create prints the URL)
     pr_url = ""
     if isinstance(tool_output, str):
@@ -80,10 +87,8 @@ def _maybe_notify_pr_created(data: dict):
                 pr_url = line
                 break
 
-    from config import get_config
     from notifications import NotificationEvent, notify
 
-    config = get_config(os.getcwd())
     event = NotificationEvent(
         event_type="pr_created",
         title="PR Created",

--- a/packages/claude-code-plugin/hooks/stop.py
+++ b/packages/claude-code-plugin/hooks/stop.py
@@ -27,6 +27,10 @@ def handle_stop(data: dict):
 
         session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
         stats = SessionStats(session_id=session_id)
+
+        # Flush pending in-memory stats before finalize (#931)
+        stats.flush()
+
         summary = stats.format_summary()
         stats.finalize()
 
@@ -36,6 +40,8 @@ def handle_stop(data: dict):
 
             db = HistoryDB()
             db.end_session(session_id, outcome="completed")
+            # Close singleton connection (#931)
+            HistoryDB.close_instance()
             db.close()
         except Exception:
             pass  # Never block session stop

--- a/packages/claude-code-plugin/tests/test_history_db.py
+++ b/packages/claude-code-plugin/tests/test_history_db.py
@@ -197,3 +197,41 @@ class TestCleanupAndConcurrency:
         db2.close()
 
         assert len(errors) == 0, f"Concurrent access errors: {errors}"
+
+
+class TestSingleton:
+    """Tests for HistoryDB singleton pattern (#931)."""
+
+    def test_get_instance_returns_same_object(self, db_path):
+        """get_instance() should return the same HistoryDB across calls."""
+        try:
+            inst1 = HistoryDB.get_instance(db_path=db_path)
+            inst2 = HistoryDB.get_instance(db_path=db_path)
+            assert inst1 is inst2
+        finally:
+            HistoryDB.close_instance()
+
+    def test_get_instance_reuses_connection(self, db_path):
+        """Singleton should reuse the same SQLite connection."""
+        try:
+            inst1 = HistoryDB.get_instance(db_path=db_path)
+            conn1 = inst1._conn
+            inst2 = HistoryDB.get_instance(db_path=db_path)
+            conn2 = inst2._conn
+            assert conn1 is conn2
+        finally:
+            HistoryDB.close_instance()
+
+    def test_close_instance_clears_singleton(self, db_path):
+        """close_instance() should clear the singleton so next get_instance creates new."""
+        try:
+            inst1 = HistoryDB.get_instance(db_path=db_path)
+            HistoryDB.close_instance()
+            inst2 = HistoryDB.get_instance(db_path=db_path)
+            assert inst1 is not inst2
+        finally:
+            HistoryDB.close_instance()
+
+    def test_close_instance_noop_when_no_instance(self):
+        """close_instance() should not raise when no instance exists."""
+        HistoryDB.close_instance()  # Should not raise

--- a/packages/claude-code-plugin/tests/test_post_tool_use.py
+++ b/packages/claude-code-plugin/tests/test_post_tool_use.py
@@ -135,3 +135,82 @@ class TestPrCreatedNotification:
         )
         assert result is None
         mock_notify.assert_not_called()
+
+
+class TestSingletonWiring:
+    """Tests for HistoryDB singleton usage in post-tool-use (#931)."""
+
+    @patch("history_db.HistoryDB")
+    def test_uses_get_instance_not_constructor(self, mock_db_cls, monkeypatch, capsys):
+        """post-tool-use should use HistoryDB.get_instance() instead of HistoryDB()."""
+        mock_instance = MagicMock()
+        mock_db_cls.get_instance.return_value = mock_instance
+
+        _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "ls"}},
+            monkeypatch, capsys,
+        )
+
+        mock_db_cls.get_instance.assert_called()
+        # Constructor should NOT be called directly
+        mock_db_cls.assert_not_called()
+
+    @patch("history_db.HistoryDB")
+    def test_does_not_close_db_after_each_call(self, mock_db_cls, monkeypatch, capsys):
+        """post-tool-use should NOT close the DB connection (stop hook does that)."""
+        mock_instance = MagicMock()
+        mock_db_cls.get_instance.return_value = mock_instance
+
+        _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "ls"}},
+            monkeypatch, capsys,
+        )
+
+        mock_instance.close.assert_not_called()
+
+
+class TestConditionalNotification:
+    """Tests for conditional notification skip (#931)."""
+
+    @patch("config.get_config")
+    def test_skips_notify_call_when_disabled(self, mock_config, monkeypatch, capsys):
+        """_maybe_notify_pr_created should not call notify when notifications disabled."""
+        mock_config.return_value = {
+            "notifications": {
+                "enabled": False,
+            }
+        }
+        ptu = _load_module()
+        # Call _maybe_notify_pr_created directly with a PR-creating payload
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'gh pr create --title "test"'},
+            "tool_output": "https://github.com/org/repo/pull/99\n",
+        }
+        with patch("notifications.notify") as mock_notify:
+            ptu._maybe_notify_pr_created(data)
+            mock_notify.assert_not_called()
+
+    @patch("notifications.notify")
+    @patch("config.get_config")
+    def test_still_notifies_when_enabled(self, mock_config, mock_notify, monkeypatch, capsys):
+        """Should still notify when notifications are enabled."""
+        mock_config.return_value = {
+            "notifications": {
+                "enabled": True,
+                "events": {"pr_created": True},
+                "platforms": ["slack"],
+            }
+        }
+        mock_notify.return_value = {"slack": True}
+
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": 'gh pr create --title "test"'},
+                "tool_output": "https://github.com/org/repo/pull/99\n",
+            },
+            monkeypatch, capsys,
+        )
+        assert result is None
+        mock_notify.assert_called_once()

--- a/packages/claude-code-plugin/tests/test_stats.py
+++ b/packages/claude-code-plugin/tests/test_stats.py
@@ -110,6 +110,7 @@ class TestRoundtrip:
         s1 = SessionStats(session_id="rt-test", data_dir=data_dir)
         s1.record_tool_call("Bash")
         s1.record_tool_call("Edit")
+        s1.flush()  # Flush to disk before new instance reads
 
         # New instance same session
         s2 = SessionStats(session_id="rt-test", data_dir=data_dir)
@@ -128,6 +129,70 @@ class TestLocking:
             s.record_tool_call(f"Tool{i % 5}")
         result = s.finalize()
         assert result["tool_count"] == 50
+
+
+class TestInMemoryAccumulation:
+    """Tests for in-memory accumulation with periodic flush (#931)."""
+
+    def test_record_does_not_write_immediately(self, data_dir):
+        """record_tool_call should NOT write to disk on every call."""
+        s = SessionStats(session_id="lazy-test", data_dir=data_dir, flush_interval=10)
+        # Read initial file content
+        with open(s.stats_file, "r") as f:
+            initial = json.load(f)
+        initial_count = initial.get("tool_count", 0)
+
+        s.record_tool_call("Bash")
+        # File should still have initial count (not flushed yet)
+        with open(s.stats_file, "r") as f:
+            on_disk = json.load(f)
+        assert on_disk["tool_count"] == initial_count
+
+    def test_flush_writes_accumulated_data(self, data_dir):
+        """flush() should persist all accumulated stats to disk."""
+        s = SessionStats(session_id="flush-test", data_dir=data_dir, flush_interval=100)
+        s.record_tool_call("Bash")
+        s.record_tool_call("Edit")
+        s.record_tool_call("Read")
+        s.flush()
+
+        with open(s.stats_file, "r") as f:
+            on_disk = json.load(f)
+        assert on_disk["tool_count"] == 3
+        assert on_disk["tool_names"]["Bash"] == 1
+        assert on_disk["tool_names"]["Edit"] == 1
+
+    def test_auto_flush_at_interval(self, data_dir):
+        """Should auto-flush when flush_interval calls are reached."""
+        s = SessionStats(session_id="auto-flush", data_dir=data_dir, flush_interval=3)
+        s.record_tool_call("Bash")
+        s.record_tool_call("Edit")
+        # Not yet flushed (2 < 3)
+        with open(s.stats_file, "r") as f:
+            on_disk = json.load(f)
+        assert on_disk["tool_count"] == 0
+
+        s.record_tool_call("Read")  # 3rd call -> auto-flush
+        with open(s.stats_file, "r") as f:
+            on_disk = json.load(f)
+        assert on_disk["tool_count"] == 3
+
+    def test_finalize_flushes_pending(self, data_dir):
+        """finalize() should flush pending stats before returning."""
+        s = SessionStats(session_id="fin-flush", data_dir=data_dir, flush_interval=100)
+        s.record_tool_call("Bash")
+        s.record_tool_call("Edit")
+        result = s.finalize()
+        assert result["tool_count"] == 2
+
+    def test_format_summary_uses_memory_data(self, data_dir):
+        """format_summary() should reflect in-memory state, not just disk."""
+        s = SessionStats(session_id="mem-summary", data_dir=data_dir, flush_interval=100)
+        s.record_tool_call("Bash")
+        s.record_tool_call("Bash")
+        summary = s.format_summary()
+        assert "2 tools" in summary
+        assert "Bash:2" in summary
 
 
 class TestCleanup:

--- a/packages/claude-code-plugin/tests/test_stop.py
+++ b/packages/claude-code-plugin/tests/test_stop.py
@@ -105,6 +105,36 @@ class TestSessionEndNotification:
         mock_notify.assert_not_called()
 
 
+class TestStopFlush:
+    """Tests for pending stats flush and DB singleton close at stop (#931)."""
+
+    @patch("history_db.HistoryDB")
+    @patch("stats.SessionStats")
+    def test_stop_flushes_pending_stats(self, mock_stats_cls, mock_db_cls, monkeypatch, capsys):
+        """Stop hook should call flush() on SessionStats before finalize."""
+        mock_stats = MagicMock()
+        mock_stats.format_summary.return_value = "Session: 5 tools"
+        mock_stats_cls.return_value = mock_stats
+
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "test-session")
+        _run_hook({"stop_hook_active": True}, monkeypatch, capsys)
+
+        mock_stats.flush.assert_called()
+
+    @patch("history_db.HistoryDB")
+    @patch("stats.SessionStats")
+    def test_stop_closes_db_singleton(self, mock_stats_cls, mock_db_cls, monkeypatch, capsys):
+        """Stop hook should call HistoryDB.close_instance() at the end."""
+        mock_stats = MagicMock()
+        mock_stats.format_summary.return_value = "Session: 3 tools"
+        mock_stats_cls.return_value = mock_stats
+
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "test-session")
+        _run_hook({"stop_hook_active": True}, monkeypatch, capsys)
+
+        mock_db_cls.close_instance.assert_called()
+
+
 class TestAutoLearningSuggestions:
     """Tests for auto-learning pattern detection wiring (#929)."""
 


### PR DESCRIPTION
## Summary
- **HistoryDB singleton**: `get_instance()`/`close_instance()` classmethods for DB connection reuse across tool calls (1 open per session instead of per-call)
- **SessionStats in-memory accumulation**: `record_tool_call()` accumulates in memory, auto-flushes every N calls (default 10) or on explicit `flush()`
- **Conditional notification**: checks `config.notifications.enabled` before importing notification modules — fully skips when disabled
- **Stop hook integration**: flushes pending stats + closes DB singleton at session end

## Test plan
- [x] 158 tests passing (143 existing + 15 new)
- [x] HistoryDB singleton: identity, connection reuse, close/recreate, noop close (4 tests)
- [x] SessionStats in-memory: no immediate write, flush works, auto-flush at interval, finalize flushes, summary reflects memory (5 tests)
- [x] Conditional notification: skip when disabled, still notify when enabled (2 tests)
- [x] Singleton wiring: uses get_instance not constructor, no close after each call (2 tests)
- [x] Stop hook flush: calls flush() and close_instance() (2 tests)

Closes #931