### PR TITLE
feat(mcp): add get_session_impact MCP tool

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/impact.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/impact.handler.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ImpactHandler } from './impact.handler';
+import { ImpactReportService } from '../../impact/impact-report.service';
+import type { ImpactSummary } from '../../impact/impact.types';
+
+describe('ImpactHandler', () => {
+  let handler: ImpactHandler;
+  let mockReportService: ImpactReportService;
+
+  const mockSummary: ImpactSummary = {
+    sessionId: 'test-session',
+    eventCount: 3,
+    byType: { mode_activated: 1, agent_dispatched: 2 },
+    impact: {
+      issuesPrevented: 1,
+      issuesByDomain: { security: 1 },
+      issuesBySeverity: { high: 1 },
+      agentsDispatched: 2,
+      agentNames: ['security-specialist'],
+      checklistsGenerated: 0,
+      checklistDomains: [],
+      modeTransitions: ['PLAN'],
+      contextDecisions: 0,
+    },
+  };
+
+  beforeEach(() => {
+    mockReportService = {
+      getSessionSummary: vi.fn().mockReturnValue(mockSummary),
+    } as unknown as ImpactReportService;
+
+    handler = new ImpactHandler(mockReportService);
+  });
+
+  describe('handle', () => {
+    it('should return null for unhandled tools', async () => {
+      const result = await handler.handle('unknown_tool', {});
+      expect(result).toBeNull();
+    });
+
+    it('should return impact summary for given sessionId', async () => {
+      const result = await handler.handle('get_session_impact', {
+        sessionId: 'test-session',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      expect(mockReportService.getSessionSummary).toHaveBeenCalledWith('test-session');
+      const parsed = JSON.parse(result!.content[0].text);
+      expect(parsed.sessionId).toBe('test-session');
+      expect(parsed.eventCount).toBe(3);
+    });
+
+    it('should use "current" as default sessionId when not provided', async () => {
+      const result = await handler.handle('get_session_impact', {});
+
+      expect(result?.isError).toBeFalsy();
+      expect(mockReportService.getSessionSummary).toHaveBeenCalledWith('current');
+    });
+
+    it('should return empty summary for unknown sessionId', async () => {
+      const emptySummary: ImpactSummary = {
+        sessionId: 'unknown',
+        eventCount: 0,
+        byType: {},
+        impact: {
+          issuesPrevented: 0,
+          issuesByDomain: {},
+          issuesBySeverity: {},
+          agentsDispatched: 0,
+          agentNames: [],
+          checklistsGenerated: 0,
+          checklistDomains: [],
+          modeTransitions: [],
+          contextDecisions: 0,
+        },
+      };
+      mockReportService.getSessionSummary = vi.fn().mockReturnValue(emptySummary);
+
+      const result = await handler.handle('get_session_impact', {
+        sessionId: 'unknown',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result!.content[0].text);
+      expect(parsed.eventCount).toBe(0);
+    });
+  });
+
+  describe('getToolDefinitions', () => {
+    it('should return tool definition for get_session_impact', () => {
+      const definitions = handler.getToolDefinitions();
+
+      expect(definitions).toHaveLength(1);
+      expect(definitions[0].name).toBe('get_session_impact');
+    });
+
+    it('should have sessionId as optional parameter', () => {
+      const definitions = handler.getToolDefinitions();
+      const def = definitions[0];
+
+      expect(def.inputSchema.properties).toHaveProperty('sessionId');
+      expect(def.inputSchema.required).toBeUndefined();
+    });
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/impact.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/impact.handler.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import type { ToolDefinition } from './base.handler';
+import type { ToolResponse } from '../response.utils';
+import { AbstractHandler } from './abstract-handler';
+import { ImpactReportService } from '../../impact/impact-report.service';
+import { createJsonResponse } from '../response.utils';
+
+@Injectable()
+export class ImpactHandler extends AbstractHandler {
+  constructor(private readonly reportService: ImpactReportService) {
+    super();
+  }
+
+  protected getHandledTools(): string[] {
+    return ['get_session_impact'];
+  }
+
+  protected async handleTool(
+    toolName: string,
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    const sessionId =
+      typeof args?.sessionId === 'string' && args.sessionId.length > 0 ? args.sessionId : 'current';
+
+    const summary = this.reportService.getSessionSummary(sessionId);
+    return createJsonResponse(summary);
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'get_session_impact',
+        description:
+          'Get impact summary for a session including events, issues prevented, agents dispatched, and checklists generated.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            sessionId: {
+              type: 'string',
+              description:
+                'Optional session ID for session-isolated context. Omit for legacy single-file behavior.',
+            },
+          },
+        },
+      },
+    ];
+  }
+}

--- a/apps/mcp-server/src/mcp/handlers/index.ts
+++ b/apps/mcp-server/src/mcp/handlers/index.ts
@@ -121,6 +121,12 @@ export { ContextArchiveHandler } from './context-archive.handler';
 export { RuleInsightsHandler } from './rule-insights.handler';
 
 /**
+ * Handler for impact tools (get_session_impact)
+ * @see {@link ImpactHandler}
+ */
+export { ImpactHandler } from './impact.handler';
+
+/**
  * Injection token for the array of all tool handlers.
  *
  * Use this token to inject all handlers into a service that needs to

--- a/apps/mcp-server/src/mcp/mcp.module.ts
+++ b/apps/mcp-server/src/mcp/mcp.module.ts
@@ -12,6 +12,7 @@ import { StateModule } from '../state/state.module';
 import { DiagnosticModule } from '../diagnostic/diagnostic.module';
 import { TuiEventsModule } from '../tui/events';
 import { PipelineModule } from '../pipeline/pipeline.module';
+import { ImpactModule } from '../impact';
 import { SkillRecommendationService } from '../skill/skill-recommendation.service';
 import { LanguageService } from '../shared/language.service';
 import { ModelResolverService } from '../model';
@@ -33,6 +34,7 @@ import {
   DiscussionHandler,
   ParallelValidationHandler,
   PipelineHandler,
+  ImpactHandler,
 } from './handlers';
 
 const handlers = [
@@ -50,6 +52,7 @@ const handlers = [
   DiscussionHandler,
   ParallelValidationHandler,
   PipelineHandler,
+  ImpactHandler,
 ];
 
 @Module({
@@ -65,6 +68,7 @@ const handlers = [
     DiagnosticModule,
     TuiEventsModule,
     PipelineModule,
+    ImpactModule,
   ],
   controllers: [McpController],
   providers: [


### PR DESCRIPTION
## Summary

- Add `ImpactHandler` extending `AbstractHandler` with `get_session_impact` tool
- Register `ImpactHandler` in handlers array and `ImpactModule` in imports in `mcp.module.ts`
- Export `ImpactHandler` from handlers barrel (`index.ts`)

## Test plan

- [x] 6 handler unit tests passing (happy path, default sessionId, unknown session, tool definitions)
- [x] All 5327 existing tests still passing
- [x] Typecheck passes
- [x] Prettier/lint clean on changed files

Closes #1062