### PR TITLE
feat(mcp): add RuleEventCollector for in-memory rule event tracking

### DIFF
--- a/apps/mcp-server/src/rules/rule-event-collector.spec.ts
+++ b/apps/mcp-server/src/rules/rule-event-collector.spec.ts
@@ -1,0 +1,117 @@
+import { RuleEventCollector } from './rule-event-collector';
+import { RuleEvent } from './rule-event.types';
+
+describe('RuleEventCollector', () => {
+  let collector: RuleEventCollector;
+
+  beforeEach(() => {
+    collector = new RuleEventCollector();
+  });
+
+  const createEvent = (overrides: Partial<RuleEvent> = {}): RuleEvent => ({
+    type: 'mode_activated',
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  });
+
+  describe('record()', () => {
+    it('should add an event to the buffer', () => {
+      const event = createEvent();
+      collector.record(event);
+
+      const events = collector.getEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('mode_activated');
+    });
+
+    it('should auto-generate timestamp if not provided', () => {
+      const { timestamp: _, ...eventWithoutTimestamp } = createEvent();
+      collector.record(eventWithoutTimestamp as RuleEvent);
+
+      const events = collector.getEvents();
+      expect(events[0].timestamp).toBeDefined();
+      expect(() => new Date(events[0].timestamp)).not.toThrow();
+    });
+
+    it('should preserve provided timestamp', () => {
+      const timestamp = '2026-01-01T00:00:00.000Z';
+      collector.record(createEvent({ timestamp }));
+
+      expect(collector.getEvents()[0].timestamp).toBe(timestamp);
+    });
+
+    it('should store multiple events in order', () => {
+      collector.record(createEvent({ type: 'mode_activated' }));
+      collector.record(createEvent({ type: 'checklist_generated' }));
+      collector.record(createEvent({ type: 'violation_caught' }));
+
+      const events = collector.getEvents();
+      expect(events).toHaveLength(3);
+      expect(events.map(e => e.type)).toEqual([
+        'mode_activated',
+        'checklist_generated',
+        'violation_caught',
+      ]);
+    });
+
+    it('should store optional fields (domain, rule, details)', () => {
+      collector.record(
+        createEvent({
+          domain: 'security',
+          rule: 'no-eval',
+          details: { file: 'app.ts' },
+        }),
+      );
+
+      const event = collector.getEvents()[0];
+      expect(event.domain).toBe('security');
+      expect(event.rule).toBe('no-eval');
+      expect(event.details).toEqual({ file: 'app.ts' });
+    });
+
+    it('should throw on invalid event type', () => {
+      expect(() => collector.record({ type: 'invalid_type' } as unknown as RuleEvent)).toThrow(
+        'Invalid rule event type: invalid_type',
+      );
+    });
+  });
+
+  describe('getEvents()', () => {
+    it('should return empty array when no events recorded', () => {
+      expect(collector.getEvents()).toEqual([]);
+    });
+
+    it('should return a copy of events (not the internal buffer)', () => {
+      collector.record(createEvent());
+
+      const events1 = collector.getEvents();
+      const events2 = collector.getEvents();
+      expect(events1).toEqual(events2);
+      expect(events1).not.toBe(events2);
+    });
+  });
+
+  describe('flush()', () => {
+    it('should return all events and clear the buffer', () => {
+      collector.record(createEvent({ type: 'mode_activated' }));
+      collector.record(createEvent({ type: 'checklist_generated' }));
+
+      const flushed = collector.flush();
+      expect(flushed).toHaveLength(2);
+      expect(collector.getEvents()).toEqual([]);
+    });
+
+    it('should return empty array when buffer is empty', () => {
+      expect(collector.flush()).toEqual([]);
+    });
+
+    it('should allow recording new events after flush', () => {
+      collector.record(createEvent({ type: 'mode_activated' }));
+      collector.flush();
+
+      collector.record(createEvent({ type: 'violation_caught' }));
+      expect(collector.getEvents()).toHaveLength(1);
+      expect(collector.getEvents()[0].type).toBe('violation_caught');
+    });
+  });
+});

--- a/apps/mcp-server/src/rules/rule-event-collector.ts
+++ b/apps/mcp-server/src/rules/rule-event-collector.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { RuleEvent, RULE_EVENT_TYPES } from './rule-event.types';
+
+@Injectable()
+export class RuleEventCollector {
+  private events: RuleEvent[] = [];
+
+  record(event: RuleEvent): void {
+    if (!RULE_EVENT_TYPES.includes(event.type)) {
+      throw new Error(`Invalid rule event type: ${event.type}`);
+    }
+
+    this.events.push({
+      ...event,
+      timestamp: event.timestamp ?? new Date().toISOString(),
+    });
+  }
+
+  getEvents(): RuleEvent[] {
+    return [...this.events];
+  }
+
+  flush(): RuleEvent[] {
+    const flushed = [...this.events];
+    this.events = [];
+    return flushed;
+  }
+}

--- a/apps/mcp-server/src/rules/rule-event.types.ts
+++ b/apps/mcp-server/src/rules/rule-event.types.ts
@@ -1,0 +1,16 @@
+export const RULE_EVENT_TYPES = [
+  'mode_activated',
+  'checklist_generated',
+  'specialist_dispatched',
+  'violation_caught',
+] as const;
+
+export type RuleEventType = (typeof RULE_EVENT_TYPES)[number];
+
+export interface RuleEvent {
+  type: RuleEventType;
+  timestamp: string;
+  domain?: string;
+  rule?: string;
+  details?: Record<string, unknown>;
+}

--- a/apps/mcp-server/src/rules/rules.module.ts
+++ b/apps/mcp-server/src/rules/rules.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { RulesService } from './rules.service';
 import { RuleInsightsService } from './rule-insights.service';
+import { RuleEventCollector } from './rule-event-collector';
 import { CustomModule } from '../custom';
 import { CodingBuddyConfigModule } from '../config/config.module';
 
 @Module({
   imports: [CustomModule, CodingBuddyConfigModule],
-  providers: [RulesService, RuleInsightsService],
-  exports: [RulesService, RuleInsightsService],
+  providers: [RulesService, RuleInsightsService, RuleEventCollector],
+  exports: [RulesService, RuleInsightsService, RuleEventCollector],
 })
 export class RulesModule {}


### PR DESCRIPTION
## Summary

- Add `RuleEventCollector` injectable NestJS service for in-memory rule event tracking
- Define `RuleEvent` types (`mode_activated`, `checklist_generated`, `specialist_dispatched`, `violation_caught`)
- Implement `record()`, `getEvents()`, `flush()` API with type validation
- Register service in `RulesModule` for dependency injection

## Test plan

- [x] `record()` adds events to buffer with auto-timestamp
- [x] `record()` preserves provided timestamps
- [x] `record()` rejects invalid event types
- [x] `getEvents()` returns copy of buffer (immutable)
- [x] `flush()` returns events and clears buffer atomically
- [x] All 11 tests passing
- [x] Build successful (`yarn workspace codingbuddy build`)

Closes #1129