### PR TITLE
feat(rules): add adapter auto-sync mechanism (yarn sync-rules)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "test:wiki": "yarn workspace codingbuddy exec vitest run --config ../../scripts/wiki/vitest.config.ts --root ../../scripts/wiki",
     "sync:settings": "npx tsx scripts/sync-settings/index.ts",
     "test:sync": "node apps/mcp-server/node_modules/.bin/vitest run --config scripts/sync-settings/vitest.config.ts --root .",
-    "test:hooks": "cd packages/claude-code-plugin && python3 -m pytest tests/ -v"
+    "test:hooks": "cd packages/claude-code-plugin && python3 -m pytest tests/ -v",
+    "sync-rules": "npx tsx scripts/sync-rules.ts",
+    "test:sync-rules": "node apps/mcp-server/node_modules/.bin/vitest run --config scripts/sync-rules.vitest.config.ts --root ."
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",

--- a/scripts/__tests__/sync-rules.spec.ts
+++ b/scripts/__tests__/sync-rules.spec.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  syncRules,
+  readSourceData,
+  generateFiles,
+  diffFiles,
+  writeFiles,
+} from '../sync-rules';
+
+describe('sync-rules', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sync-rules-test-'));
+
+    // Create .ai-rules source structure
+    const agentsDir = path.join(tmpDir, 'packages/rules/.ai-rules/agents');
+    const rulesDir = path.join(tmpDir, 'packages/rules/.ai-rules/rules');
+    await fs.mkdir(agentsDir, { recursive: true });
+    await fs.mkdir(rulesDir, { recursive: true });
+
+    // Create agent fixture
+    await fs.writeFile(
+      path.join(agentsDir, 'frontend-developer.json'),
+      JSON.stringify({
+        name: 'Frontend Developer',
+        description: 'Frontend specialist',
+        expertise: ['React'],
+      }),
+    );
+
+    // Create rule fixture
+    await fs.writeFile(path.join(rulesDir, 'core.md'), '# Core Rules\n');
+
+    // Create target directories
+    for (const dir of [
+      '.cursor/rules',
+      '.claude/rules',
+      '.antigravity/rules',
+      '.codex/rules',
+      '.q/rules',
+      '.kiro/rules',
+    ]) {
+      await fs.mkdir(path.join(tmpDir, dir), { recursive: true });
+    }
+  });
+
+  describe('readSourceData', () => {
+    it('reads agents and rules from .ai-rules', async () => {
+      const data = await readSourceData(tmpDir);
+
+      expect(data.agents).toHaveLength(1);
+      expect(data.agents[0].displayName).toBe('Frontend Developer');
+      expect(data.rules).toHaveLength(1);
+      expect(data.rules[0].name).toBe('core');
+    });
+  });
+
+  describe('generateFiles', () => {
+    it('generates files for all tools', async () => {
+      const data = await readSourceData(tmpDir);
+      const files = generateFiles(data);
+
+      expect(files.length).toBeGreaterThanOrEqual(7);
+      expect(files.some(f => f.relativePath.startsWith('.cursor/'))).toBe(true);
+      expect(files.some(f => f.relativePath.startsWith('.claude/'))).toBe(true);
+      expect(files.some(f => f.relativePath.startsWith('.codex/'))).toBe(true);
+    });
+
+    it('generates files for a specific tool', async () => {
+      const data = await readSourceData(tmpDir);
+      const files = generateFiles(data, ['cursor']);
+
+      expect(files).toHaveLength(2);
+      expect(files.every(f => f.relativePath.startsWith('.cursor/'))).toBe(true);
+    });
+  });
+
+  describe('diffFiles', () => {
+    it('reports added for missing files', async () => {
+      const data = await readSourceData(tmpDir);
+      const files = generateFiles(data, ['q']);
+      // Don't write anything first — file is "new"
+      // But we created the dir, so remove the file if it exists
+      const absPath = path.join(tmpDir, '.q/rules/customizations.md');
+      try {
+        await fs.unlink(absPath);
+      } catch {
+        // doesn't exist, that's fine
+      }
+
+      const changes = await diffFiles(tmpDir, files);
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0].status).toBe('added');
+    });
+
+    it('reports unchanged for identical files', async () => {
+      const data = await readSourceData(tmpDir);
+      const files = generateFiles(data, ['q']);
+      await writeFiles(tmpDir, files);
+
+      const changes = await diffFiles(tmpDir, files);
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0].status).toBe('unchanged');
+    });
+
+    it('reports modified for differing files', async () => {
+      const data = await readSourceData(tmpDir);
+      const files = generateFiles(data, ['q']);
+      // Write stale content
+      const absPath = path.join(tmpDir, files[0].relativePath);
+      await fs.writeFile(absPath, 'stale content', 'utf-8');
+
+      const changes = await diffFiles(tmpDir, files);
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0].status).toBe('modified');
+    });
+  });
+
+  describe('syncRules', () => {
+    it('writes files in default mode', async () => {
+      const result = await syncRules(tmpDir);
+
+      expect(result.outOfSync).toBe(true);
+      expect(result.changes.some(c => c.status === 'added')).toBe(true);
+
+      // Verify files were actually written
+      const content = await fs.readFile(
+        path.join(tmpDir, '.cursor/rules/auto-agent.mdc'),
+        'utf-8',
+      );
+      expect(content).toContain('frontend-developer');
+    });
+
+    it('does not write files in dry-run mode', async () => {
+      const result = await syncRules(tmpDir, { dryRun: true });
+
+      expect(result.outOfSync).toBe(true);
+
+      // Files should NOT have been written
+      await expect(
+        fs.readFile(path.join(tmpDir, '.codex/rules/system-prompt.md'), 'utf-8'),
+      ).rejects.toThrow();
+    });
+
+    it('does not write files in check mode', async () => {
+      const result = await syncRules(tmpDir, { check: true });
+
+      expect(result.outOfSync).toBe(true);
+
+      // Files should NOT have been written
+      await expect(
+        fs.readFile(path.join(tmpDir, '.codex/rules/system-prompt.md'), 'utf-8'),
+      ).rejects.toThrow();
+    });
+
+    it('returns outOfSync=false when files match', async () => {
+      // First sync to write all files
+      await syncRules(tmpDir);
+
+      // Check mode should pass
+      const result = await syncRules(tmpDir, { check: true });
+
+      expect(result.outOfSync).toBe(false);
+      expect(result.changes.every(c => c.status === 'unchanged')).toBe(true);
+    });
+
+    it('syncs only specified tools', async () => {
+      const result = await syncRules(tmpDir, { tools: ['kiro'] });
+
+      expect(result.changes).toHaveLength(1);
+      expect(result.changes[0].relativePath).toBe('.kiro/rules/guidelines.md');
+    });
+
+    it('is idempotent — running twice produces same result', async () => {
+      await syncRules(tmpDir);
+      const first = await fs.readFile(
+        path.join(tmpDir, '.cursor/rules/auto-agent.mdc'),
+        'utf-8',
+      );
+
+      await syncRules(tmpDir);
+      const second = await fs.readFile(
+        path.join(tmpDir, '.cursor/rules/auto-agent.mdc'),
+        'utf-8',
+      );
+
+      expect(first).toBe(second);
+    });
+  });
+});

--- a/scripts/sync-rules.ts
+++ b/scripts/sync-rules.ts
@@ -1,0 +1,211 @@
+#!/usr/bin/env npx tsx
+/**
+ * sync-rules — Keep tool-specific config files in sync with .ai-rules/ (Single Source of Truth).
+ *
+ * Usage:
+ *   npx tsx scripts/sync-rules.ts              # sync all tools (write files)
+ *   npx tsx scripts/sync-rules.ts --dry-run    # preview changes without writing
+ *   npx tsx scripts/sync-rules.ts --check      # CI validation — exit 1 if out of sync
+ *   npx tsx scripts/sync-rules.ts cursor       # sync single tool
+ *   npx tsx scripts/sync-rules.ts --check kiro # check single tool
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { readAgents, readRules } from './sync-settings/readers';
+import { generateAll, generateForTool } from './sync-settings/generators';
+import type { GeneratedFile, SourceData, ToolName } from './sync-settings/types';
+
+const VALID_TOOLS: ToolName[] = ['cursor', 'claude', 'antigravity', 'codex', 'q', 'kiro'];
+
+export interface SyncRulesOptions {
+  dryRun?: boolean;
+  check?: boolean;
+  tools?: ToolName[];
+}
+
+export interface FileChange {
+  relativePath: string;
+  status: 'added' | 'modified' | 'unchanged';
+}
+
+export interface SyncRulesResult {
+  changes: FileChange[];
+  outOfSync: boolean;
+}
+
+/**
+ * Read .ai-rules source data.
+ */
+export async function readSourceData(projectRoot: string): Promise<SourceData> {
+  const aiRulesBase = path.join(projectRoot, 'packages/rules/.ai-rules');
+  return {
+    agents: await readAgents(path.join(aiRulesBase, 'agents')),
+    rules: await readRules(path.join(aiRulesBase, 'rules'), 'packages/rules/.ai-rules/rules'),
+  };
+}
+
+/**
+ * Generate files for the requested tools.
+ */
+export function generateFiles(data: SourceData, tools?: ToolName[]): GeneratedFile[] {
+  return tools ? tools.flatMap(t => generateForTool(t, data)) : generateAll(data);
+}
+
+/**
+ * Compare generated content with what's on disk.
+ * Returns changes with status for each file.
+ */
+export async function diffFiles(
+  projectRoot: string,
+  files: GeneratedFile[],
+): Promise<FileChange[]> {
+  const changes: FileChange[] = [];
+
+  for (const file of files) {
+    const absPath = path.join(projectRoot, file.relativePath);
+    let current: string | null = null;
+    try {
+      current = await fs.readFile(absPath, 'utf-8');
+    } catch {
+      // file does not exist
+    }
+
+    if (current === null) {
+      changes.push({ relativePath: file.relativePath, status: 'added' });
+    } else if (current !== file.content) {
+      changes.push({ relativePath: file.relativePath, status: 'modified' });
+    } else {
+      changes.push({ relativePath: file.relativePath, status: 'unchanged' });
+    }
+  }
+
+  return changes;
+}
+
+/**
+ * Write generated files to disk.
+ */
+export async function writeFiles(
+  projectRoot: string,
+  files: GeneratedFile[],
+): Promise<void> {
+  for (const file of files) {
+    const absPath = path.join(projectRoot, file.relativePath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, file.content, 'utf-8');
+  }
+}
+
+/**
+ * Run sync-rules with the given options.
+ */
+export async function syncRules(
+  projectRoot: string,
+  options: SyncRulesOptions = {},
+): Promise<SyncRulesResult> {
+  const data = await readSourceData(projectRoot);
+  const files = generateFiles(data, options.tools);
+  const changes = await diffFiles(projectRoot, files);
+  const outOfSync = changes.some(c => c.status !== 'unchanged');
+
+  if (!options.dryRun && !options.check && outOfSync) {
+    await writeFiles(projectRoot, files);
+  }
+
+  return { changes, outOfSync };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv: string[]): SyncRulesOptions {
+  const args = argv.slice(2);
+  const options: SyncRulesOptions = {};
+  const toolArgs: string[] = [];
+
+  for (const arg of args) {
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--check') {
+      options.check = true;
+    } else {
+      toolArgs.push(arg);
+    }
+  }
+
+  if (toolArgs.length > 0) {
+    options.tools = toolArgs.map(arg => {
+      if (!VALID_TOOLS.includes(arg as ToolName)) {
+        console.error(`Unknown tool: ${arg}. Valid tools: ${VALID_TOOLS.join(', ')}`);
+        process.exit(1);
+      }
+      return arg as ToolName;
+    });
+  }
+
+  return options;
+}
+
+function formatStatus(status: FileChange['status']): string {
+  switch (status) {
+    case 'added':
+      return '+ (new)';
+    case 'modified':
+      return '~ (modified)';
+    case 'unchanged':
+      return '= (up to date)';
+  }
+}
+
+async function main(): Promise<void> {
+  const projectRoot = path.resolve(__dirname, '..');
+  const options = parseArgs(process.argv);
+
+  const scope = options.tools ? options.tools.join(', ') : 'all tools';
+
+  if (options.check) {
+    console.log(`Checking sync status for: ${scope}`);
+  } else if (options.dryRun) {
+    console.log(`Dry run for: ${scope}`);
+  } else {
+    console.log(`Syncing rules for: ${scope}`);
+  }
+
+  const result = await syncRules(projectRoot, options);
+
+  // Print status for each file
+  for (const change of result.changes) {
+    console.log(`  ${formatStatus(change.status)}  ${change.relativePath}`);
+  }
+
+  const changedCount = result.changes.filter(c => c.status !== 'unchanged').length;
+
+  if (options.check) {
+    if (result.outOfSync) {
+      console.error(`\nOut of sync! ${changedCount} file(s) differ from .ai-rules/ source.`);
+      console.error('Run `yarn sync-rules` to update.');
+      process.exit(1);
+    } else {
+      console.log('\nAll files are in sync.');
+    }
+  } else if (options.dryRun) {
+    if (result.outOfSync) {
+      console.log(`\n${changedCount} file(s) would be updated.`);
+    } else {
+      console.log('\nAll files are already in sync. No changes needed.');
+    }
+  } else {
+    if (changedCount > 0) {
+      console.log(`\nDone! ${changedCount} file(s) updated.`);
+    } else {
+      console.log('\nAll files already in sync. Nothing to do.');
+    }
+  }
+}
+
+main().catch(err => {
+  console.error('sync-rules failed:', err);
+  process.exit(1);
+});

--- a/scripts/sync-rules.vitest.config.ts
+++ b/scripts/sync-rules.vitest.config.ts
@@ -1,0 +1,7 @@
+export default {
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['scripts/__tests__/sync-rules.spec.ts'],
+  },
+};


### PR DESCRIPTION
## Summary

- `.ai-rules/` → 각 AI 도구 설정 파일 자동 동기화 CLI 추가
- `yarn sync-rules` — 모든 도구 설정 생성/업데이트
- `yarn sync-rules --dry-run` — 변경 사항 미리보기 (쓰기 없음)
- `yarn sync-rules --check` — CI 검증 모드 (비동기 시 exit 1)

## Changes

- `scripts/sync-rules.ts` — CLI 엔트리포인트 (기존 sync-settings readers/generators 재사용)
- `scripts/sync-rules.vitest.config.ts` — 테스트 설정
- `scripts/__tests__/sync-rules.spec.ts` — 12개 테스트 (dry-run, check, diff, idempotent 등)
- `package.json` — `sync-rules`, `test:sync-rules` 스크립트 추가

## Test plan

- [x] `yarn test:sync-rules` — 12 tests passing
- [x] `yarn sync-rules --check` — all files in sync
- [x] `yarn sync-rules --dry-run` — preview works correctly
- [x] Existing `yarn test:sync` — 23 tests still passing (no regression)

Closes #997