### PR TITLE
feat(plugin): add companion TUI launcher with tmux split (#970)

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/tui_launcher.py
+++ b/packages/claude-code-plugin/hooks/lib/tui_launcher.py
@@ -1,0 +1,257 @@
+"""TUI launcher for CodingBuddy companion TUI (#970).
+
+Manages tmux-based companion TUI alongside Claude Code:
+- Detects tmux environment and terminal width
+- Creates split pane with appropriate sizing
+- Tracks pane state for cleanup on session stop
+"""
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+# Width thresholds
+MIN_WIDTH = 120
+WIDE_WIDTH = 160
+WIDE_TUI_PERCENT = 40
+NARROW_TUI_PERCENT = 30
+DEFAULT_TUI_COMMAND = "codingbuddy-tui"
+
+# i18n messages
+MESSAGES: Dict[str, Dict[str, str]] = {
+    "en": {
+        "tui_disabled": "TUI disabled in config",
+        "no_tmux": "Install tmux for CodingBuddy companion TUI: brew install tmux",
+        "not_in_tmux": "Start Claude Code inside tmux for companion TUI",
+        "too_narrow": "Terminal too narrow for TUI (need {min}+ cols, current: {current})",
+        "tui_launched": "Companion TUI launched (pane {pane_id})",
+        "tui_cmd_not_found": "CodingBuddy TUI not found. Install: npm install -g codingbuddy-tui",
+        "tui_launch_error": "TUI launch failed: {error}",
+        "tui_cleaned": "TUI pane closed",
+    },
+    "ko": {
+        "tui_disabled": "설정에서 TUI 비활성화됨",
+        "no_tmux": "CodingBuddy 컴패니언 TUI를 위해 tmux를 설치하세요: brew install tmux",
+        "not_in_tmux": "컴패니언 TUI를 위해 tmux 안에서 Claude Code를 시작하세요",
+        "too_narrow": "TUI를 위한 터미널 너비 부족 ({min}+ 필요, 현재: {current})",
+        "tui_launched": "컴패니언 TUI 실행됨 (pane {pane_id})",
+        "tui_cmd_not_found": "CodingBuddy TUI를 찾을 수 없습니다. 설치: npm install -g codingbuddy-tui",
+        "tui_launch_error": "TUI 실행 실패: {error}",
+        "tui_cleaned": "TUI pane이 닫혔습니다",
+    },
+    "ja": {
+        "tui_disabled": "設定でTUIが無効です",
+        "no_tmux": "CodingBuddyコンパニオンTUI用にtmuxをインストール: brew install tmux",
+        "not_in_tmux": "コンパニオンTUI用にtmux内でClaude Codeを起動してください",
+        "too_narrow": "TUIに十分なターミナル幅がありません ({min}+列必要、現在: {current})",
+        "tui_launched": "コンパニオンTUI起動 (pane {pane_id})",
+        "tui_cmd_not_found": "CodingBuddy TUIが見つかりません。インストール: npm install -g codingbuddy-tui",
+        "tui_launch_error": "TUI起動失敗: {error}",
+        "tui_cleaned": "TUI paneを閉じました",
+    },
+    "zh": {
+        "tui_disabled": "配置中TUI已禁用",
+        "no_tmux": "请安装tmux以使用CodingBuddy伴侣TUI: brew install tmux",
+        "not_in_tmux": "请在tmux中启动Claude Code以使用伴侣TUI",
+        "too_narrow": "终端宽度不足 (需要{min}+列, 当前: {current})",
+        "tui_launched": "伴侣TUI已启动 (pane {pane_id})",
+        "tui_cmd_not_found": "未找到CodingBuddy TUI。安装: npm install -g codingbuddy-tui",
+        "tui_launch_error": "TUI启动失败: {error}",
+        "tui_cleaned": "TUI pane已关闭",
+    },
+    "es": {
+        "tui_disabled": "TUI deshabilitado en configuracion",
+        "no_tmux": "Instale tmux para CodingBuddy companion TUI: brew install tmux",
+        "not_in_tmux": "Inicie Claude Code dentro de tmux para companion TUI",
+        "too_narrow": "Terminal demasiado estrecho para TUI (necesita {min}+ cols, actual: {current})",
+        "tui_launched": "Companion TUI iniciado (pane {pane_id})",
+        "tui_cmd_not_found": "CodingBuddy TUI no encontrado. Instalar: npm install -g codingbuddy-tui",
+        "tui_launch_error": "Fallo al iniciar TUI: {error}",
+        "tui_cleaned": "TUI pane cerrado",
+    },
+}
+
+
+def _msg(key: str, language: str = "en", **kwargs) -> str:
+    """Get localized message."""
+    lang_msgs = MESSAGES.get(language, MESSAGES["en"])
+    template = lang_msgs.get(key) or MESSAGES["en"].get(key, key)
+    return template.format(**kwargs) if kwargs else template
+
+
+def is_tmux_available() -> bool:
+    """Check if tmux is installed on the system."""
+    return shutil.which("tmux") is not None
+
+
+def is_in_tmux() -> bool:
+    """Check if currently running inside a tmux session."""
+    return bool(os.environ.get("TMUX"))
+
+
+def get_terminal_width() -> int:
+    """Get current terminal width in columns."""
+    try:
+        return os.get_terminal_size().columns
+    except (ValueError, OSError):
+        return 0
+
+
+def get_split_percentage(width: int) -> int:
+    """Calculate TUI pane split percentage based on terminal width.
+
+    Returns:
+        Split percentage for TUI pane, or 0 if too narrow.
+    """
+    if width >= WIDE_WIDTH:
+        return WIDE_TUI_PERCENT
+    if width >= MIN_WIDTH:
+        return NARROW_TUI_PERCENT
+    return 0
+
+
+def should_launch(config: dict) -> Tuple[bool, str]:
+    """Determine if TUI should be launched based on config and environment.
+
+    Returns:
+        (should_launch, reason_message) tuple.
+    """
+    language = config.get("language", "en")
+
+    if not config.get("tui", True):
+        return False, _msg("tui_disabled", language)
+
+    if not is_tmux_available():
+        return False, _msg("no_tmux", language)
+
+    if not is_in_tmux():
+        return False, _msg("not_in_tmux", language)
+
+    width = get_terminal_width()
+    if get_split_percentage(width) == 0:
+        return False, _msg("too_narrow", language, min=MIN_WIDTH, current=width)
+
+    return True, ""
+
+
+def _get_state_dir() -> Path:
+    """Get directory for TUI state files."""
+    data_dir = os.environ.get(
+        "CLAUDE_PLUGIN_DATA",
+        os.path.join(str(Path.home()), ".codingbuddy"),
+    )
+    return Path(data_dir)
+
+
+def _get_state_path(session_id: str) -> Path:
+    """Get state file path for a session's TUI pane."""
+    return _get_state_dir() / f"tui-{session_id}.json"
+
+
+def _save_state(session_id: str, pane_id: str) -> None:
+    """Persist TUI pane info for later cleanup."""
+    state_dir = _get_state_dir()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    state = {"pane_id": pane_id, "session_id": session_id}
+    with open(_get_state_path(session_id), "w", encoding="utf-8") as f:
+        json.dump(state, f)
+
+
+def _load_state(session_id: str) -> Optional[dict]:
+    """Load saved TUI pane state."""
+    path = _get_state_path(session_id)
+    if not path.exists():
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _remove_state(session_id: str) -> None:
+    """Remove TUI state file."""
+    try:
+        _get_state_path(session_id).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def launch(session_id: str, config: dict) -> Tuple[bool, str]:
+    """Launch companion TUI in a tmux split pane.
+
+    Returns:
+        (success, message) tuple.
+    """
+    language = config.get("language", "en")
+
+    ok, reason = should_launch(config)
+    if not ok:
+        return False, reason
+
+    tui_command = config.get("tui_command", DEFAULT_TUI_COMMAND)
+    if not shutil.which(tui_command):
+        return False, _msg("tui_cmd_not_found", language)
+
+    width = get_terminal_width()
+    pct = get_split_percentage(width)
+
+    try:
+        result = subprocess.run(
+            [
+                "tmux", "split-window", "-h",
+                "-d",
+                "-p", str(pct),
+                "-P", "-F", "#{pane_id}",
+                f"{tui_command} --session-id {session_id}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+        if result.returncode != 0:
+            return False, _msg(
+                "tui_launch_error", language, error=result.stderr.strip()
+            )
+
+        pane_id = result.stdout.strip()
+        if pane_id:
+            _save_state(session_id, pane_id)
+
+        return True, _msg("tui_launched", language, pane_id=pane_id)
+
+    except subprocess.TimeoutExpired:
+        return False, _msg("tui_launch_error", language, error="timeout")
+    except Exception as e:
+        return False, _msg("tui_launch_error", language, error=str(e))
+
+
+def cleanup(session_id: str) -> bool:
+    """Clean up TUI pane for the given session.
+
+    Returns:
+        True if cleanup was performed, False if no TUI pane found.
+    """
+    state = _load_state(session_id)
+    if not state:
+        return False
+
+    pane_id = state.get("pane_id")
+    if not pane_id:
+        _remove_state(session_id)
+        return False
+
+    try:
+        subprocess.run(
+            ["tmux", "kill-pane", "-t", pane_id],
+            capture_output=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, Exception):
+        pass
+
+    _remove_state(session_id)
+    return True

--- a/packages/claude-code-plugin/hooks/session-start.py
+++ b/packages/claude-code-plugin/hooks/session-start.py
@@ -521,6 +521,21 @@ def main():
         except Exception:
             pass  # Never block session start
 
+        # Step 7: Launch companion TUI (#970)
+        try:
+            _ensure_lib_path()
+            from tui_launcher import launch as launch_tui
+            from config import get_config as _get_tui_cfg
+
+            _tui_sid = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+            _tui_cwd = os.environ.get("CLAUDE_PROJECT_DIR", str(Path.cwd()))
+            _tui_cfg = _get_tui_cfg(_tui_cwd)
+            _tui_ok, _tui_msg = launch_tui(_tui_sid, _tui_cfg)
+            if _tui_msg:
+                print(_tui_msg, file=sys.stderr)
+        except Exception:
+            pass  # Never block session start
+
         sys.exit(0)
 
     except PermissionError as e:

--- a/packages/claude-code-plugin/hooks/stop.py
+++ b/packages/claude-code-plugin/hooks/stop.py
@@ -26,6 +26,14 @@ def handle_stop(data: dict):
         from stats import SessionStats
 
         session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+
+        # Clean up companion TUI pane (#970)
+        try:
+            from tui_launcher import cleanup as cleanup_tui
+            cleanup_tui(session_id)
+        except Exception:
+            pass  # Never block session stop
+
         stats = SessionStats(session_id=session_id)
 
         # Flush pending in-memory stats before finalize (#931)

--- a/packages/claude-code-plugin/tests/test_tui_launcher.py
+++ b/packages/claude-code-plugin/tests/test_tui_launcher.py
@@ -1,0 +1,400 @@
+"""Tests for hooks/lib/tui_launcher.py — TUI companion launcher (#970)."""
+import json
+import os
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks", "lib"))
+
+from tui_launcher import (
+    MIN_WIDTH,
+    NARROW_TUI_PERCENT,
+    WIDE_TUI_PERCENT,
+    WIDE_WIDTH,
+    _load_state,
+    _msg,
+    _remove_state,
+    _save_state,
+    cleanup,
+    get_split_percentage,
+    get_terminal_width,
+    is_in_tmux,
+    is_tmux_available,
+    launch,
+    should_launch,
+)
+
+
+class TestMsg:
+    """Tests for localized message helper."""
+
+    def test_returns_english_by_default(self):
+        assert "disabled" in _msg("tui_disabled")
+
+    def test_returns_korean_message(self):
+        assert "비활성화" in _msg("tui_disabled", "ko")
+
+    def test_formats_kwargs(self):
+        result = _msg("too_narrow", "en", min=120, current=80)
+        assert "120" in result
+        assert "80" in result
+
+    def test_falls_back_to_english(self):
+        result = _msg("tui_disabled", "xx")
+        assert "disabled" in result
+
+
+class TestIsTmuxAvailable:
+    """Tests for tmux installation detection."""
+
+    @patch("shutil.which", return_value="/usr/bin/tmux")
+    def test_returns_true_when_installed(self, _):
+        assert is_tmux_available() is True
+
+    @patch("shutil.which", return_value=None)
+    def test_returns_false_when_not_installed(self, _):
+        assert is_tmux_available() is False
+
+
+class TestIsInTmux:
+    """Tests for tmux session detection."""
+
+    def test_true_when_tmux_env_set(self, monkeypatch):
+        monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,12345,0")
+        assert is_in_tmux() is True
+
+    def test_false_when_tmux_env_unset(self, monkeypatch):
+        monkeypatch.delenv("TMUX", raising=False)
+        assert is_in_tmux() is False
+
+    def test_false_when_tmux_env_empty(self, monkeypatch):
+        monkeypatch.setenv("TMUX", "")
+        assert is_in_tmux() is False
+
+
+class TestGetTerminalWidth:
+    """Tests for terminal width detection."""
+
+    @patch("os.get_terminal_size")
+    def test_returns_columns(self, mock_size):
+        mock_size.return_value = os.terminal_size((200, 50))
+        assert get_terminal_width() == 200
+
+    @patch("os.get_terminal_size", side_effect=OSError("not a terminal"))
+    def test_returns_zero_on_error(self, _):
+        assert get_terminal_width() == 0
+
+
+class TestGetSplitPercentage:
+    """Tests for split percentage calculation by terminal width."""
+
+    def test_wide_terminal_gets_40_percent(self):
+        assert get_split_percentage(200) == WIDE_TUI_PERCENT
+        assert get_split_percentage(WIDE_WIDTH) == WIDE_TUI_PERCENT
+
+    def test_medium_terminal_gets_30_percent(self):
+        assert get_split_percentage(159) == NARROW_TUI_PERCENT
+        assert get_split_percentage(MIN_WIDTH) == NARROW_TUI_PERCENT
+
+    def test_narrow_terminal_gets_zero(self):
+        assert get_split_percentage(119) == 0
+        assert get_split_percentage(80) == 0
+        assert get_split_percentage(0) == 0
+
+
+class TestShouldLaunch:
+    """Tests for TUI launch decision logic."""
+
+    @patch("tui_launcher.get_terminal_width", return_value=200)
+    @patch("tui_launcher.is_in_tmux", return_value=True)
+    @patch("tui_launcher.is_tmux_available", return_value=True)
+    def test_should_launch_when_all_conditions_met(self, *_):
+        ok, msg = should_launch({"tui": True})
+        assert ok is True
+        assert msg == ""
+
+    def test_should_not_launch_when_tui_disabled(self):
+        ok, msg = should_launch({"tui": False})
+        assert ok is False
+        assert "disabled" in msg.lower() or "비활성" in msg
+
+    @patch("tui_launcher.is_tmux_available", return_value=False)
+    def test_should_not_launch_when_no_tmux(self, _):
+        ok, msg = should_launch({"tui": True})
+        assert ok is False
+        assert "tmux" in msg.lower()
+
+    @patch("tui_launcher.is_in_tmux", return_value=False)
+    @patch("tui_launcher.is_tmux_available", return_value=True)
+    def test_should_not_launch_when_not_in_tmux(self, *_):
+        ok, msg = should_launch({"tui": True})
+        assert ok is False
+        assert "tmux" in msg.lower()
+
+    @patch("tui_launcher.get_terminal_width", return_value=100)
+    @patch("tui_launcher.is_in_tmux", return_value=True)
+    @patch("tui_launcher.is_tmux_available", return_value=True)
+    def test_should_not_launch_when_too_narrow(self, *_):
+        ok, msg = should_launch({"tui": True})
+        assert ok is False
+        assert "120" in msg
+
+    def test_uses_config_language_for_messages(self):
+        ok, msg = should_launch({"tui": False, "language": "ko"})
+        assert ok is False
+        assert "비활성화" in msg
+
+    def test_tui_defaults_to_true(self):
+        """Config without tui key should default to True (then fail on tmux check)."""
+        with patch("tui_launcher.is_tmux_available", return_value=False):
+            ok, _ = should_launch({})
+            assert ok is False  # Fails on tmux, not on tui config
+
+
+class TestStateManagement:
+    """Tests for TUI pane state persistence."""
+
+    def test_save_and_load_state(self, tmp_path):
+        with patch("tui_launcher._get_state_dir", return_value=tmp_path):
+            _save_state("sess-1", "%42")
+            state = _load_state("sess-1")
+
+        assert state is not None
+        assert state["pane_id"] == "%42"
+        assert state["session_id"] == "sess-1"
+
+    def test_load_returns_none_when_no_state(self, tmp_path):
+        with patch("tui_launcher._get_state_dir", return_value=tmp_path):
+            assert _load_state("nonexistent") is None
+
+    def test_load_returns_none_on_corrupted_file(self, tmp_path):
+        state_file = tmp_path / "tui-bad.json"
+        state_file.write_text("not json{{{")
+        with patch("tui_launcher._get_state_dir", return_value=tmp_path):
+            assert _load_state("bad") is None
+
+    def test_remove_state_deletes_file(self, tmp_path):
+        with patch("tui_launcher._get_state_dir", return_value=tmp_path):
+            _save_state("sess-1", "%42")
+            _remove_state("sess-1")
+            assert _load_state("sess-1") is None
+
+    def test_remove_nonexistent_state_is_noop(self, tmp_path):
+        with patch("tui_launcher._get_state_dir", return_value=tmp_path):
+            _remove_state("nonexistent")  # Should not raise
+
+    def test_save_creates_directory(self, tmp_path):
+        nested = tmp_path / "sub" / "dir"
+        with patch("tui_launcher._get_state_dir", return_value=nested):
+            _save_state("sess-1", "%42")
+            assert (nested / "tui-sess-1.json").exists()
+
+
+class TestLaunch:
+    """Tests for TUI launch in tmux split pane."""
+
+    def test_launches_tui_successfully(self):
+        with (
+            patch("tui_launcher.should_launch", return_value=(True, "")),
+            patch("tui_launcher.get_terminal_width", return_value=200),
+            patch("shutil.which", return_value="/usr/bin/codingbuddy-tui"),
+            patch("subprocess.run") as mock_run,
+            patch("tui_launcher._save_state") as mock_save,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="%42\n", stderr=""
+            )
+
+            ok, msg = launch("sess-1", {"tui": True})
+
+            assert ok is True
+            assert "%42" in msg
+            mock_save.assert_called_once_with("sess-1", "%42")
+            cmd = mock_run.call_args[0][0]
+            assert "tmux" == cmd[0]
+            assert "split-window" == cmd[1]
+            assert "-d" in cmd
+
+    def test_skips_when_should_not_launch(self):
+        with patch("tui_launcher.should_launch", return_value=(False, "TUI disabled")):
+            ok, msg = launch("sess-1", {"tui": False})
+
+        assert ok is False
+        assert msg == "TUI disabled"
+
+    def test_skips_when_tui_command_not_found(self):
+        with (
+            patch("tui_launcher.should_launch", return_value=(True, "")),
+            patch("shutil.which", return_value=None),
+        ):
+            ok, msg = launch("sess-1", {"tui": True})
+
+        assert ok is False
+        assert "not found" in msg.lower() or "찾을 수 없" in msg
+
+    def test_uses_custom_tui_command(self):
+        with (
+            patch("tui_launcher.should_launch", return_value=(True, "")),
+            patch("tui_launcher.get_terminal_width", return_value=200),
+            patch("shutil.which", return_value="/usr/bin/my-tui"),
+            patch("subprocess.run") as mock_run,
+            patch("tui_launcher._save_state"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="%99\n", stderr=""
+            )
+
+            launch("sess-1", {"tui": True, "tui_command": "my-tui"})
+
+            cmd_str = mock_run.call_args[0][0][-1]
+            assert "my-tui" in cmd_str
+
+    def test_handles_subprocess_error(self):
+        with (
+            patch("tui_launcher.should_launch", return_value=(True, "")),
+            patch("tui_launcher.get_terminal_width", return_value=200),
+            patch("shutil.which", return_value="/usr/bin/codingbuddy-tui"),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr="pane error"
+            )
+
+            ok, msg = launch("sess-1", {"tui": True})
+
+            assert ok is False
+            assert "pane error" in msg
+
+    def test_handles_timeout(self):
+        with (
+            patch("tui_launcher.should_launch", return_value=(True, "")),
+            patch("tui_launcher.get_terminal_width", return_value=200),
+            patch("shutil.which", return_value="/usr/bin/codingbuddy-tui"),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired("tmux", 5),
+            ),
+        ):
+            ok, msg = launch("sess-1", {"tui": True})
+
+            assert ok is False
+            assert "timeout" in msg.lower()
+
+    def test_handles_unexpected_exception(self):
+        with (
+            patch("tui_launcher.should_launch", return_value=(True, "")),
+            patch("tui_launcher.get_terminal_width", return_value=200),
+            patch("shutil.which", return_value="/usr/bin/codingbuddy-tui"),
+            patch("subprocess.run", side_effect=OSError("no such file")),
+        ):
+            ok, msg = launch("sess-1", {"tui": True})
+
+            assert ok is False
+            assert "no such file" in msg
+
+    def test_split_percentage_matches_width(self):
+        """Wide terminal should use 40% split."""
+        with (
+            patch("tui_launcher.should_launch", return_value=(True, "")),
+            patch("tui_launcher.get_terminal_width", return_value=200),
+            patch("shutil.which", return_value="/usr/bin/codingbuddy-tui"),
+            patch("subprocess.run") as mock_run,
+            patch("tui_launcher._save_state"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="%1\n", stderr=""
+            )
+
+            launch("sess-1", {"tui": True})
+
+            cmd = mock_run.call_args[0][0]
+            p_idx = cmd.index("-p")
+            assert cmd[p_idx + 1] == str(WIDE_TUI_PERCENT)
+
+    def test_compact_split_for_medium_width(self):
+        """Medium terminal (120-159) should use 30% split."""
+        with (
+            patch("tui_launcher.should_launch", return_value=(True, "")),
+            patch("tui_launcher.get_terminal_width", return_value=140),
+            patch("shutil.which", return_value="/usr/bin/codingbuddy-tui"),
+            patch("subprocess.run") as mock_run,
+            patch("tui_launcher._save_state"),
+        ):
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="%1\n", stderr=""
+            )
+
+            launch("sess-1", {"tui": True})
+
+            cmd = mock_run.call_args[0][0]
+            p_idx = cmd.index("-p")
+            assert cmd[p_idx + 1] == str(NARROW_TUI_PERCENT)
+
+
+class TestCleanup:
+    """Tests for TUI pane cleanup."""
+
+    def test_kills_tui_pane(self, tmp_path):
+        with (
+            patch("tui_launcher._get_state_dir", return_value=tmp_path),
+            patch("subprocess.run") as mock_run,
+        ):
+            _save_state("sess-1", "%42")
+
+            result = cleanup("sess-1")
+
+            assert result is True
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert cmd == ["tmux", "kill-pane", "-t", "%42"]
+
+    def test_removes_state_after_cleanup(self, tmp_path):
+        with (
+            patch("tui_launcher._get_state_dir", return_value=tmp_path),
+            patch("subprocess.run"),
+        ):
+            _save_state("sess-1", "%42")
+            cleanup("sess-1")
+
+            assert _load_state("sess-1") is None
+
+    def test_returns_false_when_no_state(self, tmp_path):
+        with patch("tui_launcher._get_state_dir", return_value=tmp_path):
+            assert cleanup("nonexistent") is False
+
+    def test_returns_false_when_no_pane_id(self, tmp_path):
+        state_file = tmp_path / "tui-bad-state.json"
+        state_file.write_text(json.dumps({"session_id": "bad-state"}))
+        with patch("tui_launcher._get_state_dir", return_value=tmp_path):
+            result = cleanup("bad-state")
+
+        assert result is False
+
+    def test_handles_kill_error_gracefully(self, tmp_path):
+        with (
+            patch("tui_launcher._get_state_dir", return_value=tmp_path),
+            patch("subprocess.run", side_effect=Exception("tmux not running")),
+        ):
+            _save_state("sess-1", "%42")
+
+            result = cleanup("sess-1")
+
+            assert result is True
+            assert _load_state("sess-1") is None
+
+    def test_handles_kill_timeout(self, tmp_path):
+        with (
+            patch("tui_launcher._get_state_dir", return_value=tmp_path),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.TimeoutExpired("tmux", 5),
+            ),
+        ):
+            _save_state("sess-1", "%42")
+
+            result = cleanup("sess-1")
+
+            assert result is True


### PR DESCRIPTION
## Summary
- Add `tui_launcher.py` module for managing companion TUI via tmux split panes
- Integrate TUI launch in `session-start.py` (Step 7) and cleanup in `stop.py`
- Graceful degradation: tmux unavailable → skip with helpful message

## Changes
- **NEW** `packages/claude-code-plugin/hooks/lib/tui_launcher.py` — TUI launch/cleanup module with i18n (en/ko/ja/zh/es)
- **NEW** `packages/claude-code-plugin/tests/test_tui_launcher.py` — 42 unit tests
- **MOD** `packages/claude-code-plugin/hooks/session-start.py` — Step 7: TUI launch
- **MOD** `packages/claude-code-plugin/hooks/stop.py` — TUI pane cleanup

## Behavior
| Condition | Action |
|-----------|--------|
| `tui: true` + tmux + ≥160 cols | 40% right split |
| `tui: true` + tmux + 120-159 cols | 30% compact split |
| `tui: true` + tmux + <120 cols | Skip (too narrow) |
| `tui: false` | Skip |
| No tmux | Skip + install hint |
| Not in tmux session | Skip + usage hint |

## Test plan
- [x] 42 unit tests pass (`pytest test_tui_launcher.py`)
- [x] No regressions in existing 264 tests
- [ ] Manual: verify tmux split in real tmux session
- [ ] Manual: verify graceful skip outside tmux

Closes #970