### PR TITLE
feat(skills): add /plan-to-issues as built-in codingbuddy skill

### DIFF
--- a/packages/rules/.ai-rules/skills/plan-to-issues/SKILL.md
+++ b/packages/rules/.ai-rules/skills/plan-to-issues/SKILL.md
@@ -80,11 +80,11 @@ The skill accepts one of:
 
 2. **Validate with MCP tool**
 
-```
-Call: codingbuddy validate_parallel_issues
-  issues: [issue_numbers]
-  issueContents: { "1": "body1", "2": "body2", ... }
-```
+   ```
+   Call: codingbuddy validate_parallel_issues
+     issues: [issue_numbers]
+     issueContents: { "1": "body1", "2": "body2", ... }
+   ```
 
 3. **Apply the Iron Rule**
    - Same file in two deliverables = different waves


### PR DESCRIPTION
## Summary

- Add `/plan-to-issues` skill to `packages/rules/.ai-rules/skills/plan-to-issues/SKILL.md`
- Decomposes specs/plans into independent GitHub issues with dependency graphs, wave grouping, and file overlap analysis
- 5-phase workflow: Analyze, Overlap Detection, Prioritize, Create, Summarize

## Key Features

- **Iron Rule enforcement**: issues modifying the same file are never in the same wave
- **Integration** with `validate_parallel_issues` MCP tool for overlap validation
- **Wave grouping** compatible with `/taskmaestro` parallel execution
- **Priority labels** (P0-P3) and wave labels with auto-creation
- **Structured issue bodies** with acceptance criteria, file touchpoints, and dependency links

Closes #981

## Test plan

- [ ] Verify SKILL.md has valid YAML frontmatter (name, description)
- [ ] Verify skill follows existing skill format conventions
- [ ] Verify all 5 phases are documented with completion criteria
- [ ] Verify Iron Rule is enforced in overlap detection phase
- [ ] Verify `validate_parallel_issues` integration is documented
- [ ] Verify wave assignment rules prevent intra-wave file overlap
- [ ] Verify issue body template includes all required sections