### PR TITLE
feat(mcp-server): add rule effectiveness tracking for usage analytics (#948)

### DIFF
--- a/apps/mcp-server/src/keyword/keyword.service.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.ts
@@ -31,6 +31,7 @@ import { filterRulesByMode } from './rule-filter';
 import { truncateSkillContent } from '../skill/skill-content.utils';
 import { createAgentSummary } from '../agent/agent-summary.utils';
 import { truncateRuleContent } from '../rules/rules-content.utils';
+import { RuleTracker } from '../rules/rule-tracker';
 import { getDefaultModeConfig } from '../shared/keyword-core';
 import { isTaskmaestroAvailable } from './taskmaestro-detector';
 import { type ClientType } from '../shared/client-type';
@@ -239,6 +240,7 @@ export class KeywordService {
   ) => Promise<AgentSystemPromptInfo | null>;
   private readonly getMaxIncludedSkillsFn?: () => Promise<number | null>;
   private readonly getClientTypeFn?: () => ClientType;
+  private ruleTracker?: RuleTracker;
 
   /**
    * Context-aware specialist patterns for automatic agent recommendation.
@@ -323,6 +325,13 @@ export class KeywordService {
 
     // Environment-based TTL: 5 minutes for development, 1 hour for production
     this.cacheTTL = process.env.NODE_ENV === 'production' ? 3600000 : 300000;
+
+    // Rule effectiveness tracking (#948)
+    try {
+      this.ruleTracker = new RuleTracker();
+    } catch {
+      // Graceful degradation - never block KeywordService init
+    }
   }
 
   async parseMode(prompt: string, options?: ParseModeOptions): Promise<ParseModeResult> {
@@ -519,6 +528,14 @@ export class KeywordService {
     rules: RuleContent[],
   ): ParseModeResult {
     const filteredRules = filterRulesByMode(rules, mode);
+
+    // Track rule usage (#948)
+    try {
+      const ruleNames = filteredRules.map((r) => r.name);
+      this.ruleTracker?.recordUsage(ruleNames, mode);
+    } catch {
+      // Never block parseMode
+    }
 
     const result: ParseModeResult = {
       mode,

--- a/apps/mcp-server/src/rules/rule-tracker.spec.ts
+++ b/apps/mcp-server/src/rules/rule-tracker.spec.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { RuleTracker } from './rule-tracker';
+import type { RuleStats } from './rule-tracker';
+
+describe('RuleTracker', () => {
+  let tmpDir: string;
+  let statsPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rule-tracker-test-'));
+    statsPath = path.join(tmpDir, 'rule_stats.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('recordUsage', () => {
+    it('should record first usage of a rule with correct stats', () => {
+      const tracker = new RuleTracker(statsPath);
+      tracker.recordUsage(['core', 'security'], 'PLAN');
+
+      const coreStats = tracker.getStats('core');
+      expect(coreStats).toBeDefined();
+      expect(coreStats!.name).toBe('core');
+      expect(coreStats!.callCount).toBe(1);
+      expect(coreStats!.modes).toEqual({ PLAN: 1 });
+      expect(coreStats!.firstUsedAt).toBeTruthy();
+      expect(coreStats!.lastUsedAt).toBeTruthy();
+    });
+
+    it('should increment call count on repeated usage', () => {
+      const tracker = new RuleTracker(statsPath);
+      tracker.recordUsage(['core'], 'PLAN');
+      tracker.recordUsage(['core'], 'ACT');
+      tracker.recordUsage(['core'], 'PLAN');
+
+      const stats = tracker.getStats('core');
+      expect(stats!.callCount).toBe(3);
+      expect(stats!.modes).toEqual({ PLAN: 2, ACT: 1 });
+    });
+
+    it('should preserve firstUsedAt across multiple calls', () => {
+      const tracker = new RuleTracker(statsPath);
+      tracker.recordUsage(['core'], 'PLAN');
+      const firstUsedAt = tracker.getStats('core')!.firstUsedAt;
+
+      tracker.recordUsage(['core'], 'ACT');
+      expect(tracker.getStats('core')!.firstUsedAt).toBe(firstUsedAt);
+    });
+  });
+
+  describe('save and load', () => {
+    it('should persist stats to disk and reload them', () => {
+      const tracker1 = new RuleTracker(statsPath);
+      tracker1.recordUsage(['core', 'security'], 'PLAN');
+      tracker1.save();
+
+      const tracker2 = new RuleTracker(statsPath);
+      expect(tracker2.getStats('core')!.callCount).toBe(1);
+      expect(tracker2.getStats('security')!.callCount).toBe(1);
+    });
+
+    it('should handle missing stats file gracefully', () => {
+      const tracker = new RuleTracker(path.join(tmpDir, 'nonexistent', 'stats.json'));
+      expect(tracker.getAllStats()).toEqual([]);
+    });
+
+    it('should recover from corrupt stats file', () => {
+      fs.writeFileSync(statsPath, '{invalid json!!!');
+      const tracker = new RuleTracker(statsPath);
+      expect(tracker.getAllStats()).toEqual([]);
+    });
+  });
+
+  describe('getAllStats', () => {
+    it('should return all recorded rule stats', () => {
+      const tracker = new RuleTracker(statsPath);
+      tracker.recordUsage(['core', 'security', 'performance'], 'PLAN');
+
+      const allStats = tracker.getAllStats();
+      expect(allStats).toHaveLength(3);
+      const names = allStats.map((s: RuleStats) => s.name).sort();
+      expect(names).toEqual(['core', 'performance', 'security']);
+    });
+  });
+
+  describe('getUnusedRules', () => {
+    it('should detect rules not used within N days', () => {
+      const tracker = new RuleTracker(statsPath);
+      // 'core' was used, 'security' and 'performance' were never used
+      tracker.recordUsage(['core'], 'PLAN');
+
+      const allKnown = ['core', 'security', 'performance'];
+      const unused = tracker.getUnusedRules(30, allKnown);
+      expect(unused.sort()).toEqual(['performance', 'security']);
+    });
+
+    it('should detect rules with stale lastUsedAt beyond N days', () => {
+      const tracker = new RuleTracker(statsPath);
+      tracker.recordUsage(['core'], 'PLAN');
+
+      // Manually set lastUsedAt to 60 days ago
+      const stats = tracker.getStats('core')!;
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 60);
+      stats.lastUsedAt = oldDate.toISOString();
+
+      const unused = tracker.getUnusedRules(30, ['core']);
+      expect(unused).toEqual(['core']);
+    });
+  });
+
+  describe('generateReport', () => {
+    it('should generate a complete effectiveness report', () => {
+      const tracker = new RuleTracker(statsPath);
+      tracker.recordUsage(['core'], 'PLAN');
+      tracker.recordUsage(['core'], 'ACT');
+      tracker.recordUsage(['security'], 'EVAL');
+
+      const allKnown = ['core', 'security', 'performance', 'accessibility'];
+      const report = tracker.generateReport(allKnown);
+
+      expect(report.totalRules).toBe(4);
+      expect(report.activeRules).toHaveLength(2);
+      expect(report.unusedRules.sort()).toEqual(['accessibility', 'performance']);
+      expect(report.topRules[0].name).toBe('core');
+      expect(report.topRules[0].callCount).toBe(2);
+      expect(report.generatedAt).toBeTruthy();
+    });
+
+    it('should limit topRules to 10 entries', () => {
+      const tracker = new RuleTracker(statsPath);
+      // Create 15 rules with different call counts
+      for (let i = 0; i < 15; i++) {
+        const name = `rule-${i}`;
+        for (let j = 0; j <= i; j++) {
+          tracker.recordUsage([name], 'PLAN');
+        }
+      }
+
+      const report = tracker.generateReport();
+      expect(report.topRules).toHaveLength(10);
+      // Top rule should have highest call count
+      expect(report.topRules[0].callCount).toBeGreaterThanOrEqual(
+        report.topRules[9].callCount,
+      );
+    });
+  });
+});

--- a/apps/mcp-server/src/rules/rule-tracker.ts
+++ b/apps/mcp-server/src/rules/rule-tracker.ts
@@ -1,0 +1,127 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface RuleStats {
+  name: string;
+  callCount: number;
+  lastUsedAt: string;
+  firstUsedAt: string;
+  modes: Record<string, number>;
+}
+
+export interface RuleEffectivenessReport {
+  totalRules: number;
+  activeRules: RuleStats[];
+  unusedRules: string[];
+  topRules: RuleStats[];
+  generatedAt: string;
+}
+
+export class RuleTracker {
+  private statsPath: string;
+  private stats: Map<string, RuleStats>;
+
+  constructor(statsPath?: string) {
+    this.statsPath =
+      statsPath ?? path.join(os.homedir(), '.codingbuddy', 'rule_stats.json');
+    this.stats = new Map();
+    this.load();
+  }
+
+  recordUsage(ruleNames: string[], mode: string): void {
+    const now = new Date().toISOString();
+    for (const name of ruleNames) {
+      const existing = this.stats.get(name);
+      if (existing) {
+        existing.callCount += 1;
+        existing.lastUsedAt = now;
+        existing.modes[mode] = (existing.modes[mode] ?? 0) + 1;
+      } else {
+        this.stats.set(name, {
+          name,
+          callCount: 1,
+          lastUsedAt: now,
+          firstUsedAt: now,
+          modes: { [mode]: 1 },
+        });
+      }
+    }
+    this.save();
+  }
+
+  load(): void {
+    try {
+      if (fs.existsSync(this.statsPath)) {
+        const raw = fs.readFileSync(this.statsPath, 'utf-8');
+        const entries: RuleStats[] = JSON.parse(raw);
+        for (const entry of entries) {
+          this.stats.set(entry.name, entry);
+        }
+      }
+    } catch {
+      this.stats = new Map();
+    }
+  }
+
+  save(): void {
+    try {
+      const dir = path.dirname(this.statsPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      fs.writeFileSync(
+        this.statsPath,
+        JSON.stringify(Array.from(this.stats.values()), null, 2),
+        'utf-8',
+      );
+    } catch {
+      // Never block caller
+    }
+  }
+
+  getStats(ruleName: string): RuleStats | undefined {
+    return this.stats.get(ruleName);
+  }
+
+  getAllStats(): RuleStats[] {
+    return Array.from(this.stats.values());
+  }
+
+  getUnusedRules(days: number = 30, allKnownRules?: string[]): string[] {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    const cutoffIso = cutoff.toISOString();
+
+    const knownSet = allKnownRules ?? [];
+    const unused: string[] = [];
+
+    for (const ruleName of knownSet) {
+      const stat = this.stats.get(ruleName);
+      if (!stat || stat.lastUsedAt < cutoffIso) {
+        unused.push(ruleName);
+      }
+    }
+
+    return unused;
+  }
+
+  generateReport(allKnownRules?: string[]): RuleEffectivenessReport {
+    const activeRules = this.getAllStats();
+    const allKnown = allKnownRules ?? activeRules.map((s) => s.name);
+
+    const unusedRules = this.getUnusedRules(30, allKnown);
+
+    const topRules = [...activeRules]
+      .sort((a, b) => b.callCount - a.callCount)
+      .slice(0, 10);
+
+    return {
+      totalRules: allKnown.length,
+      activeRules,
+      unusedRules,
+      topRules,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- parse_mode 호출 시 반환된 rules의 name을 자동 tracking
- rule별 호출 횟수, 마지막 사용 시각, 모드별 분포 기록
- 미사용 rule 감지 및 effectiveness 리포트 생성

Closes #948

## Changes
- **New**: `apps/mcp-server/src/rules/rule-tracker.ts` — RuleTracker class
- **New**: `apps/mcp-server/src/rules/rule-tracker.spec.ts` — 11 tests
- **Modified**: `apps/mcp-server/src/keyword/keyword.service.ts` — ruleTracker integration

## Test plan
- [x] 11 unit tests pass (`yarn test -- --testPathPattern=rule-tracker`)
- [x] Full MCP server test suite passes (5104 tests, 190 files)
- [x] Build succeeds (`yarn build`)
- [ ] Manual verification of ~/.codingbuddy/rule_stats.json generation