### PR TITLE
fix(ci): add include-hidden-files to marketplace deployment

### DIFF
--- a/.github/workflows/marketplace.yml
+++ b/.github/workflows/marketplace.yml
@@ -146,6 +146,7 @@ jobs:
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: '_site'
+          include-hidden-files: true
 
   deploy:
     # Defense-in-depth: Additional repository check


### PR DESCRIPTION
## Summary

- Fix `claude plugin install codingbuddy@jeremydev87` failing with "Plugin not found in marketplace" error
- Root cause: `actions/upload-pages-artifact@v4` defaults `include-hidden-files` to `false`, excluding `.claude-plugin/` directories from the GitHub Pages upload artifact
- Add `include-hidden-files: true` to the upload step in `marketplace.yml`

## Test plan

- [ ] Merge PR and wait for marketplace-deploy workflow to complete
- [ ] Verify `curl -s https://jeremydev87.github.io/codingbuddy/.claude-plugin/marketplace.json` returns 200
- [ ] Verify `curl -s https://jeremydev87.github.io/codingbuddy/packages/claude-code-plugin/.claude-plugin/plugin.json` returns 200
- [ ] Run `claude marketplace add JeremyDev87/codingbuddy` and `claude plugin install codingbuddy@jeremydev87` successfully