### PR TITLE
feat(tui): add PLAN/ACT/EVAL mode screens to Companion TUI

### DIFF
--- a/apps/mcp-server/src/tui/components/ActModeScreen.tsx
+++ b/apps/mcp-server/src/tui/components/ActModeScreen.tsx
@@ -1,0 +1,64 @@
+/**
+ * ACT Mode Screen — Ink/React TUI component.
+ *
+ * Shows TDD phase progress, step-by-step status, and overall progress.
+ */
+import React, { useMemo } from 'react';
+import { Box, Text } from 'ink';
+import type { TddPhase, TddStep, DashboardNode } from '../dashboard-types';
+import { BORDER_COLORS } from '../utils/theme';
+import { renderActScreen, PHASE_COLORS, type ActScreenLine } from './act-screen.pure';
+
+export interface ActModeScreenProps {
+  currentPhase: TddPhase | null;
+  steps: readonly TddStep[];
+  agents: ReadonlyMap<string, DashboardNode>;
+  width: number;
+  height: number;
+}
+
+function getLineColor(line: ActScreenLine, currentPhase: TddPhase | null): string {
+  if (line.type === 'header') return 'magenta';
+  if (line.type === 'phase-bar' && currentPhase) return PHASE_COLORS[currentPhase];
+  if (line.type === 'progress') return 'cyan';
+  if (line.type === 'empty') return 'gray';
+  return 'white';
+}
+
+export function ActModeScreen({
+  currentPhase,
+  steps,
+  agents,
+  width,
+  height,
+}: ActModeScreenProps): React.ReactElement {
+  const lines = useMemo(
+    () => renderActScreen(currentPhase, steps, agents, width - 2),
+    [currentPhase, steps, agents, width],
+  );
+
+  const maxLines = Math.max(0, height - 2);
+  const visibleLines = lines.slice(0, maxLines);
+
+  return (
+    <Box
+      flexDirection="column"
+      width={width}
+      height={height}
+      borderStyle="round"
+      borderColor={BORDER_COLORS.panel}
+    >
+      {visibleLines.map((line, i) => (
+        <Text
+          key={i}
+          color={getLineColor(line, currentPhase)}
+          bold={line.type === 'header' || line.type === 'phase-bar'}
+          dimColor={line.type === 'empty'}
+          wrap="truncate"
+        >
+          {line.text}
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/apps/mcp-server/src/tui/components/EvalModeScreen.tsx
+++ b/apps/mcp-server/src/tui/components/EvalModeScreen.tsx
@@ -1,0 +1,60 @@
+/**
+ * EVAL Mode Screen — Ink/React TUI component.
+ *
+ * Shows per-agent review results, category scores, and aggregate score.
+ */
+import React, { useMemo } from 'react';
+import { Box, Text } from 'ink';
+import type { AgentReviewResult } from '../dashboard-types';
+import { BORDER_COLORS } from '../utils/theme';
+import { renderEvalScreen, type EvalScreenLine } from './eval-screen.pure';
+
+export interface EvalModeScreenProps {
+  results: readonly AgentReviewResult[];
+  width: number;
+  height: number;
+}
+
+const LINE_COLORS: Record<EvalScreenLine['type'], string> = {
+  header: 'magenta',
+  'agent-result': 'white',
+  category: 'cyan',
+  'total-score': 'green',
+  empty: 'gray',
+};
+
+export function EvalModeScreen({
+  results,
+  width,
+  height,
+}: EvalModeScreenProps): React.ReactElement {
+  const lines = useMemo(
+    () => renderEvalScreen(results, width - 2),
+    [results, width],
+  );
+
+  const maxLines = Math.max(0, height - 2);
+  const visibleLines = lines.slice(0, maxLines);
+
+  return (
+    <Box
+      flexDirection="column"
+      width={width}
+      height={height}
+      borderStyle="round"
+      borderColor={BORDER_COLORS.panel}
+    >
+      {visibleLines.map((line, i) => (
+        <Text
+          key={i}
+          color={LINE_COLORS[line.type]}
+          bold={line.type === 'header' || line.type === 'total-score'}
+          dimColor={line.type === 'empty'}
+          wrap="truncate"
+        >
+          {line.text}
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/apps/mcp-server/src/tui/components/ModeScreenRouter.tsx
+++ b/apps/mcp-server/src/tui/components/ModeScreenRouter.tsx
@@ -1,0 +1,142 @@
+/**
+ * Mode Screen Router — Routes to the correct mode-specific screen.
+ *
+ * Switches content area based on currentMode:
+ * - PLAN → PlanModeScreen (agent summoning + discussion)
+ * - ACT → ActModeScreen (TDD progress + steps)
+ * - EVAL → EvalModeScreen (review results + scores)
+ * - AUTO → cycles through the above based on current phase
+ * - null → FlowMap (default/idle)
+ *
+ * Also shows a disconnection banner when event bridge is disconnected.
+ */
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { Mode } from '../types';
+import type { DashboardState, ConnectionStatus, LayoutMode } from '../dashboard-types';
+import { PlanModeScreen } from './PlanModeScreen';
+import { ActModeScreen } from './ActModeScreen';
+import { EvalModeScreen } from './EvalModeScreen';
+import { FlowMap } from './FlowMap';
+
+export interface ModeScreenRouterProps {
+  state: DashboardState;
+  layoutMode: LayoutMode;
+  width: number;
+  height: number;
+  tick: number;
+  now: number;
+}
+
+/**
+ * Determine which mode screen to render.
+ * AUTO mode delegates to PLAN/ACT/EVAL based on context.
+ */
+export function resolveModeScreen(
+  mode: Mode | null,
+  hasDiscussionRounds: boolean,
+  hasTddSteps: boolean,
+  hasReviewResults: boolean,
+): 'plan' | 'act' | 'eval' | 'flow' {
+  if (mode === null) return 'flow';
+
+  if (mode === 'AUTO') {
+    // AUTO: choose screen based on available data
+    if (hasReviewResults) return 'eval';
+    if (hasTddSteps) return 'act';
+    if (hasDiscussionRounds) return 'plan';
+    return 'plan'; // default AUTO starts with PLAN
+  }
+
+  switch (mode) {
+    case 'PLAN':
+      return 'plan';
+    case 'ACT':
+      return 'act';
+    case 'EVAL':
+      return 'eval';
+  }
+}
+
+/**
+ * Render disconnection banner when event bridge is disconnected.
+ */
+function DisconnectBanner({
+  status,
+  width,
+}: {
+  status: ConnectionStatus;
+  width: number;
+}): React.ReactElement | null {
+  if (status === 'connected') return null;
+  const icon = status === 'reconnecting' ? '🔄' : '⚠️';
+  const msg = status === 'reconnecting' ? 'Reconnecting...' : 'Disconnected';
+  return (
+    <Box width={width} height={1}>
+      <Text color="yellow" bold>
+        {`${icon} Event Bridge: ${msg}`}
+      </Text>
+    </Box>
+  );
+}
+
+export function ModeScreenRouter({
+  state,
+  layoutMode,
+  width,
+  height,
+  tick,
+  now,
+}: ModeScreenRouterProps): React.ReactElement {
+  const bannerHeight = state.connectionStatus !== 'connected' ? 1 : 0;
+  const contentHeight = height - bannerHeight;
+
+  const screen = resolveModeScreen(
+    state.currentMode,
+    state.discussionRounds.length > 0,
+    state.tddSteps.length > 0,
+    state.reviewResults.length > 0,
+  );
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      <DisconnectBanner status={state.connectionStatus} width={width} />
+      {screen === 'plan' && (
+        <PlanModeScreen
+          agents={state.agents}
+          rounds={state.discussionRounds}
+          width={width}
+          height={contentHeight}
+        />
+      )}
+      {screen === 'act' && (
+        <ActModeScreen
+          currentPhase={state.tddCurrentPhase}
+          steps={state.tddSteps}
+          agents={state.agents}
+          width={width}
+          height={contentHeight}
+        />
+      )}
+      {screen === 'eval' && (
+        <EvalModeScreen
+          results={state.reviewResults}
+          width={width}
+          height={contentHeight}
+        />
+      )}
+      {screen === 'flow' && (
+        <FlowMap
+          agents={state.agents}
+          edges={state.edges}
+          layoutMode={layoutMode}
+          width={width}
+          height={contentHeight}
+          activeStage={state.currentMode}
+          tick={tick}
+          now={now}
+        />
+      )}
+    </Box>
+  );
+}

--- a/apps/mcp-server/src/tui/components/PlanModeScreen.tsx
+++ b/apps/mcp-server/src/tui/components/PlanModeScreen.tsx
@@ -1,0 +1,74 @@
+/**
+ * PLAN Mode Screen — Ink/React TUI component.
+ *
+ * Shows agent summoning list, discussion panel, and consensus.
+ */
+import React, { useMemo } from 'react';
+import { Box, Text } from 'ink';
+import type { DashboardNode } from '../dashboard-types';
+import type { DiscussionRound } from '../../collaboration/types';
+import { BORDER_COLORS } from '../utils/theme';
+import { renderPlanScreen, type PlanScreenLine } from './plan-screen.pure';
+import { AgentDiscussionPanel } from './AgentDiscussionPanel';
+
+export interface PlanModeScreenProps {
+  agents: ReadonlyMap<string, DashboardNode>;
+  rounds: readonly DiscussionRound[];
+  width: number;
+  height: number;
+}
+
+const LINE_COLORS: Record<PlanScreenLine['type'], string> = {
+  header: 'magenta',
+  agent: 'white',
+  discussion: 'cyan',
+  consensus: 'green',
+  empty: 'gray',
+};
+
+export function PlanModeScreen({
+  agents,
+  rounds,
+  width,
+  height,
+}: PlanModeScreenProps): React.ReactElement {
+  const summaryLines = useMemo(
+    () => renderPlanScreen(agents, rounds, width - 2),
+    [agents, rounds, width],
+  );
+
+  // Split height: summary panel gets ~40%, discussion gets ~60%
+  const summaryHeight = Math.max(5, Math.floor(height * 0.4));
+  const discussionHeight = height - summaryHeight;
+
+  return (
+    <Box flexDirection="column" width={width} height={height}>
+      <Box
+        flexDirection="column"
+        width={width}
+        height={summaryHeight}
+        borderStyle="round"
+        borderColor={BORDER_COLORS.panel}
+      >
+        {summaryLines.slice(0, summaryHeight - 2).map((line, i) => (
+          <Text
+            key={i}
+            color={LINE_COLORS[line.type]}
+            bold={line.type === 'header' || line.type === 'consensus'}
+            dimColor={line.type === 'empty'}
+            wrap="truncate"
+          >
+            {line.text}
+          </Text>
+        ))}
+      </Box>
+      {rounds.length > 0 && discussionHeight > 3 && (
+        <AgentDiscussionPanel
+          rounds={rounds}
+          width={width}
+          height={discussionHeight}
+        />
+      )}
+    </Box>
+  );
+}

--- a/apps/mcp-server/src/tui/components/act-screen.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/act-screen.pure.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderTddPhaseBar,
+  renderProgressBar,
+  renderTddSteps,
+  renderOverallProgress,
+  renderActScreen,
+} from './act-screen.pure';
+import type { TddStep, DashboardNode } from '../dashboard-types';
+
+function makeAgents(...entries: [string, Partial<DashboardNode>][]): Map<string, DashboardNode> {
+  const map = new Map<string, DashboardNode>();
+  for (const [id, partial] of entries) {
+    map.set(id, {
+      id,
+      name: partial.name ?? id,
+      stage: partial.stage ?? 'ACT',
+      status: partial.status ?? 'running',
+      isPrimary: partial.isPrimary ?? false,
+      progress: partial.progress ?? 0,
+      isParallel: partial.isParallel ?? false,
+    });
+  }
+  return map;
+}
+
+describe('act-screen.pure', () => {
+  describe('renderTddPhaseBar', () => {
+    it('should render all three phases', () => {
+      const lines = renderTddPhaseBar('RED', 80);
+      expect(lines[0].type).toBe('header');
+      const bar = lines[1].text;
+      expect(bar).toContain('RED');
+      expect(bar).toContain('GREEN');
+      expect(bar).toContain('REFACTOR');
+    });
+
+    it('should mark current phase with ►', () => {
+      const lines = renderTddPhaseBar('GREEN', 80);
+      const bar = lines[1].text;
+      expect(bar).toContain('►');
+      // RED should not have ►
+      const redIdx = bar.indexOf('RED');
+      const greenIdx = bar.indexOf('GREEN');
+      const markerIdx = bar.indexOf('►');
+      expect(markerIdx).toBeGreaterThan(redIdx);
+      expect(markerIdx).toBeLessThan(greenIdx);
+    });
+
+    it('should handle null phase', () => {
+      const lines = renderTddPhaseBar(null, 80);
+      expect(lines[1].text).not.toContain('►');
+    });
+  });
+
+  describe('renderProgressBar', () => {
+    it('should render 0%', () => {
+      const bar = renderProgressBar(0, 10);
+      expect(bar).toContain('░'.repeat(10));
+      expect(bar).toContain('0%');
+    });
+
+    it('should render 100%', () => {
+      const bar = renderProgressBar(100, 10);
+      expect(bar).toContain('█'.repeat(10));
+      expect(bar).toContain('100%');
+    });
+
+    it('should render 50%', () => {
+      const bar = renderProgressBar(50, 10);
+      expect(bar).toContain('█'.repeat(5));
+      expect(bar).toContain('░'.repeat(5));
+    });
+  });
+
+  describe('renderTddSteps', () => {
+    it('should show empty message when no steps', () => {
+      const lines = renderTddSteps([], 80);
+      expect(lines[1].text).toContain('no steps yet');
+    });
+
+    it('should render steps with status icons', () => {
+      const steps: TddStep[] = [
+        { id: '1', label: 'Write test', phase: 'RED', agentId: 'test-eng', status: 'done' },
+        { id: '2', label: 'Implement', phase: 'GREEN', agentId: null, status: 'active' },
+      ];
+      const lines = renderTddSteps(steps, 80);
+      expect(lines[1].text).toContain('✓');
+      expect(lines[1].text).toContain('Write test');
+      expect(lines[2].text).toContain('●');
+      expect(lines[2].text).toContain('Implement');
+    });
+  });
+
+  describe('renderOverallProgress', () => {
+    it('should calculate step-based progress', () => {
+      const steps: TddStep[] = [
+        { id: '1', label: 'a', phase: 'RED', agentId: null, status: 'done' },
+        { id: '2', label: 'b', phase: 'GREEN', agentId: null, status: 'done' },
+        { id: '3', label: 'c', phase: 'REFACTOR', agentId: null, status: 'pending' },
+      ];
+      const lines = renderOverallProgress(new Map(), steps, 80);
+      const text = lines.map(l => l.text).join(' ');
+      expect(text).toContain('67%');
+      expect(text).toContain('2/3');
+    });
+
+    it('should fall back to agent-based progress when no steps', () => {
+      const agents = makeAgents(['a1', { progress: 50 }]);
+      const lines = renderOverallProgress(agents, [], 80);
+      const text = lines.map(l => l.text).join(' ');
+      expect(text).toContain('50%');
+    });
+  });
+
+  describe('renderActScreen', () => {
+    it('should combine all sections', () => {
+      const lines = renderActScreen('RED', [], new Map(), 80);
+      expect(lines.some(l => l.type === 'header')).toBe(true);
+      expect(lines.some(l => l.type === 'phase-bar')).toBe(true);
+    });
+  });
+});

--- a/apps/mcp-server/src/tui/components/act-screen.pure.ts
+++ b/apps/mcp-server/src/tui/components/act-screen.pure.ts
@@ -1,0 +1,143 @@
+/**
+ * ACT Mode Screen — Pure rendering functions.
+ *
+ * Renders TDD phase progress bar (RED/GREEN/REFACTOR),
+ * step-by-step agent status, and overall progress for the ACT mode TUI screen.
+ */
+import type { TddPhase, TddStep, DashboardNode } from '../dashboard-types';
+
+export interface ActScreenLine {
+  type: 'header' | 'phase-bar' | 'step' | 'progress' | 'empty';
+  text: string;
+}
+
+const PHASE_ICONS: Record<TddPhase, string> = {
+  RED: '🔴',
+  GREEN: '🟢',
+  REFACTOR: '🔧',
+};
+
+const PHASE_COLORS: Record<TddPhase, string> = {
+  RED: 'red',
+  GREEN: 'green',
+  REFACTOR: 'yellow',
+};
+
+export { PHASE_COLORS };
+
+/**
+ * Render the TDD phase indicator bar.
+ * Shows RED → GREEN → REFACTOR with the current phase highlighted.
+ */
+export function renderTddPhaseBar(currentPhase: TddPhase | null, _width: number): ActScreenLine[] {
+  const lines: ActScreenLine[] = [];
+  lines.push({ type: 'header', text: '🧪 TDD Cycle' });
+
+  const phases: TddPhase[] = ['RED', 'GREEN', 'REFACTOR'];
+  const parts = phases.map(phase => {
+    const icon = PHASE_ICONS[phase];
+    const active = phase === currentPhase;
+    const marker = active ? '►' : ' ';
+    return `${marker}${icon} ${phase}`;
+  });
+
+  lines.push({ type: 'phase-bar', text: `  ${parts.join('  →  ')}` });
+  return lines;
+}
+
+/**
+ * Render a progress bar string of given width.
+ */
+export function renderProgressBar(percent: number, barWidth: number): string {
+  const filled = Math.round((percent / 100) * barWidth);
+  const empty = barWidth - filled;
+  return `[${'█'.repeat(filled)}${'░'.repeat(empty)}] ${percent}%`;
+}
+
+/**
+ * Render TDD steps with their status.
+ */
+export function renderTddSteps(steps: readonly TddStep[], width: number): ActScreenLine[] {
+  const lines: ActScreenLine[] = [];
+  lines.push({ type: 'header', text: '📝 Steps' });
+
+  if (steps.length === 0) {
+    lines.push({ type: 'empty', text: '  (no steps yet)' });
+    return lines;
+  }
+
+  for (const step of steps) {
+    const statusIcon = getStepStatusIcon(step.status);
+    const phaseIcon = PHASE_ICONS[step.phase];
+    const agent = step.agentId ? ` [${step.agentId}]` : '';
+    const text = `  ${statusIcon} ${phaseIcon} ${step.label}${agent}`;
+    lines.push({ type: 'step', text: text.slice(0, width) });
+  }
+
+  return lines;
+}
+
+function getStepStatusIcon(status: TddStep['status']): string {
+  switch (status) {
+    case 'pending':
+      return '○';
+    case 'active':
+      return '●';
+    case 'done':
+      return '✓';
+    case 'failed':
+      return '✗';
+  }
+}
+
+/**
+ * Render overall progress based on agent and step completion.
+ */
+export function renderOverallProgress(
+  agents: ReadonlyMap<string, DashboardNode>,
+  steps: readonly TddStep[],
+  width: number,
+): ActScreenLine[] {
+  const lines: ActScreenLine[] = [];
+
+  // Calculate step-based progress
+  const totalSteps = steps.length;
+  const doneSteps = steps.filter(s => s.status === 'done').length;
+  const stepPercent = totalSteps > 0 ? Math.round((doneSteps / totalSteps) * 100) : 0;
+
+  // Calculate agent-based progress
+  const agentArr = Array.from(agents.values()).filter(a => a.status !== 'idle' || a.isParallel);
+  const agentPercent =
+    agentArr.length > 0
+      ? Math.round(agentArr.reduce((sum, a) => sum + a.progress, 0) / agentArr.length)
+      : 0;
+
+  const overallPercent = totalSteps > 0 ? stepPercent : agentPercent;
+  const barWidth = Math.max(10, Math.min(40, width - 20));
+
+  lines.push({ type: 'header', text: '📊 Overall Progress' });
+  lines.push({ type: 'progress', text: `  ${renderProgressBar(overallPercent, barWidth)}` });
+  if (totalSteps > 0) {
+    lines.push({ type: 'progress', text: `  Steps: ${doneSteps}/${totalSteps}` });
+  }
+
+  return lines;
+}
+
+/**
+ * Render the complete ACT mode screen.
+ */
+export function renderActScreen(
+  currentPhase: TddPhase | null,
+  steps: readonly TddStep[],
+  agents: ReadonlyMap<string, DashboardNode>,
+  width: number,
+): ActScreenLine[] {
+  const lines: ActScreenLine[] = [];
+  lines.push(...renderTddPhaseBar(currentPhase, width));
+  lines.push({ type: 'empty', text: '' });
+  lines.push(...renderTddSteps(steps, width));
+  lines.push({ type: 'empty', text: '' });
+  lines.push(...renderOverallProgress(agents, steps, width));
+  return lines;
+}

--- a/apps/mcp-server/src/tui/components/eval-screen.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/eval-screen.pure.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderScoreBar,
+  renderAgentResult,
+  calculateAggregateScore,
+  renderEvalScreen,
+} from './eval-screen.pure';
+import type { AgentReviewResult } from '../dashboard-types';
+
+describe('eval-screen.pure', () => {
+  describe('renderScoreBar', () => {
+    it('should render 0 score', () => {
+      const bar = renderScoreBar(0, 100, 10);
+      expect(bar).toContain('░'.repeat(10));
+      expect(bar).toContain('0/100');
+    });
+
+    it('should render full score', () => {
+      const bar = renderScoreBar(100, 100, 10);
+      expect(bar).toContain('█'.repeat(10));
+      expect(bar).toContain('100/100');
+    });
+
+    it('should handle zero maxScore', () => {
+      const bar = renderScoreBar(0, 0, 10);
+      expect(bar).toContain('0/0');
+    });
+  });
+
+  describe('renderAgentResult', () => {
+    it('should render agent name with status icon', () => {
+      const result: AgentReviewResult = {
+        agentId: 'sec',
+        agentName: 'Security Specialist',
+        categories: [{ name: 'OWASP', score: 80, maxScore: 100 }],
+        totalScore: 80,
+        maxTotalScore: 100,
+        status: 'done',
+      };
+      const lines = renderAgentResult(result, 80);
+      expect(lines[0].text).toContain('✅');
+      expect(lines[0].text).toContain('Security Specialist');
+      expect(lines[1].text).toContain('OWASP');
+      expect(lines[2].text).toContain('Total');
+    });
+
+    it('should render pending status icon', () => {
+      const result: AgentReviewResult = {
+        agentId: 'a1',
+        agentName: 'Agent',
+        categories: [],
+        totalScore: 0,
+        maxTotalScore: 100,
+        status: 'pending',
+      };
+      const lines = renderAgentResult(result, 80);
+      expect(lines[0].text).toContain('⏳');
+    });
+  });
+
+  describe('calculateAggregateScore', () => {
+    it('should return zeros for empty results', () => {
+      expect(calculateAggregateScore([])).toEqual({ total: 0, max: 0, percent: 0 });
+    });
+
+    it('should aggregate multiple results', () => {
+      const results: AgentReviewResult[] = [
+        {
+          agentId: 'a1',
+          agentName: 'A1',
+          categories: [],
+          totalScore: 80,
+          maxTotalScore: 100,
+          status: 'done',
+        },
+        {
+          agentId: 'a2',
+          agentName: 'A2',
+          categories: [],
+          totalScore: 60,
+          maxTotalScore: 100,
+          status: 'done',
+        },
+      ];
+      const agg = calculateAggregateScore(results);
+      expect(agg.total).toBe(140);
+      expect(agg.max).toBe(200);
+      expect(agg.percent).toBe(70);
+    });
+  });
+
+  describe('renderEvalScreen', () => {
+    it('should show empty message when no results', () => {
+      const lines = renderEvalScreen([], 80);
+      expect(lines[1].text).toContain('no review results yet');
+    });
+
+    it('should render results with aggregate score', () => {
+      const results: AgentReviewResult[] = [
+        {
+          agentId: 'sec',
+          agentName: 'Security',
+          categories: [{ name: 'Auth', score: 90, maxScore: 100 }],
+          totalScore: 90,
+          maxTotalScore: 100,
+          status: 'done',
+        },
+      ];
+      const lines = renderEvalScreen(results, 80);
+      expect(lines.some(l => l.text.includes('Security'))).toBe(true);
+      expect(lines.some(l => l.text.includes('Aggregate'))).toBe(true);
+    });
+  });
+});

--- a/apps/mcp-server/src/tui/components/eval-screen.pure.ts
+++ b/apps/mcp-server/src/tui/components/eval-screen.pure.ts
@@ -1,0 +1,114 @@
+/**
+ * EVAL Mode Screen — Pure rendering functions.
+ *
+ * Renders per-agent review results (progress bar),
+ * category scores, and total score for the EVAL mode TUI screen.
+ */
+import type { AgentReviewResult } from '../dashboard-types';
+
+export interface EvalScreenLine {
+  type: 'header' | 'agent-result' | 'category' | 'total-score' | 'empty';
+  text: string;
+}
+
+/**
+ * Render a score bar (filled/empty) with percentage.
+ */
+export function renderScoreBar(score: number, maxScore: number, barWidth: number): string {
+  const percent = maxScore > 0 ? Math.round((score / maxScore) * 100) : 0;
+  const filled = Math.round((percent / 100) * barWidth);
+  const empty = barWidth - filled;
+  return `[${'█'.repeat(filled)}${'░'.repeat(empty)}] ${score}/${maxScore}`;
+}
+
+/**
+ * Render a single agent's review result.
+ */
+export function renderAgentResult(result: AgentReviewResult, width: number): EvalScreenLine[] {
+  const lines: EvalScreenLine[] = [];
+  const statusIcon = getResultStatusIcon(result.status);
+  const barWidth = Math.max(8, Math.min(20, width - 30));
+
+  lines.push({
+    type: 'agent-result',
+    text: `  ${statusIcon} ${result.agentName}`,
+  });
+
+  for (const cat of result.categories) {
+    const bar = renderScoreBar(cat.score, cat.maxScore, barWidth);
+    lines.push({
+      type: 'category',
+      text: `    ${padRight(cat.name, 16)} ${bar}`,
+    });
+  }
+
+  const totalBar = renderScoreBar(result.totalScore, result.maxTotalScore, barWidth);
+  lines.push({
+    type: 'total-score',
+    text: `    ${'Total'.padEnd(16)} ${totalBar}`,
+  });
+
+  return lines;
+}
+
+function getResultStatusIcon(status: AgentReviewResult['status']): string {
+  switch (status) {
+    case 'pending':
+      return '⏳';
+    case 'in-progress':
+      return '🔄';
+    case 'done':
+      return '✅';
+  }
+}
+
+function padRight(str: string, len: number): string {
+  return str.length >= len ? str.slice(0, len) : str + ' '.repeat(len - str.length);
+}
+
+/**
+ * Calculate the aggregate score across all review results.
+ */
+export function calculateAggregateScore(results: readonly AgentReviewResult[]): {
+  total: number;
+  max: number;
+  percent: number;
+} {
+  if (results.length === 0) return { total: 0, max: 0, percent: 0 };
+  const total = results.reduce((sum, r) => sum + r.totalScore, 0);
+  const max = results.reduce((sum, r) => sum + r.maxTotalScore, 0);
+  const percent = max > 0 ? Math.round((total / max) * 100) : 0;
+  return { total, max, percent };
+}
+
+/**
+ * Render the complete EVAL mode screen.
+ */
+export function renderEvalScreen(
+  results: readonly AgentReviewResult[],
+  width: number,
+): EvalScreenLine[] {
+  const lines: EvalScreenLine[] = [];
+  lines.push({ type: 'header', text: '📊 Review Results' });
+
+  if (results.length === 0) {
+    lines.push({ type: 'empty', text: '  (no review results yet)' });
+    return lines;
+  }
+
+  for (const result of results) {
+    lines.push(...renderAgentResult(result, width));
+    lines.push({ type: 'empty', text: '' });
+  }
+
+  // Aggregate score
+  const agg = calculateAggregateScore(results);
+  const barWidth = Math.max(8, Math.min(20, width - 30));
+  lines.push({ type: 'header', text: '🏆 Aggregate Score' });
+  lines.push({
+    type: 'total-score',
+    text: `  ${renderScoreBar(agg.total, agg.max, barWidth)} (${agg.percent}%)`,
+  });
+
+  return lines;
+}

--- a/apps/mcp-server/src/tui/components/index.ts
+++ b/apps/mcp-server/src/tui/components/index.ts
@@ -31,6 +31,32 @@ export { ActivityVisualizer, type ActivityVisualizerProps } from './ActivityVisu
 export { renderAgentTree, renderAgentStatusCard } from './activity-visualizer.pure';
 export { SessionTabBar } from './SessionTabBar';
 export type { SessionTabBarProps } from './SessionTabBar';
+export { PlanModeScreen } from './PlanModeScreen';
+export type { PlanModeScreenProps } from './PlanModeScreen';
+export { ActModeScreen } from './ActModeScreen';
+export type { ActModeScreenProps } from './ActModeScreen';
+export { EvalModeScreen } from './EvalModeScreen';
+export type { EvalModeScreenProps } from './EvalModeScreen';
+export { ModeScreenRouter, resolveModeScreen } from './ModeScreenRouter';
+export type { ModeScreenRouterProps } from './ModeScreenRouter';
+export {
+  renderPlanScreen,
+  renderAgentSummonList,
+  renderConsensusSummary,
+} from './plan-screen.pure';
+export {
+  renderActScreen,
+  renderTddPhaseBar,
+  renderTddSteps,
+  renderOverallProgress,
+  renderProgressBar,
+} from './act-screen.pure';
+export {
+  renderEvalScreen,
+  renderAgentResult,
+  renderScoreBar,
+  calculateAggregateScore,
+} from './eval-screen.pure';
 export {
   formatElapsed,
   formatRelativeTime,

--- a/apps/mcp-server/src/tui/components/plan-screen.pure.spec.ts
+++ b/apps/mcp-server/src/tui/components/plan-screen.pure.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderAgentSummonList,
+  renderConsensusSummary,
+  renderPlanScreen,
+} from './plan-screen.pure';
+import type { DashboardNode } from '../dashboard-types';
+import { createAgentOpinion, createDiscussionRound } from '../../collaboration/types';
+
+function makeAgents(...entries: [string, Partial<DashboardNode>][]): Map<string, DashboardNode> {
+  const map = new Map<string, DashboardNode>();
+  for (const [id, partial] of entries) {
+    map.set(id, {
+      id,
+      name: partial.name ?? id,
+      stage: partial.stage ?? 'PLAN',
+      status: partial.status ?? 'idle',
+      isPrimary: partial.isPrimary ?? false,
+      progress: partial.progress ?? 0,
+      isParallel: partial.isParallel ?? false,
+    });
+  }
+  return map;
+}
+
+describe('plan-screen.pure', () => {
+  describe('renderAgentSummonList', () => {
+    it('should show empty message when no agents', () => {
+      const lines = renderAgentSummonList(new Map(), 80);
+      expect(lines).toHaveLength(2);
+      expect(lines[0].type).toBe('header');
+      expect(lines[1].text).toContain('no agents summoned');
+    });
+
+    it('should render agents with status icons', () => {
+      const agents = makeAgents(
+        ['a1', { name: 'architect', status: 'running', isPrimary: true }],
+        ['a2', { name: 'security', status: 'idle' }],
+      );
+      const lines = renderAgentSummonList(agents, 80);
+      expect(lines.length).toBeGreaterThanOrEqual(3);
+      expect(lines[1].text).toContain('architect');
+      expect(lines[1].text).toContain('★');
+      expect(lines[2].text).toContain('security');
+    });
+
+    it('should truncate long lines to width', () => {
+      const agents = makeAgents(['a1', { name: 'a-very-long-agent-name-that-exceeds-width' }]);
+      const lines = renderAgentSummonList(agents, 30);
+      expect(lines[1].text.length).toBeLessThanOrEqual(30);
+    });
+  });
+
+  describe('renderConsensusSummary', () => {
+    it('should show empty message when no rounds', () => {
+      const lines = renderConsensusSummary([]);
+      expect(lines[0].text).toContain('no discussion yet');
+    });
+
+    it('should render consensus from last round', () => {
+      const round = createDiscussionRound(1, [
+        createAgentOpinion({ agentId: 'a1', agentName: 'A1', stance: 'approve', reasoning: 'ok' }),
+        createAgentOpinion({ agentId: 'a2', agentName: 'A2', stance: 'concern', reasoning: 'hmm' }),
+      ]);
+      const lines = renderConsensusSummary([round]);
+      expect(lines[0].type).toBe('header');
+      expect(lines[0].text).toContain('Round 1');
+      const consensusText = lines.map(l => l.text).join(' ');
+      expect(consensusText).toContain('Consensus reached');
+    });
+
+    it('should show not reached when rejections exist', () => {
+      const round = createDiscussionRound(1, [
+        createAgentOpinion({ agentId: 'a1', agentName: 'A1', stance: 'reject', reasoning: 'no' }),
+      ]);
+      const lines = renderConsensusSummary([round]);
+      const text = lines.map(l => l.text).join(' ');
+      expect(text).toContain('not reached');
+    });
+  });
+
+  describe('renderPlanScreen', () => {
+    it('should combine agent list and consensus', () => {
+      const agents = makeAgents(['a1', { name: 'architect', status: 'running' }]);
+      const lines = renderPlanScreen(agents, [], 80);
+      expect(lines.some(l => l.type === 'header')).toBe(true);
+      expect(lines.some(l => l.type === 'agent')).toBe(true);
+    });
+  });
+});

--- a/apps/mcp-server/src/tui/components/plan-screen.pure.ts
+++ b/apps/mcp-server/src/tui/components/plan-screen.pure.ts
@@ -1,0 +1,95 @@
+/**
+ * PLAN Mode Screen — Pure rendering functions.
+ *
+ * Renders agent summoning list (character + status), discussion display,
+ * and consensus result for the PLAN mode TUI screen.
+ */
+import type { DashboardNode } from '../dashboard-types';
+import type { DiscussionRound } from '../../collaboration/types';
+import { calculateConsensus, STANCE_ICONS } from '../../collaboration/types';
+
+export interface PlanScreenLine {
+  type: 'header' | 'agent' | 'discussion' | 'consensus' | 'empty';
+  text: string;
+}
+
+/**
+ * Render the agent summoning list for PLAN mode.
+ * Shows each agent with status indicator and role.
+ */
+export function renderAgentSummonList(
+  agents: ReadonlyMap<string, DashboardNode>,
+  width: number,
+): PlanScreenLine[] {
+  const lines: PlanScreenLine[] = [];
+  lines.push({ type: 'header', text: '📋 Summoned Agents' });
+
+  if (agents.size === 0) {
+    lines.push({ type: 'empty', text: '  (no agents summoned)' });
+    return lines;
+  }
+
+  for (const agent of agents.values()) {
+    const statusIcon = getAgentStatusIcon(agent.status);
+    const primaryTag = agent.isPrimary ? ' ★' : '';
+    const text = `  ${statusIcon} ${agent.name}${primaryTag} [${agent.status}]`;
+    lines.push({ type: 'agent', text: text.slice(0, width) });
+  }
+
+  return lines;
+}
+
+function getAgentStatusIcon(status: DashboardNode['status']): string {
+  switch (status) {
+    case 'running':
+      return '🔄';
+    case 'done':
+      return '✅';
+    case 'error':
+      return '❌';
+    case 'idle':
+      return '⏳';
+    case 'blocked':
+      return '🚫';
+  }
+}
+
+/**
+ * Render consensus summary from discussion rounds.
+ */
+export function renderConsensusSummary(rounds: readonly DiscussionRound[]): PlanScreenLine[] {
+  if (rounds.length === 0) {
+    return [{ type: 'empty', text: '  (no discussion yet)' }];
+  }
+
+  const lastRound = rounds[rounds.length - 1];
+  const consensus = calculateConsensus(lastRound.opinions);
+  const lines: PlanScreenLine[] = [];
+
+  lines.push({ type: 'header', text: `🗳️ Consensus (Round ${lastRound.roundNumber})` });
+  lines.push({
+    type: 'consensus',
+    text: `  ${STANCE_ICONS.approve} ${consensus.approveCount}  ${STANCE_ICONS.concern} ${consensus.concernCount}  ${STANCE_ICONS.reject} ${consensus.rejectCount}`,
+  });
+  lines.push({
+    type: 'consensus',
+    text: consensus.reached ? '  ✅ Consensus reached' : '  ⏳ Consensus not reached',
+  });
+
+  return lines;
+}
+
+/**
+ * Render the complete PLAN mode screen.
+ */
+export function renderPlanScreen(
+  agents: ReadonlyMap<string, DashboardNode>,
+  rounds: readonly DiscussionRound[],
+  width: number,
+): PlanScreenLine[] {
+  const lines: PlanScreenLine[] = [];
+  lines.push(...renderAgentSummonList(agents, width));
+  lines.push({ type: 'empty', text: '' });
+  lines.push(...renderConsensusSummary(rounds));
+  return lines;
+}

--- a/apps/mcp-server/src/tui/dashboard-app.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.tsx
@@ -6,8 +6,7 @@ import { useTerminalSize } from './hooks/use-terminal-size';
 import { useTick } from './hooks/use-tick';
 import { useDashboardState } from './hooks/use-dashboard-state';
 import { HeaderBar } from './components/HeaderBar';
-import { FlowMap } from './components/FlowMap';
-import { AgentDiscussionPanel } from './components/AgentDiscussionPanel';
+import { ModeScreenRouter } from './components/ModeScreenRouter';
 import { FocusedAgentPanel } from './components/FocusedAgentPanel';
 import { ChecklistPanel } from './components/ChecklistPanel';
 import { StageHealthBar } from './components/StageHealthBar';
@@ -78,24 +77,14 @@ export function DashboardApp({
             tick={tick}
             now={now}
           />
-          {state.discussionRounds.length > 0 ? (
-            <AgentDiscussionPanel
-              rounds={state.discussionRounds}
-              width={grid.flowMap.width}
-              height={grid.flowMap.height}
-            />
-          ) : (
-            <FlowMap
-              agents={state.agents}
-              edges={state.edges}
-              layoutMode={layoutMode}
-              width={grid.flowMap.width}
-              height={grid.flowMap.height}
-              activeStage={state.currentMode}
-              tick={tick}
-              now={now}
-            />
-          )}
+          <ModeScreenRouter
+            state={state}
+            layoutMode={layoutMode}
+            width={grid.flowMap.width}
+            height={grid.flowMap.height}
+            tick={tick}
+            now={now}
+          />
         </Box>
       ) : (
         <Box
@@ -104,24 +93,14 @@ export function DashboardApp({
           height={grid.checklistPanel.height + grid.focusedAgent.height}
         >
           <Box flexDirection="column" width={grid.flowMap.width}>
-            {state.discussionRounds.length > 0 ? (
-              <AgentDiscussionPanel
-                rounds={state.discussionRounds}
-                width={grid.flowMap.width}
-                height={grid.flowMap.height}
-              />
-            ) : (
-              <FlowMap
-                agents={state.agents}
-                edges={state.edges}
-                layoutMode={layoutMode}
-                width={grid.flowMap.width}
-                height={grid.flowMap.height}
-                activeStage={state.currentMode}
-                tick={tick}
-                now={now}
-              />
-            )}
+            <ModeScreenRouter
+              state={state}
+              layoutMode={layoutMode}
+              width={grid.flowMap.width}
+              height={grid.flowMap.height}
+              tick={tick}
+              now={now}
+            />
             <ActivityVisualizer
               currentMode={state.currentMode}
               focusedAgent={focusedAgent}

--- a/apps/mcp-server/src/tui/dashboard-types.spec.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.spec.ts
@@ -4,12 +4,19 @@ import {
   DASHBOARD_NODE_STATUSES,
   createEmptyStageStats,
   getLayoutMode,
+  createDefaultTddStep,
+  createDefaultReviewResult,
+  TDD_PHASES,
   type DashboardNode,
   type DashboardState,
   type StageStats,
   type GridRegion,
   type DashboardGrid,
   type ToolCallRecord,
+  type TddStep,
+  type AgentReviewResult,
+  type ReviewCategory,
+  type ConnectionStatus,
 } from './dashboard-types';
 import { createInitialDashboardState } from './hooks/use-dashboard-state';
 
@@ -197,6 +204,10 @@ describe('tui/dashboard-types', () => {
         contextMode: null,
         contextStatus: null,
         discussionRounds: [],
+        tddCurrentPhase: null,
+        tddSteps: [],
+        reviewResults: [],
+        connectionStatus: 'connected',
       };
       expect(state.toolInvokeCount).toBe(0);
       expect(state.outputStats).toEqual({ files: 0, commits: 0 });
@@ -226,6 +237,10 @@ describe('tui/dashboard-types', () => {
         contextMode: null,
         contextStatus: null,
         discussionRounds: [],
+        tddCurrentPhase: null,
+        tddSteps: [],
+        reviewResults: [],
+        connectionStatus: 'connected',
       };
       expect(state.agentActivateCount).toBe(0);
       expect(state.skillInvokeCount).toBe(0);
@@ -248,6 +263,97 @@ describe('tui/dashboard-types', () => {
       expect(grid.focusedAgent).toBeDefined();
       expect(grid.stageHealth).toBeDefined();
       expect(grid.total).toBeDefined();
+    });
+  });
+
+  describe('TDD_PHASES', () => {
+    it('should contain RED, GREEN, REFACTOR in order', () => {
+      expect(TDD_PHASES).toEqual(['RED', 'GREEN', 'REFACTOR']);
+    });
+
+    it('should be frozen', () => {
+      expect(Object.isFrozen(TDD_PHASES)).toBe(true);
+    });
+  });
+
+  describe('createDefaultTddStep', () => {
+    it('should apply defaults for optional fields', () => {
+      const step: TddStep = createDefaultTddStep({
+        id: 'step-1',
+        label: 'Write failing test',
+        phase: 'RED',
+      });
+      expect(step).toEqual({
+        id: 'step-1',
+        label: 'Write failing test',
+        phase: 'RED',
+        agentId: null,
+        status: 'pending',
+      });
+    });
+
+    it('should allow overriding defaults', () => {
+      const step: TddStep = createDefaultTddStep({
+        id: 'step-2',
+        label: 'Implement',
+        phase: 'GREEN',
+        agentId: 'test-engineer',
+        status: 'active',
+      });
+      expect(step.agentId).toBe('test-engineer');
+      expect(step.status).toBe('active');
+    });
+  });
+
+  describe('createDefaultReviewResult', () => {
+    it('should apply defaults for optional fields', () => {
+      const result: AgentReviewResult = createDefaultReviewResult({
+        agentId: 'security-specialist',
+        agentName: 'Security Specialist',
+      });
+      expect(result).toEqual({
+        agentId: 'security-specialist',
+        agentName: 'Security Specialist',
+        categories: [],
+        totalScore: 0,
+        maxTotalScore: 100,
+        status: 'pending',
+      });
+    });
+
+    it('should allow overriding defaults', () => {
+      const categories: ReviewCategory[] = [
+        { name: 'Security', score: 85, maxScore: 100 },
+        { name: 'Performance', score: 70, maxScore: 100 },
+      ];
+      const result: AgentReviewResult = createDefaultReviewResult({
+        agentId: 'code-reviewer',
+        agentName: 'Code Reviewer',
+        categories,
+        totalScore: 77,
+        maxTotalScore: 100,
+        status: 'done',
+      });
+      expect(result.categories).toHaveLength(2);
+      expect(result.totalScore).toBe(77);
+      expect(result.status).toBe('done');
+    });
+  });
+
+  describe('ConnectionStatus type', () => {
+    it('should accept valid connection statuses', () => {
+      const statuses: ConnectionStatus[] = ['connected', 'disconnected', 'reconnecting'];
+      expect(statuses).toHaveLength(3);
+    });
+  });
+
+  describe('DashboardState mode-screen fields', () => {
+    it('createInitialDashboardState includes new mode-screen fields', () => {
+      const state = createInitialDashboardState();
+      expect(state.tddCurrentPhase).toBeNull();
+      expect(state.tddSteps).toEqual([]);
+      expect(state.reviewResults).toEqual([]);
+      expect(state.connectionStatus).toBe('connected');
     });
   });
 });

--- a/apps/mcp-server/src/tui/dashboard-types.ts
+++ b/apps/mcp-server/src/tui/dashboard-types.ts
@@ -155,6 +155,80 @@ export interface ToolCallRecord {
 }
 
 /**
+ * TDD cycle phase for ACT mode screen.
+ */
+export type TddPhase = 'RED' | 'GREEN' | 'REFACTOR';
+
+export const TDD_PHASES: readonly TddPhase[] = Object.freeze(['RED', 'GREEN', 'REFACTOR']);
+
+/**
+ * A single TDD step in the ACT mode screen.
+ */
+export interface TddStep {
+  id: string;
+  label: string;
+  phase: TddPhase;
+  agentId: string | null;
+  status: 'pending' | 'active' | 'done' | 'failed';
+}
+
+/**
+ * Creates a TddStep with defaults.
+ */
+export function createDefaultTddStep(
+  params: Pick<TddStep, 'id' | 'label' | 'phase'> &
+    Partial<Omit<TddStep, 'id' | 'label' | 'phase'>>,
+): TddStep {
+  return {
+    agentId: null,
+    status: 'pending',
+    ...params,
+  };
+}
+
+/**
+ * A category score within an agent's EVAL review result.
+ */
+export interface ReviewCategory {
+  name: string;
+  score: number;
+  maxScore: number;
+}
+
+/**
+ * A single agent's review result in EVAL mode.
+ */
+export interface AgentReviewResult {
+  agentId: string;
+  agentName: string;
+  categories: ReviewCategory[];
+  totalScore: number;
+  maxTotalScore: number;
+  status: 'pending' | 'in-progress' | 'done';
+}
+
+/**
+ * Creates an AgentReviewResult with defaults.
+ */
+export function createDefaultReviewResult(
+  params: Pick<AgentReviewResult, 'agentId' | 'agentName'> &
+    Partial<Omit<AgentReviewResult, 'agentId' | 'agentName'>>,
+): AgentReviewResult {
+  return {
+    categories: [],
+    totalScore: 0,
+    maxTotalScore: 100,
+    status: 'pending',
+    ...params,
+  };
+}
+
+/**
+ * Event bridge connection status.
+ */
+export type ConnectionStatus = 'connected' | 'disconnected' | 'reconnecting';
+
+/**
  * Complete dashboard state containing all data needed to render the TUI.
  */
 export interface DashboardState {
@@ -180,6 +254,10 @@ export interface DashboardState {
   contextMode: string | null;
   contextStatus: string | null;
   discussionRounds: DiscussionRound[];
+  tddCurrentPhase: TddPhase | null;
+  tddSteps: TddStep[];
+  reviewResults: AgentReviewResult[];
+  connectionStatus: ConnectionStatus;
 }
 
 /**

--- a/apps/mcp-server/src/tui/events/index.ts
+++ b/apps/mcp-server/src/tui/events/index.ts
@@ -21,6 +21,10 @@ export {
   type SessionResetEvent,
   type ContextUpdatedEvent,
   type DiscussionRoundAddedEvent,
+  type TddPhaseChangedEvent,
+  type TddStepUpdatedEvent,
+  type ReviewResultAddedEvent,
+  type ConnectionStatusChangedEvent,
 } from './types';
 export {
   type AgentMetadata,

--- a/apps/mcp-server/src/tui/events/types.spec.ts
+++ b/apps/mcp-server/src/tui/events/types.spec.ts
@@ -18,7 +18,7 @@ import {
 
 describe('tui/events/types', () => {
   describe('TUI_EVENTS', () => {
-    it('should define all 14 event names', () => {
+    it('should define all 18 event names', () => {
       expect(TUI_EVENTS).toEqual({
         AGENT_ACTIVATED: 'agent:activated',
         AGENT_DEACTIVATED: 'agent:deactivated',
@@ -34,6 +34,10 @@ describe('tui/events/types', () => {
         SESSION_RESET: 'session:reset',
         CONTEXT_UPDATED: 'context:updated',
         DISCUSSION_ROUND_ADDED: 'discussion:round-added',
+        TDD_PHASE_CHANGED: 'tdd:phase-changed',
+        TDD_STEP_UPDATED: 'tdd:step-updated',
+        REVIEW_RESULT_ADDED: 'review:result-added',
+        CONNECTION_STATUS_CHANGED: 'connection:status-changed',
       });
     });
 
@@ -189,6 +193,21 @@ describe('tui/events/types', () => {
         'session:reset': { reason: 'new-plan-session' },
         'context:updated': { decisions: ['Use JWT'], notes: [], mode: null, status: null },
         'discussion:round-added': { round: { roundNumber: 1, opinions: [], crossReviews: [] } },
+        'tdd:phase-changed': { phase: 'RED', previousPhase: null },
+        'tdd:step-updated': {
+          step: { id: 's1', label: 'Write test', phase: 'RED', agentId: null, status: 'pending' },
+        },
+        'review:result-added': {
+          result: {
+            agentId: 'a1',
+            agentName: 'Security',
+            categories: [],
+            totalScore: 0,
+            maxTotalScore: 100,
+            status: 'pending',
+          },
+        },
+        'connection:status-changed': { status: 'connected' },
       };
       expect(map['agent:activated'].agentId).toBe('a1');
     });

--- a/apps/mcp-server/src/tui/events/types.ts
+++ b/apps/mcp-server/src/tui/events/types.ts
@@ -5,7 +5,13 @@
  * Each event has a typed payload interface for type-safe emit/subscribe.
  */
 import type { Mode } from '../types';
-import type { EdgeType } from '../dashboard-types';
+import type {
+  EdgeType,
+  TddPhase,
+  TddStep,
+  AgentReviewResult,
+  ConnectionStatus,
+} from '../dashboard-types';
 import type { DiscussionRound } from '../../collaboration/types';
 import type { AgentMetadata } from './agent-metadata.types';
 
@@ -28,6 +34,10 @@ export const TUI_EVENTS = Object.freeze({
   SESSION_RESET: 'session:reset',
   CONTEXT_UPDATED: 'context:updated',
   DISCUSSION_ROUND_ADDED: 'discussion:round-added',
+  TDD_PHASE_CHANGED: 'tdd:phase-changed',
+  TDD_STEP_UPDATED: 'tdd:step-updated',
+  REVIEW_RESULT_ADDED: 'review:result-added',
+  CONNECTION_STATUS_CHANGED: 'connection:status-changed',
 } as const);
 
 export type TuiEventName = (typeof TUI_EVENTS)[keyof typeof TUI_EVENTS];
@@ -120,6 +130,28 @@ export interface DiscussionRoundAddedEvent {
   round: DiscussionRound;
 }
 
+/** Payload when TDD phase changes in ACT mode */
+export interface TddPhaseChangedEvent {
+  phase: TddPhase;
+  previousPhase: TddPhase | null;
+}
+
+/** Payload when a TDD step is updated in ACT mode */
+export interface TddStepUpdatedEvent {
+  step: TddStep;
+}
+
+/** Payload when an agent review result is added in EVAL mode */
+export interface ReviewResultAddedEvent {
+  result: AgentReviewResult;
+}
+
+/** Payload when event bridge connection status changes */
+export interface ConnectionStatusChangedEvent {
+  status: ConnectionStatus;
+  reason?: string;
+}
+
 /**
  * Maps event names to their payload types for type-safe emit/subscribe.
  */
@@ -138,4 +170,8 @@ export interface TuiEventMap {
   [TUI_EVENTS.SESSION_RESET]: SessionResetEvent;
   [TUI_EVENTS.CONTEXT_UPDATED]: ContextUpdatedEvent;
   [TUI_EVENTS.DISCUSSION_ROUND_ADDED]: DiscussionRoundAddedEvent;
+  [TUI_EVENTS.TDD_PHASE_CHANGED]: TddPhaseChangedEvent;
+  [TUI_EVENTS.TDD_STEP_UPDATED]: TddStepUpdatedEvent;
+  [TUI_EVENTS.REVIEW_RESULT_ADDED]: ReviewResultAddedEvent;
+  [TUI_EVENTS.CONNECTION_STATUS_CHANGED]: ConnectionStatusChangedEvent;
 }

--- a/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
+++ b/apps/mcp-server/src/tui/hooks/use-dashboard-state.ts
@@ -25,6 +25,10 @@ import {
   type SessionResetEvent,
   type ContextUpdatedEvent,
   type DiscussionRoundAddedEvent,
+  type TddPhaseChangedEvent,
+  type TddStepUpdatedEvent,
+  type ReviewResultAddedEvent,
+  type ConnectionStatusChangedEvent,
 } from '../events';
 import { selectFocusedAgent } from './use-focus-agent';
 
@@ -62,6 +66,10 @@ export function createInitialDashboardState(): DashboardState {
     contextMode: null,
     contextStatus: null,
     discussionRounds: [],
+    tddCurrentPhase: null,
+    tddSteps: [],
+    reviewResults: [],
+    connectionStatus: 'connected',
   };
 }
 
@@ -80,6 +88,10 @@ export type DashboardAction =
   | { type: 'SESSION_RESET'; payload: SessionResetEvent }
   | { type: 'CONTEXT_UPDATED'; payload: ContextUpdatedEvent }
   | { type: 'ADD_DISCUSSION_ROUND'; payload: DiscussionRoundAddedEvent }
+  | { type: 'TDD_PHASE_CHANGED'; payload: TddPhaseChangedEvent }
+  | { type: 'TDD_STEP_UPDATED'; payload: TddStepUpdatedEvent }
+  | { type: 'REVIEW_RESULT_ADDED'; payload: ReviewResultAddedEvent }
+  | { type: 'CONNECTION_STATUS_CHANGED'; payload: ConnectionStatusChangedEvent }
   | { type: 'CLEANUP_STALE_AGENTS'; payload: { now: number; ttlMs: number } };
 
 function cloneAgents(agents: Map<string, DashboardNode>): Map<string, DashboardNode> {
@@ -340,6 +352,34 @@ export function dashboardReducer(state: DashboardState, action: DashboardAction)
       return { ...state, agents, focusedAgentId };
     }
 
+    case 'TDD_PHASE_CHANGED': {
+      return { ...state, tddCurrentPhase: action.payload.phase };
+    }
+
+    case 'TDD_STEP_UPDATED': {
+      const { step } = action.payload;
+      const existing = state.tddSteps.findIndex(s => s.id === step.id);
+      const tddSteps =
+        existing >= 0
+          ? state.tddSteps.map((s, i) => (i === existing ? step : s))
+          : [...state.tddSteps, step];
+      return { ...state, tddSteps };
+    }
+
+    case 'REVIEW_RESULT_ADDED': {
+      const { result } = action.payload;
+      const idx = state.reviewResults.findIndex(r => r.agentId === result.agentId);
+      const reviewResults =
+        idx >= 0
+          ? state.reviewResults.map((r, i) => (i === idx ? result : r))
+          : [...state.reviewResults, result];
+      return { ...state, reviewResults };
+    }
+
+    case 'CONNECTION_STATUS_CHANGED': {
+      return { ...state, connectionStatus: action.payload.status };
+    }
+
     // Reserved: no emitter currently produces PARALLEL_COMPLETED. Subscription kept for forward compatibility.
     case 'PARALLEL_COMPLETED':
     case 'AGENTS_LOADED':
@@ -386,6 +426,14 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
       dispatch({ type: 'CONTEXT_UPDATED', payload: p });
     const onDiscussionRoundAdded = (p: DiscussionRoundAddedEvent) =>
       dispatch({ type: 'ADD_DISCUSSION_ROUND', payload: p });
+    const onTddPhaseChanged = (p: TddPhaseChangedEvent) =>
+      dispatch({ type: 'TDD_PHASE_CHANGED', payload: p });
+    const onTddStepUpdated = (p: TddStepUpdatedEvent) =>
+      dispatch({ type: 'TDD_STEP_UPDATED', payload: p });
+    const onReviewResultAdded = (p: ReviewResultAddedEvent) =>
+      dispatch({ type: 'REVIEW_RESULT_ADDED', payload: p });
+    const onConnectionStatusChanged = (p: ConnectionStatusChangedEvent) =>
+      dispatch({ type: 'CONNECTION_STATUS_CHANGED', payload: p });
 
     eventBus.on(TUI_EVENTS.AGENT_ACTIVATED, onActivated);
     eventBus.on(TUI_EVENTS.AGENT_DEACTIVATED, onDeactivated);
@@ -401,6 +449,10 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
     eventBus.on(TUI_EVENTS.SESSION_RESET, onSessionReset);
     eventBus.on(TUI_EVENTS.CONTEXT_UPDATED, onContextUpdated);
     eventBus.on(TUI_EVENTS.DISCUSSION_ROUND_ADDED, onDiscussionRoundAdded);
+    eventBus.on(TUI_EVENTS.TDD_PHASE_CHANGED, onTddPhaseChanged);
+    eventBus.on(TUI_EVENTS.TDD_STEP_UPDATED, onTddStepUpdated);
+    eventBus.on(TUI_EVENTS.REVIEW_RESULT_ADDED, onReviewResultAdded);
+    eventBus.on(TUI_EVENTS.CONNECTION_STATUS_CHANGED, onConnectionStatusChanged);
 
     return () => {
       eventBus.off(TUI_EVENTS.AGENT_ACTIVATED, onActivated);
@@ -417,6 +469,10 @@ export function useDashboardState(eventBus: TuiEventBus | undefined): DashboardS
       eventBus.off(TUI_EVENTS.SESSION_RESET, onSessionReset);
       eventBus.off(TUI_EVENTS.CONTEXT_UPDATED, onContextUpdated);
       eventBus.off(TUI_EVENTS.DISCUSSION_ROUND_ADDED, onDiscussionRoundAdded);
+      eventBus.off(TUI_EVENTS.TDD_PHASE_CHANGED, onTddPhaseChanged);
+      eventBus.off(TUI_EVENTS.TDD_STEP_UPDATED, onTddStepUpdated);
+      eventBus.off(TUI_EVENTS.REVIEW_RESULT_ADDED, onReviewResultAdded);
+      eventBus.off(TUI_EVENTS.CONNECTION_STATUS_CHANGED, onConnectionStatusChanged);
     };
   }, [eventBus]);
 


### PR DESCRIPTION
## Summary

- Add mode-specific TUI screens: PLAN (agent summoning + discussion + consensus), ACT (TDD phase bar + step progress), EVAL (review results + category scores + aggregate)
- Implement `ModeScreenRouter` that auto-switches content area based on `currentMode`
- Add new event types (`TDD_PHASE_CHANGED`, `TDD_STEP_UPDATED`, `REVIEW_RESULT_ADDED`, `CONNECTION_STATUS_CHANGED`) with full reducer handling
- Extend `DashboardState` with `tddCurrentPhase`, `tddSteps`, `reviewResults`, `connectionStatus`
- Pure/impure separation: all rendering logic in `.pure.ts` files with 27 unit tests
- Graceful disconnection banner when event bridge connection drops

## Test plan

- [x] All 27 new pure function tests pass (plan-screen, act-screen, eval-screen)
- [x] All 5140 existing tests pass (191 test files)
- [x] Lint: 0 errors
- [x] Format: all files formatted
- [x] Typecheck: passes
- [x] Circular dependency: none
- [x] Build: successful

Closes #973