### PR TITLE
fix(plugin): close TUI sidebar pane on session stop

### DIFF
--- a/packages/claude-code-plugin/hooks/stop.py
+++ b/packages/claude-code-plugin/hooks/stop.py
@@ -5,6 +5,7 @@ Outputs a systemMessage with the session summary on Stop event.
 """
 import json
 import os
+import subprocess
 import sys
 
 # Resolve hooks/lib and add to path
@@ -175,6 +176,12 @@ def handle_stop(data: dict):
         except Exception:
             pass  # Never block session stop
 
+        # Close TUI sidebar pane (#1109)
+        try:
+            _close_tui_sidebar()
+        except Exception:
+            pass  # Never block session stop
+
         if summary:
             return {
                 "systemMessage": summary,
@@ -283,6 +290,26 @@ def _render_impact_report(session_id, project_dir):
     lines.append(f"╰{hr}╯")
 
     return "\n".join(lines)
+
+
+def _close_tui_sidebar():
+    """Close codingbuddy TUI sidebar pane on session stop (#1109)."""
+    if not os.environ.get("TMUX"):
+        return
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-F", "#{pane_id} #{pane_current_command}"],
+            capture_output=True, text=True, timeout=2,
+        )
+        for line in result.stdout.strip().splitlines():
+            parts = line.split(None, 1)
+            if len(parts) == 2 and "codingbuddy" in parts[1]:
+                subprocess.run(
+                    ["tmux", "kill-pane", "-t", parts[0]],
+                    capture_output=True, timeout=2,
+                )
+    except Exception:
+        pass  # Never block session stop
 
 
 def _maybe_notify_session_end(summary: str):

--- a/packages/claude-code-plugin/tests/test_stop.py
+++ b/packages/claude-code-plugin/tests/test_stop.py
@@ -229,6 +229,49 @@ class TestAutoLearningSuggestions:
         assert "Auto-Learning" not in result["systemMessage"]
 
 
+class TestCloseTuiSidebar:
+    """Tests for TUI sidebar cleanup on session stop (#1109)."""
+
+    def test_noop_when_not_in_tmux(self, monkeypatch):
+        """Should do nothing when TMUX env var is not set."""
+        monkeypatch.delenv("TMUX", raising=False)
+        mod = _load_module()
+        # Should not raise
+        mod._close_tui_sidebar()
+
+    @patch("subprocess.run")
+    def test_kills_codingbuddy_pane(self, mock_run, monkeypatch):
+        """Should kill panes running codingbuddy."""
+        monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,12345,0")
+        mock_run.return_value = MagicMock(
+            stdout="%1 zsh\n%2 codingbuddy\n%3 vim\n",
+        )
+        mod = _load_module()
+        mod._close_tui_sidebar()
+
+        assert mock_run.call_count == 2  # list-panes + kill-pane
+        kill_call = mock_run.call_args_list[1]
+        assert kill_call[0][0] == ["tmux", "kill-pane", "-t", "%2"]
+
+    @patch("subprocess.run")
+    def test_no_kill_when_no_codingbuddy_pane(self, mock_run, monkeypatch):
+        """Should not call kill-pane when no codingbuddy pane exists."""
+        monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,12345,0")
+        mock_run.return_value = MagicMock(stdout="%1 zsh\n%2 vim\n")
+        mod = _load_module()
+        mod._close_tui_sidebar()
+
+        assert mock_run.call_count == 1  # only list-panes
+
+    @patch("subprocess.run", side_effect=Exception("tmux crashed"))
+    def test_exception_does_not_propagate(self, mock_run, monkeypatch):
+        """Should swallow all exceptions."""
+        monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,12345,0")
+        mod = _load_module()
+        # Should not raise
+        mod._close_tui_sidebar()
+
+
 class TestSessionSummaryRendering:
     """Tests for buddy session summary rendering in stop hook (#972)."""
 


### PR DESCRIPTION
## Summary

- Add `_close_tui_sidebar()` to stop hook that detects and kills codingbuddy tmux panes on session exit
- Uses `tmux list-panes` to find panes running codingbuddy, then `tmux kill-pane` to close them
- Fully exception-safe — stop hook never blocks Claude Code shutdown
- 4 new tests covering all scenarios (no-tmux, kill, no-match, exception)

## Test plan

- [x] `yarn workspace codingbuddy-claude-plugin test:coverage` — 423 passed
- [ ] Manual: Start Claude Code in tmux → verify TUI sidebar opens → exit → verify TUI pane closes

Closes #1109