### PR TITLE
fix(plugin): resolve session ID with fallback when CLAUDE_SESSION_ID missing

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/session_utils.py
+++ b/packages/claude-code-plugin/hooks/lib/session_utils.py
@@ -1,0 +1,118 @@
+"""Session ID resolution utilities for CodingBuddy hooks (#976).
+
+Claude Code CLI does not always provide CLAUDE_SESSION_ID as an environment
+variable.  This module implements a multi-strategy fallback so that every hook
+can obtain a stable, unique session identifier.
+
+Resolution order:
+1. CLAUDE_SESSION_ID environment variable (official, when available)
+2. Last entry in ~/.claude/history.jsonl (sessionId field)
+3. Generate a UUID and persist it for the lifetime of the process
+"""
+
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Optional
+
+# Module-level cache — resolved once per process
+_cached_session_id: Optional[str] = None
+
+
+def _from_env() -> Optional[str]:
+    """Try CLAUDE_SESSION_ID environment variable."""
+    value = os.environ.get("CLAUDE_SESSION_ID")
+    if value and value != "unknown":
+        return value
+    return None
+
+
+def _from_history() -> Optional[str]:
+    """Parse the last line of ~/.claude/history.jsonl for sessionId."""
+    try:
+        history_file = Path.home() / ".claude" / "history.jsonl"
+        if not history_file.exists():
+            return None
+
+        # Read only the last line efficiently
+        with open(history_file, "rb") as f:
+            # Seek to end, then scan backwards for the last newline
+            f.seek(0, 2)  # end of file
+            size = f.tell()
+            if size == 0:
+                return None
+
+            # Read last 4KB at most (a single JSONL entry is typically small)
+            read_size = min(4096, size)
+            f.seek(size - read_size)
+            tail = f.read().decode("utf-8", errors="replace")
+
+        # Get the last non-empty line
+        lines = tail.strip().split("\n")
+        if not lines:
+            return None
+
+        last_line = lines[-1].strip()
+        if not last_line:
+            return None
+
+        data = json.loads(last_line)
+        session_id = data.get("sessionId")
+        if session_id and isinstance(session_id, str) and session_id != "unknown":
+            return session_id
+    except Exception:
+        pass
+    return None
+
+
+def _generate_persistent() -> str:
+    """Generate a UUID and persist it for the current session.
+
+    The file is written to ~/.codingbuddy/current_session_id so that
+    multiple hooks within the same session share the same generated ID.
+    """
+    session_file = Path(
+        os.environ.get("CLAUDE_PLUGIN_DATA", "")
+        or os.path.join(str(Path.home()), ".codingbuddy")
+    ) / "current_session_id"
+
+    # If a persisted ID already exists, reuse it
+    try:
+        if session_file.exists():
+            stored = session_file.read_text(encoding="utf-8").strip()
+            if stored:
+                return stored
+    except OSError:
+        pass
+
+    # Generate a new one
+    new_id = str(uuid.uuid4())
+    try:
+        session_file.parent.mkdir(parents=True, exist_ok=True)
+        session_file.write_text(new_id, encoding="utf-8")
+    except OSError:
+        pass  # Best-effort persistence
+    return new_id
+
+
+def get_session_id() -> str:
+    """Resolve the current Claude Code session ID.
+
+    Uses a module-level cache so the resolution runs at most once per
+    process (each hook invocation is a separate process, so the cache
+    lives for the duration of a single hook execution).
+
+    Returns:
+        A non-empty session ID string, never "unknown".
+    """
+    global _cached_session_id
+    if _cached_session_id is not None:
+        return _cached_session_id
+
+    _cached_session_id = (
+        _from_env()
+        or _from_history()
+        or _generate_persistent()
+    )
+    return _cached_session_id

--- a/packages/claude-code-plugin/hooks/post-tool-use.py
+++ b/packages/claude-code-plugin/hooks/post-tool-use.py
@@ -29,7 +29,8 @@ def handle_post_tool_use(data: dict):
     try:
         from stats import SessionStats
 
-        session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+        from session_utils import get_session_id
+        session_id = get_session_id()
         stats = SessionStats(session_id=session_id)
         tool_name = data.get("tool_name", "unknown")
         stats.record_tool_call(tool_name, success=True)
@@ -43,7 +44,8 @@ def handle_post_tool_use(data: dict):
         db = HistoryDB.get_instance()
         tool_name = data.get("tool_name", "unknown")
         input_summary = str(data.get("tool_input", {}))[:200]
-        session_id = os.environ.get("CLAUDE_SESSION_ID", "")
+        from session_utils import get_session_id as _get_sid_db
+        session_id = _get_sid_db()
         db.record_tool_call(session_id, tool_name, input_summary, success=True)
     except Exception:
         pass  # Never block tool execution

--- a/packages/claude-code-plugin/hooks/session-start.py
+++ b/packages/claude-code-plugin/hooks/session-start.py
@@ -514,7 +514,8 @@ def main():
 
             from stats import SessionStats
 
-            session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+            from session_utils import get_session_id
+            session_id = get_session_id()
             SessionStats(session_id=session_id)
             SessionStats.cleanup_stale(
                 os.environ.get("CLAUDE_PLUGIN_DATA",
@@ -529,7 +530,8 @@ def main():
 
             from history_db import HistoryDB
 
-            session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+            from session_utils import get_session_id as _get_sid_hist
+            session_id = _get_sid_hist()
             cwd = os.environ.get("CLAUDE_PROJECT_DIR", str(Path.cwd()))
             model = os.environ.get("CLAUDE_MODEL", "unknown")
             db = HistoryDB()
@@ -568,7 +570,8 @@ def main():
             try:
                 from history_db import HistoryDB as _HistoryDB
 
-                session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+                from session_utils import get_session_id as _get_sid_ret
+                session_id = _get_sid_ret()
                 _db = _HistoryDB()
                 previous_session = _db.get_previous_session(session_id, cwd)
                 _db.close()
@@ -596,7 +599,8 @@ def main():
             from tui_launcher import launch as launch_tui
             from config import get_config as _get_tui_cfg
 
-            _tui_sid = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+            from session_utils import get_session_id as _get_sid_tui
+            _tui_sid = _get_sid_tui()
             _tui_cwd = os.environ.get("CLAUDE_PROJECT_DIR", str(Path.cwd()))
             _tui_cfg = _get_tui_cfg(_tui_cwd)
             _tui_ok, _tui_msg = launch_tui(_tui_sid, _tui_cfg)

--- a/packages/claude-code-plugin/hooks/stop.py
+++ b/packages/claude-code-plugin/hooks/stop.py
@@ -25,7 +25,8 @@ def handle_stop(data: dict):
     try:
         from stats import SessionStats
 
-        session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+        from session_utils import get_session_id
+        session_id = get_session_id()
 
         # Clean up companion TUI pane (#970)
         try:


### PR DESCRIPTION
## Summary
- Add `session_utils.py` with multi-strategy session ID resolution: env var → `history.jsonl` → generate+persist UUID
- Update `session-start.py`, `post-tool-use.py`, and `stop.py` to use `get_session_id()` instead of direct `os.environ.get("CLAUDE_SESSION_ID", "unknown")`
- Fixes TUI showing empty data and all session records merging into single "unknown" entry

## Root Cause
Claude Code CLI does not provide `CLAUDE_SESSION_ID` as an environment variable, so all hooks defaulted to `"unknown"`.

## Changes
| File | Change |
|------|--------|
| `hooks/lib/session_utils.py` | **New** — `get_session_id()` with 3-tier fallback + module-level cache |
| `hooks/session-start.py` | Replace 4x `os.environ.get("CLAUDE_SESSION_ID", "unknown")` |
| `hooks/post-tool-use.py` | Replace 2x `CLAUDE_SESSION_ID` usage |
| `hooks/stop.py` | Replace 1x `CLAUDE_SESSION_ID` usage |

## Test plan
- [x] `session_utils` module imports and all functions work
- [x] `_from_env()` returns `None` when env var missing or "unknown"
- [x] `_from_env()` returns correct value when set
- [x] `get_session_id()` never returns empty or "unknown"
- [x] Module-level caching works correctly
- [x] No remaining direct `CLAUDE_SESSION_ID` references in hooks

Closes #976