### PR TITLE
fix(scripts): add marketplace.json to bump-version.sh

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -81,7 +81,17 @@ node -e "
 "
 echo "  ✅ packages/claude-code-plugin/.claude-plugin/plugin.json"
 
-# 6. .mcp.json (if exists — gitignored, local only)
+# 6. .claude-plugin/marketplace.json (plugins[0].version)
+node -e "
+  const fs = require('fs');
+  const p = '.claude-plugin/marketplace.json';
+  const mkt = JSON.parse(fs.readFileSync(p, 'utf-8'));
+  mkt.plugins[0].version = '$NEW_VERSION';
+  fs.writeFileSync(p, JSON.stringify(mkt, null, 2) + '\n');
+"
+echo "  ✅ .claude-plugin/marketplace.json"
+
+# 7. .mcp.json (if exists — gitignored, local only)
 if [ -f ".mcp.json" ]; then
   node -e "
     const fs = require('fs');


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` (`plugins[0].version`) to `bump-version.sh` as target #6
- Renumber `.mcp.json` section from #6 to #7
- Ensures marketplace.json version is updated atomically with all other version-bearing files

Closes #961

## Test plan
- [ ] Run `bash -n scripts/bump-version.sh` — syntax check passes
- [ ] Run `./scripts/bump-version.sh 5.1.0` on a test branch and verify `.claude-plugin/marketplace.json` is updated