### PR TITLE
refactor(mcp-server): remove TUI auto-launch from bootstrap and init

### DIFF
--- a/apps/mcp-server/src/cli/init/init.command.spec.ts
+++ b/apps/mcp-server/src/cli/init/init.command.spec.ts
@@ -315,7 +315,6 @@ describe('init.command', () => {
 
       expect(mockEnsureClaudeSettingsEnv).toHaveBeenCalledWith({
         ENABLE_TOOL_SEARCH: 'false',
-        CODINGBUDDY_AUTO_TUI: '1',
       });
     });
 
@@ -375,7 +374,6 @@ describe('init.command', () => {
 
       expect(mockEnsureClaudeSettingsEnv).toHaveBeenCalledWith({
         ENABLE_TOOL_SEARCH: 'false',
-        CODINGBUDDY_AUTO_TUI: '1',
       });
     });
 

--- a/apps/mcp-server/src/cli/init/init.constants.ts
+++ b/apps/mcp-server/src/cli/init/init.constants.ts
@@ -14,7 +14,6 @@ import type { GitignoreEntry } from './gitignore.utils';
  */
 export const CLAUDE_SETTINGS_ENV_ENTRIES: Record<string, string> = {
   ENABLE_TOOL_SEARCH: 'false',
-  CODINGBUDDY_AUTO_TUI: '1',
 };
 
 /**

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import * as path from 'path';
 import { NestFactory } from '@nestjs/core';
 import type { INestApplicationContext } from '@nestjs/common';
 import { AppModule } from './app.module';
@@ -102,24 +101,6 @@ async function initTui(
   }) => TuiInstance;
   const eventBus = app.get(TuiEventBus);
   return startTui({ eventBus, ...(stdout ? { stdout } : {}) });
-}
-
-/**
- * Auto-launch TUI client in a new terminal window (non-blocking helper).
- * Extracted to avoid duplication between SSE and stdio modes.
- */
-async function launchAutoTui(
-  ipcServer: { clientCount(): number },
-  tuiEnabled: boolean,
-): Promise<void> {
-  const { TuiAutoLauncher } = await import('./tui/ipc');
-  const codingbuddyBin = path.resolve(process.argv[1]);
-  const launcher = new TuiAutoLauncher({
-    enabled: tuiEnabled || process.env.CODINGBUDDY_AUTO_TUI === '1',
-    codingbuddyBin,
-  });
-  const result = await launcher.launch(ipcServer);
-  debugLog(`TUI auto-launch: ${result.reason}${result.pid ? ` (PID: ${result.pid})` : ''}`);
 }
 
 interface InitIpcResult {
@@ -254,11 +235,6 @@ export async function bootstrap(): Promise<void> {
     try {
       const ipcResult = await initIpc(app);
       sseShutdownManager.register(ipcResult.cleanup);
-
-      // Auto-launch TUI client in a new terminal window (non-blocking)
-      launchAutoTui(ipcResult.ipcServer, tuiEnabled).catch(err => {
-        debugLog(`TUI auto-launch failed (non-blocking): ${err}`);
-      });
     } catch (error) {
       logger.warn(`IPC server failed to start (non-blocking): ${error}`);
     }
@@ -294,11 +270,6 @@ export async function bootstrap(): Promise<void> {
     try {
       const ipcResult = await initIpc(app);
       shutdownManager.register(ipcResult.cleanup);
-
-      // Auto-launch TUI client in a new terminal window (non-blocking)
-      launchAutoTui(ipcResult.ipcServer, tuiEnabled).catch(err => {
-        debugLog(`TUI auto-launch failed (non-blocking): ${err}`);
-      });
     } catch (error) {
       debugLog(`IPC server failed to start (non-blocking): ${error}`);
     }


### PR DESCRIPTION
## Summary
- Remove `launchAutoTui()` function and calls from MCP server bootstrap
- Remove `CODINGBUDDY_AUTO_TUI` env var from init constants
- `TuiAutoLauncher` class kept (used by `restart-tui.ts`)

## Changes
- `main.ts`: Delete `launchAutoTui()` function + 2 call sites (SSE + stdio) + unused `path` import
- `init.constants.ts`: Remove `CODINGBUDDY_AUTO_TUI: '1'`
- `init.command.spec.ts`: Update 2 test assertions

## Test plan
- [x] `yarn workspace codingbuddy build` passes
- [x] `yarn workspace codingbuddy test` passes (207 files, 5358 tests)
- [x] No grep hits for `launchAutoTui`
- [x] `TuiAutoLauncher` class and restart-tui tests intact

Closes #1113