### PR TITLE
feat(plugin): add postinstall welcome banner with buddy character

### DIFF
--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -28,14 +28,15 @@
   "files": [
     ".claude-plugin",
     ".mcp.json",
-    "README.md"
+    "README.md",
+    "scripts/postinstall.js"
   ],
   "scripts": {
     "build": "ts-node scripts/build.ts --mode=production",
     "build:dev": "ts-node scripts/build.ts --mode=development",
     "sync-version": "node scripts/sync-version.js",
     "prebuild": "npm run sync-version",
-    "postinstall": "echo '\\n[CodingBuddy Plugin] For full MCP tools support, install codingbuddy globally:\\n  npm install -g codingbuddy\\n\\nDocumentation: https://github.com/JeremyDev87/codingbuddy\\n'",
+    "postinstall": "node scripts/postinstall.js",
     "prepublishOnly": "npm run build",
     "lint": "eslint src/ scripts/",
     "typecheck": "tsc --noEmit",

--- a/packages/claude-code-plugin/scripts/postinstall.js
+++ b/packages/claude-code-plugin/scripts/postinstall.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+'use strict';
+
+// Skip banner in CI environments
+if (process.env.CI === 'true' || process.env.CI === '1') {
+  process.exit(0);
+}
+
+const path = require('path');
+const fs = require('fs');
+
+// Read version from package.json
+let version = 'unknown';
+try {
+  const pkgPath = path.join(__dirname, '..', 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  version = pkg.version || 'unknown';
+} catch {
+  // silently fall back to 'unknown'
+}
+
+const banner = `
+\x1b[36m╭━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╮
+│                                              │
+│           ╭━━━╮                              │
+│           ┃ ◕‿◕ ┃  Hey! I am CodingBuddy!    │
+│           ╰━┳━╯                              │
+│          ╭──┻──╮   Your new coding buddy.    │
+│          │ CB  │                              │
+│          ╰─────╯   v${version.padEnd(27)}│
+│                                              │
+│   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   │
+│                                              │
+│   35 specialist agents ready                 │
+│   PLAN → ACT → EVAL workflow                 │
+│   TDD-first development                     │
+│                                              │
+│   Start a session and I will introduce       │
+│   myself!                                    │
+│                                              │
+╰━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╯\x1b[0m
+
+\x1b[33m[CodingBuddy Plugin]\x1b[0m For full MCP tools support, install codingbuddy globally:
+  npm install -g codingbuddy
+
+Documentation: https://github.com/JeremyDev87/codingbuddy
+`;
+
+console.log(banner);


### PR DESCRIPTION
## Summary

- Add ASCII art buddy character welcome banner displayed after `npm install`
- Dynamically read version number from `package.json`
- Suppress banner in CI environments (`CI=true`)
- Preserve existing MCP global installation guidance message
- New `scripts/postinstall.js` included in published package files

## Test plan

- [x] `node packages/claude-code-plugin/scripts/postinstall.js` — banner displays with correct version
- [x] `CI=true node packages/claude-code-plugin/scripts/postinstall.js` — no output, exit 0
- [x] All 71 existing tests pass
- [x] lint, format, typecheck, circular, build — all pass

Closes #967