### PR TITLE
fix(plugin): quote HOOK_COMMAND path to handle spaces in home directory

### DIFF
--- a/packages/claude-code-plugin/hooks/session-start.py
+++ b/packages/claude-code-plugin/hooks/session-start.py
@@ -271,7 +271,7 @@ def _is_hook_in_settings(settings: dict) -> bool:
     user_prompt_hooks = settings.get("hooks", {}).get("UserPromptSubmit", [])
     for hook_group in user_prompt_hooks:
         for hook in hook_group.get("hooks", []):
-            if hook.get("command") == HOOK_COMMAND:
+            if HOOK_FILENAME in hook.get("command", ""):
                 return True
     return False
 


### PR DESCRIPTION
## Summary
- Quote `HOOK_COMMAND` path using `$HOME` with double quotes instead of unquoted `~`
- Prevents breakage when the home directory path contains spaces

Fixes #993

## Test plan
- [x] `yarn test:hooks` — 389 tests passed