### PR TITLE
fix(scripts): add yarn install to bump-version.sh

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -105,6 +105,12 @@ else
   echo "  ⏭️  .mcp.json (not found, skipped)"
 fi
 
+# 8. Update lockfile (peerDependencies changed)
 echo ""
-echo "✅ All files bumped to v$NEW_VERSION"
+echo "🔒 Updating lockfile..."
+yarn install
+echo "  ✅ yarn.lock"
+
+echo ""
+echo "✅ All files bumped to v$NEW_VERSION (including yarn.lock)"
 echo "   Next: git commit -am \"chore(release): prepare v$NEW_VERSION\""


### PR DESCRIPTION
## Summary
- Add `yarn install` step after all version files are updated in `bump-version.sh`
- Prevents CI `YN0028` lockfile-mismatch failures that occurred on every release (v5.1.0, v5.1.1)
- Updates final success message to include yarn.lock

## Test plan
- [x] Review: `scripts/bump-version.sh` diff shows yarn install added as Step 8
- [ ] Manual: Run `./scripts/bump-version.sh 99.99.99`, verify `yarn.lock` is updated, then `git checkout -- .`

Closes #1079