### PR TITLE
feat(cli): add codingbuddy install command

### DIFF
--- a/apps/mcp-server/src/cli/cli.ts
+++ b/apps/mcp-server/src/cli/cli.ts
@@ -8,14 +8,14 @@
 import { runInit } from './init';
 import { bootstrap } from '../main';
 import { getPackageVersion } from '../shared/version.utils';
-import type { InitOptions, TuiOptions } from './cli.types';
+import type { InitOptions, TuiOptions, InstallOptions } from './cli.types';
 
 /**
  * Parsed command line arguments
  */
 export interface ParsedArgs {
-  command: 'init' | 'mcp' | 'tui' | 'help' | 'version';
-  options: Partial<InitOptions> & Partial<TuiOptions>;
+  command: 'init' | 'install' | 'mcp' | 'tui' | 'help' | 'version';
+  options: Partial<InitOptions> & Partial<TuiOptions> & Partial<InstallOptions>;
 }
 
 /**
@@ -47,6 +47,15 @@ export function parseArgs(args: string[]): ParsedArgs {
   if (command === 'tui') {
     const restart = args.includes('--restart');
     return { command: 'tui', options: { ...options, restart } };
+  }
+
+  if (command === 'install') {
+    const installSource = args[1];
+    const installForce = args.includes('--force') || args.includes('-f');
+    return {
+      command: 'install',
+      options: { ...options, installSource, installForce },
+    };
   }
 
   if (command !== 'init') {
@@ -81,6 +90,7 @@ CodingBuddy CLI - AI-powered project configuration generator
 
 Usage:
   codingbuddy init [path] [options]    Initialize configuration
+  codingbuddy install <git-url>        Install a plugin from git repository
   codingbuddy mcp                      Start MCP server (stdio mode)
   codingbuddy tui                      Monitor agent execution in real-time
   codingbuddy tui --restart            Restart TUI client (fixes blank screen)
@@ -88,7 +98,7 @@ Usage:
   codingbuddy --version                Show version
 
 Options:
-  --force, -f           Overwrite existing config
+  --force, -f           Overwrite existing config / force install
   --yes, -y             Accept detected defaults (quick setup)
   --api-key <key>       Anthropic API key (or set ANTHROPIC_API_KEY env)
 
@@ -96,6 +106,7 @@ Examples:
   codingbuddy init                     Initialize in current directory
   codingbuddy init ./my-project        Initialize in specific directory
   codingbuddy init --force             Overwrite existing config
+  codingbuddy install github:user/repo Install a community plugin
   codingbuddy mcp                      Start MCP server for AI assistants
 
 Note:
@@ -160,6 +171,24 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<void
     case 'tui': {
       const { runTui } = await import('./run-tui');
       await runTui({ restart: options.restart ?? false });
+      break;
+    }
+
+    case 'install': {
+      const { runInstall } = await import('./plugin/install.command');
+      if (!options.installSource) {
+        process.stderr.write('Error: Missing git URL. Usage: codingbuddy install <git-url>\n');
+        process.exitCode = 1;
+        break;
+      }
+      const installResult = await runInstall({
+        source: options.installSource,
+        projectRoot: options.projectRoot ?? process.cwd(),
+        force: options.installForce ?? false,
+      });
+      if (!installResult.success) {
+        process.exitCode = 1;
+      }
       break;
     }
 

--- a/apps/mcp-server/src/cli/cli.types.ts
+++ b/apps/mcp-server/src/cli/cli.types.ts
@@ -48,6 +48,16 @@ export interface TuiOptions {
 }
 
 /**
+ * Install command options (parsed from CLI args)
+ */
+export interface InstallOptions {
+  /** Git URL or github:user/repo shorthand */
+  installSource?: string;
+  /** Force overwrite on name conflicts */
+  installForce?: boolean;
+}
+
+/**
  * Console output levels
  */
 export type LogLevel = 'info' | 'success' | 'warn' | 'error';

--- a/apps/mcp-server/src/cli/plugin/install.command.spec.ts
+++ b/apps/mcp-server/src/cli/plugin/install.command.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockInstall = vi.fn();
+const mockConsoleUtils = {
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+  },
+};
+
+vi.mock('../../plugin/plugin-installer.service', () => ({
+  PluginInstallerService: class {
+    install = mockInstall;
+  },
+}));
+
+vi.mock('../utils/console', () => ({
+  createConsoleUtils: () => mockConsoleUtils,
+}));
+
+import { runInstall, InstallCommandOptions } from './install.command';
+
+describe('install.command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const defaultOptions: InstallCommandOptions = {
+    source: 'github:user/repo',
+    projectRoot: '/project',
+    force: false,
+  };
+
+  it('should call PluginInstallerService.install with correct options', async () => {
+    mockInstall.mockResolvedValue({
+      success: true,
+      pluginName: 'my-plugin',
+      summary: 'Installed my-plugin@1.0.0: 1 agents, 1 rules, 0 skills',
+    });
+
+    await runInstall(defaultOptions);
+
+    expect(mockInstall).toHaveBeenCalledWith({
+      source: 'github:user/repo',
+      targetRoot: '/project',
+      force: false,
+    });
+  });
+
+  it('should print success summary on successful install', async () => {
+    mockInstall.mockResolvedValue({
+      success: true,
+      pluginName: 'my-plugin',
+      summary: 'Installed my-plugin@1.0.0: 1 agents, 1 rules, 0 skills',
+    });
+
+    const result = await runInstall(defaultOptions);
+
+    expect(result.success).toBe(true);
+    expect(mockConsoleUtils.log.success).toHaveBeenCalledWith(
+      expect.stringContaining('my-plugin@1.0.0'),
+    );
+  });
+
+  it('should print error message on failure', async () => {
+    mockInstall.mockResolvedValue({
+      success: false,
+      error: 'Invalid plugin manifest: name is required',
+    });
+
+    const result = await runInstall(defaultOptions);
+
+    expect(result.success).toBe(false);
+    expect(mockConsoleUtils.log.error).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid plugin manifest'),
+    );
+  });
+
+  it('should pass force flag through', async () => {
+    mockInstall.mockResolvedValue({
+      success: true,
+      pluginName: 'my-plugin',
+      summary: 'Installed my-plugin@1.0.0',
+    });
+
+    await runInstall({ ...defaultOptions, force: true });
+
+    expect(mockInstall).toHaveBeenCalledWith(expect.objectContaining({ force: true }));
+  });
+
+  it('should handle unexpected errors gracefully', async () => {
+    mockInstall.mockRejectedValue(new Error('Network error'));
+
+    const result = await runInstall(defaultOptions);
+
+    expect(result.success).toBe(false);
+    expect(mockConsoleUtils.log.error).toHaveBeenCalled();
+  });
+
+  it('should log install step before starting', async () => {
+    mockInstall.mockResolvedValue({
+      success: true,
+      pluginName: 'my-plugin',
+      summary: 'Installed',
+    });
+
+    await runInstall(defaultOptions);
+
+    expect(mockConsoleUtils.log.step).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('github:user/repo'),
+    );
+  });
+});

--- a/apps/mcp-server/src/cli/plugin/install.command.ts
+++ b/apps/mcp-server/src/cli/plugin/install.command.ts
@@ -1,0 +1,47 @@
+/**
+ * Plugin Install Command
+ *
+ * CLI command handler for `codingbuddy install <git-url>`.
+ * Delegates to PluginInstallerService for the actual installation logic.
+ */
+
+import { PluginInstallerService } from '../../plugin/plugin-installer.service';
+import { createConsoleUtils } from '../utils/console';
+
+export interface InstallCommandOptions {
+  source: string;
+  projectRoot: string;
+  force: boolean;
+}
+
+export interface InstallCommandResult {
+  success: boolean;
+  error?: string;
+}
+
+export async function runInstall(options: InstallCommandOptions): Promise<InstallCommandResult> {
+  const console = createConsoleUtils();
+  const installer = new PluginInstallerService();
+
+  console.log.step('📦', `Installing plugin from ${options.source}...`);
+
+  try {
+    const result = await installer.install({
+      source: options.source,
+      targetRoot: options.projectRoot,
+      force: options.force,
+    });
+
+    if (result.success) {
+      console.log.success(result.summary ?? `Installed ${result.pluginName}`);
+      return { success: true };
+    }
+
+    console.log.error(result.error ?? 'Installation failed');
+    return { success: false, error: result.error };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log.error(`Unexpected error: ${message}`);
+    return { success: false, error: message };
+  }
+}

--- a/apps/mcp-server/src/plugin/plugin-installer.service.spec.ts
+++ b/apps/mcp-server/src/plugin/plugin-installer.service.spec.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const {
+  mockExecSync,
+  mockExistsSync,
+  mockReadFileSync,
+  mockWriteFileSync,
+  mockMkdirSync,
+  mockCpSync,
+  mockRmSync,
+  mockReaddirSync,
+  mockMkdtempSync,
+} = vi.hoisted(() => ({
+  mockExecSync: vi.fn(),
+  mockExistsSync: vi.fn(),
+  mockReadFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockCpSync: vi.fn(),
+  mockRmSync: vi.fn(),
+  mockReaddirSync: vi.fn(),
+  mockMkdtempSync: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execSync: mockExecSync,
+}));
+
+vi.mock('fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+  cpSync: mockCpSync,
+  rmSync: mockRmSync,
+  readdirSync: mockReaddirSync,
+  mkdtempSync: mockMkdtempSync,
+}));
+
+vi.mock('os', () => ({
+  tmpdir: () => '/tmp',
+}));
+
+import { PluginInstallerService, InstallOptions } from './plugin-installer.service';
+
+const TEMP_DIR = '/tmp/codingbuddy-plugin-abc123';
+
+const validManifest = {
+  name: 'my-plugin',
+  version: '1.0.0',
+  description: 'A test plugin',
+  author: 'Test Author',
+  compatibility: '>=5.0.0',
+  provides: {
+    agents: ['custom-agent-1'],
+    rules: ['custom-rule-1'],
+    skills: ['custom-skill-1'],
+    checklists: [],
+  },
+};
+
+function setupCloneSuccess(): void {
+  mockMkdtempSync.mockReturnValue(TEMP_DIR);
+  mockExecSync.mockImplementation(() => Buffer.from(''));
+
+  mockExistsSync.mockImplementation((path: string) => {
+    // plugin.json in temp dir
+    if (path === `${TEMP_DIR}/plugin.json`) return true;
+    // Source asset directories in temp
+    if (path === `${TEMP_DIR}/agents`) return true;
+    if (path === `${TEMP_DIR}/rules`) return true;
+    if (path === `${TEMP_DIR}/skills`) return true;
+    if (path === `${TEMP_DIR}/checklists`) return false;
+    // plugins.json doesn't exist yet
+    if (path.includes('plugins.json')) return false;
+    // .codingbuddy dir exists
+    if (path.endsWith('.codingbuddy')) return true;
+    // No conflict — target asset files don't exist
+    return false;
+  });
+
+  mockReadFileSync.mockImplementation((path: string) => {
+    if (path.includes('plugin.json')) return JSON.stringify(validManifest);
+    return '';
+  });
+
+  mockReaddirSync.mockImplementation((path: string) => {
+    if (path === `${TEMP_DIR}/agents`) return ['custom-agent-1.json'];
+    if (path === `${TEMP_DIR}/rules`) return ['custom-rule-1.md'];
+    if (path === `${TEMP_DIR}/skills`) return ['custom-skill-1.md'];
+    return [];
+  });
+}
+
+describe('PluginInstallerService', () => {
+  let service: PluginInstallerService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new PluginInstallerService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('resolveGitUrl', () => {
+    it('should convert github:user/repo shorthand to HTTPS URL', () => {
+      const result = service.resolveGitUrl('github:user/repo');
+      expect(result).toBe('https://github.com/user/repo.git');
+    });
+
+    it('should pass through full HTTPS URLs', () => {
+      const result = service.resolveGitUrl('https://github.com/user/repo');
+      expect(result).toBe('https://github.com/user/repo');
+    });
+
+    it('should pass through HTTPS URLs with .git suffix', () => {
+      const result = service.resolveGitUrl('https://github.com/user/repo.git');
+      expect(result).toBe('https://github.com/user/repo.git');
+    });
+
+    it('should throw on invalid URL format', () => {
+      expect(() => service.resolveGitUrl('not-a-url')).toThrow('Invalid git URL');
+    });
+  });
+
+  describe('install', () => {
+    const defaultOptions: InstallOptions = {
+      source: 'github:user/repo',
+      targetRoot: '/project',
+      force: false,
+    };
+
+    it('should install from github:user/repo shorthand', async () => {
+      setupCloneSuccess();
+
+      const result = await service.install(defaultOptions);
+
+      expect(result.success).toBe(true);
+      expect(result.pluginName).toBe('my-plugin');
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining('git clone --depth=1'),
+        expect.any(Object),
+      );
+    });
+
+    it('should install from full HTTPS URL', async () => {
+      setupCloneSuccess();
+
+      const result = await service.install({
+        ...defaultOptions,
+        source: 'https://github.com/user/repo',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining('https://github.com/user/repo'),
+        expect.any(Object),
+      );
+    });
+
+    it('should reject invalid manifest', async () => {
+      mockMkdtempSync.mockReturnValue(TEMP_DIR);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path === `${TEMP_DIR}/plugin.json`) return true;
+        return false;
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify({ name: '' }));
+
+      const result = await service.install(defaultOptions);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid plugin manifest');
+    });
+
+    it('should reject when plugin.json is missing', async () => {
+      mockMkdtempSync.mockReturnValue(TEMP_DIR);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+      mockExistsSync.mockReturnValue(false);
+
+      const result = await service.install(defaultOptions);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('plugin.json not found');
+    });
+
+    it('should reject incompatible version', async () => {
+      const incompatibleManifest = {
+        ...validManifest,
+        compatibility: '>=99.0.0',
+      };
+      mockMkdtempSync.mockReturnValue(TEMP_DIR);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path === `${TEMP_DIR}/plugin.json`) return true;
+        return false;
+      });
+      mockReadFileSync.mockReturnValue(JSON.stringify(incompatibleManifest));
+
+      const result = await service.install(defaultOptions);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('incompatible');
+    });
+
+    it('should detect and refuse on name conflict', async () => {
+      mockMkdtempSync.mockReturnValue(TEMP_DIR);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path === `${TEMP_DIR}/plugin.json`) return true;
+        // Existing agent file at target — conflict
+        if (path === '/project/.ai-rules/agents/custom-agent-1.json') return true;
+        return false;
+      });
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.includes('plugin.json')) return JSON.stringify(validManifest);
+        return '';
+      });
+
+      const result = await service.install(defaultOptions);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('conflict');
+    });
+
+    it('should overwrite on conflict when --force is set', async () => {
+      mockMkdtempSync.mockReturnValue(TEMP_DIR);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path === `${TEMP_DIR}/plugin.json`) return true;
+        if (path === '/project/.ai-rules/agents/custom-agent-1.json') return true;
+        if (path.includes('plugins.json')) return false;
+        if (path.endsWith('.codingbuddy')) return true;
+        // Source dirs
+        if (path === `${TEMP_DIR}/agents`) return true;
+        if (path === `${TEMP_DIR}/rules`) return true;
+        if (path === `${TEMP_DIR}/skills`) return true;
+        return false;
+      });
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.includes('plugin.json')) return JSON.stringify(validManifest);
+        return '';
+      });
+      mockReaddirSync.mockImplementation((path: string) => {
+        if (path === `${TEMP_DIR}/agents`) return ['custom-agent-1.json'];
+        if (path === `${TEMP_DIR}/rules`) return ['custom-rule-1.md'];
+        if (path === `${TEMP_DIR}/skills`) return ['custom-skill-1.md'];
+        return [];
+      });
+
+      const result = await service.install({ ...defaultOptions, force: true });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should update plugins.json after install', async () => {
+      setupCloneSuccess();
+
+      await service.install(defaultOptions);
+
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('plugins.json'),
+        expect.stringContaining('"my-plugin"'),
+        'utf-8',
+      );
+    });
+
+    it('should include correct counts in result summary', async () => {
+      setupCloneSuccess();
+
+      const result = await service.install(defaultOptions);
+
+      expect(result.summary).toContain('my-plugin@1.0.0');
+      expect(result.summary).toContain('1 agents');
+      expect(result.summary).toContain('1 rules');
+      expect(result.summary).toContain('1 skills');
+    });
+
+    it('should clean up temp directory on success', async () => {
+      setupCloneSuccess();
+
+      await service.install(defaultOptions);
+
+      expect(mockRmSync).toHaveBeenCalledWith(
+        TEMP_DIR,
+        expect.objectContaining({ recursive: true }),
+      );
+    });
+
+    it('should clean up temp directory on failure', async () => {
+      mockMkdtempSync.mockReturnValue(TEMP_DIR);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+      mockExistsSync.mockReturnValue(false);
+
+      await service.install(defaultOptions);
+
+      expect(mockRmSync).toHaveBeenCalledWith(
+        TEMP_DIR,
+        expect.objectContaining({ recursive: true }),
+      );
+    });
+
+    it('should handle git clone failure gracefully', async () => {
+      mockMkdtempSync.mockReturnValue(TEMP_DIR);
+      mockExecSync.mockImplementation(() => {
+        throw new Error('fatal: repository not found');
+      });
+
+      const result = await service.install(defaultOptions);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('clone');
+    });
+
+    it('should append to existing plugins.json', async () => {
+      const existingPlugins = {
+        plugins: [
+          {
+            name: 'existing-plugin',
+            version: '2.0.0',
+            source: 'github:other/repo',
+            installedAt: '2026-01-01T00:00:00Z',
+            provides: { agents: [], rules: [], skills: [], checklists: [] },
+          },
+        ],
+      };
+
+      mockMkdtempSync.mockReturnValue(TEMP_DIR);
+      mockExecSync.mockImplementation(() => Buffer.from(''));
+      mockExistsSync.mockImplementation((path: string) => {
+        if (path === `${TEMP_DIR}/plugin.json`) return true;
+        if (path.includes('plugins.json')) return true;
+        if (path.endsWith('.codingbuddy')) return true;
+        if (path === `${TEMP_DIR}/agents`) return true;
+        if (path === `${TEMP_DIR}/rules`) return true;
+        if (path === `${TEMP_DIR}/skills`) return true;
+        return false;
+      });
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.includes('plugin.json') && path.includes(TEMP_DIR))
+          return JSON.stringify(validManifest);
+        if (path.includes('plugins.json')) return JSON.stringify(existingPlugins);
+        return '';
+      });
+      mockReaddirSync.mockImplementation((path: string) => {
+        if (path === `${TEMP_DIR}/agents`) return ['custom-agent-1.json'];
+        if (path === `${TEMP_DIR}/rules`) return ['custom-rule-1.md'];
+        if (path === `${TEMP_DIR}/skills`) return ['custom-skill-1.md'];
+        return [];
+      });
+
+      await service.install(defaultOptions);
+
+      const writeCall = mockWriteFileSync.mock.calls.find(
+        (call: unknown[]) =>
+          typeof call[0] === 'string' && (call[0] as string).includes('plugins.json'),
+      );
+      expect(writeCall).toBeDefined();
+      const written = JSON.parse(writeCall![1] as string);
+      expect(written.plugins).toHaveLength(2);
+      expect(written.plugins[0].name).toBe('existing-plugin');
+      expect(written.plugins[1].name).toBe('my-plugin');
+    });
+  });
+});

--- a/apps/mcp-server/src/plugin/plugin-installer.service.ts
+++ b/apps/mcp-server/src/plugin/plugin-installer.service.ts
@@ -1,0 +1,301 @@
+/**
+ * Plugin Installer Service
+ *
+ * Handles cloning, validating, and installing plugins from git repositories.
+ * Copies plugin assets (agents, rules, skills, checklists) into .ai-rules/
+ * and records installations in .codingbuddy/plugins.json.
+ */
+
+import { execSync } from 'child_process';
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  cpSync,
+  rmSync,
+  readdirSync,
+  mkdtempSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { validatePluginManifest, PluginManifest } from './plugin-manifest.schema';
+import { getPackageVersion } from '../shared/version.utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface InstallOptions {
+  source: string;
+  targetRoot: string;
+  force: boolean;
+}
+
+export interface InstallResult {
+  success: boolean;
+  pluginName?: string;
+  summary?: string;
+  error?: string;
+}
+
+export interface PluginRecord {
+  name: string;
+  version: string;
+  source: string;
+  installedAt: string;
+  provides: {
+    agents: string[];
+    rules: string[];
+    skills: string[];
+    checklists: string[];
+  };
+}
+
+interface PluginsRegistry {
+  plugins: PluginRecord[];
+}
+
+// ============================================================================
+// Asset directories to copy
+// ============================================================================
+
+const ASSET_DIRS = ['agents', 'rules', 'skills', 'checklists'] as const;
+
+// ============================================================================
+// Service
+// ============================================================================
+
+export class PluginInstallerService {
+  /**
+   * Resolve a git source string to a clone-able URL.
+   * Supports: github:user/repo shorthand, full HTTPS URLs.
+   */
+  resolveGitUrl(source: string): string {
+    if (source.startsWith('github:')) {
+      const path = source.slice('github:'.length);
+      return `https://github.com/${path}.git`;
+    }
+
+    if (source.startsWith('https://')) {
+      return source;
+    }
+
+    throw new Error(`Invalid git URL format: "${source}". Use github:user/repo or https://...`);
+  }
+
+  /**
+   * Install a plugin from a git source.
+   */
+  async install(options: InstallOptions): Promise<InstallResult> {
+    let tempDir: string | undefined;
+
+    try {
+      // 1. Resolve URL
+      const gitUrl = this.resolveGitUrl(options.source);
+
+      // 2. Clone to temp directory
+      tempDir = mkdtempSync(join(tmpdir(), 'codingbuddy-plugin-'));
+      try {
+        execSync(`git clone --depth=1 ${gitUrl} ${tempDir}`, {
+          stdio: 'pipe',
+          timeout: 60_000,
+        });
+      } catch {
+        return this.fail(
+          'Failed to clone repository. Check the URL and your network connection.',
+          tempDir,
+        );
+      }
+
+      // 3. Validate plugin.json
+      const manifestPath = join(tempDir, 'plugin.json');
+      if (!existsSync(manifestPath)) {
+        return this.fail('plugin.json not found in repository root.', tempDir);
+      }
+
+      let manifest: PluginManifest;
+      try {
+        const raw = readFileSync(manifestPath, 'utf-8');
+        manifest = validatePluginManifest(JSON.parse(raw));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return this.fail(message, tempDir);
+      }
+
+      // 4. Check compatibility
+      if (manifest.compatibility) {
+        if (!this.isCompatible(manifest.compatibility)) {
+          return this.fail(
+            `Plugin "${manifest.name}" requires codingbuddy ${manifest.compatibility} but current version is ${getPackageVersion()}. Version incompatible.`,
+            tempDir,
+          );
+        }
+      }
+
+      // 5. Detect conflicts
+      const aiRulesDir = join(options.targetRoot, '.ai-rules');
+      if (!options.force) {
+        const conflicts = this.detectConflicts(tempDir, aiRulesDir, manifest);
+        if (conflicts.length > 0) {
+          return this.fail(
+            `Name conflict detected: ${conflicts.join(', ')}. Use --force to overwrite.`,
+            tempDir,
+          );
+        }
+      }
+
+      // 6. Copy assets
+      const provides = this.copyAssets(tempDir, aiRulesDir);
+
+      // 7. Record in plugins.json
+      const pluginsJsonPath = join(options.targetRoot, '.codingbuddy', 'plugins.json');
+      this.recordInstallation(pluginsJsonPath, {
+        name: manifest.name,
+        version: manifest.version,
+        source: options.source,
+        installedAt: new Date().toISOString(),
+        provides,
+      });
+
+      // 8. Build summary
+      const summary = `Installed ${manifest.name}@${manifest.version}: ${provides.agents.length} agents, ${provides.rules.length} rules, ${provides.skills.length} skills`;
+
+      // 9. Cleanup
+      this.cleanup(tempDir);
+
+      return { success: true, pluginName: manifest.name, summary };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return this.fail(message, tempDir);
+    }
+  }
+
+  /**
+   * Check if current version satisfies the compatibility range.
+   * Supports simple >=X.Y.Z format.
+   */
+  private isCompatible(compatibility: string): boolean {
+    const currentVersion = getPackageVersion();
+    const match = compatibility.match(/^>=(\d+\.\d+\.\d+)$/);
+    if (!match) return true; // Unknown format — skip check
+
+    const required = match[1];
+    return this.compareVersions(currentVersion, required) >= 0;
+  }
+
+  /**
+   * Simple semver comparison. Returns negative if a < b, 0 if equal, positive if a > b.
+   */
+  private compareVersions(a: string, b: string): number {
+    const partsA = a.split('.').map(Number);
+    const partsB = b.split('.').map(Number);
+
+    for (let i = 0; i < 3; i++) {
+      const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+      if (diff !== 0) return diff;
+    }
+    return 0;
+  }
+
+  /**
+   * Detect name conflicts between plugin assets and existing assets.
+   */
+  private detectConflicts(tempDir: string, aiRulesDir: string, manifest: PluginManifest): string[] {
+    const conflicts: string[] = [];
+
+    for (const dir of ASSET_DIRS) {
+      const providedNames = manifest.provides[dir] ?? [];
+      for (const name of providedNames) {
+        // Check common file extensions
+        const extensions = dir === 'agents' ? ['.json'] : ['.md', '.json', '.yaml', '.yml'];
+        for (const ext of extensions) {
+          const targetPath = join(aiRulesDir, dir, `${name}${ext}`);
+          if (existsSync(targetPath)) {
+            conflicts.push(`${dir}/${name}`);
+            break;
+          }
+        }
+      }
+    }
+
+    return conflicts;
+  }
+
+  /**
+   * Copy plugin assets from temp directory to .ai-rules/.
+   */
+  private copyAssets(
+    tempDir: string,
+    aiRulesDir: string,
+  ): { agents: string[]; rules: string[]; skills: string[]; checklists: string[] } {
+    const provides: { agents: string[]; rules: string[]; skills: string[]; checklists: string[] } =
+      { agents: [], rules: [], skills: [], checklists: [] };
+
+    for (const dir of ASSET_DIRS) {
+      const sourceDir = join(tempDir, dir);
+      const targetDir = join(aiRulesDir, dir);
+
+      if (!existsSync(sourceDir)) continue;
+
+      mkdirSync(targetDir, { recursive: true });
+
+      const files = readdirSync(sourceDir);
+      for (const file of files) {
+        cpSync(join(sourceDir, file), join(targetDir, file), { recursive: true });
+        // Track by name without extension
+        const name = file.replace(/\.[^.]+$/, '');
+        provides[dir].push(name);
+      }
+    }
+
+    return provides;
+  }
+
+  /**
+   * Record plugin installation in plugins.json.
+   */
+  private recordInstallation(pluginsJsonPath: string, record: PluginRecord): void {
+    let registry: PluginsRegistry = { plugins: [] };
+
+    if (existsSync(pluginsJsonPath)) {
+      try {
+        registry = JSON.parse(readFileSync(pluginsJsonPath, 'utf-8'));
+      } catch {
+        // Corrupted file — start fresh
+        registry = { plugins: [] };
+      }
+    }
+
+    // Remove existing record for same plugin name (update scenario)
+    registry.plugins = registry.plugins.filter(p => p.name !== record.name);
+    registry.plugins.push(record);
+
+    // Ensure directory exists
+    const dir = pluginsJsonPath.replace(/[/\\][^/\\]+$/, '');
+    mkdirSync(dir, { recursive: true });
+
+    writeFileSync(pluginsJsonPath, JSON.stringify(registry, null, 2), 'utf-8');
+  }
+
+  /**
+   * Cleanup temp directory.
+   */
+  private cleanup(tempDir?: string): void {
+    if (tempDir) {
+      try {
+        rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // Best effort cleanup
+      }
+    }
+  }
+
+  /**
+   * Return failure result and cleanup.
+   */
+  private fail(error: string, tempDir?: string): InstallResult {
+    this.cleanup(tempDir);
+    return { success: false, error };
+  }
+}


### PR DESCRIPTION
## Summary
- Implements `codingbuddy install <git-url>` CLI command for installing community plugins from git repositories
- Supports both `github:user/repo` shorthand and full HTTPS URLs
- Validates `plugin.json` manifest using Zod schema from #1135, checks version compatibility, detects name conflicts with `--force` override
- Copies plugin assets (agents, rules, skills, checklists) into `.ai-rules/` and records in `.codingbuddy/plugins.json`

## Test plan
- [x] 17 unit tests for `PluginInstallerService` (URL resolution, clone, validation, conflicts, registry, cleanup)
- [x] 6 unit tests for `install.command` (delegation, output, error handling)
- [x] All 5469 existing tests pass
- [x] Lint, typecheck, prettier clean

Closes #1136