### PR TITLE
feat(mcp): add create_briefing MCP tool

### DIFF
--- a/apps/mcp-server/src/context/briefing.service.spec.ts
+++ b/apps/mcp-server/src/context/briefing.service.spec.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { BriefingService } from './briefing.service';
+import type { ConfigService } from '../config/config.service';
+import * as fs from 'fs/promises';
+import { existsSync, mkdirSync } from 'fs';
+import { BRIEFING_DIR } from './briefing.types';
+
+// Mock fs/promises
+vi.mock('fs/promises');
+
+// Mock fs sync functions
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+});
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'child_process';
+
+// Sample context document for testing
+const SAMPLE_CONTEXT = `# Context: Implement auth feature
+
+**Created**: 2026-03-28T10:00:00.000Z
+**Updated**: 2026-03-28T10:30:00.000Z
+**Current Mode**: ACT
+**Status**: active
+
+---
+
+## PLAN (10:00)
+
+### Task
+Implement JWT authentication
+
+### Decisions
+- Use JWT tokens for session management
+- Store refresh tokens in HTTP-only cookies
+
+### Notes
+- Consider database migration for user table changes
+
+---
+
+## ACT (10:30)
+
+### Task
+Implementing JWT auth module
+
+### Progress
+- Created auth service
+- Added login endpoint
+
+**Status**: in_progress
+`;
+
+const _EMPTY_CONTEXT = '';
+
+const MINIMAL_CONTEXT = `# Context: Quick fix
+
+**Created**: 2026-04-01T08:00:00.000Z
+**Updated**: 2026-04-01T08:00:00.000Z
+**Current Mode**: PLAN
+**Status**: active
+
+---
+
+## PLAN (08:00)
+
+### Task
+Fix a typo in README
+`;
+
+const SAMPLE_GIT_DIFF = ` src/auth/auth.service.ts  | 42 ++++++++++++
+ src/auth/auth.module.ts   | 15 +++++
+ src/auth/auth.guard.ts    | 28 ++++++++
+ 3 files changed, 85 insertions(+)
+`;
+
+describe('BriefingService', () => {
+  let service: BriefingService;
+  const mockProjectRoot = '/test/project';
+
+  const mockConfigService = {
+    getProjectRoot: () => mockProjectRoot,
+  } as unknown as ConfigService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(existsSync).mockReturnValue(false);
+    service = new BriefingService(mockConfigService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('createBriefing', () => {
+    it('should generate a briefing from context with decisions and pending tasks', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(SAMPLE_CONTEXT);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(SAMPLE_GIT_DIFF));
+
+      const result = await service.createBriefing();
+
+      expect(result.decisions).toContain('Use JWT tokens for session management');
+      expect(result.decisions).toContain('Store refresh tokens in HTTP-only cookies');
+      expect(result.pendingTasks).toHaveLength(2);
+      expect(result.pendingTasks).toContain('Created auth service');
+      expect(result.pendingTasks).toContain('Added login endpoint');
+      expect(result.changedFiles).toContain('src/auth/auth.service.ts');
+      expect(result.changedFiles).toContain('src/auth/auth.module.ts');
+      expect(result.changedFiles).toContain('src/auth/auth.guard.ts');
+      expect(result.filePath).toContain(BRIEFING_DIR);
+      expect(result.resumeCommand).toBeTruthy();
+    });
+
+    it('should parse git diff --stat output correctly', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(SAMPLE_CONTEXT);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(SAMPLE_GIT_DIFF));
+
+      const result = await service.createBriefing();
+
+      expect(result.changedFiles).toEqual([
+        'src/auth/auth.service.ts',
+        'src/auth/auth.module.ts',
+        'src/auth/auth.guard.ts',
+      ]);
+    });
+
+    it('should handle empty context gracefully', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(''));
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      const result = await service.createBriefing();
+
+      expect(result.decisions).toEqual([]);
+      expect(result.pendingTasks).toEqual([]);
+      expect(result.changedFiles).toEqual([]);
+      expect(result.filePath).toContain(BRIEFING_DIR);
+      expect(result.resumeCommand).toBeTruthy();
+    });
+
+    it('should handle no git changes gracefully', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(SAMPLE_CONTEXT);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(''));
+
+      const result = await service.createBriefing();
+
+      expect(result.changedFiles).toEqual([]);
+    });
+
+    it('should handle git diff command failure gracefully', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(SAMPLE_CONTEXT);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockImplementation(() => {
+        throw new Error('not a git repository');
+      });
+
+      const result = await service.createBriefing();
+
+      expect(result.changedFiles).toEqual([]);
+    });
+
+    it('should create briefing directory if it does not exist', async () => {
+      vi.mocked(existsSync).mockImplementation((p: Parameters<typeof existsSync>[0]) => {
+        const pathStr = String(p);
+        if (pathStr.includes('briefings')) return false;
+        if (pathStr.includes('context.md')) return true;
+        return false;
+      });
+      vi.mocked(fs.readFile).mockResolvedValue(MINIMAL_CONTEXT);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(''));
+
+      await service.createBriefing();
+
+      expect(mkdirSync).toHaveBeenCalledWith(expect.stringContaining('briefings'), {
+        recursive: true,
+      });
+    });
+
+    it('should write briefing markdown to file', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(SAMPLE_CONTEXT);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(SAMPLE_GIT_DIFF));
+
+      await service.createBriefing();
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('.md'),
+        expect.stringContaining('# Session Briefing'),
+        'utf-8',
+      );
+    });
+
+    it('should use custom context path when provided', async () => {
+      const customPath = 'custom/context.md';
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(MINIMAL_CONTEXT);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(''));
+
+      await service.createBriefing({ contextPath: customPath });
+
+      expect(fs.readFile).toHaveBeenCalledWith(expect.stringContaining(customPath), 'utf-8');
+    });
+
+    it('should generate resume command based on pending work', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(SAMPLE_CONTEXT);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(SAMPLE_GIT_DIFF));
+
+      const result = await service.createBriefing();
+
+      // ACT mode with in_progress status should suggest continuing ACT
+      expect(result.resumeCommand).toContain('ACT');
+    });
+
+    it('should generate PLAN resume command when no pending progress', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(MINIMAL_CONTEXT);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(''));
+
+      const result = await service.createBriefing();
+
+      expect(result.resumeCommand).toContain('PLAN');
+    });
+  });
+
+  describe('generateBriefingMarkdown', () => {
+    it('should include all sections in markdown output', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFile).mockResolvedValue(SAMPLE_CONTEXT);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(SAMPLE_GIT_DIFF));
+
+      await service.createBriefing();
+
+      const writtenContent = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
+      expect(writtenContent).toContain('# Session Briefing');
+      expect(writtenContent).toContain('## Decisions');
+      expect(writtenContent).toContain('## Changed Files');
+      expect(writtenContent).toContain('## Pending Tasks');
+      expect(writtenContent).toContain('## Resume Command');
+    });
+
+    it('should produce valid markdown for empty state', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+      vi.mocked(execSync).mockReturnValue(Buffer.from(''));
+
+      await service.createBriefing();
+
+      const writtenContent = vi.mocked(fs.writeFile).mock.calls[0][1] as string;
+      expect(writtenContent).toContain('# Session Briefing');
+      expect(writtenContent).toContain('No decisions recorded');
+      expect(writtenContent).toContain('No pending tasks');
+      expect(writtenContent).toContain('No changed files');
+    });
+  });
+
+  describe('parseGitDiffStat', () => {
+    it('should extract file paths from git diff --stat output', () => {
+      const files = service.parseGitDiffStat(SAMPLE_GIT_DIFF);
+
+      expect(files).toEqual([
+        'src/auth/auth.service.ts',
+        'src/auth/auth.module.ts',
+        'src/auth/auth.guard.ts',
+      ]);
+    });
+
+    it('should handle empty diff output', () => {
+      expect(service.parseGitDiffStat('')).toEqual([]);
+    });
+
+    it('should handle diff with summary line only', () => {
+      const summaryOnly = ' 3 files changed, 85 insertions(+)\n';
+      expect(service.parseGitDiffStat(summaryOnly)).toEqual([]);
+    });
+
+    it('should handle file paths with spaces', () => {
+      const diffWithSpaces = ' src/my file.ts | 10 +++\n 1 file changed\n';
+      const files = service.parseGitDiffStat(diffWithSpaces);
+      expect(files).toEqual(['src/my file.ts']);
+    });
+  });
+});

--- a/apps/mcp-server/src/context/briefing.service.ts
+++ b/apps/mcp-server/src/context/briefing.service.ts
@@ -1,0 +1,259 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'fs/promises';
+import { existsSync, mkdirSync } from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { ConfigService } from '../config/config.service';
+import { withTimeout } from '../shared/async.utils';
+import { CONTEXT_FILE_TIMEOUT_MS } from './context-document.types';
+import { parseContextDocument } from './context-parser.utils';
+import { BRIEFING_DIR, DEFAULT_CONTEXT_PATH, generateBriefingFilename } from './briefing.types';
+import type { BriefingInput, BriefingResult } from './briefing.types';
+
+/**
+ * Service for creating session briefing documents.
+ *
+ * Captures current session state (decisions, pending tasks, changed files)
+ * into a structured briefing document for cross-session recovery.
+ */
+@Injectable()
+export class BriefingService {
+  private readonly logger = new Logger(BriefingService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  /**
+   * Create a briefing document from current session state.
+   *
+   * 1. Read context.md and parse decisions, notes, tasks
+   * 2. Run git diff --stat to extract changed files
+   * 3. Determine resume command based on pending work
+   * 4. Write briefing to docs/codingbuddy/briefings/
+   *
+   * @param input - Optional input parameters
+   * @returns BriefingResult with file path and extracted data
+   */
+  async createBriefing(input?: BriefingInput): Promise<BriefingResult> {
+    const projectRoot = input?.projectRoot ?? this.configService.getProjectRoot();
+    const contextPath = input?.contextPath ?? DEFAULT_CONTEXT_PATH;
+    const fullContextPath = path.join(projectRoot, contextPath);
+
+    // Step 1: Parse context document
+    const { decisions, pendingTasks, currentMode } = await this.parseContext(fullContextPath);
+
+    // Step 2: Get changed files from git
+    const changedFiles = this.getChangedFiles(projectRoot);
+
+    // Step 3: Generate resume command
+    const resumeCommand = this.generateResumeCommand(currentMode, pendingTasks, decisions);
+
+    // Step 4: Generate and write briefing
+    const markdown = this.generateBriefingMarkdown({
+      decisions,
+      pendingTasks,
+      changedFiles,
+      resumeCommand,
+    });
+
+    const filePath = await this.writeBriefing(projectRoot, markdown);
+
+    return {
+      filePath,
+      decisions,
+      pendingTasks,
+      changedFiles,
+      resumeCommand,
+    };
+  }
+
+  /**
+   * Parse git diff --stat output to extract file paths.
+   *
+   * @param diffOutput - Raw output from git diff --stat
+   * @returns Array of file paths
+   */
+  parseGitDiffStat(diffOutput: string): string[] {
+    if (!diffOutput || diffOutput.trim().length === 0) {
+      return [];
+    }
+
+    const lines = diffOutput.split('\n');
+    const files: string[] = [];
+
+    for (const line of lines) {
+      // Each file line has format: " path/to/file | N +++---"
+      // Summary line has format: " N files changed, ..."
+      const match = line.match(/^\s+(.+?)\s+\|\s+\d/);
+      if (match) {
+        files.push(match[1].trim());
+      }
+    }
+
+    return files;
+  }
+
+  /**
+   * Parse context.md and extract decisions, pending tasks, and current mode.
+   */
+  private async parseContext(contextPath: string): Promise<{
+    decisions: string[];
+    pendingTasks: string[];
+    currentMode: string;
+  }> {
+    if (!existsSync(contextPath)) {
+      return { decisions: [], pendingTasks: [], currentMode: 'PLAN' };
+    }
+
+    try {
+      const content = await withTimeout(fs.readFile(contextPath, 'utf-8'), {
+        timeoutMs: CONTEXT_FILE_TIMEOUT_MS,
+        operationName: 'read context for briefing',
+      });
+
+      if (!content || content.trim().length === 0) {
+        return { decisions: [], pendingTasks: [], currentMode: 'PLAN' };
+      }
+
+      const doc = parseContextDocument(content);
+
+      // Collect all decisions across sections
+      const decisions = doc.sections.flatMap(s => s.decisions ?? []);
+
+      // Collect pending tasks: progress items from ACT sections with in_progress status
+      const pendingTasks = doc.sections
+        .filter(s => s.mode === 'ACT' && s.status === 'in_progress')
+        .flatMap(s => s.progress ?? []);
+
+      return {
+        decisions,
+        pendingTasks,
+        currentMode: doc.metadata.currentMode,
+      };
+    } catch (error) {
+      this.logger.debug(
+        `Failed to parse context: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      return { decisions: [], pendingTasks: [], currentMode: 'PLAN' };
+    }
+  }
+
+  /**
+   * Get changed files from git diff --stat.
+   */
+  private getChangedFiles(projectRoot: string): string[] {
+    try {
+      const output = execSync('git diff --stat', {
+        cwd: projectRoot,
+        encoding: 'buffer',
+      });
+      return this.parseGitDiffStat(output.toString('utf-8'));
+    } catch {
+      this.logger.debug('Failed to get git diff, possibly not a git repository');
+      return [];
+    }
+  }
+
+  /**
+   * Generate a resume command based on current session state.
+   */
+  private generateResumeCommand(
+    currentMode: string,
+    pendingTasks: string[],
+    decisions: string[],
+  ): string {
+    if (pendingTasks.length > 0) {
+      return `ACT continue implementing — ${pendingTasks.length} task(s) in progress`;
+    }
+    if (decisions.length > 0 && currentMode === 'PLAN') {
+      return `ACT execute the plan — ${decisions.length} decision(s) made`;
+    }
+    if (currentMode === 'ACT') {
+      return 'EVAL review the implementation';
+    }
+    return 'PLAN start a new task';
+  }
+
+  /**
+   * Generate briefing markdown content.
+   */
+  private generateBriefingMarkdown(data: {
+    decisions: string[];
+    pendingTasks: string[];
+    changedFiles: string[];
+    resumeCommand: string;
+  }): string {
+    const lines: string[] = [
+      '# Session Briefing',
+      '',
+      `> Generated: ${new Date().toISOString()}`,
+      '',
+    ];
+
+    // Decisions
+    lines.push('## Decisions');
+    lines.push('');
+    if (data.decisions.length > 0) {
+      for (const decision of data.decisions) {
+        lines.push(`- ${decision}`);
+      }
+    } else {
+      lines.push('No decisions recorded.');
+    }
+    lines.push('');
+
+    // Changed Files
+    lines.push('## Changed Files');
+    lines.push('');
+    if (data.changedFiles.length > 0) {
+      for (const file of data.changedFiles) {
+        lines.push(`- \`${file}\``);
+      }
+    } else {
+      lines.push('No changed files.');
+    }
+    lines.push('');
+
+    // Pending Tasks
+    lines.push('## Pending Tasks');
+    lines.push('');
+    if (data.pendingTasks.length > 0) {
+      for (const task of data.pendingTasks) {
+        lines.push(`- [ ] ${task}`);
+      }
+    } else {
+      lines.push('No pending tasks.');
+    }
+    lines.push('');
+
+    // Resume Command
+    lines.push('## Resume Command');
+    lines.push('');
+    lines.push(`\`\`\`\n${data.resumeCommand}\n\`\`\``);
+    lines.push('');
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Write briefing content to the briefings directory.
+   */
+  private async writeBriefing(projectRoot: string, content: string): Promise<string> {
+    const briefingDir = path.join(projectRoot, BRIEFING_DIR);
+
+    if (!existsSync(briefingDir)) {
+      mkdirSync(briefingDir, { recursive: true });
+      this.logger.log(`Created briefing directory: ${briefingDir}`);
+    }
+
+    const filename = generateBriefingFilename();
+    const filePath = path.join(briefingDir, filename);
+
+    await withTimeout(fs.writeFile(filePath, content, 'utf-8'), {
+      timeoutMs: CONTEXT_FILE_TIMEOUT_MS,
+      operationName: 'write briefing file',
+    });
+
+    this.logger.log(`Created briefing: ${BRIEFING_DIR}/${filename}`);
+    return `${BRIEFING_DIR}/${filename}`;
+  }
+}

--- a/apps/mcp-server/src/context/briefing.types.ts
+++ b/apps/mcp-server/src/context/briefing.types.ts
@@ -1,0 +1,60 @@
+/**
+ * Types and constants for the briefing system.
+ *
+ * Captures current session state into a structured briefing document
+ * for cross-session recovery at `docs/codingbuddy/briefings/`.
+ */
+
+/**
+ * Directory for briefing documents.
+ * Relative to project root.
+ */
+export const BRIEFING_DIR = 'docs/codingbuddy/briefings';
+
+/**
+ * Default path to the context document.
+ */
+export const DEFAULT_CONTEXT_PATH = 'docs/codingbuddy/context.md';
+
+/**
+ * Input parameters for creating a briefing.
+ */
+export interface BriefingInput {
+  /** Path to context.md (default: docs/codingbuddy/context.md) */
+  contextPath?: string;
+  /** Project root directory */
+  projectRoot?: string;
+}
+
+/**
+ * Result of creating a briefing.
+ */
+export interface BriefingResult {
+  /** Path to the written briefing file */
+  filePath: string;
+  /** Key decisions extracted from context */
+  decisions: string[];
+  /** Pending/incomplete tasks from context */
+  pendingTasks: string[];
+  /** Files changed according to git diff */
+  changedFiles: string[];
+  /** Suggested command to resume work */
+  resumeCommand: string;
+}
+
+/**
+ * Generate a briefing filename from the current timestamp.
+ * Format: YYYY-MM-DDTHH-mm-ss.md (ISO-like, filesystem-safe)
+ *
+ * @param date - Date to generate filename from (defaults to now)
+ * @returns Filename string
+ */
+export function generateBriefingFilename(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}-${minutes}-${seconds}.md`;
+}

--- a/apps/mcp-server/src/context/context.module.ts
+++ b/apps/mcp-server/src/context/context.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { ContextService } from './context.service';
 import { ContextDocumentService } from './context-document.service';
 import { ContextArchiveService } from './context-archive.service';
+import { BriefingService } from './briefing.service';
 import { ChecklistModule } from '../checklist/checklist.module';
 import { CodingBuddyConfigModule } from '../config/config.module';
 
 @Module({
   imports: [ChecklistModule, CodingBuddyConfigModule],
-  providers: [ContextService, ContextDocumentService, ContextArchiveService],
-  exports: [ContextService, ContextDocumentService, ContextArchiveService],
+  providers: [ContextService, ContextDocumentService, ContextArchiveService, BriefingService],
+  exports: [ContextService, ContextDocumentService, ContextArchiveService, BriefingService],
 })
 export class ContextModule {}

--- a/apps/mcp-server/src/context/index.ts
+++ b/apps/mcp-server/src/context/index.ts
@@ -2,3 +2,4 @@ export * from './context.module';
 export * from './context.service';
 export * from './context.types';
 export * from './context-archive.service';
+export * from './briefing.service';

--- a/apps/mcp-server/src/mcp/handlers/briefing.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/briefing.handler.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { BriefingHandler } from './briefing.handler';
+import type { BriefingService } from '../../context/briefing.service';
+import type { BriefingResult } from '../../context/briefing.types';
+
+describe('BriefingHandler', () => {
+  let handler: BriefingHandler;
+  let mockBriefingService: Partial<BriefingService>;
+
+  const mockResult: BriefingResult = {
+    filePath: 'docs/codingbuddy/briefings/2026-04-01T10-00-00.md',
+    decisions: ['Use JWT tokens', 'Add rate limiting'],
+    pendingTasks: ['Implement login endpoint'],
+    changedFiles: ['src/auth/auth.service.ts'],
+    resumeCommand: 'ACT continue implementing — 1 task(s) in progress',
+  };
+
+  beforeEach(() => {
+    mockBriefingService = {
+      createBriefing: vi.fn().mockResolvedValue(mockResult),
+    };
+    handler = new BriefingHandler(mockBriefingService as BriefingService);
+  });
+
+  describe('handle', () => {
+    it('should handle create_briefing tool', async () => {
+      const result = await handler.handle('create_briefing', {});
+
+      expect(result).not.toBeNull();
+      expect(mockBriefingService.createBriefing).toHaveBeenCalled();
+    });
+
+    it('should return null for unhandled tools', async () => {
+      const result = await handler.handle('unknown_tool', {});
+
+      expect(result).toBeNull();
+    });
+
+    it('should pass contextPath and projectRoot to service', async () => {
+      await handler.handle('create_briefing', {
+        contextPath: 'custom/context.md',
+        projectRoot: '/my/project',
+      });
+
+      expect(mockBriefingService.createBriefing).toHaveBeenCalledWith({
+        contextPath: 'custom/context.md',
+        projectRoot: '/my/project',
+      });
+    });
+
+    it('should return briefing result as JSON response', async () => {
+      const result = await handler.handle('create_briefing', {});
+
+      expect(result).not.toBeNull();
+      const parsed = JSON.parse(result!.content[0].text);
+      expect(parsed.filePath).toBe(mockResult.filePath);
+      expect(parsed.decisions).toEqual(mockResult.decisions);
+      expect(parsed.pendingTasks).toEqual(mockResult.pendingTasks);
+      expect(parsed.changedFiles).toEqual(mockResult.changedFiles);
+      expect(parsed.resumeCommand).toBe(mockResult.resumeCommand);
+      expect(parsed.message).toContain('Briefing created');
+    });
+
+    it('should return error response on service failure', async () => {
+      vi.mocked(mockBriefingService.createBriefing!).mockRejectedValue(
+        new Error('File system error'),
+      );
+
+      const result = await handler.handle('create_briefing', {});
+
+      expect(result).not.toBeNull();
+      expect(result!.isError).toBe(true);
+      expect(result!.content[0].text).toContain('Failed to create briefing');
+      expect(result!.content[0].text).toContain('File system error');
+    });
+
+    it('should handle undefined args gracefully', async () => {
+      const result = await handler.handle('create_briefing', undefined);
+
+      expect(result).not.toBeNull();
+      expect(mockBriefingService.createBriefing).toHaveBeenCalledWith({
+        contextPath: undefined,
+        projectRoot: undefined,
+      });
+    });
+  });
+
+  describe('getToolDefinitions', () => {
+    it('should return create_briefing tool definition', () => {
+      const definitions = handler.getToolDefinitions();
+
+      expect(definitions).toHaveLength(1);
+      expect(definitions[0].name).toBe('create_briefing');
+      expect(definitions[0].description).toBeTruthy();
+      expect(definitions[0].inputSchema.type).toBe('object');
+      expect(definitions[0].inputSchema.properties).toHaveProperty('contextPath');
+      expect(definitions[0].inputSchema.properties).toHaveProperty('projectRoot');
+    });
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/briefing.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/briefing.handler.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@nestjs/common';
+import type { ToolDefinition } from './base.handler';
+import type { ToolResponse } from '../response.utils';
+import { AbstractHandler } from './abstract-handler';
+import { BriefingService } from '../../context/briefing.service';
+import { createJsonResponse, createErrorResponse } from '../response.utils';
+import { extractOptionalString } from '../../shared/validation.constants';
+import { BRIEFING_DIR } from '../../context/briefing.types';
+
+/**
+ * Handler for the create_briefing MCP tool.
+ *
+ * Captures current session state into a structured briefing document
+ * for cross-session recovery.
+ */
+@Injectable()
+export class BriefingHandler extends AbstractHandler {
+  constructor(private readonly briefingService: BriefingService) {
+    super();
+  }
+
+  protected getHandledTools(): string[] {
+    return ['create_briefing'];
+  }
+
+  protected async handleTool(
+    toolName: string,
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    switch (toolName) {
+      case 'create_briefing':
+        return this.handleCreateBriefing(args);
+      default:
+        return createErrorResponse(`Unknown tool: ${toolName}`);
+    }
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'create_briefing',
+        description:
+          'Capture current session state into a briefing document for cross-session recovery. ' +
+          `Reads context.md, extracts decisions/tasks, checks git diff, and writes to ${BRIEFING_DIR}/.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            contextPath: {
+              type: 'string',
+              description: 'Path to context.md file (default: docs/codingbuddy/context.md)',
+            },
+            projectRoot: {
+              type: 'string',
+              description: 'Project root directory (defaults to auto-detected root)',
+            },
+          },
+          required: [],
+        },
+      },
+    ];
+  }
+
+  private async handleCreateBriefing(
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    try {
+      const contextPath = extractOptionalString(args, 'contextPath');
+      const projectRoot = extractOptionalString(args, 'projectRoot');
+
+      const result = await this.briefingService.createBriefing({
+        contextPath,
+        projectRoot,
+      });
+
+      return createJsonResponse({
+        ...result,
+        message: `Briefing created at ${result.filePath}`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return createErrorResponse(`Failed to create briefing: ${message}`);
+    }
+  }
+}

--- a/apps/mcp-server/src/mcp/handlers/index.ts
+++ b/apps/mcp-server/src/mcp/handlers/index.ts
@@ -139,6 +139,12 @@ export { PluginValidationHandler } from './plugin-validation.handler';
 export { ReleaseCheckHandler } from './release-check.handler';
 
 /**
+ * Handler for briefing tools (create_briefing)
+ * @see {@link BriefingHandler}
+ */
+export { BriefingHandler } from './briefing.handler';
+
+/**
  * Injection token for the array of all tool handlers.
  *
  * Use this token to inject all handlers into a service that needs to

--- a/apps/mcp-server/src/mcp/mcp.module.ts
+++ b/apps/mcp-server/src/mcp/mcp.module.ts
@@ -37,6 +37,7 @@ import {
   ImpactHandler,
   PluginValidationHandler,
   ReleaseCheckHandler,
+  BriefingHandler,
 } from './handlers';
 
 const handlers = [
@@ -57,6 +58,7 @@ const handlers = [
   ImpactHandler,
   PluginValidationHandler,
   ReleaseCheckHandler,
+  BriefingHandler,
 ];
 
 @Module({


### PR DESCRIPTION
## Summary

- Add `create_briefing` MCP tool that captures session state into a structured briefing document
- Reads `context.md`, extracts decisions/pending tasks, runs `git diff --stat` for changed files
- Writes briefing to `docs/codingbuddy/briefings/{timestamp}.md` with resume command

Closes #1122

## New Files

| File | Purpose |
|------|---------|
| `briefing.types.ts` | `BriefingInput`, `BriefingResult` interfaces, constants |
| `briefing.service.ts` | Context parsing, git diff extraction, markdown generation |
| `briefing.service.spec.ts` | 16 service tests (TDD-first) |
| `briefing.handler.ts` | MCP tool handler extending `AbstractHandler` |
| `briefing.handler.spec.ts` | 7 handler tests |

## Modified Files

- `context.module.ts` — Register `BriefingService`
- `context/index.ts` — Export `BriefingService`
- `handlers/index.ts` — Export `BriefingHandler`
- `mcp.module.ts` — Register `BriefingHandler` in handlers array

## Test plan

- [x] 16 service tests: context parsing, git diff parsing, markdown output, edge cases
- [x] 7 handler tests: tool routing, arg passing, error handling, tool definitions
- [x] All 5381 existing tests pass
- [x] TypeScript strict mode — no errors
- [x] Build succeeds