### PR TITLE
fix(plugin): address review comments for auto_issue module

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/auto_issue.py
+++ b/packages/claude-code-plugin/hooks/lib/auto_issue.py
@@ -9,7 +9,13 @@ import logging
 import os
 import re
 import subprocess
+import sys
 from typing import Dict, List, Optional, Set
+
+# Ensure hooks/lib is on sys.path so sibling imports work reliably
+_lib_dir = os.path.dirname(os.path.abspath(__file__))
+if _lib_dir not in sys.path:
+    sys.path.insert(0, _lib_dir)
 
 from config import load_config
 
@@ -120,7 +126,10 @@ def create_test_gap_issues(
             )
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
             logger.warning("gh issue create failed for %s: %s", file_path, exc)
-            return results  # stop on gh unavailable
+            # Early return: FileNotFoundError means gh binary is not installed,
+            # so all subsequent attempts would fail too. TimeoutExpired suggests
+            # a systemic connectivity issue. In both cases, skip remaining files.
+            return results
 
         if proc.returncode != 0:
             logger.warning(


### PR DESCRIPTION
Follow-up to PR #1146 which was merged with outstanding review comments.

## Fixes
- Fix fragile `from config import load_config` — use safe sys.path pattern (matches `notifications.py`, `safe_main.py`)
- Add comment explaining intentional early return when gh unavailable (FileNotFoundError = gh not installed, TimeoutExpired = systemic issue)

## Test
All 13 tests pass: `python3 -m pytest tests/test_auto_issue.py -v`

## Related
- Original PR: #1146 (merged)
- Issue: #1132