### PR TITLE
feat(plugin): add health check diagnostic module

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/health_check.py
+++ b/packages/claude-code-plugin/hooks/lib/health_check.py
@@ -1,0 +1,196 @@
+"""Plugin health check diagnostic module.
+
+Diagnoses plugin installation state, DB integrity, hook registration,
+and config file consistency in a single pass.
+"""
+import json
+import os
+import sqlite3
+import stat
+from typing import Dict, List, Optional
+
+HOOK_FILES = [
+    "session-start.py",
+    "pre-tool-use.py",
+    "post-tool-use.py",
+    "stop.py",
+    "user-prompt-submit.py",
+]
+
+REQUIRED_TABLES = ["sessions", "tool_calls"]
+
+
+def _result(check: str, status: str, message: str) -> Dict[str, str]:
+    """Build a single check result dict."""
+    return {"check": check, "status": status, "message": message}
+
+
+class HealthChecker:
+    """Runs 7 diagnostic checks on the CodingBuddy plugin environment."""
+
+    def __init__(
+        self,
+        plugin_root: str,
+        home_dir: Optional[str] = None,
+        project_dir: Optional[str] = None,
+    ):
+        self._plugin_root = plugin_root
+        self._home_dir = home_dir or os.path.expanduser("~")
+        self._project_dir = project_dir or plugin_root
+        self._hooks_dir = os.path.join(plugin_root, "hooks")
+        self._data_dir = os.path.join(self._home_dir, ".codingbuddy")
+        self._claude_dir = os.path.join(self._home_dir, ".claude")
+
+    # ------------------------------------------------------------------
+    # Check 1: hooks.json
+    # ------------------------------------------------------------------
+    def check_hooks_json(self) -> Dict[str, str]:
+        path = os.path.join(self._hooks_dir, "hooks.json")
+        if not os.path.isfile(path):
+            return _result("hooks_json", "WARN", "hooks.json not found")
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                json.load(f)
+            return _result("hooks_json", "PASS", "hooks.json is valid")
+        except json.JSONDecodeError as e:
+            return _result("hooks_json", "FAIL", f"hooks.json parse error: {e}")
+
+    # ------------------------------------------------------------------
+    # Check 2: hook script files
+    # ------------------------------------------------------------------
+    def check_hook_files(self) -> Dict[str, str]:
+        missing = [
+            name
+            for name in HOOK_FILES
+            if not os.path.isfile(os.path.join(self._hooks_dir, name))
+        ]
+        if not missing:
+            return _result("hook_files", "PASS", "All hook files present")
+        return _result(
+            "hook_files",
+            "WARN",
+            f"Missing hook files: {', '.join(missing)}",
+        )
+
+    # ------------------------------------------------------------------
+    # Check 3: history.db
+    # ------------------------------------------------------------------
+    def check_history_db(self) -> Dict[str, str]:
+        db_path = os.path.join(self._data_dir, "history.db")
+        if not os.path.isfile(db_path):
+            return _result("history_db", "WARN", "history.db not found")
+        try:
+            conn = sqlite3.connect(db_path)
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+            tables = {row[0] for row in cursor.fetchall()}
+            conn.close()
+            missing = [t for t in REQUIRED_TABLES if t not in tables]
+            if missing:
+                return _result(
+                    "history_db",
+                    "FAIL",
+                    f"Missing tables: {', '.join(missing)}",
+                )
+            return _result("history_db", "PASS", "history.db schema OK")
+        except sqlite3.Error as e:
+            return _result("history_db", "FAIL", f"DB error: {e}")
+
+    # ------------------------------------------------------------------
+    # Check 4: UserPromptSubmit hook in settings.json
+    # ------------------------------------------------------------------
+    def check_settings_hook(self) -> Dict[str, str]:
+        path = os.path.join(self._claude_dir, "settings.json")
+        if not os.path.isfile(path):
+            return _result(
+                "settings_hook", "WARN", "settings.json not found"
+            )
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            hooks = data.get("hooks", {})
+            if "UserPromptSubmit" in hooks:
+                return _result(
+                    "settings_hook", "PASS", "UserPromptSubmit hook registered"
+                )
+            return _result(
+                "settings_hook",
+                "WARN",
+                "UserPromptSubmit hook not registered in settings.json",
+            )
+        except (json.JSONDecodeError, OSError) as e:
+            return _result("settings_hook", "FAIL", f"settings.json error: {e}")
+
+    # ------------------------------------------------------------------
+    # Check 5: codingbuddy.config.json
+    # ------------------------------------------------------------------
+    def check_config(self) -> Dict[str, str]:
+        path = os.path.join(self._project_dir, "codingbuddy.config.json")
+        if not os.path.isfile(path):
+            return _result("config", "WARN", "codingbuddy.config.json not found")
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                json.load(f)
+            return _result("config", "PASS", "codingbuddy.config.json is valid")
+        except json.JSONDecodeError as e:
+            return _result("config", "FAIL", f"Config parse error: {e}")
+
+    # ------------------------------------------------------------------
+    # Check 6: secrets.json permissions
+    # ------------------------------------------------------------------
+    def check_secrets_permissions(self) -> Dict[str, str]:
+        path = os.path.join(self._data_dir, "secrets.json")
+        if not os.path.isfile(path):
+            return _result(
+                "secrets_permissions", "PASS", "secrets.json not found, skipped"
+            )
+        file_mode = stat.S_IMODE(os.stat(path).st_mode)
+        if file_mode == 0o600:
+            return _result(
+                "secrets_permissions", "PASS", "secrets.json permissions OK (0600)"
+            )
+        return _result(
+            "secrets_permissions",
+            "WARN",
+            f"secrets.json has mode {oct(file_mode)}, expected 0o600",
+        )
+
+    # ------------------------------------------------------------------
+    # Check 7: events directory
+    # ------------------------------------------------------------------
+    def check_events_dir(self) -> Dict[str, str]:
+        path = os.path.join(self._data_dir, "events")
+        if os.path.isdir(path):
+            return _result("events_dir", "PASS", "events/ directory exists")
+        return _result("events_dir", "WARN", "events/ directory not found")
+
+    # ------------------------------------------------------------------
+    # Aggregate
+    # ------------------------------------------------------------------
+    def run_all(self) -> List[Dict[str, str]]:
+        """Run all 7 diagnostic checks and return results."""
+        return [
+            self.check_hooks_json(),
+            self.check_hook_files(),
+            self.check_history_db(),
+            self.check_settings_hook(),
+            self.check_config(),
+            self.check_secrets_permissions(),
+            self.check_events_dir(),
+        ]
+
+    @staticmethod
+    def format_report(results: List[Dict[str, str]]) -> str:
+        """Format check results as a human-readable report."""
+        lines = ["CodingBuddy Plugin Health Check", "=" * 40]
+        for r in results:
+            icon = {"PASS": "OK", "WARN": "!!", "FAIL": "XX"}[r["status"]]
+            lines.append(f"[{icon}] {r['status']:4s} | {r['check']}: {r['message']}")
+        total = len(results)
+        passed = sum(1 for r in results if r["status"] == "PASS")
+        failed = sum(1 for r in results if r["status"] == "FAIL")
+        warned = sum(1 for r in results if r["status"] == "WARN")
+        lines.append("=" * 40)
+        lines.append(f"Total: {total} | PASS: {passed} | WARN: {warned} | FAIL: {failed}")
+        return "\n".join(lines)

--- a/packages/claude-code-plugin/tests/test_health_check.py
+++ b/packages/claude-code-plugin/tests/test_health_check.py
@@ -1,0 +1,262 @@
+"""Tests for hooks/lib/health_check.py — plugin health check diagnostics."""
+import json
+import os
+import sqlite3
+import stat
+import tempfile
+
+import pytest
+
+from hooks.lib.health_check import HealthChecker
+
+
+HOOK_FILES = [
+    "session-start.py",
+    "pre-tool-use.py",
+    "post-tool-use.py",
+    "stop.py",
+    "user-prompt-submit.py",
+]
+
+
+@pytest.fixture
+def env(tmp_path):
+    """Create a complete healthy plugin environment for testing."""
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+
+    # hooks.json
+    hooks_json = {
+        "hooks": {
+            "SessionStart": [{"hooks": [{"type": "command"}]}],
+        }
+    }
+    (hooks_dir / "hooks.json").write_text(json.dumps(hooks_json))
+
+    # hook files
+    for name in HOOK_FILES:
+        (hooks_dir / name).write_text("# hook")
+
+    # history.db with correct tables
+    data_dir = tmp_path / ".codingbuddy"
+    data_dir.mkdir()
+    db_path = data_dir / "history.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE sessions (id INTEGER PRIMARY KEY, session_id TEXT);
+        CREATE TABLE tool_calls (id INTEGER PRIMARY KEY, session_id TEXT);
+    """)
+    conn.close()
+
+    # ~/.claude/settings.json with UserPromptSubmit hook
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    settings = {
+        "hooks": {
+            "UserPromptSubmit": [
+                {"hooks": [{"type": "command", "command": "python3 user-prompt-submit.py"}]}
+            ]
+        }
+    }
+    (claude_dir / "settings.json").write_text(json.dumps(settings))
+
+    # codingbuddy.config.json
+    (tmp_path / "codingbuddy.config.json").write_text(json.dumps({"language": "ko"}))
+
+    # secrets.json with correct permissions
+    secrets_path = data_dir / "secrets.json"
+    secrets_path.write_text(json.dumps({"token": "abc"}))
+    os.chmod(str(secrets_path), 0o600)
+
+    # events directory
+    events_dir = data_dir / "events"
+    events_dir.mkdir()
+
+    return tmp_path
+
+
+def _make_checker(env_path):
+    """Create HealthChecker with all paths pointing to tmp_path."""
+    return HealthChecker(
+        plugin_root=str(env_path),
+        home_dir=str(env_path),
+        project_dir=str(env_path),
+    )
+
+
+class TestCheckHooksJson:
+    """Check 1: hooks.json existence and validity."""
+
+    def test_valid_hooks_json(self, env):
+        checker = _make_checker(env)
+        result = checker.check_hooks_json()
+        assert result["status"] == "PASS"
+        assert result["check"] == "hooks_json"
+
+    def test_missing_hooks_json(self, env):
+        (env / "hooks" / "hooks.json").unlink()
+        checker = _make_checker(env)
+        result = checker.check_hooks_json()
+        assert result["status"] == "WARN"
+
+    def test_invalid_hooks_json(self, env):
+        (env / "hooks" / "hooks.json").write_text("not valid json{{{")
+        checker = _make_checker(env)
+        result = checker.check_hooks_json()
+        assert result["status"] == "FAIL"
+
+
+class TestCheckHookFiles:
+    """Check 2: hook script files existence."""
+
+    def test_all_hook_files_exist(self, env):
+        checker = _make_checker(env)
+        result = checker.check_hook_files()
+        assert result["status"] == "PASS"
+
+    def test_some_hook_files_missing(self, env):
+        (env / "hooks" / "stop.py").unlink()
+        (env / "hooks" / "pre-tool-use.py").unlink()
+        checker = _make_checker(env)
+        result = checker.check_hook_files()
+        assert result["status"] == "WARN"
+        assert "stop.py" in result["message"]
+        assert "pre-tool-use.py" in result["message"]
+
+
+class TestCheckHistoryDb:
+    """Check 3: history.db access and schema."""
+
+    def test_valid_db(self, env):
+        checker = _make_checker(env)
+        result = checker.check_history_db()
+        assert result["status"] == "PASS"
+
+    def test_missing_db(self, env):
+        (env / ".codingbuddy" / "history.db").unlink()
+        checker = _make_checker(env)
+        result = checker.check_history_db()
+        assert result["status"] == "WARN"
+
+    def test_missing_tables(self, env):
+        db_path = env / ".codingbuddy" / "history.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DROP TABLE tool_calls")
+        conn.close()
+        checker = _make_checker(env)
+        result = checker.check_history_db()
+        assert result["status"] == "FAIL"
+        assert "tool_calls" in result["message"]
+
+
+class TestCheckSettingsHook:
+    """Check 4: UserPromptSubmit hook in settings.json."""
+
+    def test_hook_registered(self, env):
+        checker = _make_checker(env)
+        result = checker.check_settings_hook()
+        assert result["status"] == "PASS"
+
+    def test_hook_not_registered(self, env):
+        settings_path = env / ".claude" / "settings.json"
+        settings_path.write_text(json.dumps({"hooks": {}}))
+        checker = _make_checker(env)
+        result = checker.check_settings_hook()
+        assert result["status"] == "WARN"
+
+    def test_settings_missing(self, env):
+        (env / ".claude" / "settings.json").unlink()
+        checker = _make_checker(env)
+        result = checker.check_settings_hook()
+        assert result["status"] == "WARN"
+
+
+class TestCheckConfig:
+    """Check 5: codingbuddy.config.json parseable."""
+
+    def test_valid_config(self, env):
+        checker = _make_checker(env)
+        result = checker.check_config()
+        assert result["status"] == "PASS"
+
+    def test_missing_config(self, env):
+        (env / "codingbuddy.config.json").unlink()
+        checker = _make_checker(env)
+        result = checker.check_config()
+        assert result["status"] == "WARN"
+
+
+class TestCheckSecretsPermissions:
+    """Check 6: secrets.json file permissions."""
+
+    def test_correct_permissions(self, env):
+        checker = _make_checker(env)
+        result = checker.check_secrets_permissions()
+        assert result["status"] == "PASS"
+
+    def test_wrong_permissions(self, env):
+        secrets_path = env / ".codingbuddy" / "secrets.json"
+        os.chmod(str(secrets_path), 0o644)
+        checker = _make_checker(env)
+        result = checker.check_secrets_permissions()
+        assert result["status"] == "WARN"
+
+    def test_secrets_not_exists(self, env):
+        (env / ".codingbuddy" / "secrets.json").unlink()
+        checker = _make_checker(env)
+        result = checker.check_secrets_permissions()
+        assert result["status"] == "PASS"
+        assert "not found" in result["message"].lower() or "skip" in result["message"].lower()
+
+
+class TestCheckEventsDir:
+    """Check 7: events directory existence."""
+
+    def test_events_dir_exists(self, env):
+        checker = _make_checker(env)
+        result = checker.check_events_dir()
+        assert result["status"] == "PASS"
+
+    def test_events_dir_missing(self, env):
+        (env / ".codingbuddy" / "events").rmdir()
+        checker = _make_checker(env)
+        result = checker.check_events_dir()
+        assert result["status"] == "WARN"
+
+
+class TestRunAll:
+    """run_all() returns all 7 check results."""
+
+    def test_returns_7_results(self, env):
+        checker = _make_checker(env)
+        results = checker.run_all()
+        assert len(results) == 7
+        assert all(r["status"] == "PASS" for r in results)
+
+    def test_each_check_has_required_keys(self, env):
+        checker = _make_checker(env)
+        results = checker.run_all()
+        for r in results:
+            assert "check" in r
+            assert "status" in r
+            assert "message" in r
+            assert r["status"] in ("PASS", "WARN", "FAIL")
+
+
+class TestFormatReport:
+    """format_report() produces human-readable output."""
+
+    def test_format_report_contains_all_checks(self, env):
+        checker = _make_checker(env)
+        results = checker.run_all()
+        report = checker.format_report(results)
+        assert isinstance(report, str)
+        assert "PASS" in report
+        assert len(report) > 50
+
+    def test_format_report_shows_failures(self, env):
+        (env / "hooks" / "hooks.json").write_text("bad json")
+        checker = _make_checker(env)
+        results = checker.run_all()
+        report = checker.format_report(results)
+        assert "FAIL" in report


### PR DESCRIPTION
## Summary
- Add `HealthChecker` class with 7 diagnostic checks: hooks.json validity, hook files existence, history.db schema integrity, settings.json UserPromptSubmit hook registration, codingbuddy.config.json parsing, secrets.json permissions (0o600), and events/ directory existence
- Each check returns structured `{check, status, message}` with PASS/WARN/FAIL semantics
- `format_report()` method for human-readable diagnostic output
- 22 tests covering all checks, edge cases, `run_all()`, and `format_report()`

## Test plan
- [x] 22 unit tests pass (`pytest tests/test_health_check.py`)
- [x] Full test suite 191 tests pass with no regressions
- [x] CI checks pass: lint, format, typecheck, test:coverage, circular, build

Closes #943