### PR TITLE
feat(plugin): add smart pre-commit test runner

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/smart_test_runner.py
+++ b/packages/claude-code-plugin/hooks/lib/smart_test_runner.py
@@ -1,0 +1,94 @@
+"""Smart test runner — maps changed files to related test files."""
+
+import os
+from typing import List
+
+# Extensions recognized as testable source code
+_TESTABLE_EXTENSIONS = {".ts", ".tsx", ".js", ".jsx", ".py"}
+
+
+class SmartTestRunner:
+    """Identifies test files related to changed source files."""
+
+    def find_related_tests(self, changed_files: List[str]) -> List[str]:
+        """Return deduplicated list of potential test file paths for changed files.
+
+        Mapping rules:
+        - src/foo.ts  → src/foo.spec.ts, src/foo.test.ts,
+                         tests/foo.spec.ts, tests/foo.test.ts
+        - hooks/lib/bar.py → tests/test_bar.py
+        - src/components/Baz.tsx → src/components/Baz.spec.tsx,
+                                    src/components/__tests__/Baz.test.tsx
+        """
+        seen: set = set()
+        result: List[str] = []
+
+        for filepath in changed_files:
+            for candidate in self._candidates_for(filepath):
+                if candidate not in seen:
+                    seen.add(candidate)
+                    result.append(candidate)
+
+        return result
+
+    def format_suggestion(self, test_files: List[str]) -> str:
+        """Format a human-readable test run suggestion.
+
+        Returns empty string if no test files.
+        """
+        if not test_files:
+            return ""
+
+        files_str = " ".join(test_files)
+        return f"Consider running: {files_str}"
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _candidates_for(self, filepath: str) -> List[str]:
+        """Generate candidate test paths for a single file."""
+        ext = os.path.splitext(filepath)[1]
+        if ext not in _TESTABLE_EXTENSIONS:
+            return []
+
+        if ext == ".py":
+            return self._python_candidates(filepath)
+
+        return self._js_ts_candidates(filepath)
+
+    def _python_candidates(self, filepath: str) -> List[str]:
+        """Python: hooks/lib/bar.py → tests/test_bar.py."""
+        basename = os.path.basename(filepath)
+        name_no_ext = os.path.splitext(basename)[0]
+        return [f"tests/test_{name_no_ext}.py"]
+
+    def _js_ts_candidates(self, filepath: str) -> List[str]:
+        """JS/TS/JSX/TSX mapping rules."""
+        dirpath = os.path.dirname(filepath)
+        basename = os.path.basename(filepath)
+        name_no_ext, ext = os.path.splitext(basename)
+
+        candidates: List[str] = []
+
+        # Same directory: foo.spec.ext, foo.test.ext
+        candidates.append(os.path.join(dirpath, f"{name_no_ext}.spec{ext}"))
+        candidates.append(os.path.join(dirpath, f"{name_no_ext}.test{ext}"))
+
+        # __tests__ sibling directory
+        candidates.append(
+            os.path.join(dirpath, "__tests__", f"{name_no_ext}.test{ext}")
+        )
+
+        # Mirror under tests/ directory — strip leading src/ if present
+        rel = filepath
+        if rel.startswith("src/") or rel.startswith("src\\"):
+            rel = rel[4:]
+        rel_dir = os.path.dirname(rel)
+        rel_name = os.path.splitext(os.path.basename(rel))[0]
+
+        candidates.append(os.path.join("tests", rel_dir, f"{rel_name}.spec{ext}"))
+        candidates.append(os.path.join("tests", rel_dir, f"{rel_name}.test{ext}"))
+
+        # Normalize path separators and remove leading ./
+        return [os.path.normpath(c).replace("\\", "/") for c in candidates]

--- a/packages/claude-code-plugin/hooks/pre-tool-use.py
+++ b/packages/claude-code-plugin/hooks/pre-tool-use.py
@@ -3,13 +3,15 @@
 
 Intercepts Bash tool calls to enforce quality gates on git commit commands.
 Detects .ai-rules/config changes via FileWatcher (#823).
+Suggests related tests for staged files via SmartTestRunner (#944).
 Uses safe_main decorator to ensure Claude Code is never blocked.
 """
 import json
 import os
 import re
+import subprocess
 import sys
-from typing import Optional
+from typing import List, Optional
 
 # Resolve hooks/lib and add to path
 _hooks_dir = os.path.dirname(os.path.abspath(__file__))
@@ -123,6 +125,33 @@ def _is_git_commit(command: str) -> bool:
     return bool(_GIT_COMMIT_RE.search(command))
 
 
+def _get_staged_files() -> List[str]:
+    """Return list of staged file paths via git diff --cached."""
+    try:
+        output = subprocess.check_output(
+            ["git", "diff", "--cached", "--name-only"],
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        return [f for f in output.decode("utf-8", errors="replace").strip().split("\n") if f]
+    except Exception:
+        return []
+
+
+def _get_test_suggestion(staged_files: List[str]) -> Optional[str]:
+    """Use SmartTestRunner to build a test-run suggestion for staged files."""
+    try:
+        from smart_test_runner import SmartTestRunner
+
+        runner = SmartTestRunner()
+        related = runner.find_related_tests(staged_files)
+        if not related:
+            return None
+        return runner.format_suggestion(related)
+    except Exception:
+        return None
+
+
 def _handle(data: dict) -> Optional[dict]:
     """Core PreToolUse logic.
 
@@ -147,12 +176,19 @@ def _handle(data: dict) -> Optional[dict]:
 
     command = data.get("tool_input", {}).get("command", "")
 
-    # Check git commit quality gates
+    # Check git commit quality gates and smart test suggestion (#944)
     if _is_git_commit(command):
         config = _get_hook_config()
         quality_gates = config.get("qualityGates", {})
         if quality_gates.get("enabled", False):
             contexts.append(QUALITY_GATE_CONTEXT)
+
+        # Smart test runner — suggest related tests for staged files
+        staged = _get_staged_files()
+        if staged:
+            suggestion = _get_test_suggestion(staged)
+            if suggestion:
+                contexts.append(suggestion)
 
     if not contexts:
         return None

--- a/packages/claude-code-plugin/tests/test_pre_tool_use.py
+++ b/packages/claude-code-plugin/tests/test_pre_tool_use.py
@@ -154,3 +154,88 @@ class TestPreToolUseGitCommitQualityGates:
             monkeypatch, capsys, config=config,
         )
         assert result is None
+
+
+class TestPreToolUseSmartTestRunner:
+    """Tests for SmartTestRunner integration in pre-tool-use hook."""
+
+    def test_git_commit_injects_test_suggestion(self, monkeypatch, capsys, tmp_path):
+        """git commit should inject related test suggestion into additionalContext."""
+        # Create a fake staged file list
+        monkeypatch.setattr(
+            "subprocess.check_output",
+            lambda *a, **kw: b"src/foo.ts\n",
+        )
+        config = {"qualityGates": {"enabled": False}}
+        result = _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "git commit -m 'feat: add foo'"}},
+            monkeypatch, capsys, config=config,
+        )
+        assert result is not None
+        ctx = result["hookSpecificOutput"]["additionalContext"]
+        assert "Consider running" in ctx
+        assert "foo.spec.ts" in ctx
+
+    def test_git_commit_no_staged_files_no_suggestion(self, monkeypatch, capsys):
+        """git commit with no staged files should not inject suggestion."""
+        monkeypatch.setattr(
+            "subprocess.check_output",
+            lambda *a, **kw: b"",
+        )
+        config = {"qualityGates": {"enabled": False}}
+        result = _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "git commit -m 'test'"}},
+            monkeypatch, capsys, config=config,
+        )
+        assert result is None
+
+    def test_git_commit_config_files_only_no_suggestion(self, monkeypatch, capsys):
+        """git commit with only config files should not inject suggestion."""
+        monkeypatch.setattr(
+            "subprocess.check_output",
+            lambda *a, **kw: b"package.json\n.gitignore\n",
+        )
+        config = {"qualityGates": {"enabled": False}}
+        result = _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "git commit -m 'chore: config'"}},
+            monkeypatch, capsys, config=config,
+        )
+        assert result is None
+
+    def test_git_commit_combines_quality_gate_and_test_suggestion(self, monkeypatch, capsys):
+        """When both quality gates and test suggestion active, both in context."""
+        monkeypatch.setattr(
+            "subprocess.check_output",
+            lambda *a, **kw: b"src/bar.ts\n",
+        )
+        config = {"qualityGates": {"enabled": True}}
+        result = _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "git commit -m 'feat: bar'"}},
+            monkeypatch, capsys, config=config,
+        )
+        assert result is not None
+        ctx = result["hookSpecificOutput"]["additionalContext"]
+        assert "Consider running" in ctx
+        assert "Quality Gate" in ctx
+
+    def test_non_git_commit_no_test_suggestion(self, monkeypatch, capsys):
+        """Non-commit commands should not trigger test suggestion."""
+        result = _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "git push origin main"}},
+            monkeypatch, capsys,
+        )
+        assert result is None
+
+    def test_subprocess_failure_graceful(self, monkeypatch, capsys):
+        """If subprocess fails, hook should not crash — graceful degradation."""
+        import subprocess
+        def _raise(*a, **kw):
+            raise subprocess.CalledProcessError(1, "git")
+        monkeypatch.setattr("subprocess.check_output", _raise)
+        config = {"qualityGates": {"enabled": False}}
+        result = _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "git commit -m 'test'"}},
+            monkeypatch, capsys, config=config,
+        )
+        # Should not crash — returns None (no suggestion)
+        assert result is None

--- a/packages/claude-code-plugin/tests/test_smart_test_runner.py
+++ b/packages/claude-code-plugin/tests/test_smart_test_runner.py
@@ -1,0 +1,110 @@
+"""Tests for hooks/lib/smart_test_runner.py — SmartTestRunner."""
+import os
+import sys
+
+import pytest
+
+# Add hooks/lib to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks", "lib"))
+
+from smart_test_runner import SmartTestRunner
+
+
+class TestFindRelatedTestsTypeScript:
+    """TypeScript file → .spec.ts / .test.ts mapping."""
+
+    def test_ts_file_maps_to_spec_and_test(self):
+        """src/foo.ts → src/foo.spec.ts, src/foo.test.ts, tests/foo.spec.ts, tests/foo.test.ts"""
+        runner = SmartTestRunner()
+        result = runner.find_related_tests(["src/foo.ts"])
+        assert "src/foo.spec.ts" in result
+        assert "src/foo.test.ts" in result
+        assert "tests/foo.spec.ts" in result
+        assert "tests/foo.test.ts" in result
+
+    def test_nested_ts_file(self):
+        """src/utils/helper.ts → includes tests/utils/helper.spec.ts"""
+        runner = SmartTestRunner()
+        result = runner.find_related_tests(["src/utils/helper.ts"])
+        assert "src/utils/helper.spec.ts" in result
+        assert "tests/utils/helper.spec.ts" in result
+
+
+class TestFindRelatedTestsPython:
+    """Python file → test_*.py mapping."""
+
+    def test_python_hooks_lib_file(self):
+        """hooks/lib/bar.py → tests/test_bar.py"""
+        runner = SmartTestRunner()
+        result = runner.find_related_tests(["hooks/lib/bar.py"])
+        assert "tests/test_bar.py" in result
+
+    def test_python_nested_file(self):
+        """src/utils/parser.py → tests/test_parser.py"""
+        runner = SmartTestRunner()
+        result = runner.find_related_tests(["src/utils/parser.py"])
+        assert "tests/test_parser.py" in result
+
+
+class TestFindRelatedTestsTSX:
+    """TSX component → __tests__/ directory mapping."""
+
+    def test_tsx_component_maps_to_tests_dir(self):
+        """src/components/Baz.tsx → includes __tests__/Baz.test.tsx"""
+        runner = SmartTestRunner()
+        result = runner.find_related_tests(["src/components/Baz.tsx"])
+        assert "src/components/Baz.spec.tsx" in result
+        assert "src/components/__tests__/Baz.test.tsx" in result
+
+    def test_tsx_nested_component(self):
+        """src/features/auth/Login.tsx → includes __tests__/Login.test.tsx"""
+        runner = SmartTestRunner()
+        result = runner.find_related_tests(["src/features/auth/Login.tsx"])
+        assert "src/features/auth/__tests__/Login.test.tsx" in result
+
+
+class TestFindRelatedTestsEdgeCases:
+    """Edge cases and empty results."""
+
+    def test_no_related_tests_for_config_file(self):
+        """Non-code files like .json should return empty list."""
+        runner = SmartTestRunner()
+        result = runner.find_related_tests(["package.json"])
+        assert result == []
+
+    def test_empty_input_returns_empty(self):
+        """Empty changed_files list returns empty."""
+        runner = SmartTestRunner()
+        result = runner.find_related_tests([])
+        assert result == []
+
+    def test_multiple_files_combines_results(self):
+        """Multiple changed files should combine all related tests."""
+        runner = SmartTestRunner()
+        result = runner.find_related_tests(["src/foo.ts", "hooks/lib/bar.py"])
+        assert "src/foo.spec.ts" in result
+        assert "tests/test_bar.py" in result
+
+    def test_no_duplicates(self):
+        """Same file twice should not produce duplicate test paths."""
+        runner = SmartTestRunner()
+        result = runner.find_related_tests(["src/foo.ts", "src/foo.ts"])
+        assert len(result) == len(set(result))
+
+
+class TestFormatSuggestion:
+    """format_suggestion output."""
+
+    def test_format_with_test_files(self):
+        """Should produce a runnable command suggestion."""
+        runner = SmartTestRunner()
+        result = runner.format_suggestion(["src/foo.spec.ts", "tests/test_bar.py"])
+        assert "src/foo.spec.ts" in result
+        assert "tests/test_bar.py" in result
+        assert "Consider running" in result
+
+    def test_format_empty_returns_empty_string(self):
+        """No test files → empty string (no suggestion)."""
+        runner = SmartTestRunner()
+        result = runner.format_suggestion([])
+        assert result == ""


### PR DESCRIPTION
## Summary
- Add `SmartTestRunner` class that maps changed files to related test files (TS → .spec/.test, Python → test_*.py, TSX → __tests__/)
- Integrate into `pre-tool-use.py` hook to suggest related tests on `git commit`
- Graceful degradation: subprocess failures or missing modules don't block commits
- 18 new tests (12 unit + 6 integration), full suite 187/187 passing

## Test plan
- [x] `python3 -m pytest packages/claude-code-plugin/tests/test_smart_test_runner.py` — 12 tests pass
- [x] `python3 -m pytest packages/claude-code-plugin/tests/test_pre_tool_use.py` — 16 tests pass (6 new)
- [x] Full suite: `python3 -m pytest packages/claude-code-plugin/tests/` — 187/187 pass
- [x] CI checks: lint, format, typecheck, test:coverage, circular, build — all pass

Closes #944