### PR TITLE
ci(marketplace): add workflow and supporting files to path triggers

### DIFF
--- a/.github/workflows/marketplace.yml
+++ b/.github/workflows/marketplace.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - '.claude-plugin/**'
       - 'packages/claude-code-plugin/.claude-plugin/**'
+      - '.github/workflows/marketplace.yml'
+      - '.github/scripts/marketplace-utils.sh'
+      - '.github/templates/marketplace-index.html'
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add `.github/workflows/marketplace.yml` to its own path triggers
- Add `.github/scripts/marketplace-utils.sh` to path triggers
- Add `.github/templates/marketplace-index.html` to path triggers

Changes to the marketplace deployment infrastructure now automatically trigger the workflow instead of requiring manual `workflow_dispatch`.

## Test plan
- [x] Verify marketplace.yml syntax is valid (prettier check passed)
- [x] Verify all existing tests pass (5308 tests passed)
- [ ] Confirm workflow triggers on push to master when marketplace.yml is changed

Closes #963