### PR TITLE
feat(plugin): add first-run interactive onboarding tour (#1037)

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/onboarding_tour.py
+++ b/packages/claude-code-plugin/hooks/lib/onboarding_tour.py
@@ -1,0 +1,217 @@
+"""First-run onboarding tour for CodingBuddy.
+
+Detects first-run via ~/.codingbuddy/onboarded flag file and renders
+an interactive 3-step tour introducing core features.
+"""
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from buddy_renderer import (
+    ANSI_COLORS,
+    BUDDY_FACE,
+    DEFAULT_BUDDY_CONFIG,
+    get_buddy_config,
+)
+
+# Flag file location
+ONBOARDED_DIR = os.path.join(os.path.expanduser("~"), ".codingbuddy")
+ONBOARDED_FLAG = os.path.join(ONBOARDED_DIR, "onboarded")
+
+# Environment variable to skip tour
+SKIP_ENV_VAR = "CODINGBUDDY_SKIP_TOUR"
+
+
+def is_first_run() -> bool:
+    """Check if this is the user's first run.
+
+    Returns:
+        True if onboarded flag does not exist and skip env var is not set.
+    """
+    if os.environ.get(SKIP_ENV_VAR):
+        return False
+    return not os.path.isfile(ONBOARDED_FLAG)
+
+
+def mark_onboarded() -> None:
+    """Create the onboarded flag file to prevent future tours."""
+    os.makedirs(ONBOARDED_DIR, exist_ok=True)
+    Path(ONBOARDED_FLAG).touch()
+
+
+# ── i18n Tour Content ──────────────────────────────────────────────
+
+TOUR_WELCOME: Dict[str, str] = {
+    "en": "Welcome to CodingBuddy! Here's a quick tour...",
+    "ko": "CodingBuddy에 오신 걸 환영해요! 간단히 소개할게요...",
+    "ja": "CodingBuddyへようこそ！簡単にご紹介します...",
+    "zh": "欢迎使用CodingBuddy！快速介绍一下...",
+    "es": "Bienvenido a CodingBuddy! Un tour rapido...",
+}
+
+TOUR_STEPS: Dict[int, Dict[str, Dict[str, str]]] = {
+    1: {
+        "en": {
+            "title": "PLAN/ACT/EVAL Workflow",
+            "body": "Type PLAN to design, ACT to implement, EVAL to review — or AUTO for the full cycle.",
+            "example": 'PLAN add user authentication',
+        },
+        "ko": {
+            "title": "PLAN/ACT/EVAL 워크플로우",
+            "body": "PLAN으로 설계, ACT로 구현, EVAL로 검토 — 또는 AUTO로 전체 사이클을 실행하세요.",
+            "example": 'PLAN 사용자 인증 추가',
+        },
+        "ja": {
+            "title": "PLAN/ACT/EVAL ワークフロー",
+            "body": "PLANで設計、ACTで実装、EVALでレビュー — またはAUTOで全サイクル実行。",
+            "example": 'PLAN ユーザー認証を追加',
+        },
+        "zh": {
+            "title": "PLAN/ACT/EVAL 工作流",
+            "body": "用PLAN设计、ACT实现、EVAL审查 — 或AUTO执行完整周期。",
+            "example": 'PLAN 添加用户认证',
+        },
+        "es": {
+            "title": "Flujo PLAN/ACT/EVAL",
+            "body": "PLAN para disenar, ACT para implementar, EVAL para revisar — o AUTO para el ciclo completo.",
+            "example": 'PLAN agregar autenticacion',
+        },
+    },
+    2: {
+        "en": {
+            "title": "38 Specialist Agents",
+            "body": "Security, accessibility, performance... experts ready to analyze your code.",
+            "example": 'AUTO implement login page',
+        },
+        "ko": {
+            "title": "38명의 전문가 에이전트",
+            "body": "보안, 접근성, 성능... 전문가들이 코드 분석을 도와줍니다.",
+            "example": 'AUTO 로그인 페이지 구현',
+        },
+        "ja": {
+            "title": "38人の専門エージェント",
+            "body": "セキュリティ、アクセシビリティ、パフォーマンス...専門家がコード分析をサポート。",
+            "example": 'AUTO ログインページを実装',
+        },
+        "zh": {
+            "title": "38位专家代理",
+            "body": "安全、无障碍、性能...专家随时准备分析您的代码。",
+            "example": 'AUTO 实现登录页面',
+        },
+        "es": {
+            "title": "38 Agentes Especialistas",
+            "body": "Seguridad, accesibilidad, rendimiento... expertos listos para analizar tu codigo.",
+            "example": 'AUTO implementar pagina de login',
+        },
+    },
+    3: {
+        "en": {
+            "title": "Checklists & Skills",
+            "body": "Auto-generated quality checklists and specialized skills for every task.",
+            "example": 'EVAL review my changes',
+        },
+        "ko": {
+            "title": "체크리스트 & 스킬",
+            "body": "자동 생성되는 품질 체크리스트와 모든 작업을 위한 전문 스킬.",
+            "example": 'EVAL 변경사항 검토',
+        },
+        "ja": {
+            "title": "チェックリスト & スキル",
+            "body": "自動生成の品質チェックリストと各タスク向けの専門スキル。",
+            "example": 'EVAL 変更をレビュー',
+        },
+        "zh": {
+            "title": "清单 & 技能",
+            "body": "自动生成质量清单和每个任务的专业技能。",
+            "example": 'EVAL 审查我的更改',
+        },
+        "es": {
+            "title": "Listas & Habilidades",
+            "body": "Listas de calidad auto-generadas y habilidades especializadas para cada tarea.",
+            "example": 'EVAL revisar mis cambios',
+        },
+    },
+}
+
+TOUR_SKIP: Dict[str, str] = {
+    "en": "Skip future tours: touch ~/.codingbuddy/onboarded",
+    "ko": "투어 건너뛰기: touch ~/.codingbuddy/onboarded",
+    "ja": "ツアーをスキップ: touch ~/.codingbuddy/onboarded",
+    "zh": "跳过教程: touch ~/.codingbuddy/onboarded",
+    "es": "Saltar tour: touch ~/.codingbuddy/onboarded",
+}
+
+TOUR_HEADER: Dict[str, str] = {
+    "en": "Quick Tour",
+    "ko": "퀵 투어",
+    "ja": "クイックツアー",
+    "zh": "快速导览",
+    "es": "Tour Rapido",
+}
+
+# Step number circled digits
+_STEP_NUMBERS = {1: "\u2460", 2: "\u2461", 3: "\u2462"}
+
+
+def _get_text(mapping: Dict[str, str], language: str) -> str:
+    """Get localized text with English fallback."""
+    return mapping.get(language, mapping.get("en", ""))
+
+
+def _get_step(step_num: int, language: str) -> Dict[str, str]:
+    """Get localized step content with English fallback."""
+    step = TOUR_STEPS.get(step_num, {})
+    return step.get(language, step.get("en", {}))
+
+
+def render_onboarding_tour(
+    language: str = "en",
+    buddy_config: Optional[Dict[str, str]] = None,
+) -> str:
+    """Render the complete onboarding tour output.
+
+    Args:
+        language: Language code (en, ko, ja, zh, es).
+        buddy_config: Optional buddy customization from get_buddy_config().
+
+    Returns:
+        Formatted onboarding tour string.
+    """
+    bc = buddy_config or DEFAULT_BUDDY_CONFIG
+    face = bc.get("face", BUDDY_FACE)
+    welcome = _get_text(TOUR_WELCOME, language)
+
+    cyan = ANSI_COLORS["cyan"]
+    yellow = ANSI_COLORS["yellow"]
+    green = ANSI_COLORS["green"]
+    magenta = ANSI_COLORS["magenta"]
+    reset = ANSI_COLORS["reset"]
+
+    lines = [
+        f"\u256d\u2501\u2501\u2501\u256e",
+        f"\u2503 {face} \u2503 {cyan}{welcome}{reset}",
+        f"\u2570\u2501\u2501\u2501\u256f",
+        "",
+        f"\u2501\u2501 {_get_text(TOUR_HEADER, language)} \u2501\u2501\u2501\u2501\u2501\u2501",
+    ]
+
+    for step_num in (1, 2, 3):
+        step = _get_step(step_num, language)
+        if not step:
+            continue
+        circled = _STEP_NUMBERS.get(step_num, str(step_num))
+        title = step.get("title", "")
+        body = step.get("body", "")
+        example = step.get("example", "")
+
+        lines.append(f"")
+        lines.append(f"  {yellow}{circled}{reset} {green}{title}{reset}")
+        lines.append(f"     {body}")
+        if example:
+            lines.append(f"     {magenta}\U0001f4a1 {example}{reset}")
+
+    lines.append("")
+    lines.append(f"\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501")
+    lines.append(f"\U0001f4ac {_get_text(TOUR_SKIP, language)}")
+
+    return "\n".join(lines)

--- a/packages/claude-code-plugin/hooks/session-start.py
+++ b/packages/claude-code-plugin/hooks/session-start.py
@@ -598,6 +598,19 @@ def main():
             buddy_section = cfg.get("buddy") if isinstance(cfg.get("buddy"), dict) else {}
             typing_enabled = buddy_section.get("typingEffect", True) and not os.environ.get("CI")
 
+            # First-run onboarding tour (#1037)
+            try:
+                from onboarding_tour import is_first_run, render_onboarding_tour, mark_onboarded
+                if is_first_run() and not previous_session:
+                    tour_output = render_onboarding_tour(
+                        language=language, buddy_config=buddy_cfg,
+                    )
+                    if tour_output:
+                        print(tour_output, file=sys.stderr)
+                    mark_onboarded()
+            except Exception:
+                pass  # Never block session start for tour
+
             # Render and output
             output = render_session_start(
                 scan_data, recommendations, tone, language,

--- a/packages/claude-code-plugin/tests/test_onboarding_tour.py
+++ b/packages/claude-code-plugin/tests/test_onboarding_tour.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Unit tests for onboarding_tour.py
+
+Run with: python3 -m pytest test_onboarding_tour.py -v
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+# Ensure hooks/lib is importable
+_hooks_lib = str(Path(__file__).resolve().parent.parent / "hooks" / "lib")
+if _hooks_lib not in sys.path:
+    sys.path.insert(0, _hooks_lib)
+
+import onboarding_tour  # noqa: E402
+
+
+class TestIsFirstRun:
+    """Tests for is_first_run function."""
+
+    def test_returns_true_when_flag_missing(self):
+        """First run when no onboarded flag exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flag = os.path.join(tmpdir, "onboarded")
+            with patch.object(onboarding_tour, "ONBOARDED_FLAG", flag):
+                with patch.dict(os.environ, {}, clear=False):
+                    os.environ.pop(onboarding_tour.SKIP_ENV_VAR, None)
+                    assert onboarding_tour.is_first_run() is True
+
+    def test_returns_false_when_flag_exists(self):
+        """Not first run when onboarded flag exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flag = os.path.join(tmpdir, "onboarded")
+            Path(flag).touch()
+            with patch.object(onboarding_tour, "ONBOARDED_FLAG", flag):
+                with patch.dict(os.environ, {}, clear=False):
+                    os.environ.pop(onboarding_tour.SKIP_ENV_VAR, None)
+                    assert onboarding_tour.is_first_run() is False
+
+    def test_returns_false_when_skip_env_set(self):
+        """Skip tour when CODINGBUDDY_SKIP_TOUR env var is set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flag = os.path.join(tmpdir, "onboarded")
+            with patch.object(onboarding_tour, "ONBOARDED_FLAG", flag):
+                with patch.dict(os.environ, {onboarding_tour.SKIP_ENV_VAR: "1"}):
+                    assert onboarding_tour.is_first_run() is False
+
+
+class TestMarkOnboarded:
+    """Tests for mark_onboarded function."""
+
+    def test_creates_flag_file(self):
+        """Flag file is created after marking onboarded."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flag_dir = os.path.join(tmpdir, ".codingbuddy")
+            flag = os.path.join(flag_dir, "onboarded")
+            with patch.object(onboarding_tour, "ONBOARDED_DIR", flag_dir):
+                with patch.object(onboarding_tour, "ONBOARDED_FLAG", flag):
+                    onboarding_tour.mark_onboarded()
+                    assert os.path.isfile(flag)
+
+    def test_creates_parent_directory(self):
+        """Parent directory is created if it doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flag_dir = os.path.join(tmpdir, "nested", ".codingbuddy")
+            flag = os.path.join(flag_dir, "onboarded")
+            with patch.object(onboarding_tour, "ONBOARDED_DIR", flag_dir):
+                with patch.object(onboarding_tour, "ONBOARDED_FLAG", flag):
+                    onboarding_tour.mark_onboarded()
+                    assert os.path.isdir(flag_dir)
+                    assert os.path.isfile(flag)
+
+    def test_idempotent(self):
+        """Calling mark_onboarded twice doesn't raise."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flag_dir = os.path.join(tmpdir, ".codingbuddy")
+            flag = os.path.join(flag_dir, "onboarded")
+            with patch.object(onboarding_tour, "ONBOARDED_DIR", flag_dir):
+                with patch.object(onboarding_tour, "ONBOARDED_FLAG", flag):
+                    onboarding_tour.mark_onboarded()
+                    onboarding_tour.mark_onboarded()  # Should not raise
+                    assert os.path.isfile(flag)
+
+
+class TestRenderOnboardingTour:
+    """Tests for render_onboarding_tour function."""
+
+    def test_returns_non_empty_string(self):
+        """Tour output is non-empty."""
+        result = onboarding_tour.render_onboarding_tour()
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_contains_all_three_steps(self):
+        """Tour output contains all 3 step circled digits."""
+        result = onboarding_tour.render_onboarding_tour()
+        assert "\u2460" in result  # ①
+        assert "\u2461" in result  # ②
+        assert "\u2462" in result  # ③
+
+    def test_contains_buddy_face(self):
+        """Tour output contains the default buddy face."""
+        result = onboarding_tour.render_onboarding_tour()
+        assert onboarding_tour.BUDDY_FACE in result
+
+    def test_contains_skip_message(self):
+        """Tour output contains skip instructions."""
+        result = onboarding_tour.render_onboarding_tour()
+        assert "~/.codingbuddy/onboarded" in result
+
+    def test_english_content(self):
+        """English tour contains expected keywords."""
+        result = onboarding_tour.render_onboarding_tour(language="en")
+        assert "PLAN/ACT/EVAL" in result
+        assert "Specialist" in result
+        assert "Checklists" in result
+
+    def test_korean_content(self):
+        """Korean tour contains expected keywords."""
+        result = onboarding_tour.render_onboarding_tour(language="ko")
+        assert "워크플로우" in result
+        assert "전문가" in result
+        assert "체크리스트" in result
+
+    def test_japanese_content(self):
+        """Japanese tour contains expected keywords."""
+        result = onboarding_tour.render_onboarding_tour(language="ja")
+        assert "ワークフロー" in result
+        assert "専門エージェント" in result
+
+    def test_unknown_language_falls_back_to_english(self):
+        """Unknown language code falls back to English."""
+        result = onboarding_tour.render_onboarding_tour(language="xx")
+        assert "PLAN/ACT/EVAL" in result
+        assert "Welcome" in result
+
+    def test_custom_buddy_face(self):
+        """Custom buddy face is used when provided."""
+        custom = {"name": "TestBuddy", "face": "\u2605\u203f\u2605", "greeting": "", "farewell": ""}
+        result = onboarding_tour.render_onboarding_tour(buddy_config=custom)
+        assert "\u2605\u203f\u2605" in result
+
+    def test_welcome_message_present(self):
+        """Welcome message is in the output."""
+        result = onboarding_tour.render_onboarding_tour(language="en")
+        assert "Welcome to CodingBuddy" in result
+
+    def test_example_commands_present(self):
+        """Example commands are included in tour steps."""
+        result = onboarding_tour.render_onboarding_tour(language="en")
+        assert "PLAN add user authentication" in result
+
+
+class TestHelpers:
+    """Tests for internal helper functions."""
+
+    def test_get_text_returns_localized(self):
+        """_get_text returns localized string."""
+        mapping = {"en": "Hello", "ko": "안녕"}
+        assert onboarding_tour._get_text(mapping, "ko") == "안녕"
+
+    def test_get_text_falls_back_to_english(self):
+        """_get_text falls back to English for unknown language."""
+        mapping = {"en": "Hello", "ko": "안녕"}
+        assert onboarding_tour._get_text(mapping, "xx") == "Hello"
+
+    def test_get_step_returns_localized(self):
+        """_get_step returns step content for given language."""
+        step = onboarding_tour._get_step(1, "en")
+        assert "title" in step
+        assert "body" in step
+        assert "example" in step
+
+    def test_get_step_falls_back_to_english(self):
+        """_get_step falls back to English for unknown language."""
+        step = onboarding_tour._get_step(1, "xx")
+        assert step.get("title") == "PLAN/ACT/EVAL Workflow"
+
+    def test_get_step_invalid_number(self):
+        """_get_step returns empty dict for invalid step number."""
+        step = onboarding_tour._get_step(99, "en")
+        assert step == {}
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add 3-step onboarding tour for first-time CodingBuddy users
- Step 1: PLAN/ACT/EVAL workflow intro with example command
- Step 2: 38 specialist agents overview
- Step 3: Checklists & skills with first command recommendation
- First-run detection via `~/.codingbuddy/onboarded` flag file
- i18n support: en, ko, ja, zh, es
- Skip option via flag file or `CODINGBUDDY_SKIP_TOUR` env var
- 22 unit tests covering detection, flag management, rendering, i18n

## Test plan
- [x] 22 new tests pass (`test_onboarding_tour.py`)
- [x] 22 existing session-start tests pass
- [x] 5308 MCP server tests pass
- [x] 71 plugin tests pass
- [x] Lint clean (0 errors)

Closes #1037