### PR TITLE
fix(tui): replace flaky setTimeout(0) tick() with robust flushInk utility

### DIFF
--- a/apps/mcp-server/src/tui/__perf__/memory-stability.spec.tsx
+++ b/apps/mcp-server/src/tui/__perf__/memory-stability.spec.tsx
@@ -5,6 +5,8 @@ import { DashboardApp } from '../dashboard-app';
 import { TuiEventBus, TUI_EVENTS } from '../events';
 import type { TuiEventName } from '../events/types';
 
+import { flushInk } from '../testing/tui-test-utils';
+
 vi.mock('../utils/icons', async importOriginal => {
   const actual = await importOriginal<typeof import('../utils/icons')>();
   return {
@@ -12,8 +14,6 @@ vi.mock('../utils/icons', async importOriginal => {
     isNerdFontEnabled: () => false,
   };
 });
-
-const tick = () => new Promise(resolve => setTimeout(resolve, 0));
 
 describe('10,000 이벤트 후 메모리 증가 < 50MB (GC 없이)', () => {
   it('should keep memory growth under 50MB after 10,000 events', async () => {
@@ -38,7 +38,7 @@ describe('10,000 이벤트 후 메모리 증가 < 50MB (GC 없이)', () => {
       });
     }
 
-    await tick();
+    await flushInk();
 
     global.gc?.();
     const heapAfter = process.memoryUsage().heapUsed;
@@ -79,7 +79,7 @@ describe('리스너 누적 방지', () => {
       });
     }
 
-    await tick();
+    await flushInk();
     unmount();
 
     for (const event of Object.values(TUI_EVENTS)) {
@@ -102,7 +102,7 @@ describe('비활성화 Agent 상태 정리 확인', () => {
         isPrimary: false,
       });
     }
-    await tick();
+    await flushInk();
 
     for (let i = 0; i < 5; i++) {
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
@@ -111,7 +111,7 @@ describe('비활성화 Agent 상태 정리 확인', () => {
         durationMs: 100,
       });
     }
-    await tick();
+    await flushInk();
 
     expect(lastFrame()).toContain('IDLE');
 
@@ -121,7 +121,7 @@ describe('비활성화 Agent 상태 정리 확인', () => {
       role: 'specialist',
       isPrimary: false,
     });
-    await tick();
+    await flushInk();
 
     expect(lastFrame()).toContain('RUNNING');
   });

--- a/apps/mcp-server/src/tui/__perf__/rendering-performance.spec.tsx
+++ b/apps/mcp-server/src/tui/__perf__/rendering-performance.spec.tsx
@@ -10,6 +10,7 @@ import {
   AGENT_CATEGORY_MAP,
 } from '../events';
 import { AGENT_ICONS } from '../utils/icons';
+import { flushInk } from '../testing/tui-test-utils';
 
 vi.mock('../utils/icons', async importOriginal => {
   const actual = await importOriginal<typeof import('../utils/icons')>();
@@ -19,10 +20,7 @@ vi.mock('../utils/icons', async importOriginal => {
   };
 });
 
-const tick = () => new Promise(resolve => setTimeout(resolve, 0));
-const flushRender = async () => {
-  for (let i = 0; i < 5; i++) await tick();
-};
+const flushRender = async () => flushInk(5);
 
 const ALL_AGENT_NAMES = Object.keys(AGENT_ICONS);
 
@@ -62,7 +60,7 @@ describe(`${ALL_AGENT_NAMES.length} Agent 초기 렌더링`, () => {
       eventBus.emit(TUI_EVENTS.AGENTS_LOADED, {
         agents: buildAgentMetadata(ALL_AGENT_NAMES),
       });
-      await tick();
+      await flushInk();
 
       // Measure activation of all agents (first as primary, rest as specialists)
       const start = performance.now();
@@ -113,7 +111,7 @@ describe('단일 Agent 상태 변경 리렌더', () => {
       eventBus.emit(TUI_EVENTS.AGENTS_LOADED, {
         agents: buildAgentMetadata(ALL_AGENT_NAMES),
       });
-      await tick();
+      await flushInk();
 
       // Activate all agents (first as primary, rest as specialists)
       for (let i = 0; i < ALL_AGENT_NAMES.length; i++) {
@@ -175,7 +173,7 @@ describe(`${ALL_AGENT_NAMES.length} Agent 동시 상태 업데이트`, () => {
       eventBus.emit(TUI_EVENTS.AGENTS_LOADED, {
         agents: buildAgentMetadata(ALL_AGENT_NAMES),
       });
-      await tick();
+      await flushInk();
 
       // Activate all agents (first as primary, rest as specialists)
       for (let i = 0; i < ALL_AGENT_NAMES.length; i++) {

--- a/apps/mcp-server/src/tui/dashboard-app.spec.tsx
+++ b/apps/mcp-server/src/tui/dashboard-app.spec.tsx
@@ -4,6 +4,7 @@ import { render } from 'ink-testing-library';
 import { DashboardApp } from './dashboard-app';
 import { TuiEventBus, TUI_EVENTS } from './events';
 import { createInitialDashboardState } from './hooks/use-dashboard-state';
+import { flushInk } from './testing/tui-test-utils';
 
 vi.mock('./utils/icons', async importOriginal => {
   const actual = await importOriginal<typeof import('./utils/icons')>();
@@ -13,8 +14,6 @@ vi.mock('./utils/icons', async importOriginal => {
 vi.mock('./hooks/use-tick', () => ({
   useTick: () => 0,
 }));
-
-const tick = () => new Promise(resolve => setTimeout(resolve, 0));
 
 describe('DashboardApp', () => {
   it('renders without eventBus (idle state)', () => {
@@ -27,7 +26,7 @@ describe('DashboardApp', () => {
   it('shows RUNNING state when agent is activated', async () => {
     const eventBus = new TuiEventBus();
     const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-    await tick(); // ensure useEffect subscribes before emitting
+    await flushInk(); // ensure useEffect subscribes before emitting
 
     eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
       agentId: 'arch-1',
@@ -35,7 +34,7 @@ describe('DashboardApp', () => {
       role: 'primary',
       isPrimary: true,
     });
-    await tick();
+    await flushInk();
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('RUNNING');
@@ -45,7 +44,7 @@ describe('DashboardApp', () => {
   it('shows IDLE after all agents deactivated', async () => {
     const eventBus = new TuiEventBus();
     const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-    await tick(); // ensure useEffect subscribes before emitting
+    await flushInk(); // ensure useEffect subscribes before emitting
 
     eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
       agentId: 'a1',
@@ -53,7 +52,7 @@ describe('DashboardApp', () => {
       role: 'primary',
       isPrimary: true,
     });
-    await tick();
+    await flushInk();
     expect(lastFrame()).toContain('RUNNING');
 
     eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
@@ -61,17 +60,17 @@ describe('DashboardApp', () => {
       reason: 'completed',
       durationMs: 100,
     });
-    await tick();
+    await flushInk();
     expect(lastFrame()).toContain('IDLE');
   });
 
   it('handles mode change events', async () => {
     const eventBus = new TuiEventBus();
     const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-    await tick(); // ensure useEffect subscribes before emitting
+    await flushInk(); // ensure useEffect subscribes before emitting
 
     eventBus.emit(TUI_EVENTS.MODE_CHANGED, { from: null, to: 'PLAN' });
-    await tick();
+    await flushInk();
 
     const frame = lastFrame() ?? '';
     expect(frame).toBeTruthy();
@@ -81,7 +80,7 @@ describe('DashboardApp', () => {
   it('shows multiple agents in FlowMap', async () => {
     const eventBus = new TuiEventBus();
     const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-    await tick(); // ensure useEffect subscribes before emitting
+    await flushInk(); // ensure useEffect subscribes before emitting
 
     eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
       agentId: 'p1',
@@ -95,7 +94,7 @@ describe('DashboardApp', () => {
       role: 'specialist',
       isPrimary: false,
     });
-    await tick();
+    await flushInk();
 
     const frame = lastFrame() ?? '';
     expect(frame).toContain('RUNNING');
@@ -107,7 +106,7 @@ describe('DashboardApp', () => {
   it('shows focused agent in FocusedAgentPanel without Tools/IO section', async () => {
     const eventBus = new TuiEventBus();
     const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-    await tick();
+    await flushInk();
 
     eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
       agentId: 'a1',
@@ -115,14 +114,14 @@ describe('DashboardApp', () => {
       role: 'primary',
       isPrimary: true,
     });
-    await tick();
+    await flushInk();
 
     eventBus.emit(TUI_EVENTS.TOOL_INVOKED, {
       toolName: 'file_edit',
       agentId: 'a1',
       timestamp: Date.now(),
     });
-    await tick();
+    await flushInk();
 
     const frame = lastFrame() ?? '';
     // Tools/IO section should not be visible
@@ -133,7 +132,7 @@ describe('DashboardApp', () => {
   it('focuses on primary running agent', async () => {
     const eventBus = new TuiEventBus();
     const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-    await tick(); // ensure useEffect subscribes before emitting
+    await flushInk(); // ensure useEffect subscribes before emitting
 
     eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
       agentId: 'p1',
@@ -141,7 +140,7 @@ describe('DashboardApp', () => {
       role: 'primary',
       isPrimary: true,
     });
-    await tick();
+    await flushInk();
 
     const frame = lastFrame() ?? '';
     // FocusedAgentPanel should show the primary agent details

--- a/apps/mcp-server/src/tui/eventbus-ui.integration.spec.tsx
+++ b/apps/mcp-server/src/tui/eventbus-ui.integration.spec.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render } from 'ink-testing-library';
 import { DashboardApp } from './dashboard-app';
 import { TuiEventBus, TUI_EVENTS, TuiInterceptor } from './events';
+import { flushInk } from './testing/tui-test-utils';
 
 vi.mock('./utils/icons', async importOriginal => {
   const actual = await importOriginal<typeof import('./utils/icons')>();
@@ -16,8 +17,6 @@ vi.mock('./hooks/use-tick', () => ({
   useTick: () => 0,
 }));
 
-const tick = () => new Promise(resolve => setTimeout(resolve, 0));
-
 describe('EventBus ↔ UI Integration', () => {
   describe('Agent 활성화 → Dashboard 상태 변화', () => {
     it('should show primary agent name and RUNNING state when AGENT_ACTIVATED with isPrimary=true', async () => {
@@ -30,7 +29,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'primary',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toContain('solution-arch');
@@ -59,7 +58,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'specialist',
         isPrimary: false,
       });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       // FlowMap truncates names in 17-char-wide boxes (e.g., "security-...")
@@ -86,7 +85,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'specialist',
         isPrimary: false,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('RUNNING');
 
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
@@ -94,7 +93,7 @@ describe('EventBus ↔ UI Integration', () => {
         reason: 'completed',
         durationMs: 1200,
       });
-      await tick();
+      await flushInk();
       // Still one running
       expect(lastFrame()).toContain('RUNNING');
     });
@@ -109,7 +108,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'specialist',
         isPrimary: false,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('RUNNING');
 
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
@@ -117,7 +116,7 @@ describe('EventBus ↔ UI Integration', () => {
         reason: 'completed',
         durationMs: 1200,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('IDLE');
     });
 
@@ -131,7 +130,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'specialist',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('RUNNING');
 
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
@@ -139,7 +138,7 @@ describe('EventBus ↔ UI Integration', () => {
         reason: 'error',
         durationMs: 500,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('ERROR');
     });
 
@@ -153,7 +152,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'primary',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('solution-arch');
 
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
@@ -161,7 +160,7 @@ describe('EventBus ↔ UI Integration', () => {
         reason: 'completed',
         durationMs: 2000,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('IDLE');
     });
   });
@@ -172,7 +171,7 @@ describe('EventBus ↔ UI Integration', () => {
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
 
       eventBus.emit(TUI_EVENTS.MODE_CHANGED, { from: 'PLAN', to: 'ACT' });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toBeTruthy();
@@ -184,9 +183,9 @@ describe('EventBus ↔ UI Integration', () => {
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
 
       eventBus.emit(TUI_EVENTS.MODE_CHANGED, { from: null, to: 'ACT' });
-      await tick();
+      await flushInk();
       eventBus.emit(TUI_EVENTS.MODE_CHANGED, { from: 'ACT', to: 'EVAL' });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toBeTruthy();
@@ -199,7 +198,7 @@ describe('EventBus ↔ UI Integration', () => {
       eventBus.emit(TUI_EVENTS.MODE_CHANGED, { from: null, to: 'PLAN' });
       eventBus.emit(TUI_EVENTS.MODE_CHANGED, { from: 'PLAN', to: 'ACT' });
       eventBus.emit(TUI_EVENTS.MODE_CHANGED, { from: 'ACT', to: 'AUTO' });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toBeTruthy();
@@ -235,7 +234,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'specialist',
         isPrimary: false,
       });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       // FlowMap truncates names in 17-char-wide boxes (e.g., "security-...", "test-stra...")
@@ -270,7 +269,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'specialist',
         isPrimary: false,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('RUNNING');
 
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
@@ -290,7 +289,7 @@ describe('EventBus ↔ UI Integration', () => {
           'test-strategy-specialist': 'Tests designed',
         },
       });
-      await tick();
+      await flushInk();
 
       // Primary still running
       expect(lastFrame()).toContain('RUNNING');
@@ -301,7 +300,7 @@ describe('EventBus ↔ UI Integration', () => {
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
 
       eventBus.emit(TUI_EVENTS.MODE_CHANGED, { from: null, to: 'PLAN' });
-      await tick();
+      await flushInk();
 
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
         agentId: 'p1',
@@ -309,7 +308,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'primary',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('RUNNING');
 
       eventBus.emit(TUI_EVENTS.PARALLEL_STARTED, {
@@ -334,7 +333,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'specialist',
         isPrimary: false,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('RUNNING');
 
       eventBus.emit(TUI_EVENTS.AGENT_DEACTIVATED, {
@@ -360,7 +359,7 @@ describe('EventBus ↔ UI Integration', () => {
           'performance-specialist': 'done',
         },
       });
-      await tick();
+      await flushInk();
 
       // Only primary still running
       expect(lastFrame()).toContain('RUNNING');
@@ -380,7 +379,7 @@ describe('EventBus ↔ UI Integration', () => {
         skillName: 'test-driven-development',
         reason: 'TDD cycle',
       });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toBeTruthy();
@@ -400,8 +399,8 @@ describe('EventBus ↔ UI Integration', () => {
         skillName: 'systematic-debugging',
         reason: 'bug detected',
       });
-      await tick();
-      await tick();
+      await flushInk();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toContain('RUNNING');
@@ -422,7 +421,7 @@ describe('EventBus ↔ UI Integration', () => {
       });
 
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-      await tick();
+      await flushInk();
 
       // Agent should NOT be reflected because listener wasn't registered yet
       const frame = lastFrame() ?? '';
@@ -437,7 +436,7 @@ describe('EventBus ↔ UI Integration', () => {
       eventBus.emit(TUI_EVENTS.MODE_CHANGED, { from: null, to: 'PLAN' });
 
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-      await tick();
+      await flushInk();
 
       // Re-emit after mount to sync state
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
@@ -446,7 +445,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'primary',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toContain('RUNNING');
@@ -461,7 +460,7 @@ describe('EventBus ↔ UI Integration', () => {
 
       // 1. Mode change to PLAN
       eventBus.emit(TUI_EVENTS.MODE_CHANGED, { from: null, to: 'PLAN' });
-      await tick();
+      await flushInk();
 
       // 2. Primary agent activates
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
@@ -470,7 +469,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'primary',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('RUNNING');
 
       // 3. Parallel execution
@@ -490,7 +489,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'specialist',
         isPrimary: false,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('RUNNING');
 
       // 4. Specialists complete
@@ -511,7 +510,7 @@ describe('EventBus ↔ UI Integration', () => {
           'test-strategy-specialist': 'ok',
         },
       });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       // Primary still running
@@ -522,7 +521,7 @@ describe('EventBus ↔ UI Integration', () => {
     it('should handle error scenario: activate → error deactivation → re-activate', async () => {
       const eventBus = new TuiEventBus();
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-      await tick(); // ensure useEffect subscribes before emitting
+      await flushInk(); // ensure useEffect subscribes before emitting
 
       // 1. Activate agent
       eventBus.emit(TUI_EVENTS.AGENT_ACTIVATED, {
@@ -531,7 +530,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'specialist',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('RUNNING');
 
       // 2. Agent fails with error
@@ -540,7 +539,7 @@ describe('EventBus ↔ UI Integration', () => {
         reason: 'error',
         durationMs: 300,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('ERROR');
 
       // 3. Re-activate the same agent (retry scenario)
@@ -550,7 +549,7 @@ describe('EventBus ↔ UI Integration', () => {
         role: 'specialist',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
       expect(lastFrame()).toContain('RUNNING');
     });
   });
@@ -562,7 +561,7 @@ describe('EventBus ↔ UI Integration', () => {
       interceptor.enable();
 
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-      await tick();
+      await flushInk();
 
       await interceptor.intercept(
         'parse_mode',
@@ -581,7 +580,7 @@ describe('EventBus ↔ UI Integration', () => {
       );
 
       await new Promise(resolve => setImmediate(resolve));
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toBeTruthy();
@@ -594,7 +593,7 @@ describe('EventBus ↔ UI Integration', () => {
       interceptor.enable();
 
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-      await tick();
+      await flushInk();
 
       await interceptor.intercept('parse_mode', { prompt: 'PLAN something' }, async () => ({
         content: [
@@ -612,7 +611,7 @@ describe('EventBus ↔ UI Integration', () => {
       }));
 
       await new Promise(resolve => setImmediate(resolve));
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toBeTruthy();
@@ -624,14 +623,14 @@ describe('EventBus ↔ UI Integration', () => {
       interceptor.enable();
 
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-      await tick();
+      await flushInk();
 
       await interceptor.intercept('search_rules', { query: 'test' }, async () => ({
         content: [{ type: 'text', text: '{"results":[]}' }],
       }));
 
       await new Promise(resolve => setImmediate(resolve));
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       // After deactivation, should be IDLE
@@ -644,7 +643,7 @@ describe('EventBus ↔ UI Integration', () => {
       interceptor.enable();
 
       const { lastFrame } = render(<DashboardApp eventBus={eventBus} />);
-      await tick();
+      await flushInk();
 
       // 1. parse_mode call sets mode
       await interceptor.intercept('parse_mode', { prompt: 'EVAL review code' }, async () => ({
@@ -660,7 +659,7 @@ describe('EventBus ↔ UI Integration', () => {
       }));
 
       await new Promise(resolve => setImmediate(resolve));
-      await tick();
+      await flushInk();
 
       let frame = lastFrame() ?? '';
       expect(frame).toBeTruthy();
@@ -686,7 +685,7 @@ describe('EventBus ↔ UI Integration', () => {
       );
 
       await new Promise(resolve => setImmediate(resolve));
-      await tick();
+      await flushInk();
 
       frame = lastFrame() ?? '';
       expect(frame).toBeTruthy();

--- a/apps/mcp-server/src/tui/testing/tui-test-utils.spec.ts
+++ b/apps/mcp-server/src/tui/testing/tui-test-utils.spec.ts
@@ -1,0 +1,100 @@
+import { flushInk, waitForFrame } from './tui-test-utils';
+
+describe('tui-test-utils', () => {
+  describe('flushInk', () => {
+    it('should flush the default number of macrotask cycles (3)', async () => {
+      const spy = vi.spyOn(globalThis, 'setTimeout');
+
+      await flushInk();
+
+      // 3 cycles by default
+      const zeroDelayCalls = spy.mock.calls.filter(([, delay]) => delay === 0);
+      expect(zeroDelayCalls).toHaveLength(3);
+
+      spy.mockRestore();
+    });
+
+    it('should flush the specified number of cycles', async () => {
+      const spy = vi.spyOn(globalThis, 'setTimeout');
+
+      await flushInk(5);
+
+      const zeroDelayCalls = spy.mock.calls.filter(([, delay]) => delay === 0);
+      expect(zeroDelayCalls).toHaveLength(5);
+
+      spy.mockRestore();
+    });
+
+    it('should flush 1 cycle when specified', async () => {
+      const spy = vi.spyOn(globalThis, 'setTimeout');
+
+      await flushInk(1);
+
+      const zeroDelayCalls = spy.mock.calls.filter(([, delay]) => delay === 0);
+      expect(zeroDelayCalls).toHaveLength(1);
+
+      spy.mockRestore();
+    });
+
+    it('should resolve without error', async () => {
+      await expect(flushInk()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('waitForFrame', () => {
+    it('should resolve immediately when assertion passes on first try', async () => {
+      const getFrame = () => 'RUNNING';
+      const assertion = (frame: string) => {
+        expect(frame).toContain('RUNNING');
+      };
+
+      await expect(waitForFrame(getFrame, assertion)).resolves.toBeUndefined();
+    });
+
+    it('should retry until assertion passes', async () => {
+      let callCount = 0;
+      const getFrame = () => {
+        callCount++;
+        return callCount >= 3 ? 'RUNNING' : 'idle';
+      };
+      const assertion = (frame: string) => {
+        expect(frame).toContain('RUNNING');
+      };
+
+      await waitForFrame(getFrame, assertion);
+      expect(callCount).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should throw last error when timeout is reached', async () => {
+      const getFrame = () => 'idle';
+      const assertion = (frame: string) => {
+        expect(frame).toContain('RUNNING');
+      };
+
+      await expect(waitForFrame(getFrame, assertion, 50)).rejects.toThrow();
+    });
+
+    it('should handle undefined frame by passing empty string', async () => {
+      const getFrame = () => undefined;
+      const assertion = (frame: string) => {
+        expect(frame).toBe('');
+      };
+
+      await expect(waitForFrame(getFrame, assertion)).resolves.toBeUndefined();
+    });
+
+    it('should use default timeout of 500ms', async () => {
+      const start = Date.now();
+      const getFrame = () => 'never-match';
+      const assertion = (frame: string) => {
+        expect(frame).toContain('IMPOSSIBLE');
+      };
+
+      await expect(waitForFrame(getFrame, assertion)).rejects.toThrow();
+
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeGreaterThanOrEqual(400);
+      expect(elapsed).toBeLessThan(2000);
+    });
+  });
+});

--- a/apps/mcp-server/src/tui/testing/tui-test-utils.ts
+++ b/apps/mcp-server/src/tui/testing/tui-test-utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Flush multiple macrotask cycles so Ink completes its render pipeline.
+ * Replaces the fragile single-setTimeout tick() used across TUI tests.
+ */
+export async function flushInk(cycles = 3): Promise<void> {
+  for (let i = 0; i < cycles; i++) {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+}
+
+/**
+ * Retry an assertion until it passes or times out.
+ * Use for frame content assertions that depend on Ink render timing.
+ */
+export async function waitForFrame(
+  getFrame: () => string | undefined,
+  assertion: (frame: string) => void,
+  timeoutMs = 500,
+): Promise<void> {
+  const start = Date.now();
+  let lastError: Error | undefined;
+  while (Date.now() - start < timeoutMs) {
+    try {
+      assertion(getFrame() ?? '');
+      return;
+    } catch (err) {
+      lastError = err as Error;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+  throw lastError ?? new Error('waitForFrame timeout');
+}

--- a/apps/mcp-server/src/tui/transport-tui.integration.spec.tsx
+++ b/apps/mcp-server/src/tui/transport-tui.integration.spec.tsx
@@ -6,12 +6,12 @@ import { DashboardApp } from './dashboard-app';
 import { TuiEventBus, TUI_EVENTS } from './events';
 import { resolveTuiConfig } from './tui-config';
 
+import { flushInk } from './testing/tui-test-utils';
+
 vi.mock('./utils/icons', async importOriginal => {
   const actual = await importOriginal<typeof import('./utils/icons')>();
   return { ...actual, isNerdFontEnabled: () => false };
 });
-
-const tick = () => new Promise(resolve => setTimeout(resolve, 0));
 
 describe('Transport-TUI Integration', () => {
   describe('stdio 모드: stdout 격리', () => {
@@ -40,7 +40,7 @@ describe('Transport-TUI Integration', () => {
         role: 'primary',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
 
       expect(stdoutCapture.join('')).toBe('');
       expect(lastFrame()).toBeTruthy();
@@ -60,7 +60,7 @@ describe('Transport-TUI Integration', () => {
 
       const eventBus = new TuiEventBus();
       render(<DashboardApp eventBus={eventBus} />);
-      await tick();
+      await flushInk();
 
       expect(stdoutCapture.join('')).toContain('"jsonrpc":"2.0"');
       expect(stdoutCapture.join('')).not.toContain('CODINGBUDDY');
@@ -92,7 +92,7 @@ describe('Transport-TUI Integration', () => {
           isPrimary: id === 'arch-1',
         });
       }
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toContain('RUNNING');
@@ -119,7 +119,7 @@ describe('Transport-TUI Integration', () => {
         from: null,
         to: 'PLAN',
       });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toBeTruthy();
@@ -139,7 +139,7 @@ describe('Transport-TUI Integration', () => {
         role: 'primary',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toContain('RUNNING');
@@ -192,7 +192,7 @@ describe('Transport-TUI Integration', () => {
         role: 'primary',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toBeTruthy();
@@ -213,7 +213,7 @@ describe('Transport-TUI Integration', () => {
         role: 'primary',
         isPrimary: true,
       });
-      await tick();
+      await flushInk();
 
       const frame = lastFrame() ?? '';
       expect(frame).toContain('RUNNING');


### PR DESCRIPTION
## Summary
- Create shared `flushInk(cycles=3)` and `waitForFrame()` test utilities in `apps/mcp-server/src/tui/testing/tui-test-utils.ts`
- Replace all 74 `await tick()` call sites across 5 TUI test files with `await flushInk()`
- Remove inline `tick()` definitions that only flushed a single macrotask cycle

## Problem
TUI integration tests intermittently fail in CI because `tick()` (`setTimeout(resolve, 0)`) only waits one macrotask, but Ink's render pipeline needs 2-3 cycles to complete event → state → reconcile → render.

## Solution
- `flushInk(cycles=3)` flushes multiple macrotask cycles (default 3)
- `waitForFrame(getFrame, assertion, timeout)` retries assertions until pass or timeout
- Both utilities are tested in `tui-test-utils.spec.ts`

## Files Changed
| File | Change |
|------|--------|
| `src/tui/testing/tui-test-utils.ts` | **NEW** — shared flush utility |
| `src/tui/testing/tui-test-utils.spec.ts` | **NEW** — unit tests (9 tests) |
| `src/tui/eventbus-ui.integration.spec.tsx` | Replace tick → flushInk (44 sites) |
| `src/tui/dashboard-app.spec.tsx` | Replace tick → flushInk (14 sites) |
| `src/tui/transport-tui.integration.spec.tsx` | Replace tick → flushInk (7 sites) |
| `src/tui/__perf__/rendering-performance.spec.tsx` | Replace tick → flushInk (4+3 sites) |
| `src/tui/__perf__/memory-stability.spec.tsx` | Replace tick → flushInk (5 sites) |

## Test plan
- [x] All 215 test files pass (5455 tests)
- [x] TUI tests pass 3 consecutive runs with no flakiness
- [x] Lint, typecheck, prettier all pass

Closes #1118