### PR TITLE
feat(mcp): add create_briefing MCP tool (#1122)

### DIFF
--- a/apps/mcp-server/src/context/briefing.service.spec.ts
+++ b/apps/mcp-server/src/context/briefing.service.spec.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { BriefingService } from './briefing.service';
+import type { ConfigService } from '../config/config.service';
+import type { ContextDocumentService } from './context-document.service';
+import type { ContextDocument } from './context-document.types';
+
+function createMockConfigService(projectRoot = '/tmp/test-project'): ConfigService {
+  return {
+    getProjectRoot: vi.fn().mockReturnValue(projectRoot),
+  } as unknown as ConfigService;
+}
+
+function createMockContextDocumentService(document?: ContextDocument): ContextDocumentService {
+  return {
+    readContext: vi
+      .fn()
+      .mockResolvedValue(document ? { exists: true, document } : { exists: false }),
+  } as unknown as ContextDocumentService;
+}
+
+function createTestDocument(overrides?: Partial<ContextDocument>): ContextDocument {
+  return {
+    metadata: {
+      title: 'Test Task',
+      createdAt: '2026-04-01T00:00:00.000Z',
+      lastUpdatedAt: '2026-04-01T01:00:00.000Z',
+      currentMode: 'ACT',
+      status: 'active',
+    },
+    sections: [
+      {
+        mode: 'PLAN',
+        timestamp: '2026-04-01 00:00',
+        decisions: ['Use TypeScript strict mode', 'Follow TDD approach'],
+        notes: ['Check existing patterns first'],
+      },
+      {
+        mode: 'ACT',
+        timestamp: '2026-04-01 01:00',
+        progress: ['Implemented service layer', 'Tests passing'],
+        notes: ['Need to add handler registration'],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('BriefingService', () => {
+  let service: BriefingService;
+  let mockConfigService: ConfigService;
+  let mockContextDocService: ContextDocumentService;
+
+  beforeEach(() => {
+    mockConfigService = createMockConfigService();
+    mockContextDocService = createMockContextDocumentService(createTestDocument());
+    service = new BriefingService(mockConfigService, mockContextDocService);
+  });
+
+  describe('parseContext', () => {
+    it('should extract decisions from all sections', async () => {
+      const result = await service.parseContext();
+      expect(result.decisions).toEqual(['Use TypeScript strict mode', 'Follow TDD approach']);
+    });
+
+    it('should extract pending tasks from notes and progress', async () => {
+      const result = await service.parseContext();
+      expect(result.pendingTasks).toContain('Check existing patterns first');
+      expect(result.pendingTasks).toContain('Need to add handler registration');
+    });
+
+    it('should exclude completed progress items', async () => {
+      const doc = createTestDocument({
+        sections: [
+          {
+            mode: 'ACT',
+            timestamp: '2026-04-01 01:00',
+            progress: ['Step 1 completed', 'Step 2 in progress'],
+          },
+        ],
+      });
+      mockContextDocService = createMockContextDocumentService(doc);
+      service = new BriefingService(mockConfigService, mockContextDocService);
+
+      const result = await service.parseContext();
+      expect(result.pendingTasks).toContain('Step 2 in progress');
+      expect(result.pendingTasks).not.toContain('Step 1 completed');
+    });
+
+    it('should return current mode from metadata', async () => {
+      const result = await service.parseContext();
+      expect(result.currentMode).toBe('ACT');
+    });
+
+    it('should return title from metadata', async () => {
+      const result = await service.parseContext();
+      expect(result.title).toBe('Test Task');
+    });
+
+    it('should handle empty context gracefully', async () => {
+      mockContextDocService = createMockContextDocumentService();
+      service = new BriefingService(mockConfigService, mockContextDocService);
+
+      const result = await service.parseContext();
+      expect(result.decisions).toEqual([]);
+      expect(result.pendingTasks).toEqual([]);
+      expect(result.currentMode).toBe('PLAN');
+      expect(result.title).toBe('Untitled');
+    });
+  });
+
+  describe('getChangedFiles', () => {
+    it('should return empty array when git fails', () => {
+      // Non-existent directory will cause git to fail
+      const result = service.getChangedFiles('/nonexistent/path');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('generateResumeCommand', () => {
+    it('should suggest ACT for PLAN mode with pending tasks', () => {
+      const result = service.generateResumeCommand('PLAN', ['task1'], 'My Feature');
+      expect(result).toContain('ACT');
+      expect(result).toContain('My Feature');
+    });
+
+    it('should suggest continue ACT for ACT mode', () => {
+      const result = service.generateResumeCommand('ACT', ['task1'], 'My Feature');
+      expect(result).toContain('ACT continue');
+      expect(result).toContain('My Feature');
+    });
+
+    it('should suggest ACT apply fixes for EVAL mode', () => {
+      const result = service.generateResumeCommand('EVAL', ['fix1'], 'My Feature');
+      expect(result).toContain('ACT apply fixes');
+      expect(result).toContain('My Feature');
+    });
+
+    it('should suggest AUTO for unknown mode', () => {
+      const result = service.generateResumeCommand('OTHER', ['task1'], 'My Feature');
+      expect(result).toContain('AUTO');
+    });
+
+    it('should suggest PLAN when no pending tasks', () => {
+      const result = service.generateResumeCommand('ACT', [], 'My Feature');
+      expect(result).toContain('PLAN');
+      expect(result).toContain('My Feature');
+    });
+  });
+
+  describe('formatBriefingMarkdown', () => {
+    it('should include title in header', () => {
+      const md = service.formatBriefingMarkdown({
+        decisions: [],
+        pendingTasks: [],
+        changedFiles: [],
+        resumeCommand: 'PLAN continue',
+        currentMode: 'PLAN',
+        title: 'My Feature',
+      });
+      expect(md).toContain('# Briefing: My Feature');
+    });
+
+    it('should include mode', () => {
+      const md = service.formatBriefingMarkdown({
+        decisions: [],
+        pendingTasks: [],
+        changedFiles: [],
+        resumeCommand: 'PLAN continue',
+        currentMode: 'ACT',
+        title: 'Test',
+      });
+      expect(md).toContain('**Mode**: ACT');
+    });
+
+    it('should list decisions', () => {
+      const md = service.formatBriefingMarkdown({
+        decisions: ['Decision A', 'Decision B'],
+        pendingTasks: [],
+        changedFiles: [],
+        resumeCommand: 'PLAN continue',
+        currentMode: 'PLAN',
+        title: 'Test',
+      });
+      expect(md).toContain('- Decision A');
+      expect(md).toContain('- Decision B');
+    });
+
+    it('should list changed files', () => {
+      const md = service.formatBriefingMarkdown({
+        decisions: [],
+        pendingTasks: [],
+        changedFiles: ['src/app.ts', 'src/main.ts'],
+        resumeCommand: 'PLAN continue',
+        currentMode: 'PLAN',
+        title: 'Test',
+      });
+      expect(md).toContain('- src/app.ts');
+      expect(md).toContain('- src/main.ts');
+    });
+
+    it('should list pending tasks', () => {
+      const md = service.formatBriefingMarkdown({
+        decisions: [],
+        pendingTasks: ['Finish handler', 'Add tests'],
+        changedFiles: [],
+        resumeCommand: 'ACT continue',
+        currentMode: 'ACT',
+        title: 'Test',
+      });
+      expect(md).toContain('- Finish handler');
+      expect(md).toContain('- Add tests');
+    });
+
+    it('should include resume command in code block', () => {
+      const md = service.formatBriefingMarkdown({
+        decisions: [],
+        pendingTasks: [],
+        changedFiles: [],
+        resumeCommand: 'ACT continue "My Feature"',
+        currentMode: 'ACT',
+        title: 'Test',
+      });
+      expect(md).toContain('```\nACT continue "My Feature"\n```');
+    });
+
+    it('should show placeholder when no decisions', () => {
+      const md = service.formatBriefingMarkdown({
+        decisions: [],
+        pendingTasks: [],
+        changedFiles: [],
+        resumeCommand: 'PLAN continue',
+        currentMode: 'PLAN',
+        title: 'Test',
+      });
+      expect(md).toContain('_No decisions recorded._');
+    });
+
+    it('should show placeholder when no changed files', () => {
+      const md = service.formatBriefingMarkdown({
+        decisions: [],
+        pendingTasks: [],
+        changedFiles: [],
+        resumeCommand: 'PLAN continue',
+        currentMode: 'PLAN',
+        title: 'Test',
+      });
+      expect(md).toContain('_No files changed._');
+    });
+
+    it('should show placeholder when no pending tasks', () => {
+      const md = service.formatBriefingMarkdown({
+        decisions: [],
+        pendingTasks: [],
+        changedFiles: [],
+        resumeCommand: 'PLAN continue',
+        currentMode: 'PLAN',
+        title: 'Test',
+      });
+      expect(md).toContain('_No pending tasks._');
+    });
+  });
+});

--- a/apps/mcp-server/src/context/briefing.service.ts
+++ b/apps/mcp-server/src/context/briefing.service.ts
@@ -1,0 +1,255 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'fs/promises';
+import { existsSync, mkdirSync } from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { ConfigService } from '../config/config.service';
+import { ContextDocumentService } from './context-document.service';
+import type { BriefingInput, BriefingResult } from './briefing.types';
+import { BRIEFING_OUTPUT_DIR, GIT_DIFF_TIMEOUT_MS } from './briefing.types';
+
+/**
+ * Service for generating session briefing documents.
+ *
+ * Briefings capture the current session state (decisions, changed files,
+ * pending tasks) into a structured markdown document that can be used
+ * to resume work in a new session.
+ */
+@Injectable()
+export class BriefingService {
+  private readonly logger = new Logger(BriefingService.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly contextDocumentService: ContextDocumentService,
+  ) {}
+
+  /**
+   * Generate a briefing document from current session state.
+   *
+   * 1. Reads context.md and parses decisions, notes, tasks
+   * 2. Runs `git diff --stat` to extract changed files
+   * 3. Determines current mode from context metadata
+   * 4. Generates resumeCommand based on pending work
+   * 5. Writes to docs/codingbuddy/briefings/{ISO-timestamp}.md
+   */
+  async createBriefing(input?: BriefingInput): Promise<BriefingResult> {
+    const projectRoot = input?.projectRoot ?? this.configService.getProjectRoot();
+
+    // 1. Parse context document
+    const { decisions, pendingTasks, currentMode, title } = await this.parseContext();
+
+    // 2. Get changed files from git
+    const changedFiles = this.getChangedFiles(projectRoot);
+
+    // 3. Generate resume command
+    const resumeCommand = this.generateResumeCommand(currentMode, pendingTasks, title);
+
+    // 4. Generate and write briefing
+    const filePath = await this.writeBriefing(projectRoot, {
+      decisions,
+      pendingTasks,
+      changedFiles,
+      resumeCommand,
+      currentMode,
+      title,
+    });
+
+    return {
+      filePath,
+      decisions,
+      pendingTasks,
+      changedFiles,
+      resumeCommand,
+    };
+  }
+
+  /**
+   * Parse the context document to extract decisions, pending tasks, and mode.
+   */
+  async parseContext(): Promise<{
+    decisions: string[];
+    pendingTasks: string[];
+    currentMode: string;
+    title: string;
+  }> {
+    const readResult = await this.contextDocumentService.readContext();
+
+    if (!readResult.exists || !readResult.document) {
+      return {
+        decisions: [],
+        pendingTasks: [],
+        currentMode: 'PLAN',
+        title: 'Untitled',
+      };
+    }
+
+    const doc = readResult.document;
+    const decisions: string[] = [];
+    const pendingTasks: string[] = [];
+
+    for (const section of doc.sections) {
+      if (section.decisions) {
+        decisions.push(...section.decisions);
+      }
+      if (section.notes) {
+        pendingTasks.push(...section.notes);
+      }
+      if (section.progress) {
+        // Filter progress items that look incomplete (not marked done)
+        for (const item of section.progress) {
+          if (!item.toLowerCase().includes('completed') && !item.toLowerCase().includes('done')) {
+            pendingTasks.push(item);
+          }
+        }
+      }
+    }
+
+    return {
+      decisions,
+      pendingTasks,
+      currentMode: doc.metadata.currentMode ?? 'PLAN',
+      title: doc.metadata.title ?? 'Untitled',
+    };
+  }
+
+  /**
+   * Get list of changed files from `git diff --stat`.
+   * Returns empty array if git is not available or no changes exist.
+   */
+  getChangedFiles(projectRoot: string): string[] {
+    try {
+      const output = execSync('git diff --stat --name-only', {
+        cwd: projectRoot,
+        timeout: GIT_DIFF_TIMEOUT_MS,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      return output
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line.length > 0);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to get git diff: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Generate a resume command based on current state.
+   */
+  generateResumeCommand(currentMode: string, pendingTasks: string[], title: string): string {
+    if (pendingTasks.length === 0) {
+      return `PLAN continue "${title}"`;
+    }
+
+    switch (currentMode) {
+      case 'PLAN':
+        return `ACT execute the plan for "${title}"`;
+      case 'ACT':
+        return `ACT continue implementation of "${title}"`;
+      case 'EVAL':
+        return `ACT apply fixes from evaluation of "${title}"`;
+      default:
+        return `AUTO continue "${title}"`;
+    }
+  }
+
+  /**
+   * Write the briefing markdown file.
+   */
+  private async writeBriefing(
+    projectRoot: string,
+    data: {
+      decisions: string[];
+      pendingTasks: string[];
+      changedFiles: string[];
+      resumeCommand: string;
+      currentMode: string;
+      title: string;
+    },
+  ): Promise<string> {
+    const briefingDir = path.join(projectRoot, BRIEFING_OUTPUT_DIR);
+
+    // Ensure directory exists
+    if (!existsSync(briefingDir)) {
+      mkdirSync(briefingDir, { recursive: true });
+    }
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const fileName = `${timestamp}.md`;
+    const filePath = path.join(briefingDir, fileName);
+
+    const content = this.formatBriefingMarkdown(data);
+    await fs.writeFile(filePath, content, 'utf-8');
+
+    this.logger.log(`Briefing written to ${filePath}`);
+    return filePath;
+  }
+
+  /**
+   * Format briefing data as markdown.
+   * Pure function - no side effects.
+   */
+  formatBriefingMarkdown(data: {
+    decisions: string[];
+    pendingTasks: string[];
+    changedFiles: string[];
+    resumeCommand: string;
+    currentMode: string;
+    title: string;
+  }): string {
+    const lines: string[] = [];
+
+    lines.push(`# Briefing: ${data.title}`);
+    lines.push('');
+    lines.push(`**Mode**: ${data.currentMode}`);
+    lines.push(`**Created**: ${new Date().toISOString()}`);
+    lines.push('');
+
+    // Decisions
+    lines.push('## Decisions');
+    if (data.decisions.length > 0) {
+      for (const decision of data.decisions) {
+        lines.push(`- ${decision}`);
+      }
+    } else {
+      lines.push('_No decisions recorded._');
+    }
+    lines.push('');
+
+    // Changed Files
+    lines.push('## Changed Files');
+    if (data.changedFiles.length > 0) {
+      for (const file of data.changedFiles) {
+        lines.push(`- ${file}`);
+      }
+    } else {
+      lines.push('_No files changed._');
+    }
+    lines.push('');
+
+    // Pending Tasks
+    lines.push('## Pending Tasks');
+    if (data.pendingTasks.length > 0) {
+      for (const task of data.pendingTasks) {
+        lines.push(`- ${task}`);
+      }
+    } else {
+      lines.push('_No pending tasks._');
+    }
+    lines.push('');
+
+    // Resume Command
+    lines.push('## Resume Command');
+    lines.push('```');
+    lines.push(data.resumeCommand);
+    lines.push('```');
+    lines.push('');
+
+    return lines.join('\n');
+  }
+}

--- a/apps/mcp-server/src/context/briefing.types.ts
+++ b/apps/mcp-server/src/context/briefing.types.ts
@@ -1,0 +1,42 @@
+/**
+ * Types for the Briefing feature.
+ *
+ * Briefings capture current session state into structured documents
+ * for cross-session recovery.
+ */
+
+/**
+ * Input parameters for briefing generation.
+ */
+export interface BriefingInput {
+  /** Path to context.md file. Default: docs/codingbuddy/context.md */
+  contextPath?: string;
+  /** Project root directory. Default: resolved from ConfigService */
+  projectRoot?: string;
+}
+
+/**
+ * Result of briefing generation.
+ */
+export interface BriefingResult {
+  /** Absolute path to the written briefing file */
+  filePath: string;
+  /** Key decisions extracted from context */
+  decisions: string[];
+  /** Pending tasks extracted from context */
+  pendingTasks: string[];
+  /** Changed files from git diff */
+  changedFiles: string[];
+  /** Suggested command to resume work */
+  resumeCommand: string;
+}
+
+/**
+ * Directory path for briefing output files.
+ */
+export const BRIEFING_OUTPUT_DIR = 'docs/codingbuddy/briefings';
+
+/**
+ * Timeout for git operations in milliseconds.
+ */
+export const GIT_DIFF_TIMEOUT_MS = 10_000;

--- a/apps/mcp-server/src/context/context.module.ts
+++ b/apps/mcp-server/src/context/context.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { ContextService } from './context.service';
 import { ContextDocumentService } from './context-document.service';
 import { ContextArchiveService } from './context-archive.service';
+import { BriefingService } from './briefing.service';
 import { ChecklistModule } from '../checklist/checklist.module';
 import { CodingBuddyConfigModule } from '../config/config.module';
 
 @Module({
   imports: [ChecklistModule, CodingBuddyConfigModule],
-  providers: [ContextService, ContextDocumentService, ContextArchiveService],
-  exports: [ContextService, ContextDocumentService, ContextArchiveService],
+  providers: [ContextService, ContextDocumentService, ContextArchiveService, BriefingService],
+  exports: [ContextService, ContextDocumentService, ContextArchiveService, BriefingService],
 })
 export class ContextModule {}

--- a/apps/mcp-server/src/context/index.ts
+++ b/apps/mcp-server/src/context/index.ts
@@ -2,3 +2,5 @@ export * from './context.module';
 export * from './context.service';
 export * from './context.types';
 export * from './context-archive.service';
+export * from './briefing.service';
+export * from './briefing.types';

--- a/apps/mcp-server/src/mcp/handlers/briefing.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/briefing.handler.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { BriefingHandler } from './briefing.handler';
+import type { BriefingService } from '../../context/briefing.service';
+import type { BriefingResult } from '../../context/briefing.types';
+
+function createMockBriefingService(result?: Partial<BriefingResult>): BriefingService {
+  const defaultResult: BriefingResult = {
+    filePath: '/tmp/test-project/docs/codingbuddy/briefings/2026-04-01T00-00-00-000Z.md',
+    decisions: ['Use TypeScript strict mode'],
+    pendingTasks: ['Add handler registration'],
+    changedFiles: ['src/app.ts'],
+    resumeCommand: 'ACT continue "Test Task"',
+    ...result,
+  };
+
+  return {
+    createBriefing: vi.fn().mockResolvedValue(defaultResult),
+  } as unknown as BriefingService;
+}
+
+describe('BriefingHandler', () => {
+  let handler: BriefingHandler;
+  let mockService: BriefingService;
+
+  beforeEach(() => {
+    mockService = createMockBriefingService();
+    handler = new BriefingHandler(mockService);
+  });
+
+  it('should return null for unhandled tools', async () => {
+    const result = await handler.handle('unknown_tool', {});
+    expect(result).toBeNull();
+  });
+
+  it('should handle create_briefing tool', async () => {
+    const result = await handler.handle('create_briefing', {});
+    expect(result).not.toBeNull();
+    expect(result!.isError).toBeUndefined();
+
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.filePath).toBeDefined();
+    expect(data.decisions).toEqual(['Use TypeScript strict mode']);
+    expect(data.pendingTasks).toEqual(['Add handler registration']);
+    expect(data.changedFiles).toEqual(['src/app.ts']);
+    expect(data.resumeCommand).toContain('ACT continue');
+  });
+
+  it('should pass optional contextPath to service', async () => {
+    await handler.handle('create_briefing', {
+      contextPath: 'custom/context.md',
+    });
+
+    expect(mockService.createBriefing).toHaveBeenCalledWith({
+      contextPath: 'custom/context.md',
+      projectRoot: undefined,
+    });
+  });
+
+  it('should pass optional projectRoot to service', async () => {
+    await handler.handle('create_briefing', {
+      projectRoot: '/custom/root',
+    });
+
+    expect(mockService.createBriefing).toHaveBeenCalledWith({
+      contextPath: undefined,
+      projectRoot: '/custom/root',
+    });
+  });
+
+  it('should return error response on service failure', async () => {
+    mockService = {
+      createBriefing: vi.fn().mockRejectedValue(new Error('Test error')),
+    } as unknown as BriefingService;
+    handler = new BriefingHandler(mockService);
+
+    const result = await handler.handle('create_briefing', {});
+    expect(result).not.toBeNull();
+    expect(result!.isError).toBe(true);
+    expect(result!.content[0].text).toContain('Test error');
+  });
+
+  it('should handle empty result gracefully', async () => {
+    mockService = createMockBriefingService({
+      decisions: [],
+      pendingTasks: [],
+      changedFiles: [],
+    });
+    handler = new BriefingHandler(mockService);
+
+    const result = await handler.handle('create_briefing', {});
+    expect(result).not.toBeNull();
+    expect(result!.isError).toBeUndefined();
+
+    const data = JSON.parse(result!.content[0].text);
+    expect(data.decisions).toEqual([]);
+    expect(data.pendingTasks).toEqual([]);
+    expect(data.changedFiles).toEqual([]);
+  });
+
+  it('should expose tool definitions', () => {
+    const defs = handler.getToolDefinitions();
+    expect(defs).toHaveLength(1);
+    expect(defs[0].name).toBe('create_briefing');
+    expect(defs[0].inputSchema.type).toBe('object');
+    expect(defs[0].inputSchema.properties).toHaveProperty('contextPath');
+    expect(defs[0].inputSchema.properties).toHaveProperty('projectRoot');
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/briefing.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/briefing.handler.ts
@@ -1,0 +1,73 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { ToolDefinition } from './base.handler';
+import type { ToolResponse } from '../response.utils';
+import { AbstractHandler } from './abstract-handler';
+import { BriefingService } from '../../context/briefing.service';
+import { createJsonResponse, createErrorResponse } from '../response.utils';
+import { extractOptionalString } from '../../shared/validation.constants';
+
+/**
+ * MCP tool handler for creating session briefing documents.
+ *
+ * Exposes the `create_briefing` tool that captures current session state
+ * (decisions, changed files, pending tasks) into a structured markdown
+ * document for cross-session recovery.
+ */
+@Injectable()
+export class BriefingHandler extends AbstractHandler {
+  private readonly logger = new Logger(BriefingHandler.name);
+
+  constructor(private readonly briefingService: BriefingService) {
+    super();
+  }
+
+  protected getHandledTools(): string[] {
+    return ['create_briefing'];
+  }
+
+  protected async handleTool(
+    _toolName: string,
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    try {
+      const contextPath = extractOptionalString(args, 'contextPath');
+      const projectRoot = extractOptionalString(args, 'projectRoot');
+
+      const result = await this.briefingService.createBriefing({
+        contextPath,
+        projectRoot,
+      });
+
+      return createJsonResponse(result);
+    } catch (error) {
+      this.logger.error(`Briefing creation failed: ${error}`);
+      return createErrorResponse(
+        `Briefing creation failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'create_briefing',
+        description:
+          'Capture current session state into a briefing document for cross-session recovery',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            contextPath: {
+              type: 'string',
+              description: 'Path to context.md file (default: docs/codingbuddy/context.md)',
+            },
+            projectRoot: {
+              type: 'string',
+              description: 'Project root directory (default: auto-detected)',
+            },
+          },
+          required: [],
+        },
+      },
+    ];
+  }
+}

--- a/apps/mcp-server/src/mcp/handlers/index.ts
+++ b/apps/mcp-server/src/mcp/handlers/index.ts
@@ -145,6 +145,12 @@ export { ReleaseCheckHandler } from './release-check.handler';
 export { QualityReportHandler } from './quality-report.handler';
 
 /**
+ * Handler for briefing tools (create_briefing)
+ * @see {@link BriefingHandler}
+ */
+export { BriefingHandler } from './briefing.handler';
+
+/**
  * Injection token for the array of all tool handlers.
  *
  * Use this token to inject all handlers into a service that needs to

--- a/apps/mcp-server/src/mcp/mcp.module.ts
+++ b/apps/mcp-server/src/mcp/mcp.module.ts
@@ -39,6 +39,7 @@ import {
   PluginValidationHandler,
   ReleaseCheckHandler,
   QualityReportHandler,
+  BriefingHandler,
 } from './handlers';
 
 const handlers = [
@@ -60,6 +61,7 @@ const handlers = [
   PluginValidationHandler,
   ReleaseCheckHandler,
   QualityReportHandler,
+  BriefingHandler,
 ];
 
 @Module({


### PR DESCRIPTION
## Summary
Re-implementation of #1122 on fresh branch from master (original PR #1142 had merge conflicts with #1141).

- `BriefingService`: Captures session state (decisions, changed files, pending tasks)
- `BriefingHandler`: MCP tool `create_briefing`
- Writes structured briefing documents to `docs/codingbuddy/briefings/`

## Changes
- NEW: briefing.types.ts, briefing.service.ts, briefing.handler.ts + specs
- MODIFIED: context.module.ts, handlers/index.ts, mcp.module.ts (add briefing registrations)

## Test plan
- [x] `tsc --noEmit` passes
- [x] `yarn test` passes (214 files, 5446 tests)
- [x] `yarn lint` passes (0 errors)
- [x] Briefing generation tested with mock context
- [x] No merge conflicts with current master

Closes #1122