### PR TITLE
feat(taskmaestro): add dedicated review agent pane for PR quality gate

### DIFF
--- a/.claude/skills/taskmaestro/SKILL.md
+++ b/.claude/skills/taskmaestro/SKILL.md
@@ -1,1687 +1,134 @@
 ---
 name: taskmaestro
-description: >-
-  Orchestrate parallel Claude Code instances across tmux panes
-  with git worktree isolation. Provides wave-transition automation,
-  readiness detection via capture-pane polling, and trust/terms
-  prompt auto-handling.
-argument-hint: "wave-transition <issues> | launch <count> | status | stop | cleanup [--force]"
-allowed-tools: Bash, Read, Grep, Glob
+description: Use when orchestrating parallel Claude Code instances across tmux panes with git worktree isolation — managing multiple concurrent development tasks visually
+argument-hint: <start|assign|status|watch|send|stop> [args...]
 user-invocable: true
-disable-model-invocation: true
 ---
 
-# taskMaestro
+# TaskMaestro — tmux 패널 오케스트레이터
 
-Orchestrate parallel Claude Code workers in tmux panes with git worktree isolation.
+현재 tmux 세션의 기존 패널들에서 Claude Code를 병렬로 실행하고, 이 패널(지휘자)에서 제어한다.
+각 패널은 독립된 git worktree에서 작업하며, 지휘자가 작업 지시, 상태 감시를 수행한다.
 
-Follow every step in order. Stop and report if any step fails.
+**전제 조건:** 지휘자(이 Claude Code)가 tmux 패널 중 하나에서 실행 중이어야 하며, 나머지 패널들이 이미 열려있어야 한다.
 
-## Step 0: Prerequisite Check
+## Arguments 파싱
 
-Run these checks at the start of every command. Each check is idempotent — zero overhead when already satisfied.
+`$ARGUMENTS`를 파싱하여 서브커맨드와 인수를 분리한다:
 
-```bash
-check_prerequisites() {
-  # --- 1. tmux installed? ---
-  if ! command -v tmux &>/dev/null; then
-    echo "ERROR: tmux is not installed." >&2
+- `start [--repo <path>] [--base <branch>] [--panes <1,2,3>] [--review-pane]`
+- `assign <패널번호> "<작업 지시>"`
+- `status`
+- `watch`
+- `send <패널번호> "<텍스트>"`
+- `stop [패널번호|all]`
 
-    # Detect OS and suggest install command
-    case "$(uname -s)" in
-      Darwin)
-        if command -v brew &>/dev/null; then
-          echo "Detected macOS with Homebrew." >&2
-          echo "Run: brew install tmux" >&2
-          # Safe to auto-execute (no sudo required)
-          # Use AskUserQuestion to confirm before running
-          return 1
-        else
-          echo "Detected macOS without Homebrew." >&2
-          echo "Install Homebrew first: https://brew.sh" >&2
-          echo "Then run: brew install tmux" >&2
-          return 1
-        fi
-        ;;
-      Linux)
-        if [ -f /etc/os-release ]; then
-          . /etc/os-release
-          case "$ID" in
-            ubuntu|debian)
-              echo "Detected $PRETTY_NAME." >&2
-              echo "Run: sudo apt install -y tmux" >&2
-              ;;
-            alpine)
-              echo "Detected Alpine Linux." >&2
-              echo "Run: apk add tmux" >&2
-              ;;
-            fedora|rhel|centos)
-              echo "Detected $PRETTY_NAME." >&2
-              echo "Run: sudo dnf install -y tmux" >&2
-              ;;
-            arch|manjaro)
-              echo "Detected $PRETTY_NAME." >&2
-              echo "Run: sudo pacman -S tmux" >&2
-              ;;
-            *)
-              echo "Detected Linux ($PRETTY_NAME)." >&2
-              echo "Install tmux using your package manager." >&2
-              ;;
-          esac
-        else
-          echo "Detected Linux (unknown distro)." >&2
-          echo "Install tmux using your package manager." >&2
-        fi
-        return 1
-        ;;
-      *)
-        echo "Unsupported OS: $(uname -s)" >&2
-        echo "Install tmux manually: https://github.com/tmux/tmux/wiki/Installing" >&2
-        return 1
-        ;;
-    esac
-  fi
+서브커맨드에 해당하는 섹션으로 이동한다.
 
-  # --- 2. Running inside tmux session? ---
-  if [ -z "$TMUX" ]; then
-    echo "WARNING: Not inside a tmux session." >&2
-    echo "Creating new tmux session '${SESSION}'..." >&2
-    tmux new-session -d -s "$SESSION" 2>/dev/null || true
-    echo "Re-enter with: tmux attach -t $SESSION" >&2
-    return 1
-  fi
+## 현재 tmux 환경 감지
 
-  # --- 3. Git repository? ---
-  if ! git rev-parse --is-inside-work-tree &>/dev/null; then
-    echo "ERROR: Not inside a git repository." >&2
-    echo "Run this command from a git project root." >&2
-    return 1
-  fi
-
-  return 0
-}
-```
-
-**Check summary:**
-
-| Check | Pass | Fail |
-|-------|------|------|
-| `command -v tmux` | Continue | Detect OS → suggest install command |
-| `$TMUX` set | Continue | Create session → ask user to re-enter |
-| `git rev-parse` | Continue | Error and abort |
-
-**Install commands by OS:**
-
-| OS | Command | Auto-executable? |
-|----|---------|-------------------|
-| macOS (Homebrew) | `brew install tmux` | Yes — no sudo, confirm via AskUserQuestion |
-| Ubuntu / Debian | `sudo apt install -y tmux` | No — show command for user |
-| Alpine | `apk add tmux` | No — show command for user |
-| Fedora / RHEL | `sudo dnf install -y tmux` | No — show command for user |
-| Arch / Manjaro | `sudo pacman -S tmux` | No — show command for user |
-| Other | Manual install | No — link to tmux wiki |
-
-**Integration:** Call `check_prerequisites` at the top of `wave_transition()`, `launch_workers()`, and `status_check()` before any tmux operations.
-
-## Constants
+모든 서브커맨드에서 먼저 실행:
 
 ```bash
-SESSION="taskmaestro"
-WORKTREE_BASE=".taskmaestro"
-PROMPT_PATTERN='⏵⏵|⏵ |❯'   # ERE pattern for grep -qE
-MAX_READY_WAIT=90              # seconds to wait for Claude readiness
-POLL_INTERVAL=2                # seconds between capture-pane checks
-MAX_PROMPT_WAIT=30             # seconds to wait for trust/terms prompts
-# Layout & Colors
-CONDUCTOR_BG="#1a1a2e"          # dark navy background
-CONDUCTOR_BORDER="#E67E22"      # orange border
-WORKER_ERROR_BORDER="#E74C3C"   # red border (error state)
-WORKER_DONE_BORDER="#27AE60"    # green border (complete state)
-# Watch & Nudge
-WATCH_INTERVAL=30              # seconds between watch cycles
-MAX_NUDGE_COUNT=3              # nudges before escalation to conductor
-IDLE_CYCLES_BEFORE_NUDGE=2     # consecutive idle cycles before auto-nudge
-STATUS_PREV_DIR="/tmp/taskmaestro_status"  # duration tracking state
-WAVE_PLAN_FILE=".taskmaestro/wave-plan.json"  # wave sequence definition
-# Push Protocol
-TM_MSG_PATTERN='\[TM:(DONE|ERROR|PROGRESS)\]'  # ERE pattern for worker push messages
+# 현재 tmux 소켓, 세션, 윈도우 정보를 자동 감지
+TMUX_SOCKET=$(tmux display-message -p '#{socket_path}')
+# 소켓 이름 추출 (경로에서 마지막 부분)
+SOCKET_NAME=$(basename "$TMUX_SOCKET")
+SESSION=$(tmux display-message -p '#{session_name}')
+WIN_IDX=$(tmux display-message -p '#{window_index}')
+MY_PANE=$(tmux display-message -p '#{pane_index}')
 ```
+
+> tmux 명령어에서 `-L` 플래그는 소켓 이름을 사용한다. `tmux -L "$SOCKET_NAME" send-keys ...` 형태로 사용.
 
 ---
 
-## Core Utilities
+## Worker Completion Signaling (RESULT.json)
 
-### Readiness Detection
+워커가 작업을 완료하면 `.taskmaestro/wt-N/RESULT.json` 파일을 생성하여 지휘자에게 결과를 알린다.
+이 파일은 watch 모드의 **1차 감지 수단**이며, capture-pane은 fallback으로만 사용한다.
 
-Detect when a Claude Code instance is ready by polling `capture-pane` for the prompt indicator. **Never use fixed `sleep`** — always poll.
-
-```bash
-wait_for_ready() {
-  local pane="$1"
-  local max_wait="${2:-$MAX_READY_WAIT}"
-  local elapsed=0
-
-  while [ "$elapsed" -lt "$max_wait" ]; do
-    local content
-    content=$(tmux capture-pane -t "$pane" -p 2>/dev/null)
-
-    # Check for Claude Code prompt indicators
-    if echo "$content" | grep -qE "$PROMPT_PATTERN"; then
-      return 0
-    fi
-
-    sleep "$POLL_INTERVAL"
-    elapsed=$((elapsed + POLL_INTERVAL))
-  done
-
-  echo "TIMEOUT: pane $pane not ready after ${max_wait}s" >&2
-  return 1
-}
-```
-
-**Key points:**
-- Returns `0` on success (prompt detected), `1` on timeout
-- Caller decides how to handle timeout (retry, skip, abort)
-- `POLL_INTERVAL=2` balances responsiveness vs overhead
-
-### Trust/Terms Prompt Handling
-
-Detect and automatically respond to trust/terms prompts that appear during Claude Code startup.
-
-```bash
-handle_prompts() {
-  local pane="$1"
-  local max_wait="${2:-$MAX_PROMPT_WAIT}"
-  local elapsed=0
-  local handled=0
-
-  while [ "$elapsed" -lt "$max_wait" ]; do
-    local content
-    content=$(tmux capture-pane -t "$pane" -p 2>/dev/null)
-
-    # Trust project directory prompt — press Enter to accept
-    if echo "$content" | grep -qiE 'trust.*directory|trust.*folder|Do you trust'; then
-      tmux send-keys -t "$pane" Enter
-      sleep 1
-      handled=$((handled + 1))
-      continue
-    fi
-
-    # Terms of service / license agreement — navigate and accept
-    if echo "$content" | grep -qiE 'terms of service|license agreement|accept.*terms'; then
-      tmux send-keys -t "$pane" Down
-      sleep 0.5
-      tmux send-keys -t "$pane" Enter
-      sleep 1
-      handled=$((handled + 1))
-      continue
-    fi
-
-    # Yes/No confirmation prompt
-    if echo "$content" | grep -qiE 'Yes.*No.*\?|y/n|Y/N'; then
-      tmux send-keys -t "$pane" "y" Enter
-      sleep 1
-      handled=$((handled + 1))
-      continue
-    fi
-
-    # If prompt is ready, we're done
-    if echo "$content" | grep -qE "$PROMPT_PATTERN"; then
-      break
-    fi
-
-    sleep "$POLL_INTERVAL"
-    elapsed=$((elapsed + POLL_INTERVAL))
-  done
-
-  return "$handled"  # number of prompts handled (0 = none encountered)
-}
-```
-
-**Known prompt patterns:**
-
-| Pattern | Action | Description |
-|---------|--------|-------------|
-| `trust.*directory` | `Enter` | Trust project directory |
-| `terms of service` | `Down` + `Enter` | Accept terms |
-| `Yes.*No` / `y/n` | `y` + `Enter` | Generic confirmation |
-
-### Startup Sequence
-
-Combines trust/terms handling with readiness detection in the correct order:
-
-```bash
-wait_for_startup() {
-  local pane="$1"
-
-  # Phase 1: Handle any trust/terms prompts
-  handle_prompts "$pane" "$MAX_PROMPT_WAIT"
-
-  # Phase 2: Wait for Claude to be fully ready
-  if ! wait_for_ready "$pane" "$MAX_READY_WAIT"; then
-    echo "ERROR: pane $pane failed to reach ready state" >&2
-    return 1
-  fi
-
-  return 0
-}
-```
-
-### Conductor Layout
-
-Rearrange panes so the conductor (pane 0) occupies the bottom 25% of the window and workers fill the upper 75% in a tiled grid. Must run after `launch_workers()`.
-
-```bash
-setup_conductor_layout() {
-  local count="$1"  # total pane count
-
-  if [ "$count" -lt 2 ]; then
-    # Single pane — apply conductor styling only
-    tmux select-pane -t "${SESSION}:0.0" -P "bg=${CONDUCTOR_BG}"
-    tmux set-option -p -t "${SESSION}:0.0" \
-      pane-border-style "fg=${CONDUCTOR_BORDER}"
-    tmux set-option -p -t "${SESSION}:0.0" \
-      pane-active-border-style "fg=${CONDUCTOR_BORDER}"
-    return 0
-  fi
-
-  local last=$((count - 1))
-
-  # Move conductor (pane 0) to full-width bottom at 25% height
-  tmux swap-pane -s "${SESSION}:0.0" -t "${SESSION}:0.${last}"
-  tmux break-pane -t "${SESSION}:0.${last}" -d
-  [ "$last" -gt 1 ] && tmux select-layout -t "${SESSION}:0" tiled
-  tmux join-pane -fv -s "${SESSION}:1" -t "${SESSION}:0" -l "25%"
-
-  # Conductor is now the last pane after rejoin
-  local cond
-  cond=$(tmux list-panes -t "${SESSION}:0" -F '#{pane_index}' | tail -1)
-
-  # Session continuity: resume Claude if interrupted by pane move
-  sleep 1
-  if ! tmux capture-pane -t "${SESSION}:0.${cond}" -p 2>/dev/null \
-       | grep -qE "${PROMPT_PATTERN}"; then
-    tmux send-keys -t "${SESSION}:0.${cond}" "claude --resume" Enter
-  fi
-
-  # Apply conductor color scheme
-  tmux select-pane -t "${SESSION}:0.${cond}" -P "bg=${CONDUCTOR_BG}"
-  tmux set-option -p -t "${SESSION}:0.${cond}" \
-    pane-border-style "fg=${CONDUCTOR_BORDER}"
-  tmux set-option -p -t "${SESSION}:0.${cond}" \
-    pane-active-border-style "fg=${CONDUCTOR_BORDER}"
-}
-```
-
-**Layout procedure:**
-
-| Step | tmux Command | Effect |
-|------|-------------|--------|
-| 1. Swap | `swap-pane -s :0.0 -t :0.$last` | Move conductor content to last position |
-| 2. Break | `break-pane -t :0.$last -d` | Isolate conductor in temporary window |
-| 3. Tile | `select-layout tiled` | Arrange workers in grid |
-| 4. Join | `join-pane -fv -l 25%` | Conductor rejoins at full-width bottom |
-| 5. Resume | `claude --resume` | Restore Claude session if interrupted |
-| 6. Style | `select-pane -P`, `set-option -p` | Apply conductor colors |
-
-**Color scheme:**
-
-| Element | Property | Value | Visual |
-|---------|----------|-------|--------|
-| Conductor background | `bg` | `#1a1a2e` | Dark navy |
-| Conductor border | `pane-border-style fg` | `#E67E22` | Orange |
-| Worker (normal) | — | terminal default | — |
-| Worker (error) | `pane-border-style fg` | `#E74C3C` | Red |
-| Worker (complete) | `pane-border-style fg` | `#27AE60` | Green |
-
-### Worker Status Colors
-
-Update a worker pane's border color to reflect its current state:
-
-```bash
-set_worker_status() {
-  local pane="$1"   # target pane (e.g., "${SESSION}:0.2")
-  local status="$2" # "error", "complete", or "normal"
-
-  case "$status" in
-    error)
-      tmux set-option -p -t "$pane" pane-border-style "fg=${WORKER_ERROR_BORDER}"
-      tmux set-option -p -t "$pane" pane-active-border-style "fg=${WORKER_ERROR_BORDER}"
-      ;;
-    complete)
-      tmux set-option -p -t "$pane" pane-border-style "fg=${WORKER_DONE_BORDER}"
-      tmux set-option -p -t "$pane" pane-active-border-style "fg=${WORKER_DONE_BORDER}"
-      ;;
-    normal|*)
-      tmux set-option -p -t "$pane" -u pane-border-style
-      tmux set-option -p -t "$pane" -u pane-active-border-style
-      ;;
-  esac
-}
-```
-
-**Status transitions:**
-
-| Status | Border Color | When |
-|--------|-------------|------|
-| `normal` | terminal default | Initial state / reset |
-| `error` | `#E74C3C` (red) | Worker hits error or test failure |
-| `complete` | `#27AE60` (green) | Worker finishes successfully |
-
----
-
-## Wave Transition
-
-Transition from one wave to the next in a single operation. Stops current workers, cleans up worktrees, creates fresh ones, launches Claude Code, and assigns new tasks.
-
-### Input
-
-```
-wave_transition <issues> [--prompt <text>] [--panes <n>]
-
-  <issues>   Comma-separated issue numbers (e.g., "732,733,734")
-  --prompt   Custom prompt prefix (default: "AUTO: Issue #<N> 구현")
-  --panes    Number of panes (default: matches issue count)
-```
-
-### Process
-
-#### Step 1: Stop Current Workers
-
-Send `/exit` to each active pane and wait for termination:
-
-```bash
-stop_workers() {
-  local panes
-  panes=$(tmux list-panes -t "$SESSION" -F '#{pane_index}' 2>/dev/null)
-
-  for pane in $panes; do
-    # Send /exit command
-    tmux send-keys -t "${SESSION}:0.${pane}" "/exit" Enter
-  done
-
-  # Wait for all panes to terminate
-  sleep 3
-
-  # Verify — force kill any remaining
-  for pane in $panes; do
-    local pid
-    pid=$(tmux display-message -t "${SESSION}:0.${pane}" -p '#{pane_pid}' 2>/dev/null)
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      tmux send-keys -t "${SESSION}:0.${pane}" C-c
-      sleep 1
-    fi
-  done
-}
-```
-
-#### Step 2: Clean Existing Worktrees
-
-Remove worktrees from the previous wave:
-
-```bash
-clean_worktrees() {
-  local base_dir="${WORKTREE_BASE}"
-
-  for wt_dir in "${base_dir}"/wt-*; do
-    [ -d "$wt_dir" ] || continue
-    git worktree remove "$wt_dir" --force 2>/dev/null || rm -rf "$wt_dir"
-  done
-
-  # Prune stale worktree references
-  git worktree prune
-}
-```
-
-#### Step 3: Create New Worktrees
-
-Create fresh worktrees from master for each pane:
-
-```bash
-create_worktrees() {
-  local count="$1"
-
-  # Ensure master is up to date
-  git fetch origin master:master 2>/dev/null || true
-
-  for i in $(seq 1 "$count"); do
-    local wt_dir="${WORKTREE_BASE}/wt-${i}"
-    local branch="taskmaestro/$(date +%s)/pane-${i}"
-    git worktree add "$wt_dir" -b "$branch" master
-
-    # Artifact cleanup: remove ephemeral files that may exist from previous runs
-    rm -f "${wt_dir}/RESULT.json" "${wt_dir}/TASK.md"
-  done
-}
-```
-
-#### Step 3.5: Install Worktree Dependencies
-
-Pre-install dependencies in each worktree. Zero overhead when `node_modules` already exists.
-
-```bash
-install_worktree_deps() {
-  local count="$1"
-
-  for i in $(seq 1 "$count"); do
-    local wt_dir="${WORKTREE_BASE}/wt-${i}"
-
-    # Skip if no package.json or node_modules already present
-    [ -f "${wt_dir}/package.json" ] || continue
-    [ -d "${wt_dir}/node_modules" ] && continue
-
-    # Monorepo (yarn workspaces) → symlink node_modules from repo root
-    if [ -d "node_modules" ] && grep -q '"workspaces"' package.json 2>/dev/null; then
-      ln -s "$(pwd)/node_modules" "${wt_dir}/node_modules"
-      echo "SYMLINKED: node_modules -> wt-${i}"
-    # Standalone → yarn install in background
-    elif command -v yarn &>/dev/null; then
-      (cd "${wt_dir}" && yarn install --frozen-lockfile &>/dev/null &)
-      echo "INSTALLING: yarn install in wt-${i} (background)"
-    # Fallback → warn worker
-    else
-      echo "WARNING: wt-${i} has no node_modules — install manually"
-    fi
-  done
-}
-```
-
-**Dependency resolution strategy:**
-
-| Condition | Action | Overhead |
-|-----------|--------|----------|
-| `node_modules` exists | Skip | Zero |
-| No `package.json` | Skip | Zero |
-| Monorepo (yarn workspaces) | Symlink from repo root | ~0s |
-| Standalone project | `yarn install --frozen-lockfile` (background) | Non-blocking |
-| No yarn available | Warn worker to install manually | Zero |
-
-#### Step 4: Launch Claude Code Instances
-
-Launch Claude Code in each pane, pointing to the corresponding worktree:
-
-```bash
-launch_workers() {
-  local count="$1"
-
-  # Kill existing session if present
-  tmux kill-session -t "$SESSION" 2>/dev/null || true
-
-  # Create new session with first pane
-  tmux new-session -d -s "$SESSION" -c "${WORKTREE_BASE}/wt-1"
-  tmux send-keys -t "${SESSION}:0.0" "claude" Enter
-
-  # Create additional panes
-  for i in $(seq 2 "$count"); do
-    tmux split-window -t "$SESSION" -c "${WORKTREE_BASE}/wt-${i}"
-    tmux send-keys -t "${SESSION}:0.$((i-1))" "claude" Enter
-    tmux select-layout -t "$SESSION" tiled
-  done
-}
-```
-
-#### Step 4.5: Worker Pre-Flight Verification
-
-Before launching Claude Code, verify each worktree:
-
-```bash
-for PANE_IDX in $WORKER_PANES; do
-  WT_PATH="$DIR/.taskmaestro/wt-$PANE_IDX"
-  rm -f "$WT_PATH/RESULT.json" "$WT_PATH/TASK.md"
-  if [ -f "$REPO/.claude/settings.local.json" ]; then
-    mkdir -p "$WT_PATH/.claude"
-    cp "$REPO/.claude/settings.local.json" "$WT_PATH/.claude/settings.local.json"
-  fi
-  if ! git -C "$WT_PATH" diff --quiet 2>/dev/null; then
-    echo "WARNING: wt-$PANE_IDX has uncommitted changes"
-  fi
-done
-```
-
-#### Step 5: Wait for All Workers Ready
-
-Poll each pane for readiness using `wait_for_startup`:
-
-```bash
-wait_all_ready() {
-  local count="$1"
-  local failed=0
-
-  for i in $(seq 0 $((count - 1))); do
-    local pane="${SESSION}:0.${i}"
-
-    if ! wait_for_startup "$pane"; then
-      echo "WARNING: pane ${i} not ready, will retry once" >&2
-      # Retry: restart Claude in this pane
-      tmux send-keys -t "$pane" C-c
-      sleep 1
-      tmux send-keys -t "$pane" "claude" Enter
-      if ! wait_for_startup "$pane"; then
-        echo "ERROR: pane ${i} failed after retry" >&2
-        failed=$((failed + 1))
-      fi
-    fi
-  done
-
-  return "$failed"
-}
-```
-
-#### Step 6: Assign Tasks
-
-Send the work prompt to each ready pane. The prompt includes the **IRON LAW** for RESULT.json completion, the **ERROR RECOVERY PROTOCOL** for self-healing, and the **PUSH PROTOCOL** for structured status reporting:
-
-```bash
-assign_tasks() {
-  local -a issues=("$@")
-
-  for i in "${!issues[@]}"; do
-    local pane="${SESSION}:0.${i}"
-    local issue="${issues[$i]}"
-
-    # Worker prompt: task execution + IRON LAW + ERROR RECOVERY + PUSH PROTOCOL
-    local prompt
-    read -r -d '' prompt << WORKER_PROMPT || true
-Read TASK.md and execute ALL instructions. Follow codingbuddy PLAN→ACT→EVAL. Run 'yarn install' if node_modules missing. NEVER use 'git add -A'. If errors occur, fix yourself. Use /ship to create PR, then write RESULT.json. Start now.
-
-[IRON LAW: RESULT.json]
-RESULT.json MUST be the LAST action before idle.
-1. Complete implementation
-2. Create PR via /ship
-3. Write RESULT.json ← MANDATORY
-4. Go idle
-
-If /ship fails: write RESULT.json with status "failure" and error details.
-NEVER go idle without RESULT.json.
-
-[ERROR RECOVERY PROTOCOL]
-If any command fails:
-1. DO NOT STOP. Read the error message.
-2. Diagnose: run git status, check paths, verify deps
-3. Fix: apply minimal fix
-4. Retry (max 3 attempts)
-5. If 3 retries fail: write RESULT.json with status "failure"
-
-NEVER use 'git add -A' — always stage specific files.
-RESULT.json and TASK.md must NEVER be committed.
-
-[PUSH PROTOCOL]
-You are pane=${i}, assigned issue=#${issue}.
-After each major milestone, emit a status message via Bash:
-
-Phase transition (PLAN→ACT, ACT→EVAL):
-  echo '[TM:PROGRESS] pane=${i} issue=#${issue} phase=ACT step=starting-implementation'
-
-Successful completion (AFTER writing RESULT.json):
-  echo '[TM:DONE] pane=${i} issue=#${issue} pr=<PR_NUMBER> status=success'
-
-Unrecoverable error (AFTER writing RESULT.json with failure):
-  echo '[TM:ERROR] pane=${i} issue=#${issue} error=<SHORT_MSG>'
-
-Rules:
-- Use EXACT format — these are machine-parsed by the conductor
-- PROGRESS: emit at each mode transition
-- DONE/ERROR: emit AFTER writing RESULT.json, BEFORE going idle
-- Replace <PR_NUMBER> and <SHORT_MSG> with actual values
-[CONTINUOUS EXECUTION DIRECTIVE]
-DO NOT stop between steps. Complete ALL tasks without waiting for user input.
-Only stop AFTER writing RESULT.json.
-If you encounter an error, try to fix it yourself before stopping.
-WORKER_PROMPT
-
-    # Verify pane is ready before sending
-    if ! tmux capture-pane -t "$pane" -p | grep -qE "$PROMPT_PATTERN"; then
-      echo "SKIP: pane ${i} not ready, skipping issue #${issue}" >&2
-      continue
-    fi
-
-    tmux send-keys -t "$pane" "$prompt" Enter
-    echo "ASSIGNED: pane ${i} <- issue #${issue}"
-  done
-}
-```
-
-**Worker prompt components:**
-
-| Component | Purpose | Source |
-|-----------|---------|--------|
-| Task execution | Read TASK.md, follow PLAN→ACT→EVAL, use /ship | Base prompt |
-| IRON LAW: RESULT.json | Guarantee RESULT.json is always written before idle | #868 |
-| ERROR RECOVERY PROTOCOL | Self-diagnose and retry on failures (max 3 attempts) | #870 |
-| PUSH PROTOCOL | Emit `[TM:DONE]`, `[TM:ERROR]`, `[TM:PROGRESS]` messages for conductor | #886 |
-
-**IRON LAW enforcement:**
-
-| Scenario | Required Action |
-|----------|----------------|
-| /ship succeeds | Write RESULT.json with `status: "success"` + PR details |
-| /ship fails | Write RESULT.json with `status: "failure"` + error details |
-| Implementation fails after 3 retries | Write RESULT.json with `status: "failure"` |
-| Any other exit path | RESULT.json **must** still be written — no exceptions |
-| Conductor starts review | Update RESULT.json to `status: "review_pending"` + `review_cycle` + `review_comments` |
-| Worker addresses review | Update RESULT.json to `status: "review_addressed"` |
-| Conductor approves PR | Update RESULT.json to `status: "approved"` (진짜 완료) |
-
-**Extended RESULT.json fields for review cycle:**
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `review_cycle` | `number` | No | Current review cycle count (default: 0) |
-| `review_comments` | `string[]` | No | Summary list of conductor review comments |
-
-**Status lifecycle:**
-```
-success → review_pending → review_addressed → approved
-                ↑                    │
-                └────────────────────┘ (max 3 cycles)
-```
-
-**Error recovery flow:**
-
-```
-Command fails → Read error → Diagnose (git status, paths, deps) → Minimal fix → Retry
-                                                                         ↓
-                                                              Max 3 retries reached?
-                                                              Yes → RESULT.json (failure)
-                                                              No  → Retry command
-```
-
-### Full Wave Transition
-
-Combines all steps into one operation:
-
-```bash
-wave_transition() {
-  local issues_csv="$1"
-  local custom_prompt="${2:-}"
-
-  # Parse issues
-  IFS=',' read -ra ISSUES <<< "$issues_csv"
-  local count=${#ISSUES[@]}
-
-  echo "=== Wave Transition: ${count} issues ==="
-
-  # Step 1: Stop current workers
-  echo "[1/8] Stopping current workers..."
-  stop_workers
-
-  # Step 2: Clean worktrees
-  echo "[2/8] Cleaning worktrees..."
-  clean_worktrees
-
-  # Step 3: Create new worktrees
-  echo "[3/8] Creating ${count} worktrees..."
-  create_worktrees "$count"
-
-  # Step 3.5: Install dependencies
-  echo "[4/8] Installing worktree dependencies..."
-  install_worktree_deps "$count"
-
-  # Step 4: Launch Claude Code
-  echo "[5/8] Launching Claude Code instances..."
-  launch_workers "$count"
-
-  # Step 5: Setup conductor layout
-  echo "[6/8] Setting up conductor layout..."
-  setup_conductor_layout "$count"
-
-  # Step 6: Wait for readiness
-  echo "[7/8] Waiting for readiness..."
-  local failed
-  wait_all_ready "$count"
-  failed=$?
-  if [ "$failed" -gt 0 ]; then
-    echo "WARNING: ${failed} pane(s) failed to initialize"
-  fi
-
-  # Step 7: Assign tasks
-  echo "[8/8] Assigning tasks..."
-  assign_tasks "${ISSUES[@]}"
-
-  echo "=== Wave Transition Complete ==="
-  echo "Session: tmux attach -t $SESSION"
-}
-```
-
----
-
-## Commands
-
-### `/taskmaestro wave-transition <issues>`
-
-Run the full wave transition:
-
-```bash
-# Example: transition to wave 2 with issues 740, 741, 742
-/taskmaestro wave-transition 740,741,742
-```
-
-Execute `wave_transition` with the provided issue list.
-
-### `/taskmaestro launch <count>`
-
-Launch fresh workers without stopping existing ones:
-
-```bash
-# Example: launch 3 new workers
-/taskmaestro launch 3
-```
-
-Execute steps 3-7 only (create worktrees, launch, conductor layout, wait, but no task assignment).
-
-### `/taskmaestro status`
-
-Check the status of all active panes using **2-pass analysis with duration tracking**:
-
-```bash
-status_check() {
-  local panes
-  panes=$(tmux list-panes -t "$SESSION" -F '#{pane_index}' 2>/dev/null)
-
-  if [ -z "$panes" ]; then
-    echo "No active taskMaestro session"
-    return 1
-  fi
-
-  # Ensure status tracking directory exists
-  mkdir -p "$STATUS_PREV_DIR"
-
-  for pane in $panes; do
-    local target="${SESSION}:0.${pane}"
-    local wt_dir="${WORKTREE_BASE}/wt-$((pane + 1))"
-    local branch="none"
-    if [ -d "$wt_dir" ]; then
-      branch=$(git -C "$wt_dir" branch --show-current 2>/dev/null || echo "detached")
-    fi
-
-    # --- Pass 1: 3-Factor Analysis (30-line scan) ---
-    local content
-    content=$(tmux capture-pane -t "$target" -p 2>/dev/null | tail -30)
-
-    # Factor 1: Error scan — specific patterns (not broad "error|fail")
-    local has_error=false
-    if echo "$content" | grep -qE 'FAIL|Error:|Cannot find|fatal:|ENOENT|EPERM|ERR!|panic|FATAL'; then
-      has_error=true
-    fi
-
-    # Factor 2: Active spinner detection
-    # Animating braille characters OR Claude's active progress indicator
-    local has_active_spinner=false
-    if echo "$content" | grep -qE '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]'; then
-      has_active_spinner=true
-    fi
-    # Claude Code active format: "… (Xm · ↓X ↑X)" — NOT "Crunched for" (completed)
-    if echo "$content" | grep -qE '… \([0-9]+[sm] ·' && ! echo "$content" | grep -qE 'Crunched for'; then
-      has_active_spinner=true
-    fi
-
-    # Factor 3: Completed spinner detection (static ✓ or ✗)
-    local has_completed_spinner=false
-    if echo "$content" | grep -qE '[✓✗✔✘]|Crunched for'; then
-      has_completed_spinner=true
-    fi
-
-    # Determine state from 3 factors
-    local state="unknown"
-    if echo "$content" | grep -qE "$PROMPT_PATTERN"; then
-      state="idle"
-    elif [ "$has_error" = true ] && [ "$has_active_spinner" = false ]; then
-      state="error"
-    elif [ "$has_error" = true ] && [ "$has_active_spinner" = true ]; then
-      state="error_idle"
-    elif [ "$has_active_spinner" = true ]; then
-      state="working"
-    elif [ "$has_completed_spinner" = true ]; then
-      state="step-complete"
-    else
-      state="unknown"
-    fi
-
-    # --- Pass 2: Duration Tracking (stall detection) ---
-    local prev_file="${STATUS_PREV_DIR}/pane-${pane}.prev"
-    local content_hash
-    content_hash=$(echo "$content" | md5sum | cut -d' ' -f1 2>/dev/null || echo "$content" | md5 -q 2>/dev/null)
-    local stall_count=0
-
-    if [ -f "$prev_file" ]; then
-      local prev_hash prev_stall
-      prev_hash=$(head -1 "$prev_file")
-      prev_stall=$(tail -1 "$prev_file")
-
-      if [ "$content_hash" = "$prev_hash" ] && [ "$state" = "working" ]; then
-        stall_count=$((prev_stall + 1))
-        if [ "$stall_count" -ge 2 ]; then
-          state="STALLED"
-        fi
-      fi
-    fi
-
-    # Save current state for next cycle
-    printf '%s\n%s\n' "$content_hash" "$stall_count" > "$prev_file"
-
-    # --- RESULT.json Validation ---
-    local result_status=""
-    local result_file="${wt_dir}/RESULT.json"
-    if [ -f "$result_file" ]; then
-      local result_issue
-      result_issue=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${result_file}','utf8')).issue||'')}catch(e){console.log('')}" 2>/dev/null)
-
-      # Extract assigned issue from TASK.md if available
-      local assigned_issue=""
-      if [ -f "${wt_dir}/TASK.md" ]; then
-        assigned_issue=$(head -1 "${wt_dir}/TASK.md" | grep -oE '#[0-9]+' | head -1)
-      fi
-
-      if [ -z "$result_issue" ]; then
-        result_status="(no issue field)"
-      elif [ -n "$assigned_issue" ] && [ "#${result_issue}" != "$assigned_issue" ] && ! echo "$result_issue" | grep -qF "${assigned_issue#\#}"; then
-        # Stale RESULT.json — issue mismatch, auto-remove
-        rm -f "$result_file"
-        result_status="(STALE — removed)"
-      else
-        result_status="(issue: ${result_issue})"
-      fi
-    fi
-
-    echo "pane-${pane}: ${state} | branch: ${branch} ${result_status}"
-    if [ "$has_error" = true ]; then
-      echo "  ⚠ errors detected in 30-line scan"
-    fi
-    if [ "$state" = "STALLED" ]; then
-      echo "  🛑 STALLED: same output for ${stall_count}+ cycles — intervene"
-    fi
-  done
-}
-```
-
-**2-pass analysis:**
-
-| Pass | Purpose | Method |
-|------|---------|--------|
-| Pass 1 | 3-factor state detection | Error patterns, active/completed spinners |
-| Pass 2 | Duration-based stall detection | Content hash comparison across cycles |
-
-**Enhanced error patterns (#864):**
-
-| Pattern | Catches |
-|---------|---------|
-| `FAIL` | Test failures |
-| `Error:` | Node.js/TypeScript errors |
-| `Cannot find` | Missing module/package |
-| `fatal:` | Git fatal errors |
-| `ENOENT\|EPERM` | File system errors |
-| `ERR!` | npm/yarn errors |
-| `panic\|FATAL` | System-level panics |
-
-**Active vs Completed spinner discrimination:**
-
-| Pattern | Type | Example |
-|---------|------|---------|
-| `⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏` | Active (braille animation) | Thinking/processing |
-| `… (Xm ·` | Active (Claude progress) | `… (2m · ↓5 ↑3)` |
-| `Crunched for` | Completed | `Crunched for 1m 23s` |
-| `✓✗✔✘` | Completed (static) | Step done |
-
-**Stall detection flow:**
-
-```
-Cycle N: capture content → hash → compare with prev
-  Same hash + "working" state → stall_count++
-  stall_count >= 2 → state = "STALLED"
-  Different hash → stall_count = 0
-```
-
-**RESULT.json validation (#864):**
-
-| Check | Action |
-|-------|--------|
-| No issue field | Flag `(no issue field)` |
-| Issue matches TASK.md | Show `(issue: #N)` |
-| Issue mismatches TASK.md | Auto-remove + flag `(STALE — removed)` |
-
-### `/taskmaestro watch`
-
-Continuous monitoring loop with **auto-nudge** for stuck workers and **permission prompt auto-handling**:
-
-```bash
-# Example: start watching all workers
-/taskmaestro watch
-```
-
-#### Nudge Worker
-
-Send a contextual nudge message to a stuck worker:
-
-```bash
-nudge_worker() {
-  local pane="$1"
-  local state="$2"  # "idle" or "error_idle"
-  local nudge_count="$3"
-
-  local nudge_msg
-  if [ "$state" = "error_idle" ]; then
-    nudge_msg="You appear stuck with errors. Follow the ERROR RECOVERY PROTOCOL: read the error, diagnose with git status, apply minimal fix, retry. If 3 retries fail, write RESULT.json with status failure."
-  else
-    nudge_msg="You appear idle without RESULT.json. Continue your task: read TASK.md, complete implementation, use /ship, then write RESULT.json. Do not idle without RESULT.json."
-  fi
-
-  tmux send-keys -t "$pane" "$nudge_msg" Enter
-  echo "NUDGE (${nudge_count}/${MAX_NUDGE_COUNT}): pane $pane — ${state}"
-}
-```
-
-#### Permission Prompt Auto-Handling
-
-Detect and auto-approve permission prompts during worker execution:
-
-```bash
-handle_permission_prompts() {
-  local pane="$1"
-  local content="$2"
-  local handled=0
-
-  # Edit/proceed permission prompts
-  if echo "$content" | grep -qiE 'Do you want to (make this edit|proceed|allow|run)|Allow this|Approve this'; then
-    tmux send-keys -t "$pane" Enter
-    sleep 1
-    handled=$((handled + 1))
-    echo "AUTO-APPROVED: permission prompt in pane $pane"
-  fi
-
-  # Yes/No tool permission prompts
-  if echo "$content" | grep -qiE 'Allow tool|permission.*\(y/n\)|proceed.*\[Y/n\]'; then
-    tmux send-keys -t "$pane" "y" Enter
-    sleep 1
-    handled=$((handled + 1))
-    echo "AUTO-APPROVED: tool permission in pane $pane"
-  fi
-
-  return "$handled"
-}
-```
-
-#### Wave Plan Structure
-
-Define a wave plan as a JSON file at `.taskmaestro/wave-plan.json` to enable auto-transition between waves:
+### RESULT.json 스키마
 
 ```json
 {
-  "waves": [
-    {
-      "name": "Wave 1",
-      "issues": ["867", "868", "870"],
-      "started_at": null,
-      "completed_at": null
-    },
-    {
-      "name": "Wave 2",
-      "issues": ["861", "864", "869"],
-      "started_at": null,
-      "completed_at": null
-    }
-  ],
-  "current_wave": 0
+  "status": "success | failure | error | review_pending | review_addressed | approved",
+  "issue": "#767",
+  "pr_number": 123,
+  "pr_url": "https://github.com/org/repo/pull/123",
+  "timestamp": "2026-03-22T01:13:00.000Z",
+  "cost": "$0.45",
+  "error": null,
+  "review_cycle": 0,
+  "review_comments": []
 }
 ```
 
-**Fields:**
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `status` | `"success" \| "failure" \| "error" \| "review_pending" \| "review_addressed" \| "approved"` | ✅ | 작업 결과. `success`: PR 생성 완료 (리뷰 대기), `failure`: 작업 실패 (테스트 실패 등), `error`: 예기치 못한 오류, `review_pending`: 지휘자 리뷰 코멘트 작성 완료 (워커 응답 대기), `review_addressed`: 워커가 리뷰 반영 완료 (재리뷰 대기), `approved`: 지휘자 최종 승인 (진짜 완료) |
+| `issue` | `string \| null` | ❌ | 관련 이슈 번호 (예: `"#767"`) |
+| `pr_number` | `number \| null` | ❌ | 생성된 PR 번호 |
+| `pr_url` | `string \| null` | ❌ | 생성된 PR URL |
+| `timestamp` | `string` | ✅ | ISO 8601 완료 시각 |
+| `cost` | `string \| null` | ❌ | 세션 비용 (예: `"$0.45"`) |
+| `error` | `string \| null` | ❌ | 에러 메시지 (`status`가 `"error"`일 때) |
+| `review_cycle` | `number` | ❌ | 현재 리뷰 사이클 횟수 (기본값: 0) |
+| `review_comments` | `string[]` | ❌ | 지휘자가 남긴 리뷰 코멘트 요약 목록 |
+
+### 파일 경로 규칙
+
+- 위치: `<repo>/.taskmaestro/wt-<N>/RESULT.json` (각 워커의 worktree 루트)
+- 워커는 작업 완료 **직전** (커밋/PR 생성 후, 세션 종료 전)에 이 파일을 작성한다
+- 지휘자는 이 파일의 존재 여부로 워커 완료를 감지한다
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `waves` | array | Ordered list of waves to execute |
-| `waves[].name` | string | Human-readable wave label |
-| `waves[].issues` | string[] | Issue numbers assigned to this wave |
-| `waves[].started_at` | string\|null | ISO timestamp when wave was assigned |
-| `waves[].completed_at` | string\|null | ISO timestamp when all workers completed |
-| `current_wave` | number | 0-based index of the active wave |
-
-#### Wave Completion Report
-
-Generate a cost/time summary when a wave completes:
-
-```bash
-generate_wave_report() {
-  local wave_name="$1"
-  local wave_start="$2"  # ISO timestamp
-  local pane_count="$3"
-
-  local wave_end
-  wave_end=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-  # Calculate wave duration
-  local start_epoch end_epoch duration_s
-  start_epoch=$(date -d "$wave_start" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$wave_start" +%s 2>/dev/null)
-  end_epoch=$(date +%s)
-  duration_s=$((end_epoch - start_epoch))
-  local duration_m=$((duration_s / 60))
-  local duration_rem=$((duration_s % 60))
-
-  local total_cost=0
-  local success_count=0
-  local total_workers=0
-
-  echo ""
-  echo "╔══════════════════════════════════════════════════════════════╗"
-  echo "║  ${wave_name} Complete Report                               ║"
-  echo "╠══════════════════════════════════════════════════════════════╣"
-  echo "║  Duration: ${duration_m}m ${duration_rem}s                  ║"
-  echo "╚══════════════════════════════════════════════════════════════╝"
-  echo ""
-  printf "| %-8s | %-12s | %-10s | %-8s | %-6s |\n" "Worker" "Issue" "Status" "Cost" "PR"
-  printf "|----------|--------------|------------|----------|--------|\n"
-
-  for i in $(seq 1 "$pane_count"); do
-    local wt_dir="${WORKTREE_BASE}/wt-${i}"
-    local result_file="${wt_dir}/RESULT.json"
-    total_workers=$((total_workers + 1))
-
-    if [ -f "$result_file" ]; then
-      local r_status r_issue r_cost r_pr
-      r_status=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${result_file}','utf8')).status||'unknown')}catch(e){console.log('error')}" 2>/dev/null)
-      r_issue=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${result_file}','utf8')).issue||'?')}catch(e){console.log('?')}" 2>/dev/null)
-      r_cost=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${result_file}','utf8')).cost||'N/A')}catch(e){console.log('N/A')}" 2>/dev/null)
-      r_pr=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${result_file}','utf8')).pr_number||'—')}catch(e){console.log('—')}" 2>/dev/null)
-
-      [ "$r_status" = "success" ] && success_count=$((success_count + 1))
-
-      # Accumulate cost if numeric
-      if echo "$r_cost" | grep -qE '^[0-9.]+$'; then
-        total_cost=$(node -e "console.log(($total_cost + $r_cost).toFixed(2))" 2>/dev/null)
-      fi
-
-      printf "| pane-%-3s | %-12s | %-10s | %-8s | #%-5s |\n" "$i" "$r_issue" "$r_status" "\$${r_cost}" "$r_pr"
-    else
-      printf "| pane-%-3s | %-12s | %-10s | %-8s | %-6s |\n" "$i" "?" "no-result" "N/A" "—"
-    fi
-  done
-
-  echo ""
-  local avg_cost="N/A"
-  if [ "$total_workers" -gt 0 ] && echo "$total_cost" | grep -qE '^[0-9.]+$'; then
-    avg_cost=$(node -e "console.log(($total_cost / $total_workers).toFixed(2))" 2>/dev/null)
-  fi
-  echo "Workers: ${success_count}/${total_workers} success"
-  echo "Total cost: ~\$${total_cost} | Avg: \$${avg_cost}/worker"
-  echo ""
-}
-```
-
-**Report fields:**
-
-| Column | Source | Description |
-|--------|--------|-------------|
-| Worker | pane index | Which worktree pane |
-| Issue | `RESULT.json → issue` | Issue number(s) |
-| Status | `RESULT.json → status` | success/failure/error |
-| Cost | `RESULT.json → cost` | API cost if available |
-| PR | `RESULT.json → pr_number` | Pull request number |
-
-#### Wave Auto-Transition
-
-Automatically transition to the next wave when all workers complete successfully:
-
-```bash
-auto_wave_transition() {
-  local plan_file="$WAVE_PLAN_FILE"
-
-  if [ ! -f "$plan_file" ]; then
-    echo "No wave plan found — skipping auto-transition"
-    return 1
-  fi
-
-  # Read current wave index
-  local current_wave
-  current_wave=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${plan_file}','utf8')).current_wave)" 2>/dev/null)
-  local total_waves
-  total_waves=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${plan_file}','utf8')).waves.length)" 2>/dev/null)
-
-  # Mark current wave as completed
-  node -e "
-    const fs = require('fs');
-    const plan = JSON.parse(fs.readFileSync('${plan_file}', 'utf8'));
-    plan.waves[${current_wave}].completed_at = new Date().toISOString();
-    plan.current_wave = ${current_wave} + 1;
-    fs.writeFileSync('${plan_file}', JSON.stringify(plan, null, 2));
-  " 2>/dev/null
-
-  local next_wave=$((current_wave + 1))
-
-  if [ "$next_wave" -ge "$total_waves" ]; then
-    echo "=== All waves complete! No more waves in plan. ==="
-    return 0
-  fi
-
-  # Read next wave issues
-  local next_issues
-  next_issues=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${plan_file}','utf8')).waves[${next_wave}].issues.join(','))" 2>/dev/null)
-  local next_name
-  next_name=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${plan_file}','utf8')).waves[${next_wave}].name)" 2>/dev/null)
-
-  echo "=== Auto-Transition: ${next_name} (issues: ${next_issues}) ==="
-
-  # Mark next wave as started
-  node -e "
-    const fs = require('fs');
-    const plan = JSON.parse(fs.readFileSync('${plan_file}', 'utf8'));
-    plan.waves[${next_wave}].started_at = new Date().toISOString();
-    fs.writeFileSync('${plan_file}', JSON.stringify(plan, null, 2));
-  " 2>/dev/null
-
-  # Execute wave transition
-  wave_transition "$next_issues"
-}
-```
-
-**Auto-transition flow:**
-
-```
-All workers done (RESULT.json exists)
-     ↓
-generate_wave_report()  — print summary
-     ↓
-auto_wave_transition()
-     ├── No wave plan? → skip, stay idle
-     ├── Last wave? → "All waves complete!"
-     └── Next wave exists? → wave_transition(next_issues)
-```
-
-#### Watch Loop
-
-Main monitoring loop combining status checks, auto-nudge, permission handling, **wave completion detection**, and **auto-transition**:
-
-```bash
-watch_workers() {
-  echo "=== Watch Mode Started (interval: ${WATCH_INTERVAL}s) ==="
-  echo "Press Ctrl+C to stop watching."
-
-  # Initialize per-pane tracking
-  declare -A idle_cycles
-  declare -A nudge_counts
-  mkdir -p "$STATUS_PREV_DIR"
-
-  # Wave timing: record start time for cost/duration tracking (#872)
-  local wave_start
-  wave_start=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  local wave_name="Current Wave"
-  if [ -f "$WAVE_PLAN_FILE" ]; then
-    local cw
-    cw=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${WAVE_PLAN_FILE}','utf8')).current_wave||0)" 2>/dev/null)
-    wave_name=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${WAVE_PLAN_FILE}','utf8')).waves[${cw}].name||'Wave ${cw}')" 2>/dev/null)
-  fi
-
-  while true; do
-    local panes
-    panes=$(tmux list-panes -t "$SESSION" -F '#{pane_index}' 2>/dev/null)
-
-    if [ -z "$panes" ]; then
-      echo "No active taskMaestro session — stopping watch"
-      break
-    fi
-
-    local pane_count=0
-    local done_count=0
-
-    echo "--- $(date '+%H:%M:%S') ---"
-
-    for pane in $panes; do
-      pane_count=$((pane_count + 1))
-      local target="${SESSION}:0.${pane}"
-      local wt_dir="${WORKTREE_BASE}/wt-$((pane + 1))"
-
-      # Capture pane content
-      local content
-      content=$(tmux capture-pane -t "$target" -p 2>/dev/null | tail -30)
-
-      # --- Permission Prompt Auto-Handling (#869) ---
-      handle_permission_prompts "$target" "$content"
-
-      # --- Push Protocol: TM Message Detection (primary) (#886) ---
-      local tm_handled=false
-      local state="unknown"
-      local result_file="${wt_dir}/RESULT.json"
-      local has_result=false
-
-      # --- RESULT.json Issue Validation (#887) ---
-      if [ -f "$result_file" ]; then
-        local result_issue
-        result_issue=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${result_file}','utf8')).issue||'')}catch(e){console.log('')}" 2>/dev/null)
-
-        local assigned_issue=""
-        if [ -f "${wt_dir}/TASK.md" ]; then
-          assigned_issue=$(head -1 "${wt_dir}/TASK.md" | grep -oE '#[0-9]+' | head -1)
-        fi
-
-        if [ -n "$assigned_issue" ] && [ -n "$result_issue" ] && [ "#${result_issue}" != "$assigned_issue" ] && ! echo "$result_issue" | grep -qF "${assigned_issue#\#}"; then
-          rm -f "$result_file"
-          echo "  🗑 STALE RESULT.json removed (issue: ${result_issue}, expected: ${assigned_issue})"
-        else
-          has_result=true
-        fi
-      fi
-
-      local tm_done tm_error tm_progress
-      tm_done=$(echo "$content" | grep -oE '\[TM:DONE\] pane=[0-9]+ issue=#[0-9]+ pr=[^ ]+ status=[a-z]+' | tail -1)
-      tm_error=$(echo "$content" | grep -oE '\[TM:ERROR\] pane=[0-9]+ issue=#[0-9]+ error=.+' | tail -1)
-      tm_progress=$(echo "$content" | grep -oE '\[TM:PROGRESS\] pane=[0-9]+ issue=#[0-9]+ phase=[A-Z]+ step=.+' | tail -1)
-
-      if [ -n "$tm_done" ]; then
-        state="done"
-        set_worker_status "$target" "complete"
-        local tm_pr
-        tm_pr=$(echo "$tm_done" | grep -oE 'pr=[^ ]+' | cut -d= -f2)
-        echo "pane-${pane}: DONE (push) pr=${tm_pr}"
-        tm_handled=true
-      elif [ -n "$tm_error" ]; then
-        state="error_idle"
-        set_worker_status "$target" "error"
-        local tm_err_msg
-        tm_err_msg=$(echo "$tm_error" | sed 's/.*error=//')
-        echo "pane-${pane}: ERROR (push) ${tm_err_msg}"
-        tm_handled=true
-      elif [ -n "$tm_progress" ]; then
-        local tm_phase tm_step
-        tm_phase=$(echo "$tm_progress" | grep -oE 'phase=[A-Z]+' | cut -d= -f2)
-        tm_step=$(echo "$tm_progress" | sed 's/.*step=//')
-        echo "pane-${pane}: ${tm_phase} (push) ${tm_step}"
-        state="working"
-        idle_cycles[$pane]=0
-        tm_handled=true
-      fi
-
-      # --- Polling Fallback: 3-Factor Analysis (when no push message) ---
-      if [ "$tm_handled" = false ]; then
-        local has_error=false
-        if echo "$content" | grep -qE 'FAIL|Error:|Cannot find|fatal:|ENOENT|EPERM|ERR!|panic|FATAL'; then
-          has_error=true
-        fi
-
-        local has_active_spinner=false
-        if echo "$content" | grep -qE '[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]'; then
-          has_active_spinner=true
-        fi
-        if echo "$content" | grep -qE '… \([0-9]+[sm] ·' && ! echo "$content" | grep -qE 'Crunched for'; then
-          has_active_spinner=true
-        fi
-
-        if echo "$content" | grep -qE "$PROMPT_PATTERN"; then
-          if [ "$has_result" = true ]; then
-            state="done"
-            set_worker_status "$target" "complete"
-          elif [ "$has_error" = true ]; then
-            state="error_idle"
-            set_worker_status "$target" "error"
-          else
-            state="idle"
-          fi
-        elif [ "$has_error" = true ] && [ "$has_active_spinner" = false ]; then
-          state="error"
-          set_worker_status "$target" "error"
-        elif [ "$has_active_spinner" = true ]; then
-          state="working"
-          idle_cycles[$pane]=0  # Reset idle counter
-        fi
-
-        echo "pane-${pane}: ${state} (poll)"
-      fi
-
-      # --- Auto-Nudge Logic (#861) ---
-      if [ "$state" = "idle" ] || [ "$state" = "error_idle" ]; then
-        local prev_idle=${idle_cycles[$pane]:-0}
-        idle_cycles[$pane]=$((prev_idle + 1))
-        local current_nudges=${nudge_counts[$pane]:-0}
-
-        if [ "${idle_cycles[$pane]}" -ge "$IDLE_CYCLES_BEFORE_NUDGE" ]; then
-          if [ "$current_nudges" -lt "$MAX_NUDGE_COUNT" ]; then
-            nudge_counts[$pane]=$((current_nudges + 1))
-            nudge_worker "$target" "$state" "${nudge_counts[$pane]}"
-            idle_cycles[$pane]=0  # Reset after nudge
-          else
-            echo "⚠ ESCALATE: pane-${pane} unresponsive after ${MAX_NUDGE_COUNT} nudges — conductor intervention needed"
-            set_worker_status "$target" "error"
-          fi
-        fi
-      elif [ "$state" = "done" ]; then
-        idle_cycles[$pane]=0
-        nudge_counts[$pane]=0
-        done_count=$((done_count + 1))
-      fi
-    done
-
-    # --- Wave Completion Detection (#871 + #872) ---
-    if [ "$pane_count" -gt 0 ] && [ "$done_count" -eq "$pane_count" ]; then
-      echo ""
-      echo "🎉 ALL ${pane_count} workers completed!"
-
-      # Generate wave report (#872)
-      generate_wave_report "$wave_name" "$wave_start" "$pane_count"
-
-      # Attempt auto-transition to next wave (#871)
-      if auto_wave_transition; then
-        # New wave started — reset tracking
-        wave_start=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        idle_cycles=()
-        nudge_counts=()
-        if [ -f "$WAVE_PLAN_FILE" ]; then
-          local cw
-          cw=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${WAVE_PLAN_FILE}','utf8')).current_wave||0)" 2>/dev/null)
-          wave_name=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${WAVE_PLAN_FILE}','utf8')).waves[${cw}].name||'Wave ${cw}')" 2>/dev/null)
-        fi
-      else
-        echo "Watch complete — no more waves. Exiting."
-        break
-      fi
-    fi
-
-    sleep "$WATCH_INTERVAL"
-  done
-}
-```
-
-**Watch cycle per pane (hybrid: push primary, polling fallback):**
-
-| Priority | Check | Action |
-|----------|-------|--------|
-| 0 | Permission prompt detected | Auto-send Enter/y to approve (#869) |
-| 0.5 | RESULT.json issue mismatch | Auto-remove stale RESULT.json + log (#887) |
-| 1 (push) | `[TM:DONE]` message found | Mark done, extract PR number (#886) |
-| 1 (push) | `[TM:ERROR]` message found | Mark error, extract error message (#886) |
-| 1 (push) | `[TM:PROGRESS]` message found | Log phase/step, reset idle counter (#886) |
-| 2 (poll) | No `[TM:*]` → 3-factor analysis | Fallback for crashed/legacy workers |
-| 3 | State = `idle` (no RESULT.json) | Increment idle counter → nudge after 2 cycles (#861) |
-| 3 | State = `error_idle` (errors + prompt) | Nudge with error recovery instructions (#861) |
-| 3 | State = `done` (RESULT.json `approved`) | Mark complete, reset counters |
-| 3 | State = `review_start` (RESULT.json `success`) | Start review cycle (see Review Cycle Protocol) |
-| 3 | State = `review_pending` | Awaiting worker response — no action |
-| 3 | State = `review_addressed` | Conductor re-reviews (see Review Cycle Protocol) |
-| 3 | State = `working` | Reset idle counter, continue |
-| 4 | Nudge count >= 3 | Escalate — conductor alert (#861) |
-
-**Push protocol message format (#886):**
-
-| Message | Format | When |
-|---------|--------|------|
-| `[TM:PROGRESS]` | `pane=N issue=#NNN phase=PHASE step=DESC` | Phase transitions (PLAN→ACT, ACT→EVAL) |
-| `[TM:DONE]` | `pane=N issue=#NNN pr=NNN status=success` | After RESULT.json written (success) |
-| `[TM:ERROR]` | `pane=N issue=#NNN error=MSG` | After RESULT.json written (failure) |
-
-**Hybrid detection priority (#886):**
-
-| Priority | Source | Trigger | Reliability |
-|----------|--------|---------|-------------|
-| Primary | `[TM:*]` push messages | Worker actively emits status | High — explicit signal |
-| Fallback | 3-factor polling | No push messages in 30-line scan | Medium — UI pattern inference |
-
-**Nudge escalation:**
-
-| Idle Cycles | Nudge Count | Action |
-|-------------|-------------|--------|
-| < 2 | — | No action (worker may be pausing normally) |
-| >= 2 | 1 | First nudge — contextual message |
-| >= 2 | 2 | Second nudge — more urgent |
-| >= 2 | 3 | Third and final nudge |
-| >= 2 | > 3 | Escalate to conductor — manual intervention |
-
-### Auto-Nudge Protocol
-
-When idle pane detected (❯ visible) but task status is "working":
-
-1. **1st idle**: `tmux send-keys "continue" Enter`
-2. **2nd idle**: `tmux send-keys "continue with the next incomplete task" Enter`
-3. **3rd idle**: Send explicit instruction with task context
-4. Track nudge count per pane in watch report
-
-### `/taskmaestro stop`
-
-Stop all active workers without removing worktrees:
-
-```bash
-# Example: stop workers but keep worktrees for inspection
-/taskmaestro stop
-```
-
-Execute `stop_workers` only. Worktrees and branches remain intact for manual inspection or resumption.
-
-### `/taskmaestro cleanup [--force]`
-
-Full post-parallel cleanup: stop workers, remove worktrees, kill tmux session, delete branches.
-
-```bash
-# Clean up after a completed wave
-/taskmaestro cleanup
-
-# Force cleanup even with uncommitted changes
-/taskmaestro cleanup --force
-```
-
-#### Uncommitted Changes Detection
-
-Before removing worktrees, check for uncommitted or unpushed work:
-
-```bash
-check_uncommitted() {
-  local base_dir="${WORKTREE_BASE}"
-  local issues=()
-
-  for wt_dir in "${base_dir}"/wt-*; do
-    [ -d "$wt_dir" ] || continue
-
-    local branch
-    branch=$(git -C "$wt_dir" branch --show-current 2>/dev/null || echo "detached")
-    local has_issues=false
-
-    # Check uncommitted changes
-    local status
-    status=$(git -C "$wt_dir" status --porcelain 2>/dev/null)
-    if [ -n "$status" ]; then
-      echo "WARNING: Uncommitted changes in ${wt_dir} (${branch}):" >&2
-      echo "$status" | head -5 >&2
-      has_issues=true
-    fi
-
-    # Check unpushed commits
-    local unpushed
-    unpushed=$(git -C "$wt_dir" log --oneline @{upstream}..HEAD 2>/dev/null)
-    if [ -n "$unpushed" ]; then
-      echo "WARNING: Unpushed commits in ${wt_dir} (${branch}):" >&2
-      echo "$unpushed" | head -5 >&2
-      has_issues=true
-    fi
-
-    if [ "$has_issues" = true ]; then
-      issues+=("${wt_dir}")
-    fi
-  done
-
-  if [ ${#issues[@]} -gt 0 ]; then
-    echo "" >&2
-    echo "DANGER: ${#issues[@]} worktree(s) have unsaved work." >&2
-    echo "Use --force to cleanup anyway, or commit/push changes first." >&2
-    return 1
-  fi
-
-  return 0
-}
-```
-
-**Detection covers:**
-
-| Check | What It Catches |
-|-------|-----------------|
-| `git status --porcelain` | Uncommitted/unstaged changes, untracked files |
-| `git log @{upstream}..HEAD` | Commits not pushed to remote |
-
-#### Cleanup Process
-
-```bash
-cleanup_all() {
-  local force="${1:-false}"
-
-  echo "=== Post-Parallel Cleanup ==="
-
-  # Step 1: Check for uncommitted changes
-  echo "[1/4] Checking for uncommitted changes..."
-  if ! check_uncommitted; then
-    if [ "$force" != "true" ]; then
-      echo "ABORT: Use --force to override." >&2
-      return 1
-    fi
-    echo "WARNING: Proceeding with --force, unsaved work will be lost."
-  fi
-
-  # Step 2: Stop workers and kill tmux session
-  echo "[2/4] Stopping workers..."
-  stop_workers
-  tmux kill-session -t "$SESSION" 2>/dev/null || true
-
-  # Step 3: Remove worktrees and branches
-  echo "[3/4] Removing worktrees and branches..."
-  for wt_dir in "${WORKTREE_BASE}"/wt-*; do
-    [ -d "$wt_dir" ] || continue
-
-    local branch
-    branch=$(git -C "$wt_dir" branch --show-current 2>/dev/null)
-
-    git worktree remove "$wt_dir" --force 2>/dev/null || rm -rf "$wt_dir"
-
-    # Delete the associated branch
-    if [ -n "$branch" ]; then
-      git branch -D "$branch" 2>/dev/null || true
-    fi
-  done
-  git worktree prune
-
-  # Step 4: Clean base directory
-  echo "[4/4] Cleaning up..."
-  if [ -d "$WORKTREE_BASE" ] && [ -z "$(ls -A "$WORKTREE_BASE" 2>/dev/null)" ]; then
-    rmdir "$WORKTREE_BASE" 2>/dev/null || true
-  fi
-
-  echo "=== Cleanup Complete ==="
-  echo "Removed: worktrees, branches, tmux session"
-}
-```
-
-**Cleanup targets:**
-
-| Target | Action | Reversible? |
-|--------|--------|-------------|
-| Active workers | `/exit` + `C-c` fallback | N/A |
-| tmux session | `kill-session` | Re-create with `/taskmaestro launch` |
-| Worktree dirs | `git worktree remove --force` | No — commit first |
-| Git branches | `git branch -D` | Recover via reflog within 30 days |
-| Base directory | `rmdir` if empty | Re-created on next launch |
-
----
-
-## Error Handling
-
-| Failure | Recovery |
-|---------|----------|
-| Pane not ready after timeout | Restart Claude in that pane, retry once |
-| Worktree removal fails | `rm -rf` as fallback, then `git worktree prune` |
-| `git fetch` fails | Continue with local master (warn user) |
-| tmux session missing | Create new session from scratch |
-| Trust/terms prompt not recognized | Log the captured content, wait for manual intervention |
-| Cleanup with uncommitted changes | Abort and list dirty worktrees; user runs `--force` or commits first |
-| Branch deletion fails | Branch may be checked out elsewhere; `git worktree prune` first |
-
-## Status Report Format (with evidence)
-
-Every status line MUST include parenthetical evidence:
-
-```
-패널 1: ✅ approved - "task" → PR #N (RESULT.json: approved, review cycles: 2, pane idle ✓)
-패널 2: 🔄 working - "task" (active: ✽ Implementing… · ↓ 5.3k tokens)
-패널 3: 🔍 reviewing - "task" → PR #N (RESULT.json: success, review cycle 1/3)
-패널 4: ⏳ review_pending - "task" → PR #N (RESULT.json: review_pending, cycle 1/3, awaiting worker)
-패널 5: 📝 review_addressed - "task" → PR #N (RESULT.json: review_addressed, cycle 2/3, awaiting re-review)
-패널 6: ⚠️ uncertain - "task" (RESULT.json exists BUT pane active — cross-verify)
-패널 7: ❌ error - "task" (error in last 10 lines: "ModuleNotFoundError")
-```
-
-**Status icons:**
-
-| status | Icon | Description |
-|--------|------|-------------|
-| `approved` | ✅ | Final approval (truly done) |
-| `success` (review starting) | 🔍 | Review cycle in progress |
-| `review_pending` | ⏳ | Conductor review done, awaiting worker response |
-| `review_addressed` | 📝 | Worker addressed review, awaiting re-review |
-| `working` | 🔄 | Worker actively working |
-| `failure` / `error` | ❌ | Failed or unexpected error |
-
-Rules:
-- Never bare ✅ without evidence
-- RESULT.json `approved` + pane idle = confirmed done
-- RESULT.json `success` = start review cycle (NOT done)
-- RESULT.json `review_pending` = awaiting worker response
-- RESULT.json `review_addressed` = awaiting conductor re-review
-- "thinking" alone ≠ working
-
-## Important Notes
-
-- **Never use fixed `sleep` for readiness** — always use `wait_for_ready()` with capture-pane polling
-- **Always call `handle_prompts()` before `wait_for_ready()`** — trust/terms prompts block the ready state
-- **Wave transition is atomic** — if any critical step fails (worktree creation, launch), abort and report
-- **Pane indices are 0-based** in tmux but worktree dirs are 1-based (`wt-1`, `wt-2`, ...)
-- **Always run `cleanup` after a wave completes** — leftover worktrees and branches accumulate over time
-- **Never `cleanup --force` without checking** — review warnings first to avoid losing uncommitted work
-- **Conductor layout requires tmux ≥ 2.3** — uses `-f` flag for full-width `join-pane`
-- **After layout setup, conductor is the last pane** — pane indices shift during `swap-pane` + `break-pane` + `join-pane`
-- **Worker status colors are pane-local** — use `set_worker_status()` to update border colors per pane
-- **Push protocol is primary, polling is fallback** — watch loop checks `[TM:*]` messages first; 3-factor analysis only runs when no push messages found (#886)
-- **Workers must emit `[TM:DONE]` or `[TM:ERROR]` after writing RESULT.json** — this enables immediate conductor detection without waiting for next poll cycle
-- **`[TM:PROGRESS]` is optional but recommended** — helps conductor track phase transitions in real-time
-
-## Status Verification Rules
-
-- **RESULT.json is NOT the sole source of truth** — always validate the `issue` field matches the assigned task AND cross-verify with `capture-pane` output (or `[TM:*]` push messages)
-- **3-factor analysis is the polling fallback** — only used when no `[TM:*]` push messages are detected in the 30-line scan. Push messages take priority when present.
-- **Active vs Completed spinner discrimination** — animating characters (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) = active work; static characters (`✓✗✔✘`) = step complete. Never confuse them.
-- **"thinking" ≠ productive work** when errors are visible — if errors appear alongside thinking/reasoning indicators, the worker is stuck in a retry loop
-- **Stall detection** — duration >5 minutes on the same step with no token/cost change = STALLED. Intervene immediately.
-- **NEVER use `git add -A` or `git add .`** — always stage specific files by name. This applies to both the conductor and all worker prompts.
-- **RESULT.json and TASK.md must NEVER be committed** — these are ephemeral per-worktree artifacts. If found in staged changes, unstage immediately.
-- **Stale RESULT.json auto-removal** — if RESULT.json `issue` field does not match the currently assigned task, remove it (`rm -f RESULT.json`) before the worker starts.
-
----
 
 ## Review Cycle Protocol
 
-When a worker creates a PR and writes RESULT.json with `status: "success"`, the conductor starts a code review cycle instead of marking the task as done. The task is only "truly done" when the conductor approves with `status: "approved"`.
+워커가 PR을 생성하고 RESULT.json에 `status: "success"`를 기록하면, 리뷰 사이클을 시작한다.
+`status: "approved"`가 될 때까지 반복하며, 승인 시점이 "진짜 완료"가 된다.
+
+> **리뷰 에이전트 패널이 설정된 경우:** 지휘자가 직접 리뷰하지 않고, 리뷰 에이전트 패널에 리뷰를 위임한다.
+> 아래 [Review Agent Protocol](#review-agent-protocol) 섹션을 참조한다.
+> 리뷰 에이전트가 없는 경우에만 지휘자가 직접 리뷰를 수행한다 (아래 Fallback 참조).
 
 ### Trigger
 
-Watch mode RESULT.json status mapping:
+Watch 모드가 RESULT.json을 감지했을 때:
+- `status: "success"` → **리뷰 사이클 시작** (기존처럼 "done"으로 보고하지 않음)
+- `status: "failure"` / `"error"` → 사용자에게 보고 (기존 동작 유지)
+- `status: "review_pending"` → 워커 응답 대기 중 (지휘자 대기)
+- `status: "review_addressed"` → 재리뷰 시작
+- `status: "approved"` → 진짜 완료 ✅
 
-| status | Watch Action |
-|--------|-------------|
-| `"success"` | Start review cycle (NOT "done") |
-| `"failure"` / `"error"` | Report to user (unchanged) |
-| `"review_pending"` | Waiting for worker response |
-| `"review_addressed"` | Conductor should re-review |
-| `"approved"` | Truly done ✅ |
+### Review Routing
 
-### Review Steps
+`status: "success"` 또는 `status: "review_addressed"` 감지 시:
 
-When conductor detects `status: "success"` or `status: "review_addressed"`:
+1. **상태 파일에서 `review_pane` 확인**
+2. `review_pane`이 존재하면 → **Review Agent Protocol** 실행 (리뷰 에이전트에 위임)
+3. `review_pane`이 없으면 → **Conductor Fallback Review** 실행 (지휘자 직접 리뷰)
 
-1. **Read PR diff**
+### Conductor Fallback Review (리뷰 에이전트 없을 때)
+
+리뷰 에이전트 패널이 설정되지 않은 경우, 지휘자가 직접 리뷰를 수행한다:
+
+1. **PR diff 읽기**
    ```bash
    gh pr diff <PR_NUMBER>
    ```
 
-2. **Generate checklist**
-   Use codingbuddy `generate_checklist` MCP tool with the changed file paths for domain-specific checks.
+2. **체크리스트 생성**
+   codingbuddy `generate_checklist` MCP 도구로 변경 파일 기반 도메인별 체크리스트를 생성한다.
 
-3. **Write review comments**
-   Review the changes against the checklist and post comments on the PR:
+3. **리뷰 코멘트 작성**
+   변경 내용 + 체크리스트를 기반으로 리뷰를 수행하고 PR에 코멘트를 작성한다:
    ```bash
-   gh pr review <PR_NUMBER> --comment --body "<review comments>"
+   gh pr review <PR_NUMBER> --comment --body "<리뷰 내용>"
    ```
 
-4. **Update RESULT.json**
-   Conductor updates the worker's RESULT.json:
+4. **RESULT.json 업데이트**
+   지휘자가 RESULT.json을 업데이트한다:
    ```json
    {
      "status": "review_pending",
@@ -1690,108 +137,239 @@ When conductor detects `status: "success"` or `status: "review_addressed"`:
    }
    ```
 
-5. **Instruct worker**
+5. **워커에게 리뷰 반영 지시**
    ```bash
-   tmux send-keys -t "$target" \
-     "PR #<PR_NUMBER>에 리뷰 코멘트가 달렸다. gh pr view <PR_NUMBER> --comments 로 확인하고, 수용할 부분은 코드 수정 후 push, 거부할 부분은 PR에 반박 코멘트를 남겨라. 완료 후 RESULT.json의 status를 review_addressed로 업데이트해라." Enter
+   tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$PANE_IDX" \
+     "PR #<PR_NUMBER>에 리뷰 코멘트가 달렸다. gh pr view <PR_NUMBER> --comments 로 확인하고, 수용할 부분은 코드 수정 후 push하고, 거부할 부분은 PR에 반박 코멘트를 남겨라. 완료 후 RESULT.json의 status를 \"review_addressed\"로 업데이트해라." Enter
    ```
 
-6. **Worker responds**
-   - Accept: fix code → push
-   - Reject: post rebuttal comment with rationale
-   - Reply to each comment with "Resolved: [action taken]"
-   - Update RESULT.json: `status: "review_addressed"`
+6. **워커 응답**
+   워커가 리뷰에 대응한다:
+   - 수용: 코드 수정 → push
+   - 거부: PR에 반박 코멘트 작성 (사유 포함)
+   - 각 코멘트에 "Resolved: [수행한 작업]" 형태로 회신
+   - 완료 후 RESULT.json 업데이트: `status: "review_addressed"`
 
-7. **Re-review**
-   When conductor detects `status: "review_addressed"`:
-   - Re-read `gh pr diff <PR_NUMBER>`
-   - Check unresolved comments
-   - If improved enough → **approve** (Step 8)
-   - If not → repeat from Step 3
+7. **재리뷰**
+   지휘자가 `status: "review_addressed"`를 감지하면:
+   - `gh pr diff <PR_NUMBER>` 재확인
+   - 미해결 코멘트 확인
+   - 충분히 개선됐으면 → **승인** (Step 8)
+   - 아직 부족하면 → Step 3부터 반복
 
-8. **Final approval**
+8. **최종 승인**
    ```bash
-   # If not own PR
+   # 자신의 PR이 아닌 경우
    gh pr review <PR_NUMBER> --approve --body "LGTM - all review comments addressed"
-   # If own PR (cannot self-approve)
+   # 자신의 PR인 경우 (approve 불가) — 코멘트로 대체
    gh pr review <PR_NUMBER> --comment --body "✅ Review complete - all comments addressed"
    ```
-   Update RESULT.json: `status: "approved"`
+   RESULT.json 업데이트: `status: "approved"`
 
 ### Max Review Cycles
 
-- **Maximum 3 review cycles** (prevents infinite loops)
-- After 3 cycles, report to user:
+- **최대 3회** 리뷰 사이클 (무한 루프 방지)
+- 3회 초과 시 사용자에게 보고:
   ```
-  ⚠️ pane-N: 3 review cycles exhausted, unresolved issues remain.
+  ⚠️ 패널 N: 3회 리뷰 후에도 미해결 이슈가 있습니다.
   PR: #<PR_NUMBER>
-  Unresolved: [list of comments]
-  User decision required.
+  미해결 코멘트: [목록]
+  사용자 판단이 필요합니다.
   ```
-- Conductor stops reviewing that pane and waits for user instruction.
+- 이후 지휘자는 해당 패널의 리뷰를 중단하고 사용자 지시를 대기한다.
 
 ### Quality Criteria for Approval
 
-Conductor approves when:
-- CI fully passes (`gh pr checks <PR_NUMBER>`)
-- No unused variables/imports
-- New code has appropriate tests
-- Existing tests not broken
-- Code style consistency maintained
+approve할 조건:
+- CI 전체 통과 (`gh pr checks <PR_NUMBER>`)
+- 미사용 변수/import 없음
+- 새 코드에 적절한 테스트 존재
+- 기존 테스트 깨지지 않음
+- 코드 스타일 일관성 유지
 
-### Watch Loop Integration
+---
 
-In the watch loop, replace the simple "done" handling with review-aware logic:
+## Review Agent Protocol
 
+리뷰 에이전트 패널이 설정된 경우, 워커 PR 리뷰를 전담한다.
+지휘자는 오케스트레이션만 담당하고, 코드 리뷰는 리뷰 에이전트가 수행한다.
+
+```
+기존: Worker PR → Conductor 리뷰 (품질 낮음)
+변경: Worker PR → Review Agent 리뷰 → Conductor는 결과만 전달
+```
+
+### Trigger
+
+지휘자가 워커의 RESULT.json에서 `status: "success"` 또는 `status: "review_addressed"`를 감지하면,
+리뷰 에이전트 패널에 리뷰 프롬프트를 전송한다.
+
+### Review Agent Checklist (MANDATORY ORDER)
+
+리뷰 에이전트는 반드시 아래 순서대로 수행한다:
+
+1. **CI Gate (MUST)**: `gh pr checks <PR_NUMBER>` — ALL checks must pass. If any fail, STOP and report failure with logs. DO NOT proceed to code review.
+2. **Local Verification**: PR 브랜치에서 `yarn lint` 및 `yarn type-check` 실행하여 CI와 동일한 이슈를 로컬에서 포착
+3. **Code Quality Scan**: `gh pr diff <PR_NUMBER>` — 다음을 검사:
+   - Unused imports/variables
+   - `any` types
+   - Missing error handling
+   - Dead code
+4. **Spec Compliance**: issue 요구사항(`gh issue view <ISSUE_NUMBER>`)과 실제 구현을 대조
+5. **Test Coverage**: 새 코드에 적절한 테스트가 있는지 확인
+6. **Write Review**: `gh pr review --comment`로 구조화된 리뷰 코멘트를 PR에 작성
+
+### Review Agent Prompt Template
+
+지휘자가 리뷰 에이전트 패널에 전송하는 프롬프트:
+
+```
+Review PR #<PR_NUMBER> for issue #<ISSUE_NUMBER>.
+
+MANDATORY REVIEW CHECKLIST (follow in order):
+
+1. CI CHECK (BLOCKING):
+   gh pr checks <PR_NUMBER>
+   If ANY check fails → STOP. Report: "CI FAILED: <job_name> — <log_url>"
+   DO NOT proceed to code review if CI fails.
+
+2. LOCAL VERIFICATION:
+   git fetch origin && git checkout <branch>
+   yarn lint
+   yarn type-check
+   Report any errors.
+
+3. CODE QUALITY (gh pr diff <PR_NUMBER>):
+   - Unused imports/variables?
+   - any types?
+   - Missing error handling?
+   - Dead code?
+
+4. SPEC COMPLIANCE:
+   gh issue view <ISSUE_NUMBER>
+   Compare requirements with implementation. List any gaps.
+
+5. TEST COVERAGE:
+   Are new functions/features tested?
+   Are edge cases covered?
+
+6. WRITE REVIEW:
+   gh pr review <PR_NUMBER> --comment --body "<structured review>"
+
+Format your review as:
+## Review: [APPROVE | CHANGES_REQUESTED]
+### CI Status: [PASS | FAIL]
+### Issues Found:
+- [critical/high/medium/low]: description
+### Recommendation: [APPROVE | REQUEST_CHANGES]
+
+After posting review, write RESULT.json with:
+{
+  "status": "success",
+  "review_result": "approve | changes_requested",
+  "issues_found": <number>,
+  "critical_count": <number>,
+  "high_count": <number>
+}
+```
+
+전송 방식:
 ```bash
-# Inside watch loop, when has_result=true:
-if [ "$has_result" = true ]; then
-  local r_status
-  r_status=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('${result_file}','utf8')).status||'')}catch(e){console.log('')}" 2>/dev/null)
-
-  case "$r_status" in
-    "success")
-      # Start review cycle — NOT done yet
-      state="review_start"
-      echo "pane-${pane}: 🔍 PR ready for review"
-      # Conductor initiates review (Steps 1-5 above)
-      ;;
-    "review_pending")
-      state="review_pending"
-      echo "pane-${pane}: ⏳ awaiting worker response"
-      ;;
-    "review_addressed")
-      # Re-review needed
-      state="review_addressed"
-      echo "pane-${pane}: 📝 re-review needed"
-      # Conductor initiates re-review (Step 7 above)
-      ;;
-    "approved")
-      state="done"
-      set_worker_status "$target" "complete"
-      echo "pane-${pane}: ✅ approved (review complete)"
-      ;;
-    "failure"|"error")
-      state="error_idle"
-      set_worker_status "$target" "error"
-      ;;
-  esac
-fi
+tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$REVIEW_PANE" \
+  "$REVIEW_PROMPT" Enter
 ```
 
-### Wave Completion with Review
+> **참고:** 프롬프트가 길어 send-keys로 직접 전송 시 잘릴 수 있다. 이 경우 프롬프트를 TASK.md 파일에 저장하고 `send-keys`로 파일 경로를 참조하여 전송한다.
 
-Wave completion detection must use `"approved"` instead of simple RESULT.json existence:
+### Review Agent RESULT.json
 
+리뷰 에이전트의 결과 파일은 리뷰 에이전트 패널의 worktree에 기록된다:
+`<repo>/.taskmaestro/wt-<review_pane_idx>/RESULT.json`
+
+```json
+{
+  "status": "success",
+  "review_result": "approve | changes_requested",
+  "issues_found": 3,
+  "critical_count": 0,
+  "high_count": 1
+}
 ```
-All workers approved (RESULT.json status="approved")
-     ↓
-generate_wave_report()
-     ↓
-auto_wave_transition()
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| `status` | `"success" \| "error"` | ✅ | 리뷰 작업 자체의 성공/실패 |
+| `review_result` | `"approve" \| "changes_requested"` | ✅ | 리뷰 판정 결과 |
+| `issues_found` | `number` | ✅ | 발견된 총 이슈 수 |
+| `critical_count` | `number` | ✅ | Critical severity 이슈 수 |
+| `high_count` | `number` | ✅ | High severity 이슈 수 |
+
+### Conductor Handling of Review Agent Result
+
+지휘자가 리뷰 에이전트의 RESULT.json을 감지하면:
+
+1. **`review_result: "approve"`인 경우:**
+   - 워커의 RESULT.json을 `status: "approved"`로 업데이트
+   - 최종 승인 코멘트를 PR에 작성:
+     ```bash
+     gh pr review <PR_NUMBER> --approve --body "LGTM - review agent approved"
+     # 자신의 PR인 경우:
+     gh pr review <PR_NUMBER> --comment --body "✅ Review complete - review agent approved"
+     ```
+   - 사용자에게 완료 보고
+
+2. **`review_result: "changes_requested"`인 경우:**
+   - 워커의 RESULT.json을 `status: "review_pending"`으로 업데이트 (review_cycle 증가)
+   - 워커에게 리뷰 반영 지시:
+     ```bash
+     tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$WORKER_PANE" \
+       "PR #<PR_NUMBER>에 리뷰 코멘트가 달렸다. gh pr view <PR_NUMBER> --comments 로 확인하고, 수용할 부분은 코드 수정 후 push하고, 거부할 부분은 PR에 반박 코멘트를 남겨라. 완료 후 RESULT.json의 status를 \"review_addressed\"로 업데이트해라." Enter
+     ```
+
+3. **리뷰 에이전트 초기화:**
+   - 리뷰 에이전트의 RESULT.json 삭제 (다음 리뷰를 위한 준비):
+     ```bash
+     rm -f "$REPO/.taskmaestro/wt-$REVIEW_PANE/RESULT.json"
+     ```
+   - 리뷰 에이전트 패널의 상태를 `"idle"`로 업데이트
+
+### Review Cycle State in taskmaestro-state.json
+
+리뷰 사이클 중 각 패널의 상태 파일 필드:
+```json
+{
+  "index": 1,
+  "role": "worker",
+  "worktree": "...",
+  "branch": "...",
+  "task": "...",
+  "status": "review_pending",
+  "result": { "...RESULT.json 내용..." },
+  "review_cycle": 1,
+  "pr_number": 42
+}
 ```
 
-A worker with `status: "success"`, `"review_pending"`, or `"review_addressed"` is NOT done — the wave remains in progress.
+리뷰 에이전트 패널의 상태:
+```json
+{
+  "index": 3,
+  "role": "reviewer",
+  "worktree": "...",
+  "branch": "...",
+  "task": "Reviewing PR #42 for issue #767",
+  "status": "reviewing",
+  "result": null
+}
+```
+
+`status` 값 매핑:
+- `"working"` → 워커 작업 중
+- `"reviewing"` → 리뷰 에이전트가 PR 리뷰 중 (리뷰어 패널 전용)
+- `"review_pending"` → 리뷰 코멘트 작성 완료, 워커 응답 대기
+- `"review_addressed"` → 워커 리뷰 반영 완료, 재리뷰 대기
+- `"approved"` → 최종 승인 완료 (진짜 done)
+- `"done"` → 리뷰 없이 완료 (failure/error 포함)
 
 ---
 
@@ -1803,6 +381,7 @@ Prohibited commands:
 - `gh pr merge` (all flags: --squash, --merge, --rebase, --admin, --auto)
 - `git merge`
 - `git pull origin master` / `git pull origin main` (includes merge)
+- Any command that modifies the remote default branch
 
 Allowed:
 - `git fetch origin` (read-only)
@@ -1810,26 +389,40 @@ Allowed:
 - `gh pr view` (read-only)
 
 **Protocol:**
-1. Worker creates PR → reports PR URL
+1. Worker creates PR via `/ship` → reports PR URL
 2. Conductor reports PR URL to user
-3. User merges at their discretion
-4. User notifies conductor
+3. User merges PR at their discretion
+4. User notifies conductor: "머지했음" / "merged"
 5. Conductor runs `git fetch origin` to verify, then proceeds
 
-**Wave transition:** Report all PR URLs, wait for user merge confirmation before next wave.
+**Wave transition:**
+- After all workers in a wave create PRs, report to user: "Wave N complete. PRs: #X, #Y, #Z. 머지 후 알려주세요."
+- Wait for user confirmation before creating next wave's worktrees
 
 ---
 
 ## Wave Analysis: Shared File Prediction
 
-Before wave assignment, predict FULL file footprint per issue:
+Before assigning issues to a wave, predict the FULL file footprint per issue:
 
 1. **Explicit files**: Listed in issue body
 2. **Implicit shared files** (always check):
-   - `package.json`, `config.schema.ts`, `index.ts` barrel exports, `README.md`, `.gitignore`
-3. **MCP server issues**: Always flag `config.schema.ts`
+   - `package.json` — dependency changes
+   - `config.schema.ts` / `*.config.*` — schema/config updates
+   - `index.ts` / barrel exports — new module exports
+   - `README.md` — documentation updates
+   - `.gitignore` — new artifacts
+3. **MCP server issues**: Always flag `config.schema.ts` as potential overlap
 
-**Overlap check:** For each issue pair, if shared_files is not empty → move one to next wave.
+**Overlap check:**
+```
+For each pair of issues in the wave:
+  shared_files = issue_A.files ∩ issue_B.files
+  if shared_files is not empty:
+    → Move one issue to next wave OR make sequential in same pane
+```
+
+**Reference incident:** Wave A PR #876/#879 — config.schema.ts modified by two issues not listed in issue body, causing merge conflict.
 
 ---
 
@@ -1837,19 +430,21 @@ Before wave assignment, predict FULL file footprint per issue:
 
 ### Array Indexing Ban
 
-**NEVER use array indexing.** zsh=1-indexed, bash=0-indexed.
+**NEVER use array indexing in monitoring/watch scripts.** zsh is 1-indexed, bash is 0-indexed. This causes wrong issue mapping.
 
 ```bash
-# ❌ BANNED
+# ❌ BANNED — index mismatch between shells
 EXPECTED=("#888" "#811")
 echo ${EXPECTED[$IDX]}
 
-# ✅ REQUIRED
-for PANE_INFO in "1:#888" "2:#811"; do
+# ✅ REQUIRED — explicit key:value mapping
+for PANE_INFO in "1:#888" "2:#811" "3:#813"; do
   N="${PANE_INFO%%:*}"
   EXP="${PANE_INFO##*:}"
 done
 ```
+
+**Reference incident:** zsh 1-based indexing caused pane 3 and 4's valid RESULT.json to be deleted.
 
 ---
 
@@ -1857,8 +452,671 @@ done
 
 ### Compact Cadence
 
-- **Compact after every 2 waves**
-- **Save state** to `docs/codingbuddy/context.md` before compact
-- **After compact**: re-read taskmaestro-state.json
+For long taskMaestro sessions (multiple waves):
+- **Compact after every 2 waves** to prevent context degradation
+- **Compact before starting a new batch** of waves
+- **Save critical state** to `docs/codingbuddy/context.md` before compact (via `update_context`)
+- **After compact**: re-read taskmaestro-state.json to restore wave context
 
-Warning signs: cost > $2, context > 50%, duration > 2 hours
+Recommended flow:
+```
+Wave 1 → Wave 2 → compact → Wave 3 → Wave 4 → compact → ...
+```
+
+**Warning signs** that compact is needed:
+- Session cost exceeds $2
+- Context usage exceeds 50%
+- Response quality noticeably degrading
+- Session duration exceeds 2 hours
+
+---
+
+## Subcommand: start
+
+`/taskmaestro start [--repo <path>] [--base <branch>] [--panes <1,2,3>] [--review-pane]`
+
+현재 세션의 기존 패널들에 worktree + Claude Code를 세팅한다.
+
+### Step 1: 인수 파싱 및 기본값 설정
+
+- `--repo`: 대상 레포 경로 (기본값: 현재 작업 디렉토리)
+- `--base`: 베이스 브랜치 (기본값: 현재 브랜치)
+- `--panes`: 사용할 패널 번호 목록 (기본값: 지휘자 패널을 제외한 모든 패널)
+- `--review-pane`: 리뷰 전용 패널 할당 (기본값: 활성화). 비활성화하려면 `--no-review-pane` 사용
+
+### Step 2: 사전 검증
+
+```bash
+# repo가 git 레포인지 확인
+git -C "$REPO" rev-parse --git-dir
+```
+
+에러 시 "대상 경로가 git 레포지토리가 아닙니다" 출력 후 중단.
+
+```bash
+# 사용 가능한 패널 목록 확인 (지휘자 패널 제외)
+tmux -L "$SOCKET_NAME" list-panes -t "$SESSION:$WIN_IDX" -F '#{pane_index} #{pane_current_command}'
+```
+
+지휘자 패널($MY_PANE)을 제외한 패널들이 워커 대상이 된다. `--panes`로 지정하지 않으면 모든 비활성 패널을 사용한다.
+
+**리뷰 패널 할당 (`--review-pane`, 기본 활성화):**
+사용 가능한 패널 중 마지막 패널을 리뷰 에이전트 전용으로 할당한다.
+`--no-review-pane` 플래그로 비활성화할 수 있다.
+
+```bash
+# 리뷰 패널 할당 (기본: 마지막 패널)
+if [ "$REVIEW_PANE_ENABLED" = true ]; then
+  REVIEW_PANE=$(echo "$AVAILABLE_PANES" | tail -1)
+  WORKER_PANES=$(echo "$AVAILABLE_PANES" | head -n -1)
+
+  # 워커 패널이 최소 1개는 있어야 함
+  if [ -z "$WORKER_PANES" ]; then
+    echo "ERROR: 리뷰 패널을 할당하면 워커 패널이 없습니다. --no-review-pane을 사용하거나 패널을 추가하세요."
+    exit 1
+  fi
+else
+  REVIEW_PANE=""
+  WORKER_PANES="$AVAILABLE_PANES"
+fi
+```
+
+> **최소 패널 요구:** `--review-pane` 사용 시 지휘자 + 워커 1개 + 리뷰어 1개 = 최소 3개 패널이 필요하다.
+
+**워커 패널이 없는 경우:** 지휘자 패널만 존재하면, 첫 번째 숫자 인수(기본값 3)만큼 새 패널을 생성한다:
+
+```bash
+PANE_COUNT=${1:-3}  # 기본 3개
+DIR=$(cd "$REPO" && pwd)
+
+for ((i = 0; i < PANE_COUNT; i++)); do
+  tmux -L "$SOCKET_NAME" split-window -t "$SESSION:$WIN_IDX" -c "$DIR"
+  tmux -L "$SOCKET_NAME" select-layout -t "$SESSION:$WIN_IDX" tiled
+done
+
+# 지휘자 패널로 포커스 복귀
+tmux -L "$SOCKET_NAME" select-pane -t "$SESSION:$WIN_IDX.$MY_PANE"
+```
+
+생성 후 다시 패널 목록을 조회하여 워커 패널을 결정한다.
+
+### Step 3: 기존 상태 파일 확인
+
+```bash
+cat ~/.claude/taskmaestro-state.json 2>/dev/null
+```
+
+이미 활성 세션이 존재하면 AskUserQuestion으로 사용자에게 질문:
+- "기존 세션에 연결" → 기존 세션 정보를 로드하고 종료
+- "기존 세션 정리 후 새로 생성" → 기존 worktree/세션을 정리하고 계속 진행
+
+### Step 4: worktree 생성
+
+```bash
+TIMESTAMP=$(date +%s)
+DIR=$(cd "$REPO" && pwd)
+BASE_BRANCH="${BASE:-$(git -C "$DIR" branch --show-current)}"
+
+mkdir -p "$DIR/.taskmaestro"
+
+# .gitignore에 .taskmaestro/ 추가
+grep -qxF '.taskmaestro/' "$DIR/.gitignore" 2>/dev/null || echo '.taskmaestro/' >> "$DIR/.gitignore"
+
+# 각 워커 패널 + 리뷰 패널에 대해 worktree 생성
+ALL_PANES="$WORKER_PANES"
+[ -n "$REVIEW_PANE" ] && ALL_PANES="$ALL_PANES $REVIEW_PANE"
+
+for PANE_IDX in $ALL_PANES; do
+  BRANCH="taskmaestro/$TIMESTAMP/pane-$PANE_IDX"
+  WT_PATH="$DIR/.taskmaestro/wt-$PANE_IDX"
+  if [ -d "$WT_PATH" ]; then
+    if git -C "$DIR" worktree list | grep -q "$WT_PATH"; then
+      git -C "$DIR" worktree remove "$WT_PATH" --force
+    else
+      rm -rf "$WT_PATH"
+    fi
+  fi
+  git -C "$DIR" worktree add "$WT_PATH" -b "$BRANCH" "$BASE_BRANCH"
+done
+```
+
+### Step 4.5: Worker Pre-Flight Verification
+
+Before launching Claude Code, verify each worktree:
+
+```bash
+# 워커 + 리뷰 패널 모두 사전 검증
+ALL_PANES="$WORKER_PANES"
+[ -n "$REVIEW_PANE" ] && ALL_PANES="$ALL_PANES $REVIEW_PANE"
+
+for PANE_IDX in $ALL_PANES; do
+  WT_PATH="$DIR/.taskmaestro/wt-$PANE_IDX"
+
+  # 1. Remove stale artifacts
+  rm -f "$WT_PATH/RESULT.json" "$WT_PATH/TASK.md"
+
+  # 2. Copy permission presets (#905)
+  if [ -f "$REPO/.claude/settings.local.json" ]; then
+    mkdir -p "$WT_PATH/.claude"
+    cp "$REPO/.claude/settings.local.json" "$WT_PATH/.claude/settings.local.json"
+  fi
+
+  # 3. Install dependencies (CRITICAL — without this, yarn prettier/lint/test all fail)
+  echo "Installing dependencies in wt-$PANE_IDX..."
+  (cd "$WT_PATH" && yarn install --immutable 2>/dev/null) || echo "WARNING: yarn install failed in wt-$PANE_IDX"
+
+  # 4. Verify git status clean
+  if ! git -C "$WT_PATH" diff --quiet 2>/dev/null; then
+    echo "WARNING: wt-$PANE_IDX has uncommitted changes"
+  fi
+done
+```
+
+This prevents:
+- Stale RESULT.json from previous waves being detected as "completed"
+- **Workers unable to run local CI checks due to missing node_modules** (root cause of repeated CI failures)
+- Permission prompt interruptions blocking worker progress (#905)
+- Dirty worktree state causing unexpected behavior
+
+### Step 5: 각 패널에 Claude Code 실행
+
+```bash
+# 워커 패널에 Claude Code 실행
+for PANE_IDX in $WORKER_PANES; do
+  tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$PANE_IDX" \
+    "unset CLAUDECODE && cd $DIR/.taskmaestro/wt-$PANE_IDX && claude --dangerously-skip-permissions" Enter
+done
+
+# 리뷰 패널에 Claude Code 실행
+if [ -n "$REVIEW_PANE" ]; then
+  tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$REVIEW_PANE" \
+    "unset CLAUDECODE && cd $DIR/.taskmaestro/wt-$REVIEW_PANE && claude --dangerously-skip-permissions" Enter
+fi
+```
+
+> **중요:** 지휘자 Claude Code 세션의 tmux 패널은 `CLAUDECODE` 환경변수를 상속받아 중첩 실행이 차단된다. `unset CLAUDECODE`로 해제해야 한다.
+
+### Step 6: 초기 프롬프트 자동 처리
+
+Claude Code 시작 시 trust 프롬프트와 약관 동의 프롬프트가 나타날 수 있다:
+
+```bash
+# 10초 대기 후 trust 프롬프트 승인 (Enter = "Yes, I trust")
+sleep 10
+for PANE_IDX in $WORKER_PANES; do
+  tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$PANE_IDX" Enter
+done
+
+# 3초 대기 후 약관 동의 프롬프트 처리 (Down → "Yes, I accept" → Enter)
+sleep 3
+for PANE_IDX in $WORKER_PANES; do
+  tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$PANE_IDX" Down
+done
+sleep 1
+for PANE_IDX in $WORKER_PANES; do
+  tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$PANE_IDX" Enter
+done
+```
+
+> 이미 동의한 환경에서는 이 프롬프트가 나타나지 않을 수 있다. send-keys는 무해하게 무시된다.
+
+10초 대기 후 각 패널의 Claude Code가 프롬프트(`❯`) 상태인지 capture-pane으로 확인한다.
+
+### Step 7: 상태 파일 기록
+
+`~/.claude/taskmaestro-state.json`에 세션 정보를 기록한다.
+
+```json
+{
+  "socket_name": "workspace-1",
+  "session": "workspace-1",
+  "window_index": 0,
+  "conductor_pane": 0,
+  "review_pane": 3,
+  "repo": "절대경로",
+  "base_branch": "브랜치",
+  "created_at": "ISO timestamp",
+  "watch_cron_id": null,
+  "panes": [
+    {"index": 1, "role": "worker", "worktree": "절대경로/.taskmaestro/wt-1", "branch": "taskmaestro/ts/pane-1", "task": null, "status": "idle", "result": null},
+    {"index": 2, "role": "worker", "worktree": "절대경로/.taskmaestro/wt-2", "branch": "taskmaestro/ts/pane-2", "task": null, "status": "idle", "result": null},
+    {"index": 3, "role": "reviewer", "worktree": "절대경로/.taskmaestro/wt-3", "branch": "taskmaestro/ts/pane-3", "task": null, "status": "idle", "result": null}
+  ]
+}
+```
+
+- `review_pane`: 리뷰 에이전트 패널 인덱스. `--no-review-pane` 사용 시 `null`
+- `role`: 각 패널의 역할. `"worker"` 또는 `"reviewer"`
+- 리뷰 패널이 없는 경우(`review_pane: null`), 모든 패널의 `role`은 `"worker"`
+
+### Step 8: watch 자동 시작
+
+CronCreate로 30초 주기 cron job을 생성하여 watch 모드를 자동 시작한다.
+생성된 cron job ID를 상태 파일의 `watch_cron_id`에 기록한다.
+
+프롬프트: 각 워커 패널에 대해 **1차: RESULT.json 파일 확인 → 2차: capture-pane fallback** 순서로 상태를 감지한다. 워커의 `"success"` 감지 시 Review Routing (review_pane 존재 시 리뷰 에이전트에 위임). 리뷰 에이전트 패널의 RESULT.json도 확인하여 리뷰 결과 처리. 완료/에러 상태 패널이 있으면 사용자에게 보고한다.
+
+### Step 9: 결과 보고
+
+사용자에게 보고:
+```
+TaskMaestro 시작 완료!
+
+  세션: workspace-1
+  레포: /path/to/repo
+  지휘자: 패널 0
+  워커: 패널 1, 2
+  리뷰어: 패널 3
+  베이스: main
+
+/taskmaestro assign <번호> "작업" 으로 작업을 배정하세요.
+/taskmaestro status 로 상태를 확인하세요.
+```
+
+> **리뷰 패널이 없는 경우** (`--no-review-pane`): "리뷰어" 줄을 생략하고 모든 패널을 워커로 표시한다.
+
+---
+
+## Subcommand: assign
+
+`/taskmaestro assign <패널 번호> "<작업 지시>"`
+
+특정 패널의 Claude Code에 새 작업을 배정한다. 상태 파일의 task/status를 업데이트한다.
+
+### Step 1: 상태 파일 로드 및 검증
+
+```bash
+cat ~/.claude/taskmaestro-state.json
+```
+
+소켓/세션/윈도우 정보를 가져온다.
+패널 번호가 워커 패널 목록에 포함되는지 검증한다. 지휘자 패널이거나 존재하지 않는 패널이면 에러 출력 후 중단.
+
+### Step 2: 작업 전송
+
+워커에게 작업 지시와 함께 **RESULT.json 작성 지시**를 포함한 프롬프트를 전송한다.
+
+프롬프트 템플릿:
+```
+<작업 지시>
+
+---
+[MANDATORY PRE-PUSH VERIFICATION]
+Push 전에 반드시 아래 명령을 모두 실행하고, 실패 시 수정 후 재실행하세요.
+하나라도 실패하면 절대 push하지 마세요:
+
+1. yarn prettier --write .
+2. yarn lint --fix
+3. yarn type-check
+4. yarn test
+
+4개 모두 통과한 후에만 git push하세요. CI 실패는 허용되지 않습니다.
+
+[TASKMAESTRO COMPLETION PROTOCOL]
+작업이 완료되면 (성공/실패/에러 무관) 반드시 아래 파일을 작성하세요:
+
+파일: RESULT.json (현재 worktree 루트, 즉 현재 디렉토리)
+
+스키마:
+{
+  "status": "success | failure | error",
+  "issue": "<이슈 번호 또는 null>",
+  "pr_number": <PR 번호 또는 null>,
+  "pr_url": "<PR URL 또는 null>",
+  "timestamp": "<ISO 8601>",
+  "cost": "<세션 비용 또는 null>",
+  "error": "<에러 메시지 또는 null>"
+}
+
+- status: "success" (정상 완료), "failure" (테스트 실패 등), "error" (예기치 못한 오류)
+- 커밋/PR 생성 후, 세션 종료 전에 이 파일을 작성하세요
+- 이 파일은 지휘자가 완료 감지에 사용합니다
+
+[CONTINUOUS EXECUTION DIRECTIVE]
+DO NOT stop between steps. Complete ALL tasks without waiting for user input.
+Only stop AFTER writing RESULT.json.
+If you encounter an error, try to fix it yourself before stopping.
+If you are truly blocked, write RESULT.json with status "error" and explain in the error field.
+```
+
+send-keys로 전송:
+```bash
+tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$PANE" "$PROMPT_WITH_RESULT_PROTOCOL" Enter
+```
+
+> **참고:** 프롬프트가 길어 send-keys로 직접 전송 시 잘릴 수 있다. 이 경우 프롬프트를 임시 파일에 저장하고 `send-keys`로 파일 경로를 참조하거나, 여러 줄로 나누어 전송한다. 실제 구현 시 지휘자가 프롬프트 문자열을 조립하여 한 번에 전송한다.
+
+### Step 3: 상태 파일 업데이트
+
+해당 패널의 task와 status를 업데이트한다:
+- `task`: 작업 지시 내용
+- `status`: "working"
+
+### Step 4: 결과 보고
+
+```
+패널 $PANE에 작업을 배정했습니다: "<작업 지시>"
+```
+
+---
+
+## Subcommand: send
+
+`/taskmaestro send <패널 번호> "<텍스트>"`
+
+특정 패널에 텍스트를 직접 전송한다.
+이미 진행 중인 작업에 후속 지시나 응답을 보낼 때 사용한다.
+assign과 달리 상태 파일의 task/status를 변경하지 않는다.
+
+### Step 1: 상태 파일 로드 및 검증
+
+소켓/세션/윈도우 정보를 가져온다.
+패널 번호 유효성 검증.
+
+### Step 2: 텍스트 전송
+
+```bash
+tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$PANE" "<텍스트>" Enter
+```
+
+### Step 3: 결과 보고
+
+```
+패널 $PANE에 전송 완료: "<텍스트>"
+```
+
+---
+
+## Subcommand: status
+
+`/taskmaestro status`
+
+모든 워커 패널의 현재 상태를 수집하여 요약 보고한다.
+
+### Step 1: 상태 파일 로드
+
+```bash
+cat ~/.claude/taskmaestro-state.json
+```
+
+### Step 2: RESULT.json 확인 (1차 감지)
+
+각 워커 패널의 worktree에서 RESULT.json 존재 여부를 먼저 확인한다:
+
+```bash
+for PANE_IDX in $WORKER_PANES; do
+  RESULT_FILE="$REPO/.taskmaestro/wt-$PANE_IDX/RESULT.json"
+  if [ -f "$RESULT_FILE" ]; then
+    STATUS=$(cat "$RESULT_FILE" | jq -r '.status')
+    PR_NUMBER=$(cat "$RESULT_FILE" | jq -r '.pr_number // empty')
+    REVIEW_CYCLE=$(cat "$RESULT_FILE" | jq -r '.review_cycle // 0')
+    # → status 값에 따라 적절한 상태 아이콘과 메시지 표시
+  fi
+done
+```
+
+RESULT.json이 존재하는 패널은 status 값에 따라 분기하여 표시한다:
+- `"success"` → 리뷰 대기 (PR 생성 완료)
+- `"review_pending"` → 리뷰 코멘트 작성 완료, 워커 응답 대기
+- `"review_addressed"` → 워커 리뷰 반영 완료, 재리뷰 대기
+- `"approved"` → 최종 승인 완료 (진짜 done)
+- `"failure"` / `"error"` → 실패/에러 (기존 동작)
+
+### Step 3: capture-pane fallback (2차 감지)
+
+RESULT.json이 없는 패널에 대해서만 capture-pane으로 상태를 확인한다:
+
+```bash
+for PANE_IDX in $NO_RESULT_PANES; do
+  tmux -L "$SOCKET_NAME" capture-pane -t "$SESSION:$WIN_IDX.$PANE_IDX" -p -S -30 | tail -15
+done
+```
+
+캡처된 내용을 분석:
+- 마지막 줄에 Claude Code 프롬프트 (`❯` 또는 `>` 로 시작하는 입력 대기) → "idle"
+- 도구 실행 중 (스피너, 코드 출력 진행 중) → "working"
+- 에러 패턴 (`Error`, `error`, `failed`, `FAIL`) → "error"
+- 프로세스 없음 (zsh 프롬프트만 보임) → "crashed"
+
+### Step 4: 요약 보고
+
+상태 파일의 task 정보와 결합하여 테이블로 출력:
+```
+TaskMaestro 상태 (workspace-1):
+
+  패널 1: ✅ approved - "API 엔드포인트 구현" → PR #42 (review complete) (worker)
+  패널 2: 🔍 reviewing - PR #43 (reviewer)
+  패널 3: 📝 review_addressed - "모듈 리팩토링" → PR #44 (awaiting re-review) (worker)
+  패널 4: 🔄 working - "인증 기능 추가" (worker)
+  패널 5: ⏳ review_pending - "캐시 레이어" → PR #45 (awaiting worker response) (worker)
+  패널 6: ❌ error - "모듈을 찾을 수 없음" (worker)
+```
+
+**상태별 아이콘:**
+| status | 아이콘 | 설명 |
+|--------|--------|------|
+| `approved` | ✅ | 최종 승인 완료 (진짜 done) |
+| `success` (리뷰 시작 전) | 🔍 | 리뷰 사이클 진행 중 |
+| `reviewing` | 🔍 | 리뷰 에이전트가 PR 리뷰 중 (reviewer 패널 전용) |
+| `review_pending` | ⏳ | 리뷰 완료, 워커 응답 대기 |
+| `review_addressed` | 📝 | 워커 반영 완료, 재리뷰 대기 |
+| `working` | 🔄 | 작업 중 |
+| `failure` | ❌ | 작업 실패 |
+| `error` | ❌ | 예기치 못한 오류 |
+
+- `approved` 패널: RESULT.json에서 pr_url, cost, review_cycle 등을 함께 표시
+- 리뷰 진행 중 패널: PR 번호와 현재 리뷰 사이클 횟수 (N/3) 표시
+- `error`/`crashed` 패널: capture-pane 내용 마지막 10줄도 함께 표시
+
+### Status Report Format (with evidence)
+
+Every status line MUST include parenthetical evidence:
+
+```
+패널 1: ✅ approved - "task" → PR #N (RESULT.json: approved, review cycles: 2, pane idle ✓) (worker)
+패널 2: 🔄 working - "task" (active: ✽ Implementing… · ↓ 5.3k tokens) (worker)
+패널 3: 🔍 reviewing - PR #N (RESULT.json: reviewing PR #N for #M, pane active ✓) (reviewer)
+패널 4: ⏳ review_pending - "task" → PR #N (RESULT.json: review_pending, cycle 1/3, awaiting worker) (worker)
+패널 5: 📝 review_addressed - "task" → PR #N (RESULT.json: review_addressed, cycle 2/3, awaiting re-review) (worker)
+패널 6: ⚠️ uncertain - "task" (RESULT.json exists BUT pane still active — cross-verify needed) (worker)
+패널 7: ❌ error - "task" (error in last 10 lines: "ModuleNotFoundError") (worker)
+```
+
+**Rules:**
+- Never report bare ✅ without evidence
+- RESULT.json `approved` + pane idle = confirmed done
+- RESULT.json `success` = start review cycle (NOT done)
+- RESULT.json `review_pending` = awaiting worker response
+- RESULT.json `review_addressed` = awaiting conductor re-review
+- RESULT.json + pane active = UNCERTAIN (investigate)
+- No RESULT.json + pane idle = needs nudge
+- Active spinner (… + ↓ tokens) = confirmed working
+- "thinking" alone ≠ working — check token count changes
+
+---
+
+## Subcommand: watch
+
+`/taskmaestro watch`
+
+주기적 감시 모드를 토글한다 (시작/중지).
+
+### 감지 전략 (2단계)
+
+watch 모드는 **RESULT.json 파일 기반 감지**를 1차 수단으로 사용하고, **capture-pane을 fallback**으로만 사용한다.
+
+#### 1차: RESULT.json 파일 감지 (빠르고 정확)
+
+```bash
+# 1차: 워커 패널의 RESULT.json 확인
+for PANE_IDX in $WORKER_PANES; do
+  RESULT_FILE="$REPO/.taskmaestro/wt-$PANE_IDX/RESULT.json"
+  if [ -f "$RESULT_FILE" ]; then
+    STATUS=$(cat "$RESULT_FILE" | jq -r '.status')
+    case "$STATUS" in
+      "success")
+        # → Review Routing: review_pane 존재 시 리뷰 에이전트에 위임, 없으면 직접 리뷰
+        # Review Cycle Protocol 참조
+        ;;
+      "failure"|"error")
+        # → 사용자에게 에러/실패 보고 (기존 동작 유지)
+        ;;
+      "review_pending")
+        # → 워커 응답 대기 중. 지휘자는 대기한다
+        ;;
+      "review_addressed")
+        # → Review Routing: review_pane 존재 시 리뷰 에이전트에 재리뷰 위임, 없으면 직접 재리뷰
+        ;;
+      "approved")
+        # → 진짜 완료 ✅. 상태를 "done"으로 업데이트하고 사용자에게 보고
+        ;;
+    esac
+  fi
+done
+
+# 2차: 리뷰 에이전트 패널의 RESULT.json 확인
+if [ -n "$REVIEW_PANE" ]; then
+  REVIEW_RESULT_FILE="$REPO/.taskmaestro/wt-$REVIEW_PANE/RESULT.json"
+  if [ -f "$REVIEW_RESULT_FILE" ]; then
+    REVIEW_STATUS=$(cat "$REVIEW_RESULT_FILE" | jq -r '.status')
+    REVIEW_RESULT=$(cat "$REVIEW_RESULT_FILE" | jq -r '.review_result')
+    if [ "$REVIEW_STATUS" = "success" ]; then
+      # → Conductor Handling of Review Agent Result 참조
+      # review_result에 따라 워커 PR approve 또는 changes_requested 처리
+      # 처리 후 리뷰 에이전트의 RESULT.json 삭제 (다음 리뷰 준비)
+      rm -f "$REVIEW_RESULT_FILE"
+    fi
+  fi
+fi
+```
+
+**RESULT.json status 매핑:**
+| status | watch 동작 |
+|--------|-----------|
+| `"success"` | 리뷰 사이클 시작 ("done"이 아님) |
+| `"failure"` / `"error"` | 사용자에게 보고 (기존 동작 유지) |
+| `"review_pending"` | 워커 응답 대기 중 |
+| `"review_addressed"` | 지휘자 재리뷰 시작 |
+| `"approved"` | 진짜 완료 ✅ |
+
+- RESULT.json이 존재하면: status 값에 따라 위 매핑대로 분기한다.
+- RESULT.json이 없으면: 아직 작업 중이거나 파일 미작성. fallback으로 진행한다.
+
+#### 2차 (fallback): capture-pane 기반 감지
+
+RESULT.json이 없는 패널에 대해서만 capture-pane으로 상태를 확인한다:
+
+```bash
+for PANE_IDX in $NO_RESULT_PANES; do
+  CAPTURED=$(tmux -L "$SOCKET_NAME" capture-pane -t "$SESSION:$WIN_IDX.$PANE_IDX" -p -S -30 | tail -15)
+  # 캡처 내용 분석:
+  # - 프롬프트 대기 (❯) → "idle" (작업 완료했으나 RESULT.json 미작성)
+  # - 도구 실행 중 → "working"
+  # - 에러 패턴 → "error"
+  # - 프로세스 없음 → "crashed"
+done
+```
+
+### 시작 (watch_cron_id가 null인 경우)
+
+1. 상태 파일에서 정보 로드
+2. CronCreate로 30초 주기 cron job 생성:
+   - 프롬프트: 각 워커 패널에 대해 **1차: RESULT.json 확인 → 2차: capture-pane fallback** 순서로 상태를 감지한다. RESULT.json의 status에 따라 분기한다: `"success"` → Review Routing (review_pane 존재 시 리뷰 에이전트에 위임, 없으면 직접 리뷰), `"review_addressed"` → Review Routing으로 재리뷰, `"approved"` → 진짜 완료 보고, `"failure"`/`"error"` → 사용자에게 에러 보고. **리뷰 에이전트 패널의 RESULT.json도 확인한다**: `review_result: "approve"` → 워커 PR 승인, `"changes_requested"` → 워커에 수정 지시. Claude Code가 비정상 종료된 패널이 있으면 재시작 여부를 사용자에게 질문한다.
+3. cron job ID를 상태 파일의 `watch_cron_id`에 기록
+4. 보고: "Watch 모드를 시작합니다 (30초 주기). 중지하려면 `/taskmaestro watch`를 다시 실행하세요."
+
+### 중지 (watch_cron_id가 존재하는 경우)
+
+1. 상태 파일에서 `watch_cron_id` 확인
+2. CronDelete로 해당 cron job 제거
+3. `watch_cron_id`를 null로 업데이트
+4. 보고: "Watch 모드를 중지했습니다."
+
+### Auto-Nudge Protocol
+
+When a pane is detected as idle (❯ prompt visible) but its task status is "working":
+
+1. **First idle detection**: Send `tmux send-keys "continue" Enter`
+2. **Second consecutive idle**: Send `tmux send-keys "continue with the next incomplete task" Enter`
+3. **Third consecutive idle**: Send explicit instruction with task context
+4. **Track nudge count** per pane in the watch report
+
+Include in watch cron prompt:
+```
+If pane is idle (❯ visible) and status is "working":
+  nudge_count[pane] += 1
+  if nudge_count <= 1: send "continue"
+  elif nudge_count == 2: send "continue with the next incomplete task"
+  else: send explicit instruction
+  Report: "Pane N: IDLE → auto-nudged (#count)"
+```
+
+### 제한 사항
+
+CronCreate job은 현재 Claude Code 세션에 종속되며, 7일 후 자동 만료된다.
+세션이 종료되거나 만료 시 watch도 중단된다. 재시작하려면 `/taskmaestro watch`를 다시 실행한다.
+
+---
+
+## Subcommand: stop
+
+`/taskmaestro stop [패널 번호|all]`
+
+Claude Code를 종료하고 worktree를 정리한다.
+
+### 인수 파싱
+
+- 인수 없음 또는 `all`: 모든 워커 패널 종료
+- 숫자: 해당 패널만 종료
+
+### 단일 패널 종료
+
+1. 패널 번호가 워커 패널인지 검증. 아니면 에러 출력 후 중단.
+2. 해당 패널에 Claude Code 종료 전송:
+   ```bash
+   tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$PANE" "/exit" Enter
+   ```
+3. 5초 대기 후 worktree 정리:
+   ```bash
+   # uncommitted changes 확인
+   if git -C "$WORKTREE_PATH" diff --quiet && git -C "$WORKTREE_PATH" diff --cached --quiet; then
+     git -C "$REPO" worktree remove "$WORKTREE_PATH"
+   else
+     # AskUserQuestion으로 사용자에게 알림
+     # "패널 N의 worktree에 커밋되지 않은 변경사항이 있습니다. 강제 삭제할까요?"
+     # Yes → git worktree remove --force
+     # No → worktree 보존, 경로 안내
+   fi
+   ```
+4. 패널 닫기:
+   ```bash
+   tmux -L "$SOCKET_NAME" kill-pane -t "$SESSION:$WIN_IDX.$PANE"
+   ```
+5. 상태 파일에서 해당 패널 정보 제거
+6. 보고: `패널 N을 종료했습니다. (브랜치 taskmaestro/xxx/pane-N 유지됨)`
+
+### 전체 종료 (all)
+
+1. watch cron 중지 (활성 상태인 경우 CronDelete)
+2. 각 워커 패널에 `/exit` 전송
+3. 5초 대기
+4. 각 worktree 정리 (uncommitted changes 확인 포함)
+5. 워커 패널들 닫기 (역순으로):
+   ```bash
+   for PANE_IDX in $(echo "$WORKER_PANES" | sort -rn); do
+     tmux -L "$SOCKET_NAME" kill-pane -t "$SESSION:$WIN_IDX.$PANE_IDX"
+   done
+   ```
+6. `.taskmaestro/` 디렉토리가 비었으면 삭제:
+   ```bash
+   rmdir "$REPO/.taskmaestro" 2>/dev/null
+   ```
+7. 상태 파일 초기화
+8. 보고:
+   ```
+   TaskMaestro 종료 완료.
+     정리된 워커: N개
+     유지된 브랜치: taskmaestro/xxx/pane-1, pane-2, ...
+   ```
+
+> **주의:** `stop all`은 tmux 세션을 종료하지 않는다. 패널들은 그대로 남아있으며 zsh 상태로 돌아간다.


### PR DESCRIPTION
## Summary

- Add dedicated review agent protocol to taskMaestro skill (`--review-pane` flag, default enabled)
- Review agent pane handles 6-step mandatory checklist: CI gate → local verification → code quality scan → spec compliance → test coverage → structured review
- Conductor delegates review to review pane when available, falls back to direct review when not
- State file updated with `review_pane` field and `role` (worker/reviewer) for each pane

## Motivation

Conductor was doing both orchestration and code review, resulting in low-quality reviews (e.g., PR #1065 approved with lint failures). Separating concerns improves review quality.

## Test plan

- [ ] Verify `--review-pane` allocates last pane as reviewer in `start` flow
- [ ] Verify `--no-review-pane` disables reviewer allocation
- [ ] Verify state file includes `review_pane` field and `role` in pane entries
- [ ] Verify watch loop detects review agent RESULT.json and routes results
- [ ] Verify status report shows reviewer pane with role indicator
- [ ] Verify conductor fallback review works when no review pane configured

Closes #1067