### PR TITLE
feat(plugin): add agent status message to PreToolUse hook

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/agent_status.py
+++ b/packages/claude-code-plugin/hooks/lib/agent_status.py
@@ -1,0 +1,133 @@
+"""Agent status message builder for CodingBuddy hooks.
+
+Reads the active agent from CODINGBUDDY_ACTIVE_AGENT env var,
+loads visual data (eye, colorAnsi) from the agent JSON file,
+and builds a one-line status message for the spinner display.
+"""
+import json
+import os
+from typing import Optional
+
+_DEFAULT_STATUS = "CodingBuddy working..."
+
+_COLOR_EMOJI_MAP = {
+    "red": "\U0001f534",       # 🔴
+    "green": "\U0001f7e2",     # 🟢
+    "blue": "\U0001f535",      # 🔵
+    "yellow": "\U0001f7e1",    # 🟡
+    "cyan": "\U0001f535",      # 🔵
+    "magenta": "\U0001f7e3",   # 🟣
+    "white": "\u26aa",         # ⚪
+    "bright": "\u2728",        # ✨
+}
+
+# Cache: agents_dir path (avoids repeated filesystem walks)
+_agents_dir_cache: Optional[str] = None
+_agents_dir_cache_root: Optional[str] = None
+
+# Cache: agent_name -> visual dict
+_visual_cache: dict = {}
+
+
+def _find_agents_dir(project_root: str) -> Optional[str]:
+    """Find the .ai-rules/agents directory from the project root."""
+    global _agents_dir_cache, _agents_dir_cache_root
+    if _agents_dir_cache_root == project_root and _agents_dir_cache is not None:
+        return _agents_dir_cache if _agents_dir_cache else None
+
+    candidates = [
+        os.path.join(project_root, "packages", "rules", ".ai-rules", "agents"),
+        os.path.join(project_root, ".ai-rules", "agents"),
+    ]
+    for c in candidates:
+        if os.path.isdir(c):
+            _agents_dir_cache = c
+            _agents_dir_cache_root = project_root
+            return c
+
+    _agents_dir_cache = ""
+    _agents_dir_cache_root = project_root
+    return None
+
+
+def _load_agent_visual(agent_name: str, project_root: str) -> Optional[dict]:
+    """Load visual data for a named agent from its JSON file."""
+    if agent_name in _visual_cache:
+        return _visual_cache[agent_name]
+
+    agents_dir = _find_agents_dir(project_root)
+    if not agents_dir:
+        return None
+
+    # Fast path: slug-based filename lookup
+    slug = agent_name.lower().replace(" ", "-").replace("_", "-")
+    path = os.path.join(agents_dir, f"{slug}.json")
+    if os.path.isfile(path):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            visual = data.get("visual")
+            _visual_cache[agent_name] = visual
+            return visual
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    # Slow path: scan all JSON files by name field
+    try:
+        for fn in os.listdir(agents_dir):
+            if not fn.endswith(".json"):
+                continue
+            fp = os.path.join(agents_dir, fn)
+            try:
+                with open(fp, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if data.get("name", "").lower() == agent_name.lower():
+                    visual = data.get("visual")
+                    _visual_cache[agent_name] = visual
+                    return visual
+            except (OSError, json.JSONDecodeError):
+                continue
+    except OSError:
+        pass
+
+    _visual_cache[agent_name] = None
+    return None
+
+
+def build_status_message(project_root: Optional[str] = None) -> Optional[str]:
+    """Build a one-line agent status message for spinner display.
+
+    Returns:
+        Formatted status like '🟡 ★‿★ Frontend Developer' when agent active,
+        default 'CodingBuddy working...' when agent name set but visual not found,
+        or None when no agent is active.
+    """
+    agent_name = os.environ.get("CODINGBUDDY_ACTIVE_AGENT", "")
+    if not agent_name:
+        return None
+
+    if project_root is None:
+        project_root = os.environ.get(
+            "CLAUDE_PROJECT_DIR",
+            os.environ.get("CLAUDE_CWD", os.getcwd()),
+        )
+
+    visual = _load_agent_visual(agent_name, project_root)
+
+    if not visual:
+        return f"\U0001f916 {agent_name}"  # 🤖 fallback
+
+    eye = visual.get("eye", "\u25cf")  # ● default
+    color = visual.get("colorAnsi", "white")
+    emoji = _COLOR_EMOJI_MAP.get(color, "\u26aa")  # ⚪ default
+
+    face = f"{eye}\u203f{eye}"  # eye‿eye
+    return f"{emoji} {face} {agent_name}"
+
+
+def clear_cache() -> None:
+    """Clear all caches. Useful for testing."""
+    global _agents_dir_cache, _agents_dir_cache_root
+    _agents_dir_cache = None
+    _agents_dir_cache_root = None
+    _visual_cache.clear()

--- a/packages/claude-code-plugin/hooks/pre-tool-use.py
+++ b/packages/claude-code-plugin/hooks/pre-tool-use.py
@@ -4,6 +4,7 @@
 Intercepts Bash tool calls to enforce quality gates on git commit commands.
 Detects .ai-rules/config changes via FileWatcher (#823).
 Suggests related tests for staged files via SmartTestRunner (#944).
+Displays active agent status in spinner via statusMessage (#974).
 Uses safe_main decorator to ensure Claude Code is never blocked.
 """
 import json
@@ -21,6 +22,7 @@ if _lib_dir not in sys.path:
 
 from safe_main import safe_main
 from config import get_config
+from agent_status import build_status_message
 
 # Pattern to detect git commit in a command string
 _GIT_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
@@ -161,43 +163,46 @@ def _handle(data: dict) -> Optional[dict]:
     Returns:
         Hook output dict or None for no intervention.
     """
+    # Build agent status message for spinner (#974) — applies to ALL tools
+    status_msg = build_status_message()
+
     tool_name = data.get("tool_name", "")
-
-    # Only process Bash tool
-    if tool_name != "Bash":
-        return None
-
     contexts = []
 
-    # Check for file changes (#823)
-    file_change_msg = _check_file_changes(data)
-    if file_change_msg:
-        contexts.append(file_change_msg)
+    # Bash-specific checks
+    if tool_name == "Bash":
+        # Check for file changes (#823)
+        file_change_msg = _check_file_changes(data)
+        if file_change_msg:
+            contexts.append(file_change_msg)
 
-    command = data.get("tool_input", {}).get("command", "")
+        command = data.get("tool_input", {}).get("command", "")
 
-    # Check git commit quality gates and smart test suggestion (#944)
-    if _is_git_commit(command):
-        config = _get_hook_config()
-        quality_gates = config.get("qualityGates", {})
-        if quality_gates.get("enabled", False):
-            contexts.append(QUALITY_GATE_CONTEXT)
+        # Check git commit quality gates and smart test suggestion (#944)
+        if _is_git_commit(command):
+            config = _get_hook_config()
+            quality_gates = config.get("qualityGates", {})
+            if quality_gates.get("enabled", False):
+                contexts.append(QUALITY_GATE_CONTEXT)
 
-        # Smart test runner — suggest related tests for staged files
-        staged = _get_staged_files()
-        if staged:
-            suggestion = _get_test_suggestion(staged)
-            if suggestion:
-                contexts.append(suggestion)
+            # Smart test runner — suggest related tests for staged files
+            staged = _get_staged_files()
+            if staged:
+                suggestion = _get_test_suggestion(staged)
+                if suggestion:
+                    contexts.append(suggestion)
 
-    if not contexts:
+    # Build response — include statusMessage and/or additionalContext
+    if not status_msg and not contexts:
         return None
 
-    return {
-        "hookSpecificOutput": {
-            "additionalContext": "\n\n".join(contexts),
-        }
-    }
+    hook_output: dict = {}
+    if status_msg:
+        hook_output["statusMessage"] = status_msg
+    if contexts:
+        hook_output["additionalContext"] = "\n\n".join(contexts)
+
+    return {"hookSpecificOutput": hook_output}
 
 
 @safe_main

--- a/packages/claude-code-plugin/tests/test_agent_status.py
+++ b/packages/claude-code-plugin/tests/test_agent_status.py
@@ -1,0 +1,180 @@
+"""Tests for hooks/lib/agent_status.py — Agent status message builder."""
+import json
+import os
+import sys
+
+import pytest
+
+# Add hooks/lib to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks", "lib"))
+
+from agent_status import build_status_message, clear_cache, _COLOR_EMOJI_MAP
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    """Clear caches before each test."""
+    clear_cache()
+    yield
+    clear_cache()
+
+
+@pytest.fixture
+def agents_dir(tmp_path):
+    """Create a temporary agents directory with sample agent JSON files."""
+    agents = tmp_path / "agents"
+    agents.mkdir()
+
+    frontend = {
+        "name": "Frontend Developer",
+        "visual": {
+            "eye": "\u2605",
+            "eyeFallback": "O",
+            "colorAnsi": "yellow",
+            "group": "frontend",
+        },
+    }
+    (agents / "frontend-developer.json").write_text(
+        json.dumps(frontend), encoding="utf-8"
+    )
+
+    backend = {
+        "name": "Backend Developer",
+        "visual": {
+            "eye": "\u25cf",
+            "colorAnsi": "green",
+        },
+    }
+    (agents / "backend-developer.json").write_text(
+        json.dumps(backend), encoding="utf-8"
+    )
+
+    no_visual = {"name": "Plain Agent"}
+    (agents / "plain-agent.json").write_text(
+        json.dumps(no_visual), encoding="utf-8"
+    )
+
+    return agents
+
+
+@pytest.fixture
+def project_with_agents(tmp_path, agents_dir):
+    """Create a project root with .ai-rules/agents structure."""
+    ai_rules = tmp_path / ".ai-rules" / "agents"
+    ai_rules.mkdir(parents=True)
+
+    # Copy agent files into .ai-rules/agents
+    for f in agents_dir.iterdir():
+        (ai_rules / f.name).write_text(f.read_text(), encoding="utf-8")
+
+    return str(tmp_path)
+
+
+class TestBuildStatusMessageNoAgent:
+    """Tests when no agent is active."""
+
+    def test_returns_none_when_env_not_set(self, monkeypatch):
+        monkeypatch.delenv("CODINGBUDDY_ACTIVE_AGENT", raising=False)
+        assert build_status_message() is None
+
+    def test_returns_none_when_env_empty(self, monkeypatch):
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "")
+        assert build_status_message() is None
+
+
+class TestBuildStatusMessageWithAgent:
+    """Tests when an agent is active."""
+
+    def test_agent_with_visual_data(self, monkeypatch, project_with_agents):
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "frontend-developer")
+        result = build_status_message(project_root=project_with_agents)
+        # yellow -> 🟡, eye=★, face=★‿★
+        assert "\U0001f7e1" in result  # 🟡
+        assert "\u2605\u203f\u2605" in result  # ★‿★
+        assert "frontend-developer" in result
+
+    def test_agent_by_display_name(self, monkeypatch, project_with_agents):
+        """Should find agent by display name via slow-path scan."""
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "Backend Developer")
+        result = build_status_message(project_root=project_with_agents)
+        assert "\U0001f7e2" in result  # 🟢
+        assert "\u25cf\u203f\u25cf" in result  # ●‿●
+        assert "Backend Developer" in result
+
+    def test_agent_not_found_fallback(self, monkeypatch, project_with_agents):
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "nonexistent-agent")
+        result = build_status_message(project_root=project_with_agents)
+        assert "\U0001f916" in result  # 🤖
+        assert "nonexistent-agent" in result
+
+    def test_agent_without_visual_field(self, monkeypatch, project_with_agents):
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "plain-agent")
+        result = build_status_message(project_root=project_with_agents)
+        # No visual -> robot fallback
+        assert "\U0001f916" in result  # 🤖
+        assert "plain-agent" in result
+
+    def test_no_agents_dir_fallback(self, monkeypatch, tmp_path):
+        """When agents dir doesn't exist, returns robot fallback."""
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "some-agent")
+        result = build_status_message(project_root=str(tmp_path))
+        assert "\U0001f916" in result
+        assert "some-agent" in result
+
+
+class TestBuildStatusMessageProjectRoot:
+    """Tests for project root resolution."""
+
+    def test_uses_claude_project_dir_env(self, monkeypatch, project_with_agents):
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "frontend-developer")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", project_with_agents)
+        result = build_status_message()  # No explicit project_root
+        assert "\u2605\u203f\u2605" in result  # ★‿★
+
+    def test_uses_claude_cwd_env_fallback(self, monkeypatch, project_with_agents):
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "frontend-developer")
+        monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+        monkeypatch.setenv("CLAUDE_CWD", project_with_agents)
+        result = build_status_message()
+        assert "\u2605\u203f\u2605" in result
+
+
+class TestColorEmojiMap:
+    """Tests for the color-to-emoji mapping completeness."""
+
+    def test_all_known_colors_mapped(self):
+        expected = {"red", "green", "blue", "yellow", "cyan", "magenta", "white", "bright"}
+        assert set(_COLOR_EMOJI_MAP.keys()) == expected
+
+    def test_unknown_color_returns_white(self, monkeypatch, project_with_agents):
+        """Agent with unknown colorAnsi should get white circle."""
+        # Create agent with unknown color
+        agent_file = os.path.join(
+            project_with_agents, ".ai-rules", "agents", "custom-agent.json"
+        )
+        with open(agent_file, "w") as f:
+            json.dump(
+                {"name": "Custom Agent", "visual": {"eye": "X", "colorAnsi": "pink"}},
+                f,
+            )
+
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "custom-agent")
+        result = build_status_message(project_root=project_with_agents)
+        assert "\u26aa" in result  # ⚪ default
+
+
+class TestCaching:
+    """Tests for cache behavior."""
+
+    def test_cache_reuses_result(self, monkeypatch, project_with_agents):
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "frontend-developer")
+        r1 = build_status_message(project_root=project_with_agents)
+        r2 = build_status_message(project_root=project_with_agents)
+        assert r1 == r2
+
+    def test_clear_cache_resets(self, monkeypatch, project_with_agents):
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "frontend-developer")
+        r1 = build_status_message(project_root=project_with_agents)
+        clear_cache()
+        r2 = build_status_message(project_root=project_with_agents)
+        assert r1 == r2  # Same result, but freshly loaded

--- a/packages/claude-code-plugin/tests/test_pre_tool_use.py
+++ b/packages/claude-code-plugin/tests/test_pre_tool_use.py
@@ -239,3 +239,90 @@ class TestPreToolUseSmartTestRunner:
         )
         # Should not crash — returns None (no suggestion)
         assert result is None
+
+
+class TestPreToolUseStatusMessage:
+    """Tests for agent statusMessage in hook output (#974)."""
+
+    def test_no_agent_returns_none_for_non_bash(self, monkeypatch, capsys):
+        """Without active agent, non-Bash tools still return None."""
+        monkeypatch.delenv("CODINGBUDDY_ACTIVE_AGENT", raising=False)
+        result = _run_hook(
+            {"tool_name": "Read", "tool_input": {"file_path": "/foo"}},
+            monkeypatch, capsys,
+        )
+        assert result is None
+
+    def test_active_agent_returns_status_for_non_bash(self, monkeypatch, capsys, tmp_path):
+        """With active agent, non-Bash tools get statusMessage."""
+        # Create agents dir with a test agent
+        agents_dir = tmp_path / ".ai-rules" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "test-agent.json").write_text(json.dumps({
+            "name": "Test Agent",
+            "visual": {"eye": "\u2605", "colorAnsi": "yellow"},
+        }))
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "test-agent")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        # Clear agent_status cache
+        from agent_status import clear_cache
+        clear_cache()
+
+        result = _run_hook(
+            {"tool_name": "Read", "tool_input": {"file_path": "/foo"}},
+            monkeypatch, capsys,
+        )
+        assert result is not None
+        status = result["hookSpecificOutput"]["statusMessage"]
+        assert "\u2605" in status  # eye character
+        assert "test-agent" in status
+
+    def test_active_agent_returns_status_for_bash(self, monkeypatch, capsys, tmp_path):
+        """With active agent, Bash tools also get statusMessage."""
+        agents_dir = tmp_path / ".ai-rules" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "my-agent.json").write_text(json.dumps({
+            "name": "My Agent",
+            "visual": {"eye": "\u25cf", "colorAnsi": "green"},
+        }))
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "my-agent")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        from agent_status import clear_cache
+        clear_cache()
+
+        result = _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "ls -la"}},
+            monkeypatch, capsys,
+        )
+        assert result is not None
+        status = result["hookSpecificOutput"]["statusMessage"]
+        assert "my-agent" in status
+        # No additionalContext for non-commit bash
+        assert "additionalContext" not in result["hookSpecificOutput"]
+
+    def test_status_combined_with_quality_gate(self, monkeypatch, capsys, tmp_path):
+        """statusMessage should coexist with additionalContext."""
+        agents_dir = tmp_path / ".ai-rules" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "dev-agent.json").write_text(json.dumps({
+            "name": "Dev Agent",
+            "visual": {"eye": "\u25b2", "colorAnsi": "red"},
+        }))
+        monkeypatch.setenv("CODINGBUDDY_ACTIVE_AGENT", "dev-agent")
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+
+        from agent_status import clear_cache
+        clear_cache()
+
+        config = {"qualityGates": {"enabled": True}}
+        result = _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "git commit -m 'test'"}},
+            monkeypatch, capsys, config=config,
+        )
+        assert result is not None
+        hook_out = result["hookSpecificOutput"]
+        assert "statusMessage" in hook_out
+        assert "additionalContext" in hook_out
+        assert "Quality Gate" in hook_out["additionalContext"]


### PR DESCRIPTION
## Summary
- Add `agent_status.py` lib module that reads `CODINGBUDDY_ACTIVE_AGENT` env var and loads visual data (eye, colorAnsi) from `agents/*.json`
- Modify PreToolUse hook to include `statusMessage` in `hookSpecificOutput` for all tool calls when an agent is active
- Display formatted agent character face in spinner (e.g. `🟡 ★‿★ Frontend Developer`)
- Fallback to 🤖 emoji when agent visual data not found, `None` when no agent active

## Test plan
- [x] 13 unit tests for `agent_status.py` (no agent, with visual, display name lookup, fallback, caching, color mapping)
- [x] 4 integration tests in `test_pre_tool_use.py` (no agent returns None, statusMessage for non-Bash, statusMessage for Bash, combined with quality gate)
- [x] All existing pre-tool-use tests pass (backward compatible)
- [x] All CI checks pass (lint, format, typecheck, coverage, circular, build)

Closes #974