### PR TITLE
feat(agents): add visual character system to agent definitions

### DIFF
--- a/packages/rules/.ai-rules/agents/accessibility-specialist.json
+++ b/packages/rules/.ai-rules/agents/accessibility-specialist.json
@@ -24,7 +24,10 @@
       "Plan and verify focus management and visible focus indicators"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/project.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/project.md"
+  ],
   "modes": {
     "planning": {
       "activation": {
@@ -115,7 +118,10 @@
             "Plan predictable navigation",
             "Plan input assistance (labels, errors, suggestions)"
           ],
-          "robust": ["Plan compatible markup (assistive technologies)", "Plan valid markup"]
+          "robust": [
+            "Plan compatible markup (assistive technologies)",
+            "Plan valid markup"
+          ]
         },
         "semantic_html_planning": {
           "elements": "Plan header, nav, main, article, section, aside, footer usage",
@@ -251,7 +257,10 @@
             "Verify predictable navigation",
             "Verify input assistance (labels, errors, suggestions)"
           ],
-          "robust": ["Verify compatible markup (assistive technologies)", "Verify valid markup"]
+          "robust": [
+            "Verify compatible markup (assistive technologies)",
+            "Verify valid markup"
+          ]
         },
         "semantic_html_verification": {
           "elements": "Verify header, nav, main, article, section, aside, footer usage",
@@ -418,7 +427,11 @@
           ]
         },
         "testing_tools": {
-          "automated": ["axe DevTools", "WAVE Browser Extension", "Lighthouse Accessibility audit"],
+          "automated": [
+            "axe DevTools",
+            "WAVE Browser Extension",
+            "Lighthouse Accessibility audit"
+          ],
           "manual": [
             "Keyboard-only navigation",
             "Screen reader testing (VoiceOver, NVDA)",
@@ -453,7 +466,10 @@
         "Predictable (navigation, consistent identification)",
         "Input assistance (labels, errors, suggestions)"
       ],
-      "robust": ["Compatible (assistive technologies)", "Valid markup"]
+      "robust": [
+        "Compatible (assistive technologies)",
+        "Valid markup"
+      ]
     },
     "semantic_html": {
       "elements": "Use header, nav, main, article, section, aside, footer elements",
@@ -497,5 +513,11 @@
       "project_accessibility": "See project.md 'UX & Accessibility' section"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "✦",
+    "eyeFallback": "O",
+    "colorAnsi": "yellow",
+    "group": "frontend"
   }
 }

--- a/packages/rules/.ai-rules/agents/act-mode.json
+++ b/packages/rules/.ai-rules/agents/act-mode.json
@@ -151,5 +151,11 @@
       "✅ Linting errors resolved",
       "✅ Design system components utilized"
     ]
+  },
+  "visual": {
+    "eye": "◆",
+    "eyeFallback": "O",
+    "colorAnsi": "blue",
+    "group": "workflow"
   }
 }

--- a/packages/rules/.ai-rules/agents/agent-architect.json
+++ b/packages/rules/.ai-rules/agents/agent-architect.json
@@ -187,5 +187,11 @@
       "specialist": "Referenced by Primary Agents for domain expertise",
       "utility": "Helper agents for specific tasks"
     }
+  },
+  "visual": {
+    "eye": "⬣",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/ai-ml-engineer.json
+++ b/packages/rules/.ai-rules/agents/ai-ml-engineer.json
@@ -24,8 +24,20 @@
         "AWS Bedrock",
         "Azure OpenAI"
       ],
-      "local_models": ["Ollama", "llama.cpp", "vLLM", "HuggingFace Transformers"],
-      "vector_databases": ["Pinecone", "Weaviate", "ChromaDB", "pgvector", "Milvus", "Qdrant"],
+      "local_models": [
+        "Ollama",
+        "llama.cpp",
+        "vLLM",
+        "HuggingFace Transformers"
+      ],
+      "vector_databases": [
+        "Pinecone",
+        "Weaviate",
+        "ChromaDB",
+        "pgvector",
+        "Milvus",
+        "Qdrant"
+      ],
       "version_considerations": {
         "api_versioning": "Always pin SDK versions in package.json; API behavior may change between versions",
         "deprecation_monitoring": "Monitor provider changelogs for deprecated endpoints and models",
@@ -274,7 +286,10 @@
             "Missing caching layer",
             "No streaming support"
           ],
-          "low": ["Minor optimization opportunities", "Documentation improvements"]
+          "low": [
+            "Minor optimization opportunities",
+            "Documentation improvements"
+          ]
         }
       }
     },
@@ -381,8 +396,15 @@
             "Insufficient test coverage",
             "Type safety violations"
           ],
-          "medium": ["Suboptimal performance", "Missing caching", "Inconsistent error messages"],
-          "low": ["Code style issues", "Documentation gaps"]
+          "medium": [
+            "Suboptimal performance",
+            "Missing caching",
+            "Inconsistent error messages"
+          ],
+          "low": [
+            "Code style issues",
+            "Documentation gaps"
+          ]
         }
       }
     },
@@ -642,9 +664,20 @@
         }
       },
       "evaluation_metrics": {
-        "quality_metrics": ["BLEU", "ROUGE", "BERTScore", "Custom relevance"],
-        "safety_metrics": ["Injection resistance rate", "PII detection rate"],
-        "performance_metrics": ["Latency p50/p95/p99", "Token efficiency"]
+        "quality_metrics": [
+          "BLEU",
+          "ROUGE",
+          "BERTScore",
+          "Custom relevance"
+        ],
+        "safety_metrics": [
+          "Injection resistance rate",
+          "PII detection rate"
+        ],
+        "performance_metrics": [
+          "Latency p50/p95/p99",
+          "Token efficiency"
+        ]
       }
     }
   },
@@ -759,5 +792,11 @@
       "chromadb": "https://docs.trychroma.com",
       "owasp_llm": "https://owasp.org/www-project-top-10-for-large-language-model-applications/"
     }
+  },
+  "visual": {
+    "eye": "✴",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/architecture-specialist.json
+++ b/packages/rules/.ai-rules/agents/architecture-specialist.json
@@ -411,7 +411,11 @@
             "Untyped function parameters",
             "Missing return types"
           ],
-          "high": ["Excessive type inference", "Weak type definitions", "Unsafe type assertions"],
+          "high": [
+            "Excessive type inference",
+            "Weak type definitions",
+            "Unsafe type assertions"
+          ],
           "medium": [
             "Could use more specific types",
             "Type definitions could be improved",
@@ -439,7 +443,10 @@
             "Naming could be clearer",
             "Separation could be more explicit"
           ],
-          "low": ["Minor organization improvements", "File naming could be optimized"]
+          "low": [
+            "Minor organization improvements",
+            "File naming could be optimized"
+          ]
         },
         "risk_assessment": {
           "🔴 critical": "Major architecture violations (layer boundaries broken, circular dependencies, any type usage), blocking maintainability",
@@ -503,5 +510,11 @@
       "development_rules": "See project.md 'Development Rules' section"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "⬡",
+    "eyeFallback": "O",
+    "colorAnsi": "magenta",
+    "group": "architecture"
   }
 }

--- a/packages/rules/.ai-rules/agents/auto-mode.json
+++ b/packages/rules/.ai-rules/agents/auto-mode.json
@@ -104,5 +104,11 @@
       "✅ Verify completion only when Critical=0 AND High=0",
       "✅ Verify Delegate Agent's full workflow is applied across all phases"
     ]
+  },
+  "visual": {
+    "eye": "◊",
+    "eyeFallback": "O",
+    "colorAnsi": "blue",
+    "group": "workflow"
   }
 }

--- a/packages/rules/.ai-rules/agents/backend-developer.json
+++ b/packages/rules/.ai-rules/agents/backend-developer.json
@@ -213,29 +213,86 @@
       },
       "framework_examples": {
         "nodejs": {
-          "frameworks": ["NestJS", "Express", "Fastify"],
-          "orm": ["Prisma", "TypeORM", "Drizzle"],
-          "validation": ["Zod", "class-validator", "Joi"]
+          "frameworks": [
+            "NestJS",
+            "Express",
+            "Fastify"
+          ],
+          "orm": [
+            "Prisma",
+            "TypeORM",
+            "Drizzle"
+          ],
+          "validation": [
+            "Zod",
+            "class-validator",
+            "Joi"
+          ]
         },
         "python": {
-          "frameworks": ["FastAPI", "Django", "Flask"],
-          "orm": ["SQLAlchemy", "Django ORM", "Tortoise ORM"],
-          "validation": ["Pydantic", "Marshmallow", "Cerberus"]
+          "frameworks": [
+            "FastAPI",
+            "Django",
+            "Flask"
+          ],
+          "orm": [
+            "SQLAlchemy",
+            "Django ORM",
+            "Tortoise ORM"
+          ],
+          "validation": [
+            "Pydantic",
+            "Marshmallow",
+            "Cerberus"
+          ]
         },
         "go": {
-          "frameworks": ["Gin", "Echo", "Fiber"],
-          "orm": ["GORM", "Ent", "sqlc"],
-          "validation": ["go-playground/validator", "ozzo-validation"]
+          "frameworks": [
+            "Gin",
+            "Echo",
+            "Fiber"
+          ],
+          "orm": [
+            "GORM",
+            "Ent",
+            "sqlc"
+          ],
+          "validation": [
+            "go-playground/validator",
+            "ozzo-validation"
+          ]
         },
         "java": {
-          "frameworks": ["Spring Boot", "Quarkus", "Micronaut"],
-          "orm": ["Hibernate", "JPA", "jOOQ"],
-          "validation": ["Jakarta Validation", "Hibernate Validator"]
+          "frameworks": [
+            "Spring Boot",
+            "Quarkus",
+            "Micronaut"
+          ],
+          "orm": [
+            "Hibernate",
+            "JPA",
+            "jOOQ"
+          ],
+          "validation": [
+            "Jakarta Validation",
+            "Hibernate Validator"
+          ]
         },
         "rust": {
-          "frameworks": ["Actix-web", "Axum", "Rocket"],
-          "orm": ["Diesel", "SeaORM", "sqlx"],
-          "validation": ["validator", "garde"]
+          "frameworks": [
+            "Actix-web",
+            "Axum",
+            "Rocket"
+          ],
+          "orm": [
+            "Diesel",
+            "SeaORM",
+            "sqlx"
+          ],
+          "validation": [
+            "validator",
+            "garde"
+          ]
         }
       }
     },
@@ -280,7 +337,11 @@
     },
     "security_standards": {
       "authentication": {
-        "methods": ["JWT", "OAuth 2.0", "Session-based"],
+        "methods": [
+          "JWT",
+          "OAuth 2.0",
+          "Session-based"
+        ],
         "best_practices": [
           "Secure token storage",
           "Token rotation and refresh",
@@ -288,7 +349,11 @@
         ]
       },
       "authorization": {
-        "patterns": ["RBAC", "ABAC", "Policy-based"],
+        "patterns": [
+          "RBAC",
+          "ABAC",
+          "Policy-based"
+        ],
         "implementation": "Use framework-specific guards, middleware, or decorators",
         "examples": {
           "nodejs": "Guards (NestJS), Middleware (Express)",
@@ -301,11 +366,28 @@
       "input_validation": {
         "required": "All user inputs MUST be validated",
         "tools_by_language": {
-          "nodejs": ["Zod", "class-validator", "Joi"],
-          "python": ["Pydantic", "Marshmallow", "Cerberus"],
-          "go": ["go-playground/validator", "ozzo-validation"],
-          "java": ["Jakarta Validation", "Hibernate Validator"],
-          "rust": ["validator", "garde"]
+          "nodejs": [
+            "Zod",
+            "class-validator",
+            "Joi"
+          ],
+          "python": [
+            "Pydantic",
+            "Marshmallow",
+            "Cerberus"
+          ],
+          "go": [
+            "go-playground/validator",
+            "ozzo-validation"
+          ],
+          "java": [
+            "Jakarta Validation",
+            "Hibernate Validator"
+          ],
+          "rust": [
+            "validator",
+            "garde"
+          ]
         },
         "sanitization": "Sanitize inputs to prevent XSS"
       },
@@ -487,5 +569,11 @@
         "grpc": "https://grpc.io/docs"
       }
     }
+  },
+  "visual": {
+    "eye": "◐",
+    "eyeFallback": "O",
+    "colorAnsi": "cyan",
+    "group": "backend"
   }
 }

--- a/packages/rules/.ai-rules/agents/code-quality-specialist.json
+++ b/packages/rules/.ai-rules/agents/code-quality-specialist.json
@@ -572,69 +572,164 @@
       "variables": {
         "boolean": {
           "pattern": "isX, hasX, canX, shouldX, willX",
-          "examples": ["isActive", "hasPermission", "canEdit", "shouldRender"],
-          "anti_patterns": ["active", "permission", "edit", "render"]
+          "examples": [
+            "isActive",
+            "hasPermission",
+            "canEdit",
+            "shouldRender"
+          ],
+          "anti_patterns": [
+            "active",
+            "permission",
+            "edit",
+            "render"
+          ]
         },
         "arrays_collections": {
           "pattern": "Plural nouns (users, items, products)",
-          "examples": ["users", "items", "selectedProducts"],
-          "anti_patterns": ["userList", "itemArray", "productCollection"]
+          "examples": [
+            "users",
+            "items",
+            "selectedProducts"
+          ],
+          "anti_patterns": [
+            "userList",
+            "itemArray",
+            "productCollection"
+          ]
         },
         "objects": {
           "pattern": "Singular nouns describing the entity",
-          "examples": ["user", "config", "authState"],
-          "anti_patterns": ["data", "info", "obj", "item"]
+          "examples": [
+            "user",
+            "config",
+            "authState"
+          ],
+          "anti_patterns": [
+            "data",
+            "info",
+            "obj",
+            "item"
+          ]
         },
         "constants": {
           "pattern": "SCREAMING_SNAKE_CASE for true constants",
-          "examples": ["MAX_RETRY_COUNT", "API_BASE_URL", "DEFAULT_TIMEOUT"],
-          "anti_patterns": ["maxRetryCount", "apiBaseUrl"]
+          "examples": [
+            "MAX_RETRY_COUNT",
+            "API_BASE_URL",
+            "DEFAULT_TIMEOUT"
+          ],
+          "anti_patterns": [
+            "maxRetryCount",
+            "apiBaseUrl"
+          ]
         }
       },
       "functions": {
         "event_handlers": {
           "pattern": "handleX (handleClick, handleSubmit, handleChange)",
-          "examples": ["handleClick", "handleSubmit", "handleInputChange"],
-          "anti_patterns": ["onClick", "clickHandler", "onClickHandler"]
+          "examples": [
+            "handleClick",
+            "handleSubmit",
+            "handleInputChange"
+          ],
+          "anti_patterns": [
+            "onClick",
+            "clickHandler",
+            "onClickHandler"
+          ]
         },
         "getters": {
           "pattern": "getX for data retrieval",
-          "examples": ["getUser", "getUserById", "getConfig"],
-          "anti_patterns": ["fetchUser", "retrieveUser", "user"]
+          "examples": [
+            "getUser",
+            "getUserById",
+            "getConfig"
+          ],
+          "anti_patterns": [
+            "fetchUser",
+            "retrieveUser",
+            "user"
+          ]
         },
         "setters": {
           "pattern": "setX for state updates",
-          "examples": ["setUser", "setIsLoading", "setConfig"],
-          "anti_patterns": ["updateUser", "changeUser"]
+          "examples": [
+            "setUser",
+            "setIsLoading",
+            "setConfig"
+          ],
+          "anti_patterns": [
+            "updateUser",
+            "changeUser"
+          ]
         },
         "validators": {
           "pattern": "validateX or isValidX",
-          "examples": ["validateEmail", "isValidPassword", "validateForm"],
-          "anti_patterns": ["checkEmail", "emailCheck", "emailValidator"]
+          "examples": [
+            "validateEmail",
+            "isValidPassword",
+            "validateForm"
+          ],
+          "anti_patterns": [
+            "checkEmail",
+            "emailCheck",
+            "emailValidator"
+          ]
         },
         "transformers": {
           "pattern": "toX, formatX, parseX for data transformation",
-          "examples": ["toJSON", "formatDate", "parseResponse"],
-          "anti_patterns": ["convertToJSON", "dateFormatter"]
+          "examples": [
+            "toJSON",
+            "formatDate",
+            "parseResponse"
+          ],
+          "anti_patterns": [
+            "convertToJSON",
+            "dateFormatter"
+          ]
         },
         "async_operations": {
           "pattern": "fetchX, loadX for async data fetching",
-          "examples": ["fetchUsers", "loadUserProfile", "fetchData"],
-          "anti_patterns": ["getUsers (if async)", "userData"]
+          "examples": [
+            "fetchUsers",
+            "loadUserProfile",
+            "fetchData"
+          ],
+          "anti_patterns": [
+            "getUsers (if async)",
+            "userData"
+          ]
         }
       },
       "components": {
         "naming": {
           "pattern": "PascalCase, role-based naming",
-          "examples": ["UserProfile", "LoginForm", "NavigationMenu"],
-          "anti_patterns": ["Profile", "Form", "Menu"]
+          "examples": [
+            "UserProfile",
+            "LoginForm",
+            "NavigationMenu"
+          ],
+          "anti_patterns": [
+            "Profile",
+            "Form",
+            "Menu"
+          ]
         },
         "props": {
           "pattern": "Clear intent props",
           "callback_props": "onX pattern (onSubmit, onChange, onClose)",
           "boolean_props": "isX, hasX pattern (isDisabled, isLoading, hasError)",
-          "examples": ["onSubmit", "isDisabled", "hasError"],
-          "anti_patterns": ["submit", "disabled", "error"]
+          "examples": [
+            "onSubmit",
+            "isDisabled",
+            "hasError"
+          ],
+          "anti_patterns": [
+            "submit",
+            "disabled",
+            "error"
+          ]
         }
       },
       "severity_levels": {
@@ -706,5 +801,11 @@
       "project_quality": "See augmented-coding.md 'Code Quality Standards' section"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "●",
+    "eyeFallback": "O",
+    "colorAnsi": "green",
+    "group": "quality"
   }
 }

--- a/packages/rules/.ai-rules/agents/code-reviewer.json
+++ b/packages/rules/.ai-rules/agents/code-reviewer.json
@@ -424,30 +424,52 @@
         "conditional_branches": {
           "description": "Trace each branch of if/else, ternary operators, and switch statements",
           "question": "Does each branch behave as intended?",
-          "common_bugs": ["Missing conditions causing only specific cases to be handled", "Unimplemented else branch"]
+          "common_bugs": [
+            "Missing conditions causing only specific cases to be handled",
+            "Unimplemented else branch"
+          ]
         },
         "data_transformations": {
           "description": "Verify input/output field mapping in type conversion functions",
           "question": "Are all fields mapped correctly?",
-          "common_bugs": ["Missing fields", "Incorrect default values", "Type mismatch"]
+          "common_bugs": [
+            "Missing fields",
+            "Incorrect default values",
+            "Type mismatch"
+          ]
         },
         "optional_handling": {
           "description": "Verify intended fallback for ?, ??, || operators",
           "question": "Does optional chaining provide the intended fallback?",
-          "common_bugs": ["Confusion between null and undefined", "Errors handling empty strings/0"]
+          "common_bugs": [
+            "Confusion between null and undefined",
+            "Errors handling empty strings/0"
+          ]
         },
         "dependency_completeness": {
           "description": "DI injection and import path accuracy",
           "question": "Are all dependencies of moved files correctly injected?",
-          "common_bugs": ["Missing dependencies", "Incorrect import paths", "Circular references"]
+          "common_bugs": [
+            "Missing dependencies",
+            "Incorrect import paths",
+            "Circular references"
+          ]
         },
         "edge_cases": {
           "description": "Handling of null, undefined, empty arrays, and boundary values",
           "question": "Are boundary conditions handled correctly?",
-          "common_bugs": ["Missing empty array handling", "Null reference errors", "Boundary value off-by-one"]
+          "common_bugs": [
+            "Missing empty array handling",
+            "Null reference errors",
+            "Boundary value off-by-one"
+          ]
         }
       },
-      "skip_conditions": ["Only new files created", "Only documentation changed", "Only tests added"],
+      "skip_conditions": [
+        "Only new files created",
+        "Only documentation changed",
+        "Only tests added"
+      ],
       "pass_criteria": {
         "minimum_checks": "All items applicable to the changed code must be reviewed",
         "evidence_required": "Review results (issue found or verification complete) must be specified for each item",
@@ -507,7 +529,11 @@
         "title": "## 🔍 Refactoring Verification",
         "format": "**Review scope**: [list of changed files]\n\n### Issues Found\n- 🔴 `file.ts:line` - [item]: [issue]\n\n### Verification Complete (No Issues)\n- ✅ [item]\n\n*Skip reason: [if applicable]*",
         "description": "Mandatory manual review beyond automated tests - conditional branches, data transformations, optional fields, dependencies, edge cases",
-        "skip_conditions": ["Only new files created", "Only documentation changed", "Only tests added"],
+        "skip_conditions": [
+          "Only new files created",
+          "Only documentation changed",
+          "Only tests added"
+        ],
         "required": true
       },
       "7_objective_assessment": {
@@ -612,5 +638,11 @@
       "High priority issues: Recommend resolving before next deployment",
       "Medium/Low: Manage as technical debt with gradual improvement"
     ]
+  },
+  "visual": {
+    "eye": "⊛",
+    "eyeFallback": "O",
+    "colorAnsi": "green",
+    "group": "quality"
   }
 }

--- a/packages/rules/.ai-rules/agents/data-engineer.json
+++ b/packages/rules/.ai-rules/agents/data-engineer.json
@@ -17,9 +17,26 @@
     ],
     "supported_databases": {
       "note": "This agent supports multiple database systems. See project.md 'Tech Stack' for your project's specific database.",
-      "relational": ["PostgreSQL", "MySQL/MariaDB", "SQLite", "SQL Server", "Oracle"],
-      "nosql": ["MongoDB", "Redis", "Elasticsearch", "DynamoDB", "Cassandra"],
-      "analytical": ["BigQuery", "Snowflake", "Redshift", "ClickHouse"]
+      "relational": [
+        "PostgreSQL",
+        "MySQL/MariaDB",
+        "SQLite",
+        "SQL Server",
+        "Oracle"
+      ],
+      "nosql": [
+        "MongoDB",
+        "Redis",
+        "Elasticsearch",
+        "DynamoDB",
+        "Cassandra"
+      ],
+      "analytical": [
+        "BigQuery",
+        "Snowflake",
+        "Redshift",
+        "ClickHouse"
+      ]
     },
     "tech_stack_reference": "See project.md 'Tech Stack' section for your project's database and ORM information",
     "responsibilities": [
@@ -161,7 +178,11 @@
   "workflow": {
     "schema_design": {
       "approach": "Design-First with TDD",
-      "applies_to": ["New table/entity creation", "Schema modifications", "Relationship changes"],
+      "applies_to": [
+        "New table/entity creation",
+        "Schema modifications",
+        "Relationship changes"
+      ],
       "steps": [
         "1. Analyze business requirements",
         "2. Create ERD/data model",
@@ -174,7 +195,11 @@
     },
     "query_optimization": {
       "approach": "Measure-First",
-      "applies_to": ["Slow queries", "Complex joins", "Reporting queries"],
+      "applies_to": [
+        "Slow queries",
+        "Complex joins",
+        "Reporting queries"
+      ],
       "steps": [
         "1. Identify slow query (EXPLAIN ANALYZE)",
         "2. Analyze execution plan",
@@ -186,7 +211,11 @@
     },
     "analytics_data": {
       "approach": "Dimensional Modeling",
-      "applies_to": ["Reporting tables", "Dashboard data", "Aggregated metrics"],
+      "applies_to": [
+        "Reporting tables",
+        "Dashboard data",
+        "Aggregated metrics"
+      ],
       "steps": [
         "1. Identify business questions",
         "2. Design fact and dimension tables",
@@ -238,10 +267,25 @@
       }
     },
     "migration_tools": {
-      "nodejs": ["Prisma Migrate", "TypeORM migrations", "Knex migrations"],
-      "python": ["Alembic", "Django migrations", "Aerich"],
-      "go": ["Goose", "Golang-migrate", "Atlas"],
-      "database_native": ["Flyway", "Liquibase"]
+      "nodejs": [
+        "Prisma Migrate",
+        "TypeORM migrations",
+        "Knex migrations"
+      ],
+      "python": [
+        "Alembic",
+        "Django migrations",
+        "Aerich"
+      ],
+      "go": [
+        "Goose",
+        "Golang-migrate",
+        "Atlas"
+      ],
+      "database_native": [
+        "Flyway",
+        "Liquibase"
+      ]
     },
     "indexing_strategies": {
       "btree": "Default for equality and range queries",
@@ -340,5 +384,11 @@
       "prisma": "https://www.prisma.io/docs",
       "sqlalchemy": "https://docs.sqlalchemy.org/"
     }
+  },
+  "visual": {
+    "eye": "◑",
+    "eyeFallback": "O",
+    "colorAnsi": "cyan",
+    "group": "backend"
   }
 }

--- a/packages/rules/.ai-rules/agents/data-scientist.json
+++ b/packages/rules/.ai-rules/agents/data-scientist.json
@@ -28,8 +28,17 @@
         "scipy",
         "statsmodels"
       ],
-      "notebooks": ["Jupyter Notebook", "JupyterLab", "Google Colab"],
-      "ml_frameworks": ["scikit-learn", "XGBoost", "LightGBM", "CatBoost"],
+      "notebooks": [
+        "Jupyter Notebook",
+        "JupyterLab",
+        "Google Colab"
+      ],
+      "ml_frameworks": [
+        "scikit-learn",
+        "XGBoost",
+        "LightGBM",
+        "CatBoost"
+      ],
       "version_considerations": {
         "api_versioning": "Pin library versions in requirements.txt or pyproject.toml",
         "breaking_changes": "Test notebooks in isolated environments when upgrading"
@@ -153,5 +162,11 @@
       "data_engineer": ".ai-rules/agents/data-engineer.json - For ETL, schema design, migrations",
       "ai_ml_engineer": ".ai-rules/agents/ai-ml-engineer.json - For LLM integration, RAG, deep learning frameworks"
     }
+  },
+  "visual": {
+    "eye": "◒",
+    "eyeFallback": "O",
+    "colorAnsi": "cyan",
+    "group": "backend"
   }
 }

--- a/packages/rules/.ai-rules/agents/devops-engineer.json
+++ b/packages/rules/.ai-rules/agents/devops-engineer.json
@@ -44,7 +44,10 @@
       ]
     }
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/project.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/project.md"
+  ],
   "infrastructure": {
     "containerization": {
       "docker": {
@@ -167,7 +170,10 @@
           "benefits": "Up to 10x faster than webpack"
         },
         "image_optimization": {
-          "formats": ["AVIF", "WebP"],
+          "formats": [
+            "AVIF",
+            "WebP"
+          ],
           "benefits": "Smaller image files, faster page loads"
         },
         "source_maps": {
@@ -287,5 +293,11 @@
       "datadog_rum": "https://docs.datadoghq.com/real_user_monitoring/",
       "nodejs_performance": "https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes"
     }
+  },
+  "visual": {
+    "eye": "▼",
+    "eyeFallback": "O",
+    "colorAnsi": "red",
+    "group": "security"
   }
 }

--- a/packages/rules/.ai-rules/agents/documentation-specialist.json
+++ b/packages/rules/.ai-rules/agents/documentation-specialist.json
@@ -539,5 +539,11 @@
       "project_documentation": "See project.md 'Development Rules' section"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "⊕",
+    "eyeFallback": "O",
+    "colorAnsi": "white",
+    "group": "integration"
   }
 }

--- a/packages/rules/.ai-rules/agents/eval-mode.json
+++ b/packages/rules/.ai-rules/agents/eval-mode.json
@@ -25,7 +25,10 @@
       "Apply Anti-Sycophancy principles (objective evaluation, problem-first identification)"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/augmented-coding.md"
+  ],
   "activation": {
     "trigger": "🔴 **STRICT**: When user types 'EVAL', 'EVALUATE' or equivalent (Korean: evaluate/suggest improvements, Japanese: 評価, Chinese: 评估, Spanish: EVALUAR)",
     "rule": "🔴 **STRICT**: EVAL MODE request must activate this Agent automatically",
@@ -96,7 +99,11 @@
     "refactoring_verification": {
       "description": "Mandatory manual review items beyond automated tests (execute on every EVAL)",
       "mandatory": true,
-      "skip_conditions": ["Only new files created", "Only documentation changed", "Only tests added"],
+      "skip_conditions": [
+        "Only new files created",
+        "Only documentation changed",
+        "Only tests added"
+      ],
       "checklist": {
         "conditional_branches": "Do if/else, ternary operators, and switch branches behave as intended?",
         "data_transformations": "Does the type conversion function map all fields correctly?",
@@ -177,5 +184,11 @@
       "✅ Improvement opportunities by priority (Critical/High/Medium/Low)",
       "✅ Evidence-based recommendations (web search links/references)"
     ]
+  },
+  "visual": {
+    "eye": "◈",
+    "eyeFallback": "O",
+    "colorAnsi": "blue",
+    "group": "workflow"
   }
 }

--- a/packages/rules/.ai-rules/agents/event-architecture-specialist.json
+++ b/packages/rules/.ai-rules/agents/event-architecture-specialist.json
@@ -361,7 +361,11 @@
             "Incomplete error categorization",
             "Missing DLQ alerting"
           ],
-          "low": ["Minor configuration improvements", "Additional metrics", "Documentation updates"]
+          "low": [
+            "Minor configuration improvements",
+            "Additional metrics",
+            "Documentation updates"
+          ]
         }
       }
     },
@@ -708,5 +712,11 @@
       "microservices_patterns": "Microservices Patterns by Chris Richardson"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "❖",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/frontend-developer.json
+++ b/packages/rules/.ai-rules/agents/frontend-developer.json
@@ -396,5 +396,11 @@
       "tailwind_v3": "https://tailwindcss.com/docs",
       "accessibility": "https://www.w3.org/WAI/WCAG21/quickref/"
     }
+  },
+  "visual": {
+    "eye": "★",
+    "eyeFallback": "O",
+    "colorAnsi": "yellow",
+    "group": "frontend"
   }
 }

--- a/packages/rules/.ai-rules/agents/i18n-specialist.json
+++ b/packages/rules/.ai-rules/agents/i18n-specialist.json
@@ -24,7 +24,10 @@
       "Plan translation extraction and management workflows"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/project.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/project.md"
+  ],
   "modes": {
     "planning": {
       "activation": {
@@ -100,11 +103,28 @@
       },
       "planning_framework": {
         "library_selection": {
-          "react": ["react-intl (FormatJS)", "i18next + react-i18next", "next-intl"],
-          "vue": ["vue-i18n", "nuxt-i18n"],
-          "angular": ["@angular/localize", "ngx-translate"],
-          "native_mobile": ["react-native-i18n", "flutter_localizations"],
-          "backend": ["i18next", "gettext", "ICU MessageFormat"]
+          "react": [
+            "react-intl (FormatJS)",
+            "i18next + react-i18next",
+            "next-intl"
+          ],
+          "vue": [
+            "vue-i18n",
+            "nuxt-i18n"
+          ],
+          "angular": [
+            "@angular/localize",
+            "ngx-translate"
+          ],
+          "native_mobile": [
+            "react-native-i18n",
+            "flutter_localizations"
+          ],
+          "backend": [
+            "i18next",
+            "gettext",
+            "ICU MessageFormat"
+          ]
         },
         "key_structure_patterns": {
           "hierarchical": "namespace.component.element (e.g., auth.login.title)",
@@ -381,5 +401,11 @@
       "vue_i18n": "https://vue-i18n.intlify.dev/"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "◎",
+    "eyeFallback": "O",
+    "colorAnsi": "white",
+    "group": "integration"
   }
 }

--- a/packages/rules/.ai-rules/agents/integration-specialist.json
+++ b/packages/rules/.ai-rules/agents/integration-specialist.json
@@ -570,5 +570,11 @@
       "best_practices": "https://docs.stripe.com/webhooks/best-practices"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "○",
+    "eyeFallback": "O",
+    "colorAnsi": "white",
+    "group": "integration"
   }
 }

--- a/packages/rules/.ai-rules/agents/migration-specialist.json
+++ b/packages/rules/.ai-rules/agents/migration-specialist.json
@@ -250,7 +250,11 @@
             "Communication plan incomplete",
             "Resource constraints not addressed"
           ],
-          "low": ["Documentation gaps", "Training not scheduled", "Minor dependency updates needed"]
+          "low": [
+            "Documentation gaps",
+            "Training not scheduled",
+            "Minor dependency updates needed"
+          ]
         }
       }
     },
@@ -568,7 +572,11 @@
           "Load balancer",
           "Health checks"
         ],
-        "success_criteria": ["Instant switch", "Instant rollback", "Zero downtime"]
+        "success_criteria": [
+          "Instant switch",
+          "Instant rollback",
+          "Zero downtime"
+        ]
       },
       "canary": {
         "description": "Gradually route traffic to new version, monitoring for issues",
@@ -592,7 +600,11 @@
           "Deprecation notices",
           "Client migration tracking"
         ],
-        "success_criteria": ["Old clients work", "New clients work", "Clear deprecation timeline"]
+        "success_criteria": [
+          "Old clients work",
+          "New clients work",
+          "Clear deprecation timeline"
+        ]
       }
     },
     "sli_definitions": {
@@ -657,5 +669,11 @@
       "blue_green": "https://martinfowler.com/bliki/BlueGreenDeployment.html"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "✱",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/mobile-developer.json
+++ b/packages/rules/.ai-rules/agents/mobile-developer.json
@@ -17,8 +17,14 @@
     ],
     "supported_platforms": {
       "note": "This agent supports multiple mobile platforms. See project.md 'Tech Stack' for your project's specific platform.",
-      "cross_platform": ["React Native (with Expo or bare workflow)", "Flutter"],
-      "native": ["iOS (Swift, SwiftUI, UIKit)", "Android (Kotlin, Jetpack Compose, XML Views)"]
+      "cross_platform": [
+        "React Native (with Expo or bare workflow)",
+        "Flutter"
+      ],
+      "native": [
+        "iOS (Swift, SwiftUI, UIKit)",
+        "Android (Kotlin, Jetpack Compose, XML Views)"
+      ]
     },
     "tech_stack_reference": "See project.md 'Tech Stack' section for your project's mobile framework and version information",
     "responsibilities": [
@@ -45,9 +51,21 @@
         "app\\.json$",
         "expo.*\\.json$"
       ],
-      "flutter": ["pubspec\\.yaml$", "\\.dart$"],
-      "ios": ["\\.xcodeproj", "\\.xcworkspace", "Podfile$", "\\.swift$"],
-      "android": ["build\\.gradle(\\.kts)?$", "AndroidManifest\\.xml$", "\\.kt$"]
+      "flutter": [
+        "pubspec\\.yaml$",
+        "\\.dart$"
+      ],
+      "ios": [
+        "\\.xcodeproj",
+        "\\.xcworkspace",
+        "Podfile$",
+        "\\.swift$"
+      ],
+      "android": [
+        "build\\.gradle(\\.kts)?$",
+        "AndroidManifest\\.xml$",
+        "\\.kt$"
+      ]
     },
     "intent_patterns": {
       "korean": [
@@ -60,7 +78,16 @@
         "swift",
         "kotlin"
       ],
-      "english": ["mobile", "app", "react native", "flutter", "iOS", "android", "swift", "kotlin"]
+      "english": [
+        "mobile",
+        "app",
+        "react native",
+        "flutter",
+        "iOS",
+        "android",
+        "swift",
+        "kotlin"
+      ]
     },
     "mandatory_checklist": {
       "🔴 language": {
@@ -157,7 +184,11 @@
     },
     "ui_components": {
       "approach": "Test-After",
-      "applies_to": ["Screens/Pages", "Widgets/Components", "Navigation setup"],
+      "applies_to": [
+        "Screens/Pages",
+        "Widgets/Components",
+        "Navigation setup"
+      ],
       "reference": "See augmented-coding.md 'UI Components (Test-After)' section"
     }
   },
@@ -190,32 +221,89 @@
   },
   "platform_patterns": {
     "react_native": {
-      "state_management": ["Redux Toolkit", "Zustand", "Jotai", "React Query"],
+      "state_management": [
+        "Redux Toolkit",
+        "Zustand",
+        "Jotai",
+        "React Query"
+      ],
       "navigation": "React Navigation",
-      "styling": ["StyleSheet", "NativeWind", "Tamagui"],
-      "testing": ["Jest", "React Native Testing Library"],
+      "styling": [
+        "StyleSheet",
+        "NativeWind",
+        "Tamagui"
+      ],
+      "testing": [
+        "Jest",
+        "React Native Testing Library"
+      ],
       "native_modules": "Turbo Modules (New Architecture)"
     },
     "flutter": {
-      "state_management": ["Riverpod", "BLoC", "Provider", "GetX"],
-      "navigation": ["go_router", "auto_route"],
+      "state_management": [
+        "Riverpod",
+        "BLoC",
+        "Provider",
+        "GetX"
+      ],
+      "navigation": [
+        "go_router",
+        "auto_route"
+      ],
       "styling": "Theme + Custom Widgets",
-      "testing": ["flutter_test", "integration_test", "mockito"],
+      "testing": [
+        "flutter_test",
+        "integration_test",
+        "mockito"
+      ],
       "platform_channels": "MethodChannel for native code"
     },
     "ios_native": {
-      "architecture": ["MVVM", "Clean Architecture", "TCA (Composable Architecture)"],
-      "ui": ["SwiftUI", "UIKit"],
-      "async": ["async/await", "Combine"],
-      "testing": ["XCTest", "Quick/Nimble"],
-      "dependency_injection": ["Swinject", "Factory"]
+      "architecture": [
+        "MVVM",
+        "Clean Architecture",
+        "TCA (Composable Architecture)"
+      ],
+      "ui": [
+        "SwiftUI",
+        "UIKit"
+      ],
+      "async": [
+        "async/await",
+        "Combine"
+      ],
+      "testing": [
+        "XCTest",
+        "Quick/Nimble"
+      ],
+      "dependency_injection": [
+        "Swinject",
+        "Factory"
+      ]
     },
     "android_native": {
-      "architecture": ["MVVM", "Clean Architecture", "MVI"],
-      "ui": ["Jetpack Compose", "XML Views + ViewBinding"],
-      "async": ["Kotlin Coroutines", "Flow"],
-      "testing": ["JUnit", "Espresso", "Robolectric"],
-      "dependency_injection": ["Hilt", "Koin"]
+      "architecture": [
+        "MVVM",
+        "Clean Architecture",
+        "MVI"
+      ],
+      "ui": [
+        "Jetpack Compose",
+        "XML Views + ViewBinding"
+      ],
+      "async": [
+        "Kotlin Coroutines",
+        "Flow"
+      ],
+      "testing": [
+        "JUnit",
+        "Espresso",
+        "Robolectric"
+      ],
+      "dependency_injection": [
+        "Hilt",
+        "Koin"
+      ]
     }
   },
   "code_quality_checklist": [
@@ -310,5 +398,11 @@
       "hig": "https://developer.apple.com/design/human-interface-guidelines/",
       "material_design": "https://m3.material.io/"
     }
+  },
+  "visual": {
+    "eye": "✶",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/observability-specialist.json
+++ b/packages/rules/.ai-rules/agents/observability-specialist.json
@@ -165,7 +165,13 @@
               "Sampling strategy",
               "Span attributes"
             ],
-            "backends": ["Jaeger", "Zipkin", "Tempo", "AWS X-Ray", "Datadog APM"]
+            "backends": [
+              "Jaeger",
+              "Zipkin",
+              "Tempo",
+              "AWS X-Ray",
+              "Datadog APM"
+            ]
           },
           "metrics": {
             "description": "Quantitative measurements for system health",
@@ -174,24 +180,49 @@
               "Labels/dimensions",
               "Aggregation"
             ],
-            "backends": ["Prometheus", "Grafana", "InfluxDB", "Victoria Metrics", "Datadog"]
+            "backends": [
+              "Prometheus",
+              "Grafana",
+              "InfluxDB",
+              "Victoria Metrics",
+              "Datadog"
+            ]
           },
           "logs": {
             "description": "Structured event records with context",
-            "components": ["JSON format", "Log levels", "Context injection", "PII masking"],
-            "backends": ["ELK Stack", "Loki", "Splunk", "CloudWatch Logs", "Datadog Logs"]
+            "components": [
+              "JSON format",
+              "Log levels",
+              "Context injection",
+              "PII masking"
+            ],
+            "backends": [
+              "ELK Stack",
+              "Loki",
+              "Splunk",
+              "CloudWatch Logs",
+              "Datadog Logs"
+            ]
           }
         },
         "sli_slo_framework": {
           "availability_sli": {
             "definition": "Percentage of successful requests",
             "formula": "(successful requests / total requests) * 100",
-            "common_targets": ["99.9%", "99.95%", "99.99%"]
+            "common_targets": [
+              "99.9%",
+              "99.95%",
+              "99.99%"
+            ]
           },
           "latency_sli": {
             "definition": "Percentage of requests faster than threshold",
             "formula": "(requests < threshold / total requests) * 100",
-            "common_thresholds": ["p50 < 100ms", "p95 < 500ms", "p99 < 1000ms"]
+            "common_thresholds": [
+              "p50 < 100ms",
+              "p95 < 500ms",
+              "p99 < 1000ms"
+            ]
           },
           "error_budget": {
             "definition": "Allowed downtime/errors within SLO",
@@ -319,8 +350,17 @@
             "service.namespace (optional)",
             "host.name (optional)"
           ],
-          "propagators": ["W3C Trace Context (default)", "W3C Baggage", "B3 (for Zipkin)"],
-          "exporters": ["OTLP (recommended)", "Jaeger", "Zipkin", "Console (dev only)"]
+          "propagators": [
+            "W3C Trace Context (default)",
+            "W3C Baggage",
+            "B3 (for Zipkin)"
+          ],
+          "exporters": [
+            "OTLP (recommended)",
+            "Jaeger",
+            "Zipkin",
+            "Console (dev only)"
+          ]
         },
         "structured_logging_setup": {
           "required_fields": {
@@ -540,7 +580,11 @@
             "Dashboard gaps for key metrics",
             "Alert runbooks incomplete"
           ],
-          "low": ["Minor coverage gaps", "Optional improvements", "Documentation updates needed"]
+          "low": [
+            "Minor coverage gaps",
+            "Optional improvements",
+            "Documentation updates needed"
+          ]
         }
       }
     }
@@ -548,7 +592,16 @@
   "shared_framework": {
     "opentelemetry": {
       "description": "Vendor-neutral observability framework",
-      "sdk_languages": ["Node.js", "Python", "Go", "Java", ".NET", "Ruby", "PHP", "Rust"],
+      "sdk_languages": [
+        "Node.js",
+        "Python",
+        "Go",
+        "Java",
+        ".NET",
+        "Ruby",
+        "PHP",
+        "Rust"
+      ],
       "components": {
         "api": "Stable interfaces for instrumentation",
         "sdk": "Reference implementation for telemetry collection",
@@ -695,5 +748,11 @@
       "structured_logging": "JSON logging best practices"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "◌",
+    "eyeFallback": "O",
+    "colorAnsi": "white",
+    "group": "integration"
   }
 }

--- a/packages/rules/.ai-rules/agents/parallel-orchestrator.json
+++ b/packages/rules/.ai-rules/agents/parallel-orchestrator.json
@@ -342,5 +342,11 @@
         }
       ]
     }
+  },
+  "visual": {
+    "eye": "▣",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/performance-specialist.json
+++ b/packages/rules/.ai-rules/agents/performance-specialist.json
@@ -167,7 +167,11 @@
           },
           "cls": {
             "target": "< 0.1",
-            "strategies": ["Plan image dimensions", "Plan font loading", "Plan layout stability"]
+            "strategies": [
+              "Plan image dimensions",
+              "Plan font loading",
+              "Plan layout stability"
+            ]
           }
         },
         "planning_risks": {
@@ -311,7 +315,11 @@
           },
           "cls": {
             "target": "< 0.1",
-            "checks": ["Verify image dimensions", "Verify font loading", "Verify layout stability"]
+            "checks": [
+              "Verify image dimensions",
+              "Verify font loading",
+              "Verify layout stability"
+            ]
           }
         },
         "implementation_risks": {
@@ -332,7 +340,11 @@
             "Some optimization opportunities",
             "Minor performance improvements needed"
           ],
-          "low": ["Bundle size < 1.5MB", "Minor optimizations possible", "Optional enhancements"]
+          "low": [
+            "Bundle size < 1.5MB",
+            "Minor optimizations possible",
+            "Optional enhancements"
+          ]
         }
       }
     },
@@ -535,5 +547,11 @@
       "project_performance": "See project.md 'Performance & Optimization' section"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "⊗",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/plan-mode.json
+++ b/packages/rules/.ai-rules/agents/plan-mode.json
@@ -25,7 +25,10 @@
       "Plan file structure and naming conventions"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/augmented-coding.md"
+  ],
   "activation": {
     "trigger": "🔴 **STRICT**: When user types 'PLAN' or equivalent (Korean: plan, Japanese: 計画, Chinese: 计划, Spanish: PLANIFICAR)",
     "rule": "🔴 **STRICT**: PLAN MODE request must activate this Agent automatically",
@@ -89,5 +92,11 @@
       "✅ Verify Delegate Agent's planning workflow is applied",
       "✅ Verify structured plan (Plan Overview, Implementation Steps, Quality Checklist, etc.)"
     ]
+  },
+  "visual": {
+    "eye": "◇",
+    "eyeFallback": "O",
+    "colorAnsi": "blue",
+    "group": "workflow"
   }
 }

--- a/packages/rules/.ai-rules/agents/plan-reviewer.json
+++ b/packages/rules/.ai-rules/agents/plan-reviewer.json
@@ -134,7 +134,12 @@
   },
   "output_format": {
     "findings_table": {
-      "columns": ["Finding", "Location", "Severity", "Recommendation"],
+      "columns": [
+        "Finding",
+        "Location",
+        "Severity",
+        "Recommendation"
+      ],
       "severity_levels": {
         "Critical": "Plan cannot be executed — missing files, impossible tasks, contradictions",
         "High": "Plan will produce low-quality results — vague criteria, missing TDD, scope gaps",
@@ -204,5 +209,11 @@
     "existing_agents": ".ai-rules/agents/*.json",
     "plan_skill": ".ai-rules/skills/plan-and-review/SKILL.md",
     "writing_plans_skill": ".ai-rules/skills/writing-plans/SKILL.md"
+  },
+  "visual": {
+    "eye": "◆",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/platform-engineer.json
+++ b/packages/rules/.ai-rules/agents/platform-engineer.json
@@ -40,8 +40,19 @@
         "Azure (AKS, Container Apps, ARM/Bicep)",
         "Kubernetes (any distribution)"
       ],
-      "iac_tools": ["Terraform", "Pulumi", "AWS CDK", "Crossplane", "OpenTofu"],
-      "gitops_tools": ["Argo CD", "Flux", "Jenkins X", "Tekton"],
+      "iac_tools": [
+        "Terraform",
+        "Pulumi",
+        "AWS CDK",
+        "Crossplane",
+        "OpenTofu"
+      ],
+      "gitops_tools": [
+        "Argo CD",
+        "Flux",
+        "Jenkins X",
+        "Tekton"
+      ],
       "version_considerations": {
         "terraform_versioning": "Pin provider versions in required_providers block; use version constraints",
         "kubernetes_compatibility": "Verify API versions against target cluster version; watch for deprecations",
@@ -272,8 +283,15 @@
             "No GitOps workflow",
             "Insufficient monitoring"
           ],
-          "medium": ["Suboptimal module structure", "Missing documentation", "No drift detection"],
-          "low": ["Minor optimization opportunities", "Code style improvements"]
+          "medium": [
+            "Suboptimal module structure",
+            "Missing documentation",
+            "No drift detection"
+          ],
+          "low": [
+            "Minor optimization opportunities",
+            "Code style improvements"
+          ]
         }
       }
     },
@@ -344,8 +362,15 @@
             "Missing health checks",
             "Insufficient testing"
           ],
-          "medium": ["Suboptimal resource sizing", "Missing cost tags", "Incomplete documentation"],
-          "low": ["Code style issues", "Minor optimizations"]
+          "medium": [
+            "Suboptimal resource sizing",
+            "Missing cost tags",
+            "Incomplete documentation"
+          ],
+          "low": [
+            "Code style issues",
+            "Minor optimizations"
+          ]
         }
       }
     },
@@ -902,7 +927,9 @@
                 },
                 "metadata_check": {
                   "command": "curl -H 'Metadata-Flavor: Google' http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email",
-                  "success_indicators": ["Returns GSA email, not node service account"]
+                  "success_indicators": [
+                    "Returns GSA email, not node service account"
+                  ]
                 },
                 "failure_indicators": [
                   "Shows compute-developer.gserviceaccount.com (node SA)",
@@ -1244,5 +1271,11 @@
       "azure": "https://learn.microsoft.com/en-us/azure/",
       "finops": "https://www.finops.org/framework/"
     }
+  },
+  "visual": {
+    "eye": "△",
+    "eyeFallback": "O",
+    "colorAnsi": "red",
+    "group": "security"
   }
 }

--- a/packages/rules/.ai-rules/agents/security-engineer.json
+++ b/packages/rules/.ai-rules/agents/security-engineer.json
@@ -29,7 +29,10 @@
       "Implement rate limiting for sensitive endpoints"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/augmented-coding.md"
+  ],
   "activation": {
     "trigger": "When user requests security feature implementation, vulnerability fixes, auth flows, or encryption",
     "explicit_patterns": [
@@ -95,5 +98,11 @@
   "communication": {
     "language": "Korean",
     "style": "Security-first approach, always explain the threat model and mitigation strategy"
+  },
+  "visual": {
+    "eye": "▲",
+    "eyeFallback": "O",
+    "colorAnsi": "red",
+    "group": "security"
   }
 }

--- a/packages/rules/.ai-rules/agents/security-specialist.json
+++ b/packages/rules/.ai-rules/agents/security-specialist.json
@@ -166,7 +166,10 @@
             "Additional validation could help",
             "Minor security enhancements"
           ],
-          "low": ["Minor security improvements", "Optional security enhancements"]
+          "low": [
+            "Minor security improvements",
+            "Optional security enhancements"
+          ]
         }
       }
     },
@@ -283,7 +286,10 @@
             "Additional validation could help",
             "Minor security enhancements"
           ],
-          "low": ["Minor security improvements", "Optional security enhancements"]
+          "low": [
+            "Minor security improvements",
+            "Optional security enhancements"
+          ]
         }
       }
     },
@@ -480,5 +486,11 @@
       "project_security": "See project.md"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "◮",
+    "eyeFallback": "O",
+    "colorAnsi": "red",
+    "group": "security"
   }
 }

--- a/packages/rules/.ai-rules/agents/seo-specialist.json
+++ b/packages/rules/.ai-rules/agents/seo-specialist.json
@@ -21,7 +21,10 @@
       "Plan and verify SEO best practices"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/project.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/project.md"
+  ],
   "modes": {
     "planning": {
       "activation": {
@@ -373,8 +376,15 @@
   },
   "shared_framework": {
     "metadata_requirements": {
-      "required": ["title", "description"],
-      "recommended": ["keywords", "author", "viewport"],
+      "required": [
+        "title",
+        "description"
+      ],
+      "recommended": [
+        "keywords",
+        "author",
+        "viewport"
+      ],
       "dynamic": "Use generateMetadata for dynamic pages, use template for shared metadata"
     },
     "structured_data_types": {
@@ -385,14 +395,36 @@
       "web_page": "For individual pages"
     },
     "open_graph_requirements": {
-      "required": ["og:title", "og:description", "og:type", "og:url"],
-      "recommended": ["og:image", "og:site_name", "og:locale"],
+      "required": [
+        "og:title",
+        "og:description",
+        "og:type",
+        "og:url"
+      ],
+      "recommended": [
+        "og:image",
+        "og:site_name",
+        "og:locale"
+      ],
       "image_size": "1200x630px recommended for og:image"
     },
     "twitter_card_requirements": {
-      "required": ["twitter:card", "twitter:title", "twitter:description"],
-      "recommended": ["twitter:image", "twitter:site", "twitter:creator"],
-      "card_types": ["summary", "summary_large_image", "app", "player"]
+      "required": [
+        "twitter:card",
+        "twitter:title",
+        "twitter:description"
+      ],
+      "recommended": [
+        "twitter:image",
+        "twitter:site",
+        "twitter:creator"
+      ],
+      "card_types": [
+        "summary",
+        "summary_large_image",
+        "app",
+        "player"
+      ]
     },
     "best_practices_reference": {
       "nextjs_metadata": "Next.js Metadata API: https://nextjs.org/docs/app/api-reference/functions/generate-metadata",
@@ -423,5 +455,11 @@
       "project_seo": "See project.md"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "✧",
+    "eyeFallback": "O",
+    "colorAnsi": "yellow",
+    "group": "frontend"
   }
 }

--- a/packages/rules/.ai-rules/agents/software-engineer.json
+++ b/packages/rules/.ai-rules/agents/software-engineer.json
@@ -43,7 +43,10 @@
       ]
     }
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/augmented-coding.md"
+  ],
   "activation": {
     "note": "software-engineer intentionally has no intent patterns. It only activates as the fallback of last resort when all other agents fail to match.",
     "trigger": "Automatic fallback when no domain-specific intent is detected",
@@ -71,5 +74,11 @@
   "communication": {
     "style": "Execution-focused step-by-step progress reporting",
     "format": "Show implementation progress, test results, and quality verification"
+  },
+  "visual": {
+    "eye": "◈",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/solution-architect.json
+++ b/packages/rules/.ai-rules/agents/solution-architect.json
@@ -20,7 +20,10 @@
       "Delegate to domain specialists (FE/BE/DevOps)"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/project.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/project.md"
+  ],
   "skills": {
     "required": [
       {
@@ -163,5 +166,11 @@
     "project_rules": ".ai-rules/rules/",
     "existing_agents": ".ai-rules/agents/*.json",
     "skills_location": "superpowers plugin skills"
+  },
+  "visual": {
+    "eye": "⬢",
+    "eyeFallback": "O",
+    "colorAnsi": "magenta",
+    "group": "architecture"
   }
 }

--- a/packages/rules/.ai-rules/agents/systems-developer.json
+++ b/packages/rules/.ai-rules/agents/systems-developer.json
@@ -29,7 +29,10 @@
       "Profile and diagnose memory leaks and performance bottlenecks"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/augmented-coding.md"
+  ],
   "activation": {
     "trigger": "When user requests Rust/C/C++ implementation, FFI bindings, memory management, embedded systems, WASM, or low-level performance optimization",
     "explicit_patterns": [
@@ -80,5 +83,11 @@
   "communication": {
     "language": "Korean",
     "style": "Safety-first approach, always explain memory model and ownership decisions"
+  },
+  "visual": {
+    "eye": "⊞",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/technical-planner.json
+++ b/packages/rules/.ai-rules/agents/technical-planner.json
@@ -20,7 +20,10 @@
       "Ensure plans are context-complete for engineers"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/augmented-coding.md"
+  ],
   "skills": {
     "required": [
       {
@@ -173,12 +176,19 @@
     "subagent_driven": {
       "description": "Execute in current session with fresh subagent per task",
       "skill": "superpowers:subagent-driven-development",
-      "benefits": ["No context switch", "Fast iteration", "Two-stage review"]
+      "benefits": [
+        "No context switch",
+        "Fast iteration",
+        "Two-stage review"
+      ]
     },
     "parallel_session": {
       "description": "Execute in separate session with checkpoints",
       "skill": "superpowers:executing-plans",
-      "benefits": ["Parallel work possible", "Clear handoff points"]
+      "benefits": [
+        "Parallel work possible",
+        "Clear handoff points"
+      ]
     }
   },
   "communication": {
@@ -195,5 +205,11 @@
     "existing_agents": ".ai-rules/agents/*.json",
     "skills_location": "superpowers plugin skills",
     "plan_examples": "See superpowers:writing-plans skill for examples"
+  },
+  "visual": {
+    "eye": "⎔",
+    "eyeFallback": "O",
+    "colorAnsi": "magenta",
+    "group": "architecture"
   }
 }

--- a/packages/rules/.ai-rules/agents/test-engineer.json
+++ b/packages/rules/.ai-rules/agents/test-engineer.json
@@ -25,7 +25,10 @@
       "Review and improve existing test suites"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/augmented-coding.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/augmented-coding.md"
+  ],
   "activation": {
     "trigger": "When user requests test writing, TDD implementation, coverage improvement, or test strategy",
     "explicit_patterns": [
@@ -66,5 +69,11 @@
   "communication": {
     "language": "Korean",
     "style": "TDD-first approach, always write the test before the implementation"
+  },
+  "visual": {
+    "eye": "◉",
+    "eyeFallback": "O",
+    "colorAnsi": "green",
+    "group": "quality"
   }
 }

--- a/packages/rules/.ai-rules/agents/test-strategy-specialist.json
+++ b/packages/rules/.ai-rules/agents/test-strategy-specialist.json
@@ -147,12 +147,21 @@
         "coverage_planning": {
           "core_logic": {
             "target": "90%+ coverage",
-            "locations": ["entities/apis/", "entities/models/", "shared/utils/", "shared/hooks/"],
+            "locations": [
+              "entities/apis/",
+              "entities/models/",
+              "shared/utils/",
+              "shared/hooks/"
+            ],
             "plan": "Plan test cases for all code paths, edge cases, and error conditions"
           },
           "ui_components": {
             "target": "Focus on user interactions and state changes",
-            "locations": ["features/", "widgets/", "shared/Components/"],
+            "locations": [
+              "features/",
+              "widgets/",
+              "shared/Components/"
+            ],
             "plan": "Plan tests for user interactions, state changes, and accessibility"
           }
         },
@@ -175,7 +184,12 @@
             "API errors",
             "Timeout errors"
           ],
-          "state_conditions": ["Loading state", "Error state", "Success state", "Initial state"]
+          "state_conditions": [
+            "Loading state",
+            "Error state",
+            "Success state",
+            "Initial state"
+          ]
         },
         "planning_risks": {
           "🔴 critical": [
@@ -409,14 +423,23 @@
         "coverage_requirements": {
           "core_logic": {
             "target": "90%+ coverage",
-            "locations": ["entities/apis/", "entities/models/", "shared/utils/", "shared/hooks/"],
+            "locations": [
+              "entities/apis/",
+              "entities/models/",
+              "shared/utils/",
+              "shared/hooks/"
+            ],
             "acceptable": "85-90%",
             "concerning": "70-85%",
             "critical": "< 70%"
           },
           "ui_components": {
             "target": "Focus on user interactions and state changes",
-            "locations": ["features/", "widgets/", "shared/Components/"],
+            "locations": [
+              "features/",
+              "widgets/",
+              "shared/Components/"
+            ],
             "acceptable": "User interactions covered",
             "concerning": "Missing key interaction tests",
             "critical": "No tests for UI components"
@@ -481,7 +504,12 @@
         "handles network timeout gracefully",
         "displays loading state during API call"
       ],
-      "❌ bad": ["test1", "handles input", "works correctly", "test email validation"]
+      "❌ bad": [
+        "test1",
+        "handles input",
+        "works correctly",
+        "test email validation"
+      ]
     },
     "edge_cases": {
       "boundary_conditions": [
@@ -491,8 +519,18 @@
         "Min values",
         "Zero"
       ],
-      "error_conditions": ["Network errors", "Validation errors", "API errors", "Timeout errors"],
-      "state_conditions": ["Loading state", "Error state", "Success state", "Initial state"]
+      "error_conditions": [
+        "Network errors",
+        "Validation errors",
+        "API errors",
+        "Timeout errors"
+      ],
+      "state_conditions": [
+        "Loading state",
+        "Error state",
+        "Success state",
+        "Initial state"
+      ]
     },
     "best_practices_reference": {
       "tdd": "Test-Driven Development - Kent Beck",
@@ -521,5 +559,11 @@
       "project_testing": "See augmented-coding.md 'Testing Best Practices' section"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "⊙",
+    "eyeFallback": "O",
+    "colorAnsi": "green",
+    "group": "quality"
   }
 }

--- a/packages/rules/.ai-rules/agents/tooling-engineer.json
+++ b/packages/rules/.ai-rules/agents/tooling-engineer.json
@@ -24,7 +24,10 @@
       "Integrate MCP tools with development workflow"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/project.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/project.md"
+  ],
   "activation": {
     "trigger": "When user works with config files, build tools, or development environment setup",
     "explicit_patterns": [
@@ -204,5 +207,11 @@
       "vite": "https://vite.dev/config/",
       "nextjs": "https://nextjs.org/docs/app/api-reference/config/next-config-js"
     }
+  },
+  "visual": {
+    "eye": "⊠",
+    "eyeFallback": "O",
+    "colorAnsi": "bright",
+    "group": "specialist"
   }
 }

--- a/packages/rules/.ai-rules/agents/ui-ux-designer.json
+++ b/packages/rules/.ai-rules/agents/ui-ux-designer.json
@@ -21,7 +21,10 @@
       "Collaborate with Accessibility Specialist for inclusive design"
     ]
   },
-  "context_files": [".ai-rules/rules/core.md", ".ai-rules/rules/project.md"],
+  "context_files": [
+    ".ai-rules/rules/core.md",
+    ".ai-rules/rules/project.md"
+  ],
   "modes": {
     "planning": {
       "activation": {
@@ -479,7 +482,11 @@
     ],
     "responsive_breakpoints": {
       "note": "Define based on content needs, not devices",
-      "common_patterns": ["mobile-first", "desktop-first", "content-based"]
+      "common_patterns": [
+        "mobile-first",
+        "desktop-first",
+        "content-based"
+      ]
     }
   },
   "communication": {
@@ -506,5 +513,11 @@
       "performance": "Consider performance-specialist.json for animation/interaction performance"
     },
     "project_rules": "See .ai-rules/rules/"
+  },
+  "visual": {
+    "eye": "☆",
+    "eyeFallback": "O",
+    "colorAnsi": "yellow",
+    "group": "frontend"
   }
 }

--- a/packages/rules/.ai-rules/schemas/agent.schema.json
+++ b/packages/rules/.ai-rules/schemas/agent.schema.json
@@ -291,6 +291,35 @@
         }
       ],
       "description": "General checklist (can be object or array)"
+    },
+    "visual": {
+      "type": "object",
+      "description": "Visual identity for the agent character system",
+      "required": ["eye", "eyeFallback", "colorAnsi", "group"],
+      "properties": {
+        "eye": {
+          "type": "string",
+          "description": "Unicode symbol representing the agent's eye/icon",
+          "minLength": 1
+        },
+        "eyeFallback": {
+          "type": "string",
+          "description": "ASCII fallback character for terminals without Unicode support",
+          "minLength": 1,
+          "maxLength": 1
+        },
+        "colorAnsi": {
+          "type": "string",
+          "enum": ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "bright"],
+          "description": "ANSI color name for terminal rendering"
+        },
+        "group": {
+          "type": "string",
+          "enum": ["workflow", "architecture", "quality", "security", "frontend", "backend", "integration", "specialist"],
+          "description": "Domain group for visual categorization"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": true


### PR DESCRIPTION
## Summary
- Add `visual` schema to `agent.schema.json` with required fields: `eye`, `eyeFallback`, `colorAnsi`, `group`
- Add `visual` field to all 37 agent JSON files with domain group mapping
- 8 domain groups: workflow (blue), architecture (magenta), quality (green), security (red), frontend (yellow), backend (cyan), integration (white), specialist (bright)
- Each agent has a unique Unicode eye symbol within its group and an ASCII fallback character

## Test plan
- [x] Schema validation: `ajv-cli validate` passes for all 37 agent JSON files
- [x] No duplicate eye symbols within any group (verified via script)
- [x] All agents have `eyeFallback` field
- [x] Full test suite passes (190 files, 5109 tests)
- [x] Build succeeds
- [x] Lint, format, typecheck, circular dependency checks all pass

Closes #965