### PR TITLE
feat(mcp): add release validation tools and EVAL detection

### DIFF
--- a/apps/mcp-server/src/keyword/keyword.service.spec.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.spec.ts
@@ -2705,4 +2705,40 @@ ${'Even more content.\n'.repeat(150)}`;
       spy.mockRestore();
     });
   });
+
+  describe('release checklist auto-detection (#1085)', () => {
+    it('should add release warning in EVAL when prompt mentions version bump', async () => {
+      const result = await service.parseMode('EVAL: review version bump to 5.2.0', {});
+      expect(result.mode).toBe('EVAL');
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings!.some((w: string) => w.includes('Release checklist'))).toBe(true);
+    });
+
+    it('should add release warning in EVAL when prompt mentions release', async () => {
+      const result = await service.parseMode('EVAL: prepare release', {});
+      expect(result.warnings!.some((w: string) => w.includes('pre_release_check'))).toBe(true);
+    });
+
+    it('should add release warning in EVAL when package.json in prompt', async () => {
+      const result = await service.parseMode('EVAL: changes to package.json', {});
+      expect(result.warnings!.some((w: string) => w.includes('Release checklist'))).toBe(true);
+    });
+
+    it('should not add release warning in PLAN mode', async () => {
+      const result = await service.parseMode('PLAN: version bump', {});
+      const releaseWarning = result.warnings?.find((w: string) => w.includes('Release checklist'));
+      expect(releaseWarning).toBeUndefined();
+    });
+
+    it('should add release warning in AUTO mode with version keyword', async () => {
+      const result = await service.parseMode('AUTO: bump version to 2.0.0', {});
+      expect(result.warnings!.some((w: string) => w.includes('Release checklist'))).toBe(true);
+    });
+
+    it('should not add release warning when no version keywords', async () => {
+      const result = await service.parseMode('EVAL: review code quality', {});
+      const releaseWarning = result.warnings?.find((w: string) => w.includes('Release checklist'));
+      expect(releaseWarning).toBeUndefined();
+    });
+  });
 });

--- a/apps/mcp-server/src/keyword/keyword.service.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.ts
@@ -526,7 +526,45 @@ export class KeywordService {
         'TaskMaestro skill not found at ~/.claude/skills/taskmaestro/SKILL.md. To enable tmux-based parallel specialist execution, install the taskmaestro skill.';
     }
 
+    // 11. Auto-include release checklist in EVAL mode on version changes (#1085)
+    this.addReleaseChecklistIfNeeded(result, mode, originalPrompt);
+
     return result;
+  }
+
+  /** Version-related patterns for release checklist auto-detection (#1085). */
+  private static readonly VERSION_PATTERNS = [
+    /\bversion\b.*\b\d+\.\d+\.\d+\b/i,
+    /\bbump\b/i,
+    /\brelease\b/i,
+    /\bchangelog\b/i,
+    /package\.json/,
+    /pyproject\.toml/,
+    /build\.gradle/,
+    /Cargo\.toml/,
+    /go\.mod/,
+  ];
+
+  /**
+   * Auto-include release checklist in EVAL mode when version changes detected (#1085).
+   */
+  private addReleaseChecklistIfNeeded(
+    result: ParseModeResult,
+    mode: Mode,
+    originalPrompt: string,
+  ): void {
+    if (mode !== 'EVAL' && mode !== 'AUTO') return;
+
+    const hasVersionChanges = KeywordService.VERSION_PATTERNS.some(p => p.test(originalPrompt));
+    if (!hasVersionChanges) return;
+
+    if (!result.warnings) {
+      result.warnings = [];
+    }
+    result.warnings.push(
+      'Version-related changes detected. Release checklist has been auto-included. ' +
+        'Run `pre_release_check` for comprehensive validation.',
+    );
   }
 
   /**

--- a/apps/mcp-server/src/mcp/handlers/index.ts
+++ b/apps/mcp-server/src/mcp/handlers/index.ts
@@ -127,6 +127,18 @@ export { RuleInsightsHandler } from './rule-insights.handler';
 export { ImpactHandler } from './impact.handler';
 
 /**
+ * Handler for plugin validation tools (validate_plugin_manifest)
+ * @see {@link PluginValidationHandler}
+ */
+export { PluginValidationHandler } from './plugin-validation.handler';
+
+/**
+ * Handler for release check tools (pre_release_check)
+ * @see {@link ReleaseCheckHandler}
+ */
+export { ReleaseCheckHandler } from './release-check.handler';
+
+/**
  * Injection token for the array of all tool handlers.
  *
  * Use this token to inject all handlers into a service that needs to

--- a/apps/mcp-server/src/mcp/handlers/plugin-validation.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/plugin-validation.handler.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PluginValidationHandler } from './plugin-validation.handler';
+import { ConfigService } from '../../config/config.service';
+import { writeFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { mkdtempSync } from 'fs';
+
+describe('PluginValidationHandler', () => {
+  let handler: PluginValidationHandler;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'plugin-val-'));
+    const mockConfigService = {
+      getProjectRoot: vi.fn().mockReturnValue(projectRoot),
+    } as unknown as ConfigService;
+    handler = new PluginValidationHandler(mockConfigService);
+  });
+
+  it('should return null for unhandled tools', async () => {
+    const result = await handler.handle('unknown_tool', {});
+    expect(result).toBeNull();
+  });
+
+  it('should validate valid plugin.json', async () => {
+    await mkdir(join(projectRoot, '.claude-plugin'), { recursive: true });
+    await writeFile(
+      join(projectRoot, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({
+        name: 'my-plugin',
+        version: '1.0.0',
+        description: 'A test plugin',
+      }),
+    );
+
+    const result = await handler.handle('validate_plugin_manifest', {});
+    expect(result).not.toBeNull();
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.valid).toBe(true);
+    expect(data.issues).toHaveLength(0);
+  });
+
+  it('should detect missing required fields', async () => {
+    await mkdir(join(projectRoot, '.claude-plugin'), { recursive: true });
+    await writeFile(
+      join(projectRoot, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'test' }),
+    );
+
+    const result = await handler.handle('validate_plugin_manifest', {});
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.valid).toBe(false);
+    expect(data.issues.some((i: { field: string }) => i.field === 'version')).toBe(true);
+    expect(data.issues.some((i: { field: string }) => i.field === 'description')).toBe(true);
+  });
+
+  it('should detect unknown fields', async () => {
+    await mkdir(join(projectRoot, '.claude-plugin'), { recursive: true });
+    await writeFile(
+      join(projectRoot, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({
+        name: 'test',
+        version: '1.0.0',
+        description: 'test',
+        commands: [],
+      }),
+    );
+
+    const result = await handler.handle('validate_plugin_manifest', {});
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.valid).toBe(false);
+    expect(data.issues.some((i: { field: string }) => i.field === 'commands')).toBe(true);
+  });
+
+  it('should handle file not found', async () => {
+    const result = await handler.handle('validate_plugin_manifest', {});
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.valid).toBe(false);
+    expect(data.issues[0].message).toContain('not found');
+  });
+
+  it('should expose tool definitions', () => {
+    const defs = handler.getToolDefinitions();
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe('validate_plugin_manifest');
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/plugin-validation.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/plugin-validation.handler.ts
@@ -1,0 +1,168 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import type { ToolDefinition } from './base.handler';
+import type { ToolResponse } from '../response.utils';
+import { AbstractHandler } from './abstract-handler';
+import { ConfigService } from '../../config/config.service';
+import { createJsonResponse, createErrorResponse } from '../response.utils';
+import { extractOptionalString } from '../../shared/validation.constants';
+
+/** Known valid fields for Claude Code plugin.json */
+const VALID_PLUGIN_FIELDS = new Set(['name', 'version', 'description', 'author']);
+
+/** Required fields for Claude Code plugin.json */
+const REQUIRED_PLUGIN_FIELDS = ['name', 'version', 'description'];
+
+interface ValidationIssue {
+  field: string;
+  severity: 'error' | 'warning';
+  message: string;
+  suggestion?: string;
+}
+
+@Injectable()
+export class PluginValidationHandler extends AbstractHandler {
+  private readonly logger = new Logger(PluginValidationHandler.name);
+
+  constructor(private readonly configService: ConfigService) {
+    super();
+  }
+
+  protected getHandledTools(): string[] {
+    return ['validate_plugin_manifest'];
+  }
+
+  protected async handleTool(
+    _toolName: string,
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    const inputPath = extractOptionalString(args, 'path') || '.claude-plugin/plugin.json';
+
+    try {
+      const projectRoot = this.configService.getProjectRoot();
+      const fullPath = resolve(projectRoot, inputPath);
+
+      let raw: string;
+      try {
+        raw = await readFile(fullPath, 'utf-8');
+      } catch {
+        return createJsonResponse({
+          valid: false,
+          path: fullPath,
+          issues: [
+            {
+              field: '_file',
+              severity: 'error',
+              message: `File not found: ${inputPath}`,
+              suggestion:
+                'Create .claude-plugin/plugin.json with name, version, and description fields.',
+            },
+          ],
+        });
+      }
+
+      let manifest: Record<string, unknown>;
+      try {
+        manifest = JSON.parse(raw);
+      } catch {
+        return createJsonResponse({
+          valid: false,
+          path: fullPath,
+          issues: [
+            {
+              field: '_file',
+              severity: 'error',
+              message: 'Invalid JSON syntax',
+              suggestion: 'Fix JSON syntax errors in the file.',
+            },
+          ],
+        });
+      }
+
+      const issues: ValidationIssue[] = [];
+
+      // Check required fields
+      for (const field of REQUIRED_PLUGIN_FIELDS) {
+        if (!(field in manifest)) {
+          issues.push({
+            field,
+            severity: 'error',
+            message: `Missing required field: ${field}`,
+            suggestion: `Add "${field}" to plugin.json.`,
+          });
+        }
+      }
+
+      // Check for unknown fields
+      for (const key of Object.keys(manifest)) {
+        if (!VALID_PLUGIN_FIELDS.has(key)) {
+          issues.push({
+            field: key,
+            severity: 'error',
+            message: `Unknown field: ${key}`,
+            suggestion: `Remove "${key}" from plugin.json. Valid fields: ${[...VALID_PLUGIN_FIELDS].join(', ')}.`,
+          });
+        }
+      }
+
+      // Validate version format
+      if (
+        typeof manifest.version === 'string' &&
+        !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(manifest.version)
+      ) {
+        issues.push({
+          field: 'version',
+          severity: 'error',
+          message: `Invalid version format: ${manifest.version}`,
+          suggestion: 'Use semver format: X.Y.Z (e.g., 1.0.0)',
+        });
+      }
+
+      // Validate name format
+      if (typeof manifest.name === 'string' && !/^[a-z0-9][a-z0-9-]*$/.test(manifest.name)) {
+        issues.push({
+          field: 'name',
+          severity: 'warning',
+          message: `Name should be kebab-case: ${manifest.name}`,
+          suggestion: 'Use lowercase letters, numbers, and hyphens.',
+        });
+      }
+
+      const valid = issues.filter(i => i.severity === 'error').length === 0;
+
+      return createJsonResponse({
+        valid,
+        path: fullPath,
+        fields: Object.keys(manifest),
+        issues,
+      });
+    } catch (error) {
+      this.logger.error(`Plugin validation failed: ${error}`);
+      return createErrorResponse(
+        `Plugin validation failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'validate_plugin_manifest',
+        description:
+          'Validate a Claude Code plugin manifest (plugin.json) against the known schema. Returns validation results with actionable fix suggestions.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'string',
+              description:
+                'Path to plugin.json. Defaults to .claude-plugin/plugin.json in project root.',
+            },
+          },
+          required: [],
+        },
+      },
+    ];
+  }
+}

--- a/apps/mcp-server/src/mcp/handlers/release-check.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/release-check.handler.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ReleaseCheckHandler } from './release-check.handler';
+import { ConfigService } from '../../config/config.service';
+import { writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { mkdtempSync } from 'fs';
+
+describe('ReleaseCheckHandler', () => {
+  let handler: ReleaseCheckHandler;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'release-check-'));
+    const mockConfigService = {
+      getProjectRoot: vi.fn().mockReturnValue(projectRoot),
+      getConfig: vi.fn().mockReturnValue({}),
+    } as unknown as ConfigService;
+    handler = new ReleaseCheckHandler(mockConfigService);
+  });
+
+  it('should return null for unhandled tools', async () => {
+    const result = await handler.handle('unknown_tool', {});
+    expect(result).toBeNull();
+  });
+
+  it('should detect Node.js ecosystem', async () => {
+    await writeFile(
+      join(projectRoot, 'package.json'),
+      JSON.stringify({ name: 'test', version: '1.0.0' }),
+    );
+    await writeFile(join(projectRoot, 'yarn.lock'), '');
+
+    const result = await handler.handle('pre_release_check', {});
+    expect(result).not.toBeNull();
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.ecosystem).toBe('Node.js');
+  });
+
+  it('should check version sync — pass when consistent', async () => {
+    await writeFile(
+      join(projectRoot, 'package.json'),
+      JSON.stringify({ name: 'test', version: '2.0.0' }),
+    );
+    await writeFile(join(projectRoot, 'yarn.lock'), '');
+
+    const result = await handler.handle('pre_release_check', {
+      checks: ['version-sync'],
+    });
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.results[0].status).toBe('pass');
+    expect(data.results[0].message).toContain('2.0.0');
+  });
+
+  it('should check lockfile — pass when present', async () => {
+    await writeFile(join(projectRoot, 'package.json'), JSON.stringify({ version: '1.0.0' }));
+    await writeFile(join(projectRoot, 'yarn.lock'), '');
+
+    const result = await handler.handle('pre_release_check', {
+      checks: ['lockfile'],
+    });
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.results[0].status).toBe('pass');
+  });
+
+  it('should check lockfile — fail when missing', async () => {
+    await writeFile(join(projectRoot, 'package.json'), JSON.stringify({ version: '1.0.0' }));
+
+    const result = await handler.handle('pre_release_check', {
+      checks: ['lockfile'],
+    });
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.results[0].status).toBe('fail');
+  });
+
+  it('should check manifest — skip when no plugin', async () => {
+    await writeFile(join(projectRoot, 'package.json'), JSON.stringify({ version: '1.0.0' }));
+
+    const result = await handler.handle('pre_release_check', {
+      checks: ['manifest'],
+    });
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.results[0].status).toBe('skip');
+  });
+
+  it('should return summary with ready flag', async () => {
+    await writeFile(
+      join(projectRoot, 'package.json'),
+      JSON.stringify({ name: 'test', version: '1.0.0' }),
+    );
+    await writeFile(join(projectRoot, 'yarn.lock'), '');
+
+    const result = await handler.handle('pre_release_check', {});
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.summary).toBeDefined();
+    expect(typeof data.summary.ready).toBe('boolean');
+  });
+
+  it('should expose tool definitions', () => {
+    const defs = handler.getToolDefinitions();
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe('pre_release_check');
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/release-check.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/release-check.handler.ts
@@ -1,0 +1,281 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { readFile, access } from 'fs/promises';
+import { resolve } from 'path';
+import type { ToolDefinition } from './base.handler';
+import type { ToolResponse } from '../response.utils';
+import { AbstractHandler } from './abstract-handler';
+import { ConfigService } from '../../config/config.service';
+import { createJsonResponse, createErrorResponse } from '../response.utils';
+import { extractOptionalString, extractStringArray } from '../../shared/validation.constants';
+
+interface EcosystemConfig {
+  name: string;
+  versionFiles: string[];
+  lockfiles: string[];
+}
+
+const ECOSYSTEMS: Record<string, EcosystemConfig> = {
+  node: {
+    name: 'Node.js',
+    versionFiles: ['package.json'],
+    lockfiles: ['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml'],
+  },
+  python: {
+    name: 'Python',
+    versionFiles: ['pyproject.toml', 'setup.py', 'setup.cfg'],
+    lockfiles: ['Pipfile.lock', 'poetry.lock'],
+  },
+  go: {
+    name: 'Go',
+    versionFiles: ['go.mod'],
+    lockfiles: ['go.sum'],
+  },
+  rust: {
+    name: 'Rust',
+    versionFiles: ['Cargo.toml'],
+    lockfiles: ['Cargo.lock'],
+  },
+  java: {
+    name: 'Java',
+    versionFiles: ['build.gradle', 'build.gradle.kts', 'pom.xml'],
+    lockfiles: ['gradle.lockfile'],
+  },
+};
+
+interface CheckResult {
+  check: string;
+  status: 'pass' | 'fail' | 'skip';
+  message: string;
+  details?: string[];
+}
+
+@Injectable()
+export class ReleaseCheckHandler extends AbstractHandler {
+  private readonly logger = new Logger(ReleaseCheckHandler.name);
+
+  constructor(private readonly configService: ConfigService) {
+    super();
+  }
+
+  protected getHandledTools(): string[] {
+    return ['pre_release_check'];
+  }
+
+  protected async handleTool(
+    _toolName: string,
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    try {
+      const projectRoot = this.configService.getProjectRoot();
+      const ecosystem = extractOptionalString(args, 'ecosystem') || 'auto';
+      const requestedChecks = extractStringArray(args, 'checks') || [];
+
+      // Auto-detect ecosystem
+      const detected = await this.detectEcosystem(projectRoot, ecosystem);
+
+      // Run checks
+      const allChecks =
+        requestedChecks.length > 0 ? requestedChecks : ['version-sync', 'lockfile', 'manifest'];
+
+      const results: CheckResult[] = [];
+
+      for (const check of allChecks) {
+        switch (check) {
+          case 'version-sync':
+            results.push(await this.checkVersionSync(projectRoot, detected));
+            break;
+          case 'lockfile':
+            results.push(await this.checkLockfile(projectRoot, detected));
+            break;
+          case 'manifest':
+            results.push(await this.checkManifest(projectRoot));
+            break;
+          default:
+            results.push({
+              check,
+              status: 'skip',
+              message: `Unknown check: ${check}`,
+            });
+        }
+      }
+
+      const passed = results.filter(r => r.status === 'pass').length;
+      const failed = results.filter(r => r.status === 'fail').length;
+      const skipped = results.filter(r => r.status === 'skip').length;
+
+      return createJsonResponse({
+        ecosystem: detected.name,
+        summary: {
+          total: results.length,
+          passed,
+          failed,
+          skipped,
+          ready: failed === 0,
+        },
+        results,
+      });
+    } catch (error) {
+      this.logger.error(`Pre-release check failed: ${error}`);
+      return createErrorResponse(
+        `Pre-release check failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  private async detectEcosystem(projectRoot: string, requested: string): Promise<EcosystemConfig> {
+    if (requested !== 'auto' && ECOSYSTEMS[requested]) {
+      return ECOSYSTEMS[requested];
+    }
+
+    // Auto-detect by checking for ecosystem-specific files
+    for (const [, eco] of Object.entries(ECOSYSTEMS)) {
+      for (const file of eco.versionFiles) {
+        try {
+          await access(resolve(projectRoot, file));
+          return eco;
+        } catch {
+          // File not found, try next
+        }
+      }
+    }
+
+    return ECOSYSTEMS.node; // Default fallback
+  }
+
+  private async checkVersionSync(
+    projectRoot: string,
+    ecosystem: EcosystemConfig,
+  ): Promise<CheckResult> {
+    const versionFiles = ecosystem.versionFiles;
+    const versions: Record<string, string> = {};
+    const missing: string[] = [];
+
+    for (const file of versionFiles) {
+      try {
+        const content = await readFile(resolve(projectRoot, file), 'utf-8');
+        const parsed = JSON.parse(content);
+        if (parsed.version) {
+          versions[file] = parsed.version;
+        }
+      } catch {
+        missing.push(file);
+      }
+    }
+
+    const uniqueVersions = new Set(Object.values(versions));
+
+    if (uniqueVersions.size === 0) {
+      return {
+        check: 'version-sync',
+        status: 'skip',
+        message: 'No version files found',
+        details: missing.length > 0 ? [`Missing: ${missing.join(', ')}`] : [],
+      };
+    }
+
+    if (uniqueVersions.size === 1) {
+      const version = [...uniqueVersions][0];
+      return {
+        check: 'version-sync',
+        status: 'pass',
+        message: `All versions consistent: ${version}`,
+        details: Object.entries(versions).map(([f, v]) => `${f}: ${v}`),
+      };
+    }
+
+    return {
+      check: 'version-sync',
+      status: 'fail',
+      message: `Version mismatch detected (${uniqueVersions.size} different versions)`,
+      details: Object.entries(versions).map(([f, v]) => `${f}: ${v}`),
+    };
+  }
+
+  private async checkLockfile(
+    projectRoot: string,
+    ecosystem: EcosystemConfig,
+  ): Promise<CheckResult> {
+    for (const lockfile of ecosystem.lockfiles) {
+      try {
+        await access(resolve(projectRoot, lockfile));
+        return {
+          check: 'lockfile',
+          status: 'pass',
+          message: `Lockfile present: ${lockfile}`,
+        };
+      } catch {
+        // Try next
+      }
+    }
+
+    return {
+      check: 'lockfile',
+      status: 'fail',
+      message: `No lockfile found (expected: ${ecosystem.lockfiles.join(' or ')})`,
+    };
+  }
+
+  private async checkManifest(projectRoot: string): Promise<CheckResult> {
+    const manifestPath = resolve(projectRoot, '.claude-plugin', 'plugin.json');
+
+    try {
+      const raw = await readFile(manifestPath, 'utf-8');
+      const manifest = JSON.parse(raw);
+
+      const issues: string[] = [];
+      if (!manifest.name) issues.push('Missing "name"');
+      if (!manifest.version) issues.push('Missing "version"');
+      if (!manifest.description) issues.push('Missing "description"');
+
+      if (issues.length > 0) {
+        return {
+          check: 'manifest',
+          status: 'fail',
+          message: 'Plugin manifest has issues',
+          details: issues,
+        };
+      }
+
+      return {
+        check: 'manifest',
+        status: 'pass',
+        message: `Plugin manifest valid (v${manifest.version})`,
+      };
+    } catch {
+      return {
+        check: 'manifest',
+        status: 'skip',
+        message: 'No .claude-plugin/plugin.json found (not a plugin project)',
+      };
+    }
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'pre_release_check',
+        description:
+          'Comprehensive pre-release validation. Auto-detects project language and checks version sync, lockfile consistency, and manifest validity.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            ecosystem: {
+              type: 'string',
+              enum: ['auto', 'node', 'python', 'java', 'go', 'rust'],
+              description: 'Project ecosystem. Defaults to auto-detect.',
+            },
+            checks: {
+              type: 'array',
+              items: {
+                type: 'string',
+                enum: ['version-sync', 'lockfile', 'manifest'],
+              },
+              description: 'Specific checks to run. Defaults to all.',
+            },
+          },
+          required: [],
+        },
+      },
+    ];
+  }
+}

--- a/apps/mcp-server/src/mcp/mcp.module.ts
+++ b/apps/mcp-server/src/mcp/mcp.module.ts
@@ -35,6 +35,8 @@ import {
   ParallelValidationHandler,
   PipelineHandler,
   ImpactHandler,
+  PluginValidationHandler,
+  ReleaseCheckHandler,
 } from './handlers';
 
 const handlers = [
@@ -53,6 +55,8 @@ const handlers = [
   ParallelValidationHandler,
   PipelineHandler,
   ImpactHandler,
+  PluginValidationHandler,
+  ReleaseCheckHandler,
 ];
 
 @Module({


### PR DESCRIPTION
## Summary
- **#1082**: Add `validate_plugin_manifest` MCP tool
  - Validates plugin.json against known schema (required/unknown fields, semver, kebab-case)
  - Returns actionable fix suggestions for each issue
  - Handles missing file, invalid JSON, unknown fields gracefully
- **#1083**: Add `pre_release_check` MCP tool
  - Auto-detects ecosystem (Node.js, Python, Go, Rust, Java)
  - Checks: version-sync, lockfile presence, manifest validity
  - Returns summary with pass/fail/skip counts and `ready` flag
- **#1085**: Auto-include release checklist in EVAL/AUTO mode
  - Detects version-related keywords (bump, release, changelog, package.json, etc.)
  - Adds warning with `pre_release_check` suggestion
  - Only triggers in EVAL and AUTO modes
- 18 new tests (5 + 7 + 6), 5,352 total tests passing

## Test plan
- [x] `yarn workspace codingbuddy test -- --run` — 5,352 passed (206 files)
- [x] `yarn workspace codingbuddy lint` — pass (1 pre-existing warning)
- [x] `yarn workspace codingbuddy format:check` — pass
- [x] `yarn workspace codingbuddy typecheck` — pass
- [x] `yarn workspace codingbuddy test:coverage` — pass
- [x] `yarn workspace codingbuddy circular` — no circular deps
- [x] `yarn workspace codingbuddy build` — pass
- [x] Security audit (all 3 workspaces) — no issues

Closes #1082
Closes #1083
Closes #1085