### PR TITLE
chore(release): prepare v5.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "codingbuddy",
       "source": "./packages/claude-code-plugin",
       "description": "PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic TDD development",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "category": "development"
     }
   ]

--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -5,6 +5,25 @@ Todos los cambios notables de este proyecto se documentarán en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/),
 y este proyecto se adhiere a [Versionado Semántico](https://semver.org/lang/es/spec/v2.0.0.html).
 
+## [5.1.2] - 2026-03-29
+
+### Agregado
+- **StatusLine HUD**: Métricas de sesión en tiempo real en la UI de Claude Code (modo, costo, tasa de caché, uso de contexto)
+- **Barra lateral tmux**: Configuración automática del panel TUI como barra lateral en tmux
+- **Herramienta `validate_plugin_manifest`**: Validación de plugin.json de Claude Code contra esquema conocido con sugerencias de corrección
+- **Herramienta `pre_release_check`**: Validación pre-lanzamiento con detección automática de ecosistema (Node.js, Python, Go, Rust, Java)
+- **Dominio de checklist de lanzamiento**: 10 elementos para consistencia de versiones, sincronización de lockfile, validación de manifiesto, puerta de calidad CI
+- **Esquema de configuración de lanzamiento**: Sección `release` en codingbuddy.config.json
+- **Detección de lanzamiento en EVAL**: Inclusión automática del checklist de lanzamiento cuando se detectan palabras clave relacionadas con versiones en modo EVAL/AUTO
+- **Validación de esquema CI**: Validación de JSON Schema de plugin.json y marketplace.json en el flujo de trabajo dev
+- **Módulo de estado HUD**: Gestión de estado entre hooks para statusLine y detección de modo
+
+### Corregido
+- `bump-version.sh` ahora ejecuta `yarn install` para prevenir desviación del lockfile después de cambios en peerDependencies
+
+### Cambiado
+- `CODINGBUDDY_AUTO_TUI` por defecto es `0` — la barra lateral tmux reemplaza el TUI independiente para usuarios de Claude Code
+
 ## [4.4.0] - 2026-03-04
 
 ### Agregado

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -5,6 +5,25 @@
 このドキュメントは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) の形式に基づいており、
 [セマンティック バージョニング](https://semver.org/lang/ja/spec/v2.0.0.html) に準拠しています。
 
+## [5.1.2] - 2026-03-29
+
+### 追加
+- **StatusLine HUD**: Claude Code UIにリアルタイムセッション指標を表示（モード、コスト、キャッシュ率、コンテキスト使用量）
+- **tmuxサイドバー**: tmux内でTUIダッシュボードをサイドバーとして自動設定
+- **`validate_plugin_manifest`ツール**: Claude Codeプラグインのplugin.jsonをスキーマで検証し修正提案を提供
+- **`pre_release_check`ツール**: エコシステム自動検出によるリリース前検証（Node.js、Python、Go、Rust、Java）
+- **リリースチェックリストドメイン**: バージョン整合性、ロックファイル同期、マニフェスト検証、CI品質ゲートなど10項目
+- **リリース設定スキーマ**: codingbuddy.config.jsonに`release`セクションを追加
+- **EVALリリース検出**: EVAL/AUTOモードでバージョン関連キーワード検出時にリリースチェックリストを自動含有
+- **CIスキーマ検証**: devワークフローにplugin.json、marketplace.json JSON Schema検証を追加
+- **HUD状態モジュール**: statusLineとモード検出のためのクロスフック状態管理
+
+### 修正
+- `bump-version.sh`で`yarn install`を実行してpeerDependencies変更後のロックファイルドリフトを防止
+
+### 変更
+- `CODINGBUDDY_AUTO_TUI`のデフォルト値を`0`に変更 — Claude Codeユーザー向けにtmuxサイドバーがスタンドアロンTUIを置換
+
 ## [4.4.0] - 2026-03-04
 
 ### 追加

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -5,6 +5,25 @@
 이 문서는 [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/) 형식을 따르며,
 [Semantic Versioning](https://semver.org/lang/ko/spec/v2.0.0.html)을 준수합니다.
 
+## [5.1.2] - 2026-03-29
+
+### 추가됨
+- **StatusLine HUD**: Claude Code UI에 실시간 세션 지표 표시 (모드, 비용, 캐시율, 컨텍스트 사용량)
+- **tmux 사이드바**: tmux 내에서 TUI 대시보드를 사이드바로 자동 설정
+- **`validate_plugin_manifest` 도구**: Claude Code plugin.json을 스키마로 검증하고 수정 제안 제공
+- **`pre_release_check` 도구**: 에코시스템 자동 감지 릴리즈 사전 검증 (Node.js, Python, Go, Rust, Java)
+- **릴리즈 체크리스트 도메인**: 버전 일관성, 락파일 동기화, 매니페스트 검증, CI 품질 게이트 등 10개 항목
+- **릴리즈 설정 스키마**: codingbuddy.config.json에 `release` 섹션 추가
+- **EVAL 릴리즈 감지**: EVAL/AUTO 모드에서 버전 관련 키워드 감지 시 릴리즈 체크리스트 자동 포함
+- **CI 스키마 검증**: dev 워크플로우에 plugin.json, marketplace.json JSON Schema 검증 추가
+- **HUD 상태 모듈**: statusLine과 모드 감지를 위한 크로스-훅 상태 관리
+
+### 수정됨
+- `bump-version.sh`에서 `yarn install` 실행하여 peerDependencies 변경 후 락파일 드리프트 방지
+
+### 변경됨
+- `CODINGBUDDY_AUTO_TUI` 기본값 `0`으로 변경 — Claude Code 사용자를 위해 tmux 사이드바가 독립 TUI를 대체
+
 ## [4.4.0] - 2026-03-04
 
 ### 추가됨

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.2] - 2026-03-29
+
+### Added
+- **StatusLine HUD**: Real-time session metrics in Claude Code UI (mode, cost, cache rate, context usage)
+- **tmux sidebar**: Auto-setup TUI dashboard as sidebar pane when running in tmux
+- **`validate_plugin_manifest` tool**: Validate Claude Code plugin.json against known schema with fix suggestions
+- **`pre_release_check` tool**: Pre-release validation with ecosystem auto-detection (Node.js, Python, Go, Rust, Java)
+- **Release checklist domain**: 10 items across version consistency, lockfile sync, manifest validation, CI quality gate
+- **Release config schema**: `release` section in codingbuddy.config.json for version files, lockfile, coverage threshold
+- **EVAL release detection**: Auto-include release checklist when version-related keywords detected in EVAL/AUTO mode
+- **CI schema validation**: plugin.json and marketplace.json JSON Schema validation in dev workflow
+- **HUD state module**: Cross-hook state management for statusLine and mode detection
+
+### Fixed
+- `bump-version.sh` now runs `yarn install` to prevent lockfile drift after peerDependencies changes
+
+### Changed
+- `CODINGBUDDY_AUTO_TUI` defaults to `0` — tmux sidebar replaces standalone TUI for Claude Code users
+
 ## [5.1.0] - 2026-03-28
 
 ### Added

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,25 @@
 本文档格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)，
 并遵循 [语义化版本](https://semver.org/lang/zh-CN/spec/v2.0.0.html)。
 
+## [5.1.2] - 2026-03-29
+
+### 新增
+- **StatusLine HUD**: 在Claude Code UI中实时显示会话指标（模式、成本、缓存率、上下文使用量）
+- **tmux侧边栏**: 在tmux中自动将TUI仪表板设置为侧边栏面板
+- **`validate_plugin_manifest`工具**: 根据已知模式验证Claude Code plugin.json并提供修复建议
+- **`pre_release_check`工具**: 生态系统自动检测的预发布验证（Node.js、Python、Go、Rust、Java）
+- **发布检查清单域**: 版本一致性、锁文件同步、清单验证、CI质量门等10个项目
+- **发布配置模式**: 在codingbuddy.config.json中添加`release`部分
+- **EVAL发布检测**: 在EVAL/AUTO模式下检测到版本相关关键词时自动包含发布检查清单
+- **CI模式验证**: 在dev工作流中添加plugin.json和marketplace.json JSON Schema验证
+- **HUD状态模块**: 用于statusLine和模式检测的跨钩子状态管理
+
+### 修复
+- `bump-version.sh`现在运行`yarn install`以防止peerDependencies更改后的锁文件漂移
+
+### 变更
+- `CODINGBUDDY_AUTO_TUI`默认值改为`0` — tmux侧边栏替代Claude Code用户的独立TUI
+
 ## [4.4.0] - 2026-03-04
 
 ### 新增

--- a/README.es.md
+++ b/README.es.md
@@ -250,6 +250,20 @@ npx codingbuddy mcp --tui
 
 ---
 
+## Novedades en v5.1.2
+
+**StatusLine HUD** — Métricas de sesión en tiempo real en la UI de Claude Code: modo, costo, tasa de caché, uso de contexto.
+
+```
+◕‿◕ CB v5.1.2 | PLAN 🟢 | 12m | ~$0.23 | Cache:87% | Ctx:45%
+```
+
+**Barra lateral tmux** — Ejecute Claude Code dentro de tmux y obtenga un panel TUI automático como barra lateral.
+
+**Validación de lanzamiento** — Nuevas herramientas MCP: `validate_plugin_manifest` y `pre_release_check`.
+
+---
+
 ## Herramientas de IA Compatibles
 
 | Herramienta | Estado |

--- a/README.ja.md
+++ b/README.ja.md
@@ -250,6 +250,20 @@ npx codingbuddy mcp --tui
 
 ---
 
+## v5.1.2の新機能
+
+**StatusLine HUD** — Claude Code UIにリアルタイムセッション指標を表示：モード、コスト、キャッシュ率、コンテキスト使用量。
+
+```
+◕‿◕ CB v5.1.2 | PLAN 🟢 | 12m | ~$0.23 | Cache:87% | Ctx:45%
+```
+
+**tmuxサイドバー** — tmux内でClaude Codeを実行すると、TUIダッシュボードサイドバーが自動設定されます。
+
+**リリース検証** — `validate_plugin_manifest`と`pre_release_check` MCPツールを追加。
+
+---
+
 ## 対応AIツール
 
 | ツール | ステータス |

--- a/README.ko.md
+++ b/README.ko.md
@@ -250,6 +250,20 @@ npx codingbuddy mcp --tui
 
 ---
 
+## v5.1.2 새로운 기능
+
+**StatusLine HUD** — Claude Code UI에 실시간 세션 지표 표시: 현재 모드, 예상 비용, 캐시 적중률, 컨텍스트 사용량.
+
+```
+◕‿◕ CB v5.1.2 | PLAN 🟢 | 12m | ~$0.23 | Cache:87% | Ctx:45%
+```
+
+**tmux 사이드바** — tmux 안에서 Claude Code를 실행하면 TUI 대시보드 사이드바가 자동으로 설정됩니다.
+
+**릴리즈 검증** — `validate_plugin_manifest`(plugin.json 스키마 검증)와 `pre_release_check`(에코시스템 자동 감지 릴리즈 사전 검증) MCP 도구 추가.
+
+---
+
 ## 지원 AI 도구
 
 | 도구 | 상태 |

--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ Start coding with `PLAN`, `ACT`, `EVAL`, or `AUTO` keywords.
 
 ---
 
+## What's New in v5.1.2
+
+**StatusLine HUD** — Real-time session metrics right in the Claude Code UI: current mode, estimated cost, cache hit rate, and context usage.
+
+```
+◕‿◕ CB v5.1.2 | PLAN 🟢 | 12m | ~$0.23 | Cache:87% | Ctx:45%
+```
+
+**tmux Sidebar** — Run Claude Code inside tmux and get an auto-configured TUI dashboard sidebar with agent status, checklists, and metrics.
+
+**Release Validation** — Two new MCP tools: `validate_plugin_manifest` for schema-based plugin.json validation, and `pre_release_check` for comprehensive pre-release checks with ecosystem auto-detection (Node.js, Python, Go, Rust, Java).
+
+---
+
 ## Supported AI Tools
 
 | Tool | Integration | Setup |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -250,6 +250,20 @@ npx codingbuddy mcp --tui
 
 ---
 
+## v5.1.2 新功能
+
+**StatusLine HUD** — 在Claude Code UI中实时显示会话指标：模式、成本、缓存率、上下文使用量。
+
+```
+◕‿◕ CB v5.1.2 | PLAN 🟢 | 12m | ~$0.23 | Cache:87% | Ctx:45%
+```
+
+**tmux侧边栏** — 在tmux中运行Claude Code时，自动配置TUI仪表板侧边栏。
+
+**发布验证** — 新增`validate_plugin_manifest`和`pre_release_check` MCP工具。
+
+---
+
 ## 支持的 AI 工具
 
 | 工具 | 状态 |

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Multi-AI Rules MCP Server - One source of truth for AI coding rules across all AI assistants",
   "author": "JeremyDev87",
   "license": "MIT",

--- a/apps/mcp-server/src/shared/version.ts
+++ b/apps/mcp-server/src/shared/version.ts
@@ -2,4 +2,4 @@
  * Single source of truth for the runtime package version.
  * Updated automatically by scripts/bump-version.sh on each release.
  */
-export const VERSION = '5.1.1';
+export const VERSION = '5.1.2';

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "PLAN/ACT/EVAL workflow with auto-detection, specialist agents, and reusable skills for systematic TDD development",
   "author": {
     "name": "JeremyDev87",

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -2,18 +2,18 @@
 
 # CodingBuddy Claude Code Plugin
 
-> Version 5.1.0
+> Version 5.1.2
 
-Multi-AI Rules for consistent coding practices - PLAN/ACT/EVAL workflow, specialist agents, Impact Telemetry, and reusable skills for systematic development.
+Multi-AI Rules for consistent coding practices - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic development.
 
 ## Installation
 
 ```bash
-# 1. Add marketplace
-claude marketplace add JeremyDev87/codingbuddy
+# Via npm
+npm install codingbuddy-claude-plugin
 
-# 2. Install plugin
-claude plugin install codingbuddy@jeremydev87
+# Or via Claude Code
+claude plugin add codingbuddy
 ```
 
 ## Features
@@ -45,28 +45,6 @@ Reusable workflows for consistent development:
 - API Design
 - Refactoring
 - And more...
-
-## Experience
-
-See CodingBuddy in action — from project scan to session wrap-up.
-
-### Session Start
-
-![Session Start](docs/assets/session-start.gif)
-
-CodingBuddy greets you, scans the project structure, and loads your coding rules automatically.
-
-### During Work
-
-![During Work](docs/assets/during-work.gif)
-
-Specialist agents activate in real-time, tools execute with contextual checklists, and the PLAN/ACT/EVAL workflow keeps quality on track.
-
-### Session End
-
-![Session End](docs/assets/session-end.gif)
-
-A concise summary of what was accomplished, with achievements and quality metrics at a glance.
 
 ## MCP Integration (Required)
 

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-claude-plugin",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Claude Code Plugin for CodingBuddy - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills",
   "author": "JeremyDev87",
   "license": "MIT",
@@ -49,7 +49,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "codingbuddy": "^5.1.1"
+    "codingbuddy": "^5.1.2"
   },
   "peerDependenciesMeta": {
     "codingbuddy": {

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-rules",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "AI coding rules for consistent practices across AI assistants",
   "main": "index.js",
   "types": "index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5521,7 +5521,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:4.0.17"
   peerDependencies:
-    codingbuddy: ^5.1.1
+    codingbuddy: ^5.1.2
   peerDependenciesMeta:
     codingbuddy:
       optional: true


### PR DESCRIPTION
## Summary
- Bump version 5.1.1 → 5.1.2 in all 7 version-bearing files + yarn.lock
- Update CHANGELOG in 5 languages (en, ko, ja, zh-CN, es)
- Add "What's New in v5.1.2" section to 5 README translations
- Regenerate plugin README with updated version

### v5.1.2 highlights
- **StatusLine HUD** for Claude Code (mode, cost, cache, context)
- **tmux sidebar** auto-setup with TUI dashboard
- **`validate_plugin_manifest`** and **`pre_release_check`** MCP tools
- **Release checklist domain** and config schema
- **EVAL release detection** for version-related keywords
- **CI schema validation** for plugin.json and marketplace.json
- **bump-version.sh** lockfile drift prevention

## Test plan
- [x] `--full` CI: all 3 workspaces lint/format/typecheck/test/circular/build PASS
- [x] Security audit: all 3 workspaces — no issues
- [x] Schema validation: agent, plugin, marketplace — all valid
- [x] 5,352 MCP server tests + 71 plugin tests PASS