### PR TITLE
fix(plugin): quote CLAUDE_PLUGIN_ROOT in hook commands for paths with spaces

### DIFF
--- a/packages/claude-code-plugin/hooks/hooks.json
+++ b/packages/claude-code-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.py\"",
             "timeout": 15,
             "statusMessage": "Loading CodingBuddy..."
           }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-use.py\"",
             "timeout": 5
           }
         ]
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.py\"",
             "timeout": 5
           }
         ]
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/stop.py",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/stop.py\"",
             "timeout": 10,
             "statusMessage": "Saving session stats..."
           }


### PR DESCRIPTION
## Summary
- Quote `${CLAUDE_PLUGIN_ROOT}` with escaped double quotes in all 4 hook commands in `hooks.json`
- Fixes shell word splitting on paths containing spaces (e.g. macOS `~/Library/Mobile Documents/...`)
- Critical fix: without this, all hooks fail and Claude Code becomes unresponsive when plugin is installed in a path with spaces

## Test plan
- [ ] Install plugin in a path containing spaces (e.g. via iCloud-synced directory)
- [ ] Verify all 4 hooks execute without `No such file or directory` errors
- [ ] Verify hooks still work on paths without spaces (no regression)

Closes #991