### PR TITLE
feat(plugin): add system prompt format guide for agent collaboration

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/prompt_injection.py
+++ b/packages/claude-code-plugin/hooks/lib/prompt_injection.py
@@ -27,6 +27,56 @@ _QUALITY_GATES = (
     "all tests pass, and changes are self-reviewed."
 )
 
+# --- Format guide templates (eco=true compact / eco=false full) ---
+
+_FORMAT_GUIDE_ECO_COMPACT = (
+    "[CodingBuddy Format Guide] "
+    "Use each agent's visual character (eye + colorAnsi from agent JSON) "
+    "to show collaboration compactly. "
+    "Format — {tone_instruction}\n"
+    "# Mode: {{MODE}}\n"
+    "## {{colorEmoji}} {{eye}}_{{eye}} {{Agent Name}}\n"
+    "\n"
+    "━━ Agents: {{colorEmoji}} {{Name}}, {{colorEmoji}} {{Name}}, ...\n"
+    "━━ Consensus: {{one-line summary of agreed approach}}"
+)
+
+_FORMAT_GUIDE_ECO_FULL = (
+    "[CodingBuddy Format Guide] "
+    "Use each agent's visual character (eye + colorAnsi from agent JSON) "
+    "to show full discussion process. "
+    "Format — {tone_instruction}\n"
+    "{{colorEmoji}} {{eye}}_{{eye}} {{Agent Name}}\n"
+    "│ \"{{agent's opinion or recommendation}}\"\n"
+    "│\n"
+    "{{colorEmoji}} {{eye}}_{{eye}} {{Another Agent}}\n"
+    "│ \"{{response, critique, or agreement}}\"\n"
+    "│\n"
+    "(show full discussion dialogue between agents)"
+)
+
+_TONE_CASUAL = "Use a casual, friendly tone."
+_TONE_FORMAL = "Use a formal, professional tone."
+
+
+def _build_format_guide(config: Dict[str, Any]) -> str:
+    """Build format guide section based on eco and tone settings.
+
+    Args:
+        config: Full codingbuddy config dict.
+
+    Returns:
+        Format guide string, or empty string if not applicable.
+    """
+    eco = config.get("eco", True)
+    tone = config.get("tone", "casual")
+    tone_instruction = _TONE_FORMAL if tone == "formal" else _TONE_CASUAL
+
+    if eco:
+        return _FORMAT_GUIDE_ECO_COMPACT.format(tone_instruction=tone_instruction)
+    else:
+        return _FORMAT_GUIDE_ECO_FULL.format(tone_instruction=tone_instruction)
+
 
 class PromptInjector:
     """Builds a system prompt string from config-driven sections."""
@@ -62,6 +112,11 @@ class PromptInjector:
 
         if sections_cfg.get("qualityGates", True):
             parts.append(_QUALITY_GATES)
+
+        if sections_cfg.get("formatGuide", False):
+            guide = _build_format_guide(config)
+            if guide:
+                parts.append(guide)
 
         if not parts:
             return ""

--- a/packages/claude-code-plugin/tests/test_prompt_injection.py
+++ b/packages/claude-code-plugin/tests/test_prompt_injection.py
@@ -127,6 +127,91 @@ class TestPromptSizeLimit:
         assert len(result) > 0
 
 
+class TestFormatGuideEcoTrue:
+    """eco=true: compact format guide injected."""
+
+    def _make_config(self, tone="casual"):
+        return {
+            "eco": True,
+            "tone": tone,
+            "promptInjection": {
+                "enabled": True,
+                "sections": {
+                    "baseRules": True,
+                    "dispatchEnforcement": True,
+                    "qualityGates": True,
+                    "formatGuide": True,
+                },
+            },
+        }
+
+    def test_eco_true_contains_compact_marker(self, injector):
+        result = injector.build_system_prompt(self._make_config(), "/tmp")
+        assert "━━ Agents:" in result
+
+    def test_eco_true_contains_consensus_line(self, injector):
+        result = injector.build_system_prompt(self._make_config(), "/tmp")
+        assert "━━ Consensus:" in result
+
+    def test_eco_true_no_full_discussion(self, injector):
+        """Compact mode should NOT contain the full discussion '│' markers."""
+        result = injector.build_system_prompt(self._make_config(), "/tmp")
+        assert "│ \"" not in result
+
+    def test_eco_true_mentions_eye_character(self, injector):
+        result = injector.build_system_prompt(self._make_config(), "/tmp")
+        assert "eye" in result.lower() or "◇" in result or "캐릭터" in result.lower() or "character" in result.lower()
+
+    def test_eco_true_casual_tone(self, injector):
+        result = injector.build_system_prompt(self._make_config(tone="casual"), "/tmp")
+        assert "casual" in result.lower() or "친근" in result
+
+    def test_eco_true_formal_tone(self, injector):
+        result = injector.build_system_prompt(self._make_config(tone="formal"), "/tmp")
+        assert "formal" in result.lower() or "격식" in result
+
+
+class TestFormatGuideEcoFalse:
+    """eco=false: full discussion format guide injected."""
+
+    def _make_config(self, tone="casual"):
+        return {
+            "eco": False,
+            "tone": tone,
+            "promptInjection": {
+                "enabled": True,
+                "sections": {
+                    "baseRules": True,
+                    "dispatchEnforcement": True,
+                    "qualityGates": True,
+                    "formatGuide": True,
+                },
+            },
+        }
+
+    def test_eco_false_contains_full_discussion_marker(self, injector):
+        result = injector.build_system_prompt(self._make_config(), "/tmp")
+        assert "│ \"" in result or "│" in result
+
+    def test_eco_false_shows_agent_dialogue(self, injector):
+        result = injector.build_system_prompt(self._make_config(), "/tmp")
+        assert "discussion" in result.lower() or "토론" in result or "dialogue" in result.lower()
+
+    def test_eco_false_mentions_eye_character(self, injector):
+        result = injector.build_system_prompt(self._make_config(), "/tmp")
+        assert "eye" in result.lower() or "◇" in result or "캐릭터" in result.lower() or "character" in result.lower()
+
+
+class TestFormatGuideDisabled:
+    """formatGuide=false: no format guide injected."""
+
+    def test_no_format_guide_when_disabled(self, injector, base_config):
+        """base_config has no formatGuide key → defaults off → no guide markers."""
+        result = injector.build_system_prompt(base_config, "/tmp")
+        assert "━━ Agents:" not in result
+        assert "│ \"" not in result
+
+
 class TestDisabledInjection:
     def test_returns_empty_when_disabled(self, injector):
         config = {"promptInjection": {"enabled": False}}


### PR DESCRIPTION
## Summary

- Add format guide section to system prompt injection for visual agent collaboration display
- eco=true: compact format (━━ Agents/Consensus one-liner summary)
- eco=false: full discussion format (│ dialogue between agents with quotes)
- Supports tone setting (casual/formal) affecting guide language
- Includes agent visual character (eye + colorAnsi) usage instructions
- formatGuide section defaults to false, opt-in via config

## Test plan

- [x] 10 new unit tests covering eco true/false, tone casual/formal, disabled state
- [x] All 22 tests pass (12 existing + 10 new)
- [x] CI checks: lint, format, typecheck, test:coverage, circular, build — all pass

Closes #971