### PR TITLE
feat(plugin): auto-install statusLine, tmux sidebar, and config

### DIFF
--- a/docs/plans/2026-03-28-wave3-auto-install-tmux-sidebar.md
+++ b/docs/plans/2026-03-28-wave3-auto-install-tmux-sidebar.md
@@ -1,0 +1,216 @@
+# Wave 3: Auto-Install StatusLine + tmux Sidebar + Config Change
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire up statusLine auto-installation in session-start, add tmux sidebar auto-setup, and set `CODINGBUDDY_AUTO_TUI=0`. All changes are in `session-start.py`.
+
+**Architecture:** Three new functions added to `session-start.py`, inserted as Step 2.5, Step 4.5, and Step 6.5 in the existing `main()` flow.
+
+**Tech Stack:** Python 3, shutil, subprocess, json
+
+**Issues:** #1089, #1091, #1092
+
+## Alternatives
+
+### Decision: HUD script source discovery
+
+| Criteria | Reuse find_plugin_source() with param | Separate find function |
+|---|---|---|
+| DRY | Reuses existing 3-tier search | Duplicates logic |
+| Flexibility | Need to parameterize filename | Hardcoded to one file |
+| Risk | Changing shared function may break hook install | Isolated |
+
+**Decision:** Separate helper `_find_hud_source()` that follows the same 3-tier pattern but searches for `codingbuddy-hud.py`. Simpler and zero risk to existing hook installation.
+
+---
+
+## Part A: #1089 — Auto-Install StatusLine
+
+### Step A1: Write test — `_install_statusline`
+
+**File:** `packages/claude-code-plugin/tests/test_session_start_hud.py`
+
+Tests:
+- `test_installs_hud_script_to_claude_hud_dir` — copies file, sets permissions
+- `test_sets_statusline_in_settings` — writes statusLine config
+- `test_replaces_omc_statusline` — replaces omc-hud with codingbuddy-hud
+- `test_skips_custom_statusline` — preserves non-OMC custom statusLine
+- `test_skips_if_already_installed` — no-op when codingbuddy-hud already set
+- `test_sets_auto_tui_to_zero` — changes CODINGBUDDY_AUTO_TUI from 1 to 0
+
+### Step A2: Implement `_find_hud_source()`
+
+Same 3-tier search as `find_plugin_source()` but for `codingbuddy-hud.py`:
+1. `CLAUDE_PLUGIN_DIR` env → `hooks/codingbuddy-hud.py`
+2. Plugin cache paths → `hooks/codingbuddy-hud.py`
+3. Dev paths → `hooks/codingbuddy-hud.py`
+
+### Step A3: Implement `_install_statusline(home, settings_file)`
+
+```python
+def _install_statusline(home: Path, settings_file: Path) -> None:
+    """Install codingbuddy statusLine and set CODINGBUDDY_AUTO_TUI=0."""
+    # 1. Find source
+    source = _find_hud_source()
+    if not source:
+        return
+
+    # 2. Copy to ~/.claude/hud/
+    hud_dir = home / ".claude" / "hud"
+    hud_dir.mkdir(parents=True, exist_ok=True)
+    target = hud_dir / "codingbuddy-hud.py"
+    shutil.copy(source, target)
+    target.chmod(0o755)
+
+    # 3. Update settings.json
+    settings = _read_settings_file(settings_file) if settings_file.exists() else {}
+
+    # Check existing statusLine
+    current_sl = settings.get("statusLine", {}).get("command", "")
+    if "codingbuddy-hud" in current_sl:
+        pass  # already installed
+    elif "omc-hud" in current_sl or not current_sl:
+        settings["statusLine"] = {
+            "type": "command",
+            "command": f'python3 "{home}/.claude/hud/codingbuddy-hud.py"'
+        }
+    # else: custom statusLine, preserve
+
+    # 4. Set CODINGBUDDY_AUTO_TUI=0 (#1092)
+    env = settings.setdefault("env", {})
+    if env.get("CODINGBUDDY_AUTO_TUI") == "1":
+        env["CODINGBUDDY_AUTO_TUI"] = "0"
+
+    _write_settings_file(settings_file, settings)
+```
+
+### Step A4: Wire into `main()` as Step 2.5
+
+After line 492 (after status message), before Step 3:
+```python
+        # Step 2.5: Install codingbuddy statusLine (#1089, #1092)
+        try:
+            _install_statusline(home, settings_file)
+        except Exception:
+            pass
+```
+
+### Step A5: Implement Step 4.5 — Init HUD state
+
+After line 525 (after stats init):
+```python
+        # Step 4.5: Initialize HUD state (#1089)
+        try:
+            _ensure_lib_path()
+            from hud_state import init_hud_state
+            from session_utils import get_session_id as _get_sid_hud
+            init_hud_state(_get_sid_hud(), "5.1.1")
+        except Exception:
+            pass
+```
+
+---
+
+## Part B: #1091 — tmux Sidebar Auto-Setup
+
+### Step B1: Write test — tmux detection + sidebar
+
+**File:** `packages/claude-code-plugin/tests/test_tmux_sidebar.py`
+
+Tests:
+- `test_detects_tmux_env` — returns True when $TMUX set
+- `test_no_tmux_env` — returns False when $TMUX unset
+- `test_sidebar_pane_exists_detection` — detects existing codingbuddy pane
+- `test_prints_tmux_suggestion_when_not_in_tmux` — outputs tip message
+
+### Step B2: Implement `_setup_tmux_sidebar()`
+
+```python
+import subprocess
+
+TMUX_SUGGESTION = {
+    "en": (
+        "╭───────────────────────────────────────────────╮\n"
+        "│ ◕‿◕ Tip: Run Claude Code inside tmux for     │\n"
+        "│     the full CodingBuddy sidebar experience!  │\n"
+        "│                                               │\n"
+        "│     tmux new -s dev                           │\n"
+        "│     claude                                    │\n"
+        "╰───────────────────────────────────────────────╯"
+    ),
+    "ko": (
+        "╭───────────────────────────────────────────────╮\n"
+        "│ ◕‿◕ Tip: tmux 안에서 Claude Code를 실행하면  │\n"
+        "│     CodingBuddy 사이드바를 볼 수 있어요!      │\n"
+        "│                                               │\n"
+        "│     tmux new -s dev                           │\n"
+        "│     claude                                    │\n"
+        "╰───────────────────────────────────────────────╯"
+    ),
+}
+
+def _sidebar_pane_exists() -> bool:
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-F", "#{pane_current_command}"],
+            capture_output=True, text=True, timeout=2,
+        )
+        return "codingbuddy" in result.stdout
+    except Exception:
+        return False
+
+def _setup_tmux_sidebar() -> None:
+    if not os.environ.get("TMUX"):
+        # Print suggestion
+        lang = _get_cached_language()
+        tip = TMUX_SUGGESTION.get(lang, TMUX_SUGGESTION["en"])
+        print(tip, file=sys.stderr)
+        return
+
+    if _sidebar_pane_exists():
+        return
+
+    subprocess.Popen(
+        ["tmux", "split-window", "-h", "-l", "25%", "-d", "codingbuddy", "tui"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    subprocess.Popen(
+        ["tmux", "select-pane", "-L"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+```
+
+### Step B3: Wire into `main()` as Step 6.5
+
+After buddy greeting (end of Step 6):
+```python
+        # Step 6.5: tmux sidebar auto-setup (#1091)
+        try:
+            _setup_tmux_sidebar()
+        except Exception:
+            pass
+```
+
+---
+
+## Execution Order
+
+1. Write tests (A1 + B1)
+2. Implement functions (A2-A5 + B2-B3)
+3. Run all tests
+4. Commit + ship
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `hooks/session-start.py` | Add `_find_hud_source`, `_install_statusline`, `_setup_tmux_sidebar`, `_sidebar_pane_exists`, `TMUX_SUGGESTION` + wire Steps 2.5, 4.5, 6.5 |
+| `tests/test_session_start_hud.py` | NEW — statusLine install tests |
+| `tests/test_tmux_sidebar.py` | NEW — tmux detection tests |
+
+## Verification
+
+1. `python3 -m pytest tests/test_session_start_hud.py tests/test_tmux_sidebar.py -v`
+2. `python3 -m pytest tests/ -q` (full regression)
+3. Manual: Start new Claude Code session → check `~/.claude/settings.json` statusLine
+4. Manual (tmux): Start Claude Code in tmux → verify sidebar pane appears

--- a/packages/claude-code-plugin/hooks/session-start.py
+++ b/packages/claude-code-plugin/hooks/session-start.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -343,6 +344,179 @@ def register_hook_in_settings(settings_file: Path) -> bool:
     return True
 
 
+HUD_FILENAME = "codingbuddy-hud.py"
+
+# tmux suggestion messages (i18n)
+TMUX_SUGGESTION: Dict[str, str] = {
+    "en": (
+        "\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e\n"
+        "\u2502 \u25d5\u203f\u25d5 Tip: Run Claude Code inside tmux for     \u2502\n"
+        "\u2502     the full CodingBuddy sidebar experience!  \u2502\n"
+        "\u2502                                               \u2502\n"
+        "\u2502     tmux new -s dev                           \u2502\n"
+        "\u2502     claude                                    \u2502\n"
+        "\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f"
+    ),
+    "ko": (
+        "\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e\n"
+        "\u2502 \u25d5\u203f\u25d5 Tip: tmux \uc548\uc5d0\uc11c Claude Code\ub97c \uc2e4\ud589\ud558\uba74  \u2502\n"
+        "\u2502     CodingBuddy \uc0ac\uc774\ub4dc\ubc14\ub97c \ubcfc \uc218 \uc788\uc5b4\uc694!      \u2502\n"
+        "\u2502                                               \u2502\n"
+        "\u2502     tmux new -s dev                           \u2502\n"
+        "\u2502     claude                                    \u2502\n"
+        "\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f"
+    ),
+}
+
+
+def _get_plugin_version() -> str:
+    """Read plugin version from .claude-plugin/plugin.json.
+
+    Falls back to '0.0.0' if not found.
+    """
+    try:
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        plugin_json = os.path.join(this_dir, "..", ".claude-plugin", "plugin.json")
+        if os.path.isfile(plugin_json):
+            with open(plugin_json, "r", encoding="utf-8") as f:
+                return json.load(f).get("version", "0.0.0")
+    except Exception:
+        pass
+
+    # Try CLAUDE_PLUGIN_DIR
+    plugin_dir = os.environ.get("CLAUDE_PLUGIN_DIR")
+    if plugin_dir:
+        try:
+            pj = os.path.join(plugin_dir, ".claude-plugin", "plugin.json")
+            if os.path.isfile(pj):
+                with open(pj, "r", encoding="utf-8") as f:
+                    return json.load(f).get("version", "0.0.0")
+        except Exception:
+            pass
+
+    return "0.0.0"
+
+
+def _find_hud_source() -> Optional[Path]:
+    """Find the codingbuddy-hud.py source file.
+
+    Same 3-tier search as find_plugin_source() but for the HUD script.
+    """
+    # 1. CLAUDE_PLUGIN_DIR env
+    plugin_dir = os.environ.get("CLAUDE_PLUGIN_DIR")
+    if plugin_dir:
+        try:
+            source = Path(plugin_dir).resolve() / "hooks" / HUD_FILENAME
+            if source.exists() and source.is_file():
+                return source.resolve()
+        except (OSError, ValueError):
+            pass
+
+    home = Path.home()
+
+    # 2. Plugin cache paths
+    cache_paths = [
+        home / ".claude/plugins/cache/jeremydev87/codingbuddy",
+        home / ".claude/plugins/cache/codingbuddy",
+        home / ".claude/plugins/codingbuddy",
+    ]
+    for base_path in cache_paths:
+        try:
+            resolved_base = base_path.resolve()
+            if resolved_base.exists() and resolved_base.is_dir():
+                all_dirs = [d for d in resolved_base.iterdir() if d.is_dir()]
+                for version_dir in sort_version_dirs(all_dirs):
+                    source = version_dir / "hooks" / HUD_FILENAME
+                    if source.resolve().exists():
+                        return source.resolve()
+        except (OSError, ValueError):
+            continue
+
+    # 3. Dev paths
+    dev_patterns = [
+        "workspace/codingbuddy/packages/claude-code-plugin/hooks",
+        "dev/codingbuddy/packages/claude-code-plugin/hooks",
+        "projects/codingbuddy/packages/claude-code-plugin/hooks",
+        "code/codingbuddy/packages/claude-code-plugin/hooks",
+    ]
+    for pattern in dev_patterns:
+        try:
+            source = home / pattern / HUD_FILENAME
+            if source.resolve().exists():
+                return source.resolve()
+        except (OSError, ValueError):
+            continue
+
+    return None
+
+
+def _install_statusline(home: Path, settings_file: Path) -> None:
+    """Install codingbuddy statusLine and set CODINGBUDDY_AUTO_TUI=0 (#1089, #1092)."""
+    # 1. Find and copy HUD script
+    source = _find_hud_source()
+    if not source:
+        return
+
+    hud_dir = home / ".claude" / "hud"
+    hud_dir.mkdir(parents=True, exist_ok=True)
+    target = hud_dir / HUD_FILENAME
+    shutil.copy(source, target)
+    target.chmod(0o755)
+
+    # 2. Update settings.json
+    settings = _read_settings_file(settings_file) if settings_file.exists() else {}
+
+    current_sl = settings.get("statusLine", {}).get("command", "")
+    if "codingbuddy-hud" in current_sl:
+        pass  # already installed
+    elif "omc-hud" in current_sl or not current_sl:
+        settings["statusLine"] = {
+            "type": "command",
+            "command": f'python3 "{home}/.claude/hud/{HUD_FILENAME}"',
+        }
+    # else: custom statusLine — preserve
+
+    # 3. Set CODINGBUDDY_AUTO_TUI=0 (#1092)
+    env = settings.setdefault("env", {})
+    if env.get("CODINGBUDDY_AUTO_TUI") == "1":
+        env["CODINGBUDDY_AUTO_TUI"] = "0"
+
+    _write_settings_file(settings_file, settings)
+
+
+def _sidebar_pane_exists() -> bool:
+    """Check if a codingbuddy TUI pane exists in the current tmux window."""
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-F", "#{pane_current_command}"],
+            capture_output=True, text=True, timeout=2,
+        )
+        return "codingbuddy" in result.stdout
+    except Exception:
+        return False
+
+
+def _setup_tmux_sidebar() -> None:
+    """Detect tmux and create TUI sidebar pane (#1091)."""
+    if not os.environ.get("TMUX"):
+        lang = _get_cached_language()
+        tip = TMUX_SUGGESTION.get(lang, TMUX_SUGGESTION["en"])
+        print(tip, file=sys.stderr)
+        return
+
+    if _sidebar_pane_exists():
+        return
+
+    subprocess.Popen(
+        ["tmux", "split-window", "-h", "-l", "25%", "-d", "codingbuddy", "tui"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    subprocess.Popen(
+        ["tmux", "select-pane", "-L"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
 def _ensure_lib_path():
     """Ensure hooks/lib is on sys.path (idempotent)."""
     _hooks_dir = os.path.dirname(os.path.abspath(__file__))
@@ -491,6 +665,12 @@ def main():
             print(msg("installed"))
             print(msg("patterns"))
 
+        # Step 2.5: Install codingbuddy statusLine (#1089, #1092)
+        try:
+            _install_statusline(home, settings_file)
+        except Exception:
+            pass  # Never block session start
+
         # Step 3: System prompt injection (#828)
         # SessionStart uses plain stdout for context injection (NOT JSON)
         try:
@@ -521,6 +701,18 @@ def main():
                 os.environ.get("CLAUDE_PLUGIN_DATA",
                                os.path.join(str(home), ".codingbuddy"))
             )
+        except Exception:
+            pass  # Never block session start
+
+        # Step 4.5: Initialize HUD state for statusLine (#1089)
+        try:
+            _ensure_lib_path()
+
+            from hud_state import init_hud_state
+
+            from session_utils import get_session_id as _get_sid_hud
+            hud_version = _get_plugin_version()
+            init_hud_state(_get_sid_hud(), hud_version)
         except Exception:
             pass  # Never block session start
 
@@ -621,6 +813,12 @@ def main():
             )
             if output:
                 print(output)
+        except Exception:
+            pass  # Never block session start
+
+        # Step 6.5: tmux sidebar auto-setup (#1091)
+        try:
+            _setup_tmux_sidebar()
         except Exception:
             pass  # Never block session start
 

--- a/packages/claude-code-plugin/tests/test_session_start_hud.py
+++ b/packages/claude-code-plugin/tests/test_session_start_hud.py
@@ -1,0 +1,142 @@
+"""Tests for statusLine auto-install in session-start (#1089, #1092)."""
+import json
+import os
+import sys
+
+import pytest
+
+# Ensure hooks/ is on path
+_tests_dir = os.path.dirname(os.path.abspath(__file__))
+_hooks_dir = os.path.join(os.path.dirname(_tests_dir), "hooks")
+if _hooks_dir not in sys.path:
+    sys.path.insert(0, _hooks_dir)
+
+# Also hooks/lib for _read_settings_file, _write_settings_file
+_lib_dir = os.path.join(_hooks_dir, "lib")
+if _lib_dir not in sys.path:
+    sys.path.insert(0, _lib_dir)
+
+
+# We need to import from session-start.py which has a hyphen in the name
+from importlib import import_module
+from importlib import util as importutil
+
+_spec = importutil.spec_from_file_location(
+    "session_start", os.path.join(_hooks_dir, "session-start.py")
+)
+session_start = importutil.module_from_spec(_spec)
+_spec.loader.exec_module(session_start)
+
+
+@pytest.fixture
+def home_dir(tmp_path):
+    """Simulated home directory."""
+    (tmp_path / ".claude" / "hooks").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def settings_file(home_dir):
+    """Path to settings.json in simulated home."""
+    sf = home_dir / ".claude" / "settings.json"
+    sf.write_text(json.dumps({"env": {"CODINGBUDDY_AUTO_TUI": "1"}}))
+    return sf
+
+
+@pytest.fixture
+def hud_source(home_dir):
+    """Create a fake codingbuddy-hud.py source."""
+    hooks = home_dir / "workspace" / "codingbuddy" / "packages" / "claude-code-plugin" / "hooks"
+    hooks.mkdir(parents=True)
+    src = hooks / "codingbuddy-hud.py"
+    src.write_text("#!/usr/bin/env python3\nprint('test')")
+    return src
+
+
+class TestInstallStatusline:
+    def test_installs_hud_script_to_claude_hud_dir(self, home_dir, settings_file, hud_source, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_DIR", str(hud_source.parent.parent))
+        session_start._install_statusline(home_dir, settings_file)
+
+        target = home_dir / ".claude" / "hud" / "codingbuddy-hud.py"
+        assert target.exists()
+        assert os.access(str(target), os.X_OK)
+
+    def test_sets_statusline_in_settings(self, home_dir, settings_file, hud_source, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_DIR", str(hud_source.parent.parent))
+        session_start._install_statusline(home_dir, settings_file)
+
+        data = json.loads(settings_file.read_text())
+        assert "codingbuddy-hud" in data["statusLine"]["command"]
+        assert data["statusLine"]["type"] == "command"
+
+    def test_replaces_omc_statusline(self, home_dir, settings_file, hud_source, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_DIR", str(hud_source.parent.parent))
+        settings_file.write_text(json.dumps({
+            "statusLine": {"type": "command", "command": "node omc-hud.mjs"},
+            "env": {},
+        }))
+        session_start._install_statusline(home_dir, settings_file)
+
+        data = json.loads(settings_file.read_text())
+        assert "codingbuddy-hud" in data["statusLine"]["command"]
+        assert "omc-hud" not in data["statusLine"]["command"]
+
+    def test_skips_custom_statusline(self, home_dir, settings_file, hud_source, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_DIR", str(hud_source.parent.parent))
+        settings_file.write_text(json.dumps({
+            "statusLine": {"type": "command", "command": "my-custom-hud.sh"},
+            "env": {},
+        }))
+        session_start._install_statusline(home_dir, settings_file)
+
+        data = json.loads(settings_file.read_text())
+        assert data["statusLine"]["command"] == "my-custom-hud.sh"
+
+    def test_skips_if_already_installed(self, home_dir, settings_file, hud_source, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_DIR", str(hud_source.parent.parent))
+        settings_file.write_text(json.dumps({
+            "statusLine": {"type": "command", "command": "python3 codingbuddy-hud.py"},
+            "env": {},
+        }))
+        session_start._install_statusline(home_dir, settings_file)
+
+        data = json.loads(settings_file.read_text())
+        # command unchanged (not overwritten with full path)
+        assert data["statusLine"]["command"] == "python3 codingbuddy-hud.py"
+
+    def test_sets_auto_tui_to_zero(self, home_dir, settings_file, hud_source, monkeypatch):
+        monkeypatch.setenv("CLAUDE_PLUGIN_DIR", str(hud_source.parent.parent))
+        session_start._install_statusline(home_dir, settings_file)
+
+        data = json.loads(settings_file.read_text())
+        assert data["env"]["CODINGBUDDY_AUTO_TUI"] == "0"
+
+    def test_noop_when_source_not_found(self, home_dir, settings_file, monkeypatch):
+        monkeypatch.delenv("CLAUDE_PLUGIN_DIR", raising=False)
+        # Mock _find_hud_source to return None
+        monkeypatch.setattr(session_start, "_find_hud_source", lambda: None)
+        session_start._install_statusline(home_dir, settings_file)
+
+        data = json.loads(settings_file.read_text())
+        assert "statusLine" not in data
+
+
+class TestFindHudSource:
+    def test_finds_from_env(self, tmp_path, monkeypatch):
+        hooks = tmp_path / "hooks"
+        hooks.mkdir()
+        src = hooks / "codingbuddy-hud.py"
+        src.write_text("# test")
+        monkeypatch.setenv("CLAUDE_PLUGIN_DIR", str(tmp_path))
+
+        result = session_start._find_hud_source()
+        assert result is not None
+        assert result.name == "codingbuddy-hud.py"
+
+    def test_returns_none_when_not_found(self, monkeypatch):
+        monkeypatch.delenv("CLAUDE_PLUGIN_DIR", raising=False)
+        # Unlikely to find it in test env without proper cache
+        # This may return None or a valid path depending on the test machine
+        # Just verify it doesn't crash
+        session_start._find_hud_source()

--- a/packages/claude-code-plugin/tests/test_tmux_sidebar.py
+++ b/packages/claude-code-plugin/tests/test_tmux_sidebar.py
@@ -1,0 +1,62 @@
+"""Tests for tmux sidebar auto-setup (#1091)."""
+import io
+import os
+import sys
+
+import pytest
+
+# Import session-start module
+_tests_dir = os.path.dirname(os.path.abspath(__file__))
+_hooks_dir = os.path.join(os.path.dirname(_tests_dir), "hooks")
+if _hooks_dir not in sys.path:
+    sys.path.insert(0, _hooks_dir)
+
+from importlib import util as importutil
+
+_spec = importutil.spec_from_file_location(
+    "session_start", os.path.join(_hooks_dir, "session-start.py")
+)
+session_start = importutil.module_from_spec(_spec)
+_spec.loader.exec_module(session_start)
+
+
+class TestTmuxDetection:
+    def test_prints_suggestion_when_not_in_tmux(self, monkeypatch, capsys):
+        monkeypatch.delenv("TMUX", raising=False)
+        session_start._setup_tmux_sidebar()
+
+        captured = capsys.readouterr()
+        assert "tmux" in captured.err.lower()
+        assert "claude" in captured.err.lower()
+
+    def test_no_crash_when_not_in_tmux(self, monkeypatch):
+        monkeypatch.delenv("TMUX", raising=False)
+        # Should not raise
+        session_start._setup_tmux_sidebar()
+
+
+class TestSidebarPaneExists:
+    def test_returns_false_when_not_in_tmux(self, monkeypatch):
+        monkeypatch.delenv("TMUX", raising=False)
+        # tmux list-panes will fail outside tmux
+        assert session_start._sidebar_pane_exists() is False
+
+
+class TestTmuxSuggestionMessages:
+    def test_en_message_exists(self):
+        assert "en" in session_start.TMUX_SUGGESTION
+        assert "tmux" in session_start.TMUX_SUGGESTION["en"].lower()
+
+    def test_ko_message_exists(self):
+        assert "ko" in session_start.TMUX_SUGGESTION
+        assert "tmux" in session_start.TMUX_SUGGESTION["ko"].lower()
+
+    def test_fallback_to_english(self, monkeypatch, capsys):
+        monkeypatch.delenv("TMUX", raising=False)
+        # Force unknown language
+        monkeypatch.setattr(session_start, "_get_cached_language", lambda: "fr")
+        session_start._setup_tmux_sidebar()
+
+        captured = capsys.readouterr()
+        # Falls back to English
+        assert "CodingBuddy sidebar" in captured.err


### PR DESCRIPTION
## Summary
- **#1089**: Auto-install `codingbuddy-hud.py` to `~/.claude/hud/` and register statusLine in `settings.json`
  - Replaces OMC statusLine (`omc-hud`) automatically
  - Preserves custom (non-OMC) statusLines
  - `_find_hud_source()` with 3-tier search (env → cache → dev)
  - `_get_plugin_version()` reads version from `plugin.json` dynamically
  - Init HUD state with session ID and version (Step 4.5)
- **#1091**: tmux sidebar auto-setup in session-start
  - Detects `$TMUX` env var
  - Creates right-side split pane (25%) with `codingbuddy tui`
  - Prevents duplicate panes via `tmux list-panes` check
  - Shows i18n tip message (en/ko) when not in tmux
- **#1092**: Set `CODINGBUDDY_AUTO_TUI=0` to disable standalone terminal TUI
- 15 new tests (9 install + 6 tmux), 408 total tests passing

## Test plan
- [x] `python3 -m pytest tests/test_session_start_hud.py -v` — 9 passed
- [x] `python3 -m pytest tests/test_tmux_sidebar.py -v` — 6 passed
- [x] `python3 -m pytest tests/ -q` — 408 passed
- [x] lint, format:check, typecheck, test:coverage, circular, build — all passed
- [x] Security audit (all 3 workspaces) — no issues

Closes #1089
Closes #1091
Closes #1092