### PR TITLE
fix(ci): upgrade upload-pages-artifact for hidden files support

### DIFF
--- a/.github/workflows/marketplace.yml
+++ b/.github/workflows/marketplace.yml
@@ -143,7 +143,7 @@ jobs:
           find "$SITE_DIR" -type f
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        uses: actions/upload-pages-artifact@0ca16172ca884f0a37117fed41734f29784cc980 # main (include-hidden-files support)
         with:
           path: '_site'
           include-hidden-files: true


### PR DESCRIPTION
## Summary

- Follow-up to #959 - the previous fix added `include-hidden-files: true` but `upload-pages-artifact@v4.0.0` does **not** support this input (silently ignored)
- Upgrade from `v4.0.0` (`7b1f4a76`) to latest `main` (`0ca16172`) which adds `include-hidden-files` input support
- This enables `.claude-plugin/` directories to be included in the GitHub Pages artifact

## Root Cause

`upload-pages-artifact@v4.0.0` introduced a breaking change that excludes all dotfiles/directories via `tar --exclude ".[^/]*"`. The `include-hidden-files` parameter was added later on `main` but not yet released as a tag.

## Test plan

- [ ] Merge this PR
- [ ] Trigger marketplace workflow: `gh workflow run marketplace-deploy`
- [ ] Verify `curl -sI https://jeremydev87.github.io/codingbuddy/.claude-plugin/marketplace.json` returns 200
- [ ] Verify `claude plugin install codingbuddy@jeremydev87` succeeds