### PR TITLE
feat(tui): add fs.watch bridge for hud-state.json in stdio mode

### DIFF
--- a/apps/mcp-server/src/cli/run-tui.ts
+++ b/apps/mcp-server/src/cli/run-tui.ts
@@ -1,3 +1,5 @@
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { getInstancesFilePath } from '../tui/ipc/ipc.types';
 import { InstanceRegistry } from '../tui/ipc/instance-registry';
 import { restartTui } from './restart-tui';
@@ -55,6 +57,25 @@ export async function runTui(options: { restart?: boolean } = {}): Promise<void>
 
   manager.startPolling();
 
+  // HUD file bridge: watch hud-state.json and emit EventBus events (#1104)
+  // This enables TUI updates in stdio mode where IPC may not deliver events.
+  let hudBridge: { stop(): void } | null = null;
+  try {
+    const { HudFileBridge } = await import('../tui/events');
+    const sessions = manager.getSessions();
+    if (sessions.length > 0) {
+      const hudStatePath = path.join(
+        process.env.CODINGBUDDY_HUD_STATE_DIR ?? path.join(os.homedir(), '.codingbuddy'),
+        'hud-state.json',
+      );
+      const bridge = new HudFileBridge(sessions[0].eventBus, hudStatePath);
+      bridge.start();
+      hudBridge = bridge;
+    }
+  } catch {
+    // Non-critical — TUI still works via IPC if available
+  }
+
   let tuiInstance: { unmount: () => void } | null = null;
 
   let shuttingDown = false;
@@ -66,6 +87,7 @@ export async function runTui(options: { restart?: boolean } = {}): Promise<void>
       process.exit(0);
     }, CLIENT_SHUTDOWN_TIMEOUT_MS);
     timeout.unref();
+    hudBridge?.stop();
     void manager.disconnectAll();
     tuiInstance?.unmount();
     process.exitCode = 0;

--- a/apps/mcp-server/src/tui/events/hud-file-bridge.spec.ts
+++ b/apps/mcp-server/src/tui/events/hud-file-bridge.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { TuiEventBus } from './event-bus';
+import { TUI_EVENTS } from './types';
+import { HudFileBridge } from './hud-file-bridge';
+
+function writeHudState(filePath: string, state: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(state));
+}
+
+describe('HudFileBridge', () => {
+  let tmpDir: string;
+  let hudFile: string;
+  let eventBus: TuiEventBus;
+  let bridge: HudFileBridge;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hud-bridge-'));
+    hudFile = path.join(tmpDir, 'hud-state.json');
+    eventBus = new TuiEventBus();
+  });
+
+  afterEach(() => {
+    bridge?.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('emits MODE_CHANGED when currentMode changes in file', async () => {
+    writeHudState(hudFile, { currentMode: 'PLAN' });
+    bridge = new HudFileBridge(eventBus, hudFile, { debounceMs: 10 });
+    bridge.start();
+
+    const modeChanges: Array<{ from: string | null; to: string }> = [];
+    eventBus.on(TUI_EVENTS.MODE_CHANGED, p => modeChanges.push(p));
+
+    // Write new mode
+    writeHudState(hudFile, { currentMode: 'ACT' });
+    await sleep(500);
+
+    expect(modeChanges.length).toBeGreaterThanOrEqual(1);
+    expect(modeChanges[modeChanges.length - 1]).toEqual({ from: 'PLAN', to: 'ACT' });
+  });
+
+  it('does not emit MODE_CHANGED when mode is unchanged', async () => {
+    writeHudState(hudFile, { currentMode: 'PLAN' });
+    bridge = new HudFileBridge(eventBus, hudFile, { debounceMs: 10 });
+    bridge.start();
+
+    const modeChanges: unknown[] = [];
+    eventBus.on(TUI_EVENTS.MODE_CHANGED, p => modeChanges.push(p));
+
+    // Write same mode
+    writeHudState(hudFile, { currentMode: 'PLAN', updatedAt: new Date().toISOString() });
+    await sleep(100);
+
+    expect(modeChanges).toHaveLength(0);
+  });
+
+  it('emits AGENT_ACTIVATED when activeAgent changes', async () => {
+    writeHudState(hudFile, { currentMode: 'PLAN', activeAgent: null });
+    bridge = new HudFileBridge(eventBus, hudFile, { debounceMs: 10 });
+    bridge.start();
+
+    const activations: unknown[] = [];
+    eventBus.on(TUI_EVENTS.AGENT_ACTIVATED, p => activations.push(p));
+
+    writeHudState(hudFile, { currentMode: 'PLAN', activeAgent: 'technical-planner' });
+    await sleep(500);
+
+    expect(activations.length).toBeGreaterThanOrEqual(1);
+    expect(activations[activations.length - 1]).toMatchObject({
+      agentId: 'primary:technical-planner',
+      name: 'technical-planner',
+      isPrimary: true,
+    });
+  });
+
+  it('handles missing file gracefully on start', () => {
+    bridge = new HudFileBridge(eventBus, path.join(tmpDir, 'nonexistent.json'), { debounceMs: 10 });
+    expect(() => bridge.start()).not.toThrow();
+  });
+
+  it('does not emit after stop()', async () => {
+    writeHudState(hudFile, { currentMode: 'PLAN' });
+    bridge = new HudFileBridge(eventBus, hudFile, { debounceMs: 10 });
+    bridge.start();
+
+    const modeChanges: unknown[] = [];
+    eventBus.on(TUI_EVENTS.MODE_CHANGED, p => modeChanges.push(p));
+
+    bridge.stop();
+
+    writeHudState(hudFile, { currentMode: 'ACT' });
+    await sleep(100);
+
+    expect(modeChanges).toHaveLength(0);
+  });
+
+  it('handles malformed JSON gracefully', async () => {
+    writeHudState(hudFile, { currentMode: 'PLAN' });
+    bridge = new HudFileBridge(eventBus, hudFile, { debounceMs: 10 });
+    bridge.start();
+
+    const modeChanges: unknown[] = [];
+    eventBus.on(TUI_EVENTS.MODE_CHANGED, p => modeChanges.push(p));
+
+    fs.writeFileSync(hudFile, 'not valid json{{{');
+    await sleep(100);
+
+    expect(modeChanges).toHaveLength(0);
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/apps/mcp-server/src/tui/events/hud-file-bridge.ts
+++ b/apps/mcp-server/src/tui/events/hud-file-bridge.ts
@@ -1,0 +1,145 @@
+/**
+ * HUD File Bridge — watches ~/.codingbuddy/hud-state.json and emits
+ * TUI EventBus events so the standalone TUI sidebar stays in sync
+ * with mode/agent changes even when the MCP server runs in stdio mode.
+ *
+ * @see https://github.com/JeremyDev87/codingbuddy/issues/1104
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { TuiEventBus } from './event-bus';
+import { TUI_EVENTS } from './types';
+
+const VALID_MODES = new Set(['PLAN', 'ACT', 'EVAL', 'AUTO']);
+
+export interface HudFileBridgeOptions {
+  /** Debounce interval in ms (default: 150) */
+  debounceMs?: number;
+}
+
+interface HudState {
+  currentMode: string | null;
+  activeAgent: string | null;
+}
+
+export class HudFileBridge {
+  private readonly eventBus: TuiEventBus;
+  private readonly filePath: string;
+  private readonly debounceMs: number;
+
+  private watcher: fs.FSWatcher | null = null;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private pollInterval: ReturnType<typeof setInterval> | null = null;
+  private prev: HudState = { currentMode: null, activeAgent: null };
+  private stopped = false;
+
+  constructor(eventBus: TuiEventBus, filePath: string, options?: HudFileBridgeOptions) {
+    this.eventBus = eventBus;
+    this.filePath = filePath;
+    this.debounceMs = options?.debounceMs ?? 150;
+  }
+
+  start(): void {
+    this.stopped = false;
+    this.prev = this.readState();
+
+    // Watch the parent directory instead of the file itself.
+    // macOS FSEvents sometimes misses in-place overwrites of a single file,
+    // but reliably reports directory-level change events.
+    const dir = path.dirname(this.filePath);
+    const basename = path.basename(this.filePath);
+
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      this.watcher = fs.watch(dir, { persistent: false }, (_event, filename) => {
+        // macOS FSEvents may pass null for filename
+        if (!filename || filename === basename) this.scheduleProcess();
+      });
+      this.watcher.on('error', () => {
+        // Directory deleted or inaccessible — silently ignore
+      });
+    } catch {
+      // Directory doesn't exist yet — poll until it appears
+      this.pollUntilExists();
+    }
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
+      this.pollInterval = null;
+    }
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+  }
+
+  private scheduleProcess(): void {
+    if (this.stopped) return;
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => this.processChange(), this.debounceMs);
+  }
+
+  private processChange(): void {
+    if (this.stopped) return;
+
+    const next = this.readState();
+
+    if (
+      next.currentMode &&
+      VALID_MODES.has(next.currentMode) &&
+      next.currentMode !== this.prev.currentMode
+    ) {
+      this.eventBus.emit(TUI_EVENTS.MODE_CHANGED, {
+        from: (this.prev.currentMode as 'PLAN' | 'ACT' | 'EVAL' | 'AUTO') ?? null,
+        to: next.currentMode as 'PLAN' | 'ACT' | 'EVAL' | 'AUTO',
+      });
+    }
+
+    if (next.activeAgent && next.activeAgent !== this.prev.activeAgent) {
+      this.eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
+        agentId: `primary:${next.activeAgent}`,
+        name: next.activeAgent,
+        role: 'primary',
+        isPrimary: true,
+      });
+    }
+
+    this.prev = next;
+  }
+
+  private readState(): HudState {
+    try {
+      const raw = fs.readFileSync(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      return {
+        currentMode: typeof parsed.currentMode === 'string' ? parsed.currentMode : null,
+        activeAgent: typeof parsed.activeAgent === 'string' ? parsed.activeAgent : null,
+      };
+    } catch {
+      return { currentMode: null, activeAgent: null };
+    }
+  }
+
+  private pollUntilExists(): void {
+    if (this.stopped) return;
+    this.pollInterval = setInterval(() => {
+      if (this.stopped) {
+        clearInterval(this.pollInterval!);
+        this.pollInterval = null;
+        return;
+      }
+      if (fs.existsSync(this.filePath)) {
+        clearInterval(this.pollInterval!);
+        this.pollInterval = null;
+        this.start();
+      }
+    }, 2000);
+  }
+}

--- a/apps/mcp-server/src/tui/events/index.ts
+++ b/apps/mcp-server/src/tui/events/index.ts
@@ -32,3 +32,4 @@ export {
   AGENT_CATEGORY_MAP,
   AGENT_ICONS,
 } from './agent-metadata.types';
+export { HudFileBridge, type HudFileBridgeOptions } from './hud-file-bridge';


### PR DESCRIPTION
## Summary
- TUI sidebar was unresponsive in stdio mode because EventBus events only flow within the MCP server process
- Add `HudFileBridge` class that watches `~/.codingbuddy/hud-state.json` via `fs.watch` and emits `MODE_CHANGED` / `AGENT_ACTIVATED` events into the TUI's EventBus
- Watch parent directory (not file) for macOS FSEvents reliability, with null filename handling
- 150ms debounce to prevent rapid-fire events
- Initialize bridge in `run-tui.ts` with cleanup on shutdown
- Falls back to polling (2s interval) when hud-state.json doesn't exist yet

## Test plan
- [x] `emits MODE_CHANGED when currentMode changes in file`
- [x] `does not emit MODE_CHANGED when mode is unchanged`
- [x] `emits AGENT_ACTIVATED when activeAgent changes`
- [x] `handles missing file gracefully on start`
- [x] `does not emit after stop()`
- [x] `handles malformed JSON gracefully`
- [x] All 207 test files / 5358 tests pass
- [x] typecheck, lint, format, circular, build all pass

Closes #1104