### PR TITLE
feat(plugin): add conflict predictor for git history collision warning (#946)

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/conflict_predictor.py
+++ b/packages/claude-code-plugin/hooks/lib/conflict_predictor.py
@@ -1,0 +1,146 @@
+"""Conflict predictor — git history analysis for file collision warning.
+
+Analyzes git log to predict which issues are likely to modify the same files,
+enabling proactive conflict warnings during parallel execution planning.
+"""
+import re
+import subprocess
+from itertools import combinations
+from typing import Dict, List, Tuple
+
+
+class ConflictPredictor:
+    """Predicts file conflicts between issues using git co-change history."""
+
+    def __init__(self, repo_path: str = ".", max_commits: int = 200):
+        """Initialize with repo path and commit depth."""
+        self.repo_path = repo_path
+        self.max_commits = max_commits
+
+    def get_file_change_history(self) -> List[List[str]]:
+        """Parse git log to build list of per-commit file lists.
+
+        Returns:
+            List of file lists, one per commit.
+        """
+        try:
+            raw = subprocess.check_output(
+                [
+                    "git", "log",
+                    f"--max-count={self.max_commits}",
+                    "--name-only",
+                    "--pretty=format:---COMMIT---",
+                ],
+                cwd=self.repo_path,
+                timeout=10,
+                text=True,
+            )
+        except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+            return []
+
+        if not raw.strip():
+            return []
+
+        commits: List[List[str]] = []
+        for chunk in raw.split("---COMMIT---"):
+            files = [f for f in chunk.strip().splitlines() if f.strip()]
+            if files:
+                commits.append(files)
+        return commits
+
+    def build_co_change_matrix(self) -> Dict[Tuple[str, str], int]:
+        """Build file pair co-change frequency matrix.
+
+        Keys are sorted tuples (file_a, file_b) where file_a < file_b.
+        Values are the number of commits where both files appeared.
+        """
+        history = self.get_file_change_history()
+        matrix: Dict[Tuple[str, str], int] = {}
+        for files in history:
+            for a, b in combinations(sorted(set(files)), 2):
+                key = (a, b)
+                matrix[key] = matrix.get(key, 0) + 1
+        return matrix
+
+    def extract_target_files(self, issue_body: str) -> List[str]:
+        """Extract file paths from issue body text.
+
+        Looks for patterns like: path/to/file.ext
+        """
+        pattern = r'(?:[\w.-]+/)+[\w.-]+\.\w+'
+        matches = re.findall(pattern, issue_body)
+        seen: set = set()
+        result: List[str] = []
+        for m in matches:
+            if m not in seen:
+                seen.add(m)
+                result.append(m)
+        return result
+
+    def predict_conflicts(self, issues: List[Dict]) -> List[Dict]:
+        """Predict conflicts between issue pairs.
+
+        Args:
+            issues: list of {number: int, body: str, files: list[str]}
+        Returns:
+            list of {issue_pair: (A, B), shared_files: [...], risk: "high"|"medium"|"low"}
+        """
+        matrix = self.build_co_change_matrix()
+
+        # Resolve target files per issue: use provided files, fallback to body extraction
+        issue_files: Dict[int, List[str]] = {}
+        for issue in issues:
+            files = issue.get("files", [])
+            if not files:
+                files = self.extract_target_files(issue.get("body", ""))
+            issue_files[issue["number"]] = files
+
+        results: List[Dict] = []
+        issue_numbers = list(issue_files.keys())
+        for i_num, j_num in combinations(issue_numbers, 2):
+            i_files = set(issue_files[i_num])
+            j_files = set(issue_files[j_num])
+            shared = i_files & j_files
+
+            if not shared:
+                # Check co-change matrix for indirect conflicts
+                co_changed_shared: set = set()
+                for f_i in i_files:
+                    for f_j in j_files:
+                        key = tuple(sorted([f_i, f_j]))
+                        if key in matrix and matrix[key] >= 2:
+                            co_changed_shared.add(f_i)
+                            co_changed_shared.add(f_j)
+                if not co_changed_shared:
+                    continue
+                max_co = max(
+                    matrix.get(tuple(sorted([f_i, f_j])), 0)
+                    for f_i in i_files
+                    for f_j in j_files
+                )
+                results.append({
+                    "issue_pair": (i_num, j_num),
+                    "shared_files": sorted(co_changed_shared),
+                    "risk": self.get_risk_level(max_co),
+                })
+            else:
+                # Direct file overlap — find max co-change score for risk
+                max_co = 0
+                for f in shared:
+                    for key, count in matrix.items():
+                        if f in key:
+                            max_co = max(max_co, count)
+                results.append({
+                    "issue_pair": (i_num, j_num),
+                    "shared_files": sorted(shared),
+                    "risk": self.get_risk_level(max_co),
+                })
+        return results
+
+    def get_risk_level(self, co_change_count: int) -> str:
+        """Classify risk: high (>=5), medium (>=2), low (<2)."""
+        if co_change_count >= 5:
+            return "high"
+        if co_change_count >= 2:
+            return "medium"
+        return "low"

--- a/packages/claude-code-plugin/tests/test_conflict_predictor.py
+++ b/packages/claude-code-plugin/tests/test_conflict_predictor.py
@@ -1,0 +1,261 @@
+"""Tests for hooks/lib/conflict_predictor.py — ConflictPredictor."""
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# Add hooks/lib to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks", "lib"))
+
+from conflict_predictor import ConflictPredictor
+
+
+class TestInit:
+    """Constructor and default values."""
+
+    def test_default_values(self):
+        """Default repo_path='.' and max_commits=200."""
+        cp = ConflictPredictor()
+        assert cp.repo_path == "."
+        assert cp.max_commits == 200
+
+    def test_custom_values(self):
+        """Custom repo_path and max_commits."""
+        cp = ConflictPredictor(repo_path="/tmp/repo", max_commits=50)
+        assert cp.repo_path == "/tmp/repo"
+        assert cp.max_commits == 50
+
+
+class TestGetFileChangeHistory:
+    """Parse git log to build commit→files mapping."""
+
+    def test_parses_multiple_commits(self):
+        """Multiple commits with files are parsed correctly."""
+        git_output = (
+            "---COMMIT---\n"
+            "src/a.py\n"
+            "src/b.py\n"
+            "\n"
+            "---COMMIT---\n"
+            "src/b.py\n"
+            "src/c.py\n"
+        )
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            history = cp.get_file_change_history()
+        assert len(history) == 2
+        assert "src/a.py" in history[0]
+        assert "src/b.py" in history[0]
+        assert "src/b.py" in history[1]
+        assert "src/c.py" in history[1]
+
+    def test_empty_repo(self):
+        """Empty git log output returns empty list."""
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=""):
+            history = cp.get_file_change_history()
+        assert history == []
+
+    def test_single_commit(self):
+        """Single commit is parsed correctly."""
+        git_output = "---COMMIT---\nsrc/main.py\n"
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            history = cp.get_file_change_history()
+        assert len(history) == 1
+        assert history[0] == ["src/main.py"]
+
+    def test_filters_empty_filenames(self):
+        """Blank lines within a commit are filtered out."""
+        git_output = "---COMMIT---\nsrc/a.py\n\n\nsrc/b.py\n"
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            history = cp.get_file_change_history()
+        assert history[0] == ["src/a.py", "src/b.py"]
+
+    def test_subprocess_timeout_returns_empty(self):
+        """When git command times out, return empty list."""
+        import subprocess
+
+        cp = ConflictPredictor()
+        with patch(
+            "subprocess.check_output", side_effect=subprocess.TimeoutExpired("git", 10)
+        ):
+            history = cp.get_file_change_history()
+        assert history == []
+
+
+class TestBuildCoChangeMatrix:
+    """Build file pair co-change frequency matrix."""
+
+    def test_co_change_counted(self):
+        """Files in same commit are counted as co-changed."""
+        git_output = (
+            "---COMMIT---\n"
+            "src/a.py\n"
+            "src/b.py\n"
+            "\n"
+            "---COMMIT---\n"
+            "src/a.py\n"
+            "src/b.py\n"
+        )
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            matrix = cp.build_co_change_matrix()
+        # a,b appear together in 2 commits
+        key = ("src/a.py", "src/b.py")
+        assert matrix.get(key, 0) == 2
+
+    def test_no_co_change_for_single_file_commits(self):
+        """Single-file commits produce no co-change entries."""
+        git_output = "---COMMIT---\nsrc/a.py\n\n---COMMIT---\nsrc/b.py\n"
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            matrix = cp.build_co_change_matrix()
+        assert len(matrix) == 0
+
+    def test_matrix_key_ordering(self):
+        """Keys are always sorted alphabetically: (a, b) not (b, a)."""
+        git_output = "---COMMIT---\nsrc/z.py\nsrc/a.py\n"
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            matrix = cp.build_co_change_matrix()
+        assert ("src/a.py", "src/z.py") in matrix
+        assert ("src/z.py", "src/a.py") not in matrix
+
+
+class TestExtractTargetFiles:
+    """Extract file paths from issue body text."""
+
+    def test_extracts_file_paths(self):
+        """Finds file paths like src/foo.ts in issue body."""
+        body = "Fix the bug in src/foo.ts and update tests/test_foo.py"
+        cp = ConflictPredictor()
+        files = cp.extract_target_files(body)
+        assert "src/foo.ts" in files
+        assert "tests/test_foo.py" in files
+
+    def test_extracts_from_code_blocks(self):
+        """File paths inside markdown code blocks are extracted."""
+        body = "Edit `packages/lib/utils.ts` and `hooks/lib/bar.py`"
+        cp = ConflictPredictor()
+        files = cp.extract_target_files(body)
+        assert "packages/lib/utils.ts" in files
+        assert "hooks/lib/bar.py" in files
+
+    def test_no_files_returns_empty(self):
+        """Body with no file paths returns empty list."""
+        body = "Please fix the login bug"
+        cp = ConflictPredictor()
+        files = cp.extract_target_files(body)
+        assert files == []
+
+    def test_deduplicates_files(self):
+        """Same file mentioned twice returns single entry."""
+        body = "Check src/a.py then revisit src/a.py again"
+        cp = ConflictPredictor()
+        files = cp.extract_target_files(body)
+        assert files.count("src/a.py") == 1
+
+
+class TestGetRiskLevel:
+    """Classify risk: high (>=5), medium (>=2), low (<2)."""
+
+    def test_high_risk(self):
+        cp = ConflictPredictor()
+        assert cp.get_risk_level(5) == "high"
+        assert cp.get_risk_level(10) == "high"
+
+    def test_medium_risk(self):
+        cp = ConflictPredictor()
+        assert cp.get_risk_level(2) == "medium"
+        assert cp.get_risk_level(4) == "medium"
+
+    def test_low_risk(self):
+        cp = ConflictPredictor()
+        assert cp.get_risk_level(0) == "low"
+        assert cp.get_risk_level(1) == "low"
+
+
+class TestPredictConflicts:
+    """Predict conflicts between issue pairs."""
+
+    def test_detects_shared_files(self):
+        """Issues targeting the same file produce a conflict prediction."""
+        git_output = (
+            "---COMMIT---\n"
+            "src/shared.py\n"
+            "src/other.py\n"
+        ) * 5  # 5 commits with these two files
+        issues = [
+            {"number": 1, "body": "", "files": ["src/shared.py"]},
+            {"number": 2, "body": "", "files": ["src/shared.py"]},
+        ]
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            results = cp.predict_conflicts(issues)
+        assert len(results) == 1
+        assert set(results[0]["issue_pair"]) == {1, 2}
+        assert "src/shared.py" in results[0]["shared_files"]
+
+    def test_no_overlap_returns_empty(self):
+        """Issues with completely different files produce no predictions."""
+        git_output = "---COMMIT---\nsrc/a.py\n\n---COMMIT---\nsrc/b.py\n"
+        issues = [
+            {"number": 1, "body": "", "files": ["src/a.py"]},
+            {"number": 2, "body": "", "files": ["src/b.py"]},
+        ]
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            results = cp.predict_conflicts(issues)
+        assert results == []
+
+    def test_risk_level_in_result(self):
+        """Result includes correct risk level based on co-change count."""
+        git_output = (
+            "---COMMIT---\n"
+            "src/x.py\n"
+            "src/y.py\n"
+        ) * 3  # 3 co-changes → medium
+        issues = [
+            {"number": 10, "body": "", "files": ["src/x.py"]},
+            {"number": 20, "body": "", "files": ["src/y.py"]},
+        ]
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            results = cp.predict_conflicts(issues)
+        assert len(results) == 1
+        assert results[0]["risk"] == "medium"
+
+    def test_multiple_issue_pairs(self):
+        """Three issues with pairwise overlap produce multiple predictions."""
+        git_output = (
+            "---COMMIT---\nsrc/a.py\nsrc/b.py\nsrc/c.py\n"
+        ) * 5
+        issues = [
+            {"number": 1, "body": "", "files": ["src/a.py"]},
+            {"number": 2, "body": "", "files": ["src/b.py"]},
+            {"number": 3, "body": "", "files": ["src/a.py", "src/c.py"]},
+        ]
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            results = cp.predict_conflicts(issues)
+        # Issue 1 & 3 share src/a.py, issue pairs with co-changed files
+        pairs = [tuple(sorted(r["issue_pair"])) for r in results]
+        assert len(results) >= 2
+
+    def test_uses_body_for_file_extraction(self):
+        """When files list is empty, extracts from issue body."""
+        git_output = (
+            "---COMMIT---\nsrc/shared.py\nsrc/other.py\n"
+        ) * 5
+        issues = [
+            {"number": 1, "body": "Fix src/shared.py", "files": []},
+            {"number": 2, "body": "Update src/shared.py", "files": []},
+        ]
+        cp = ConflictPredictor()
+        with patch("subprocess.check_output", return_value=git_output):
+            results = cp.predict_conflicts(issues)
+        assert len(results) == 1
+        assert "src/shared.py" in results[0]["shared_files"]


### PR DESCRIPTION
## Summary
- git history 분석으로 파일 동시 변경 빈도 매트릭스를 생성하는 ConflictPredictor 클래스 추가
- 이슈 body에서 타겟 파일을 추출하고 이슈 쌍 간 충돌 확률(high/medium/low)을 계산
- taskMaestro Wave 계획 시 병렬 실행 충돌 사전 경고에 활용

Closes #946

## Changes
- `packages/claude-code-plugin/hooks/lib/conflict_predictor.py` — ConflictPredictor 클래스 (git log 파싱, co-change matrix, 파일 추출, 충돌 예측)
- `packages/claude-code-plugin/tests/test_conflict_predictor.py` — 22개 테스트 (TDD)

## Test plan
- [x] 22 pytest 테스트 통과 (TestInit, TestGetFileChangeHistory, TestBuildCoChangeMatrix, TestExtractTargetFiles, TestGetRiskLevel, TestPredictConflicts)
- [x] hook_timer.py 패턴 준수 (class-based Python module)
- [x] subprocess timeout/error 핸들링 검증