### PR TITLE
feat(mcp): add rule-stats.json writer service (#1131)

### DIFF
--- a/apps/mcp-server/src/rules/rule-stats-writer.spec.ts
+++ b/apps/mcp-server/src/rules/rule-stats-writer.spec.ts
@@ -1,0 +1,229 @@
+import { RuleStatsWriter, StatsFile } from './rule-stats-writer';
+import { RuleEventCollector } from './rule-event-collector';
+import { RuleEvent } from './rule-event.types';
+import { vol } from 'memfs';
+
+vi.mock('fs/promises', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs');
+  return memfs.fs.promises;
+});
+
+vi.mock('fs', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs');
+  return memfs.fs;
+});
+
+describe('RuleStatsWriter', () => {
+  let writer: RuleStatsWriter;
+  let collector: RuleEventCollector;
+  const STATS_PATH = '/docs/codingbuddy/rule-stats.json';
+
+  beforeEach(() => {
+    vol.reset();
+    collector = new RuleEventCollector();
+    writer = new RuleStatsWriter(collector, STATS_PATH);
+  });
+
+  const recordEvents = (events: Partial<RuleEvent>[]): void => {
+    for (const e of events) {
+      collector.record({
+        type: 'mode_activated',
+        timestamp: new Date().toISOString(),
+        ...e,
+      });
+    }
+  };
+
+  const readStatsFile = (): StatsFile => {
+    const raw = vol.readFileSync(STATS_PATH, 'utf-8') as string;
+    return JSON.parse(raw);
+  };
+
+  describe('flush()', () => {
+    it('should aggregate mode_activated events into rules stats', async () => {
+      recordEvents([
+        { type: 'mode_activated', rule: 'tdd-first' },
+        { type: 'mode_activated', rule: 'tdd-first' },
+        { type: 'mode_activated', rule: 'no-any' },
+      ]);
+
+      await writer.flush();
+
+      const stats = readStatsFile();
+      expect(stats.rules['tdd-first'].applied).toBe(2);
+      expect(stats.rules['tdd-first'].sessions).toBe(2);
+      expect(stats.rules['no-any'].applied).toBe(1);
+      expect(stats.rules['no-any'].sessions).toBe(1);
+    });
+
+    it('should aggregate checklist_generated events into domain stats', async () => {
+      recordEvents([
+        { type: 'checklist_generated', domain: 'security' },
+        { type: 'checklist_generated', domain: 'security' },
+        { type: 'checklist_generated', domain: 'accessibility' },
+      ]);
+
+      await writer.flush();
+
+      const stats = readStatsFile();
+      expect(stats.domains['security'].checks).toBe(2);
+      expect(stats.domains['accessibility'].checks).toBe(1);
+    });
+
+    it('should aggregate specialist_dispatched events into domain stats', async () => {
+      recordEvents([{ type: 'specialist_dispatched', domain: 'performance' }]);
+
+      await writer.flush();
+
+      const stats = readStatsFile();
+      expect(stats.domains['performance'].checks).toBe(1);
+    });
+
+    it('should aggregate violation_caught events into domain stats', async () => {
+      recordEvents([
+        { type: 'violation_caught', domain: 'security' },
+        { type: 'violation_caught', domain: 'security' },
+      ]);
+
+      await writer.flush();
+
+      const stats = readStatsFile();
+      expect(stats.domains['security'].issues_prevented).toBe(2);
+    });
+
+    it('should skip events without rule or domain as appropriate', async () => {
+      recordEvents([
+        { type: 'mode_activated' }, // no rule — skip
+        { type: 'checklist_generated' }, // no domain — skip
+      ]);
+
+      await writer.flush();
+
+      const stats = readStatsFile();
+      expect(Object.keys(stats.rules)).toHaveLength(0);
+      expect(Object.keys(stats.domains)).toHaveLength(0);
+    });
+
+    it('should set lastUpdated timestamp', async () => {
+      recordEvents([{ type: 'mode_activated', rule: 'core' }]);
+
+      await writer.flush();
+
+      const stats = readStatsFile();
+      expect(stats.lastUpdated).toBeDefined();
+      expect(() => new Date(stats.lastUpdated)).not.toThrow();
+    });
+
+    it('should clear collector events after flush', async () => {
+      recordEvents([{ type: 'mode_activated', rule: 'core' }]);
+
+      await writer.flush();
+
+      expect(collector.getEvents()).toEqual([]);
+    });
+  });
+
+  describe('merge with existing stats', () => {
+    it('should merge new stats into existing file', async () => {
+      const existing: StatsFile = {
+        lastUpdated: '2026-01-01T00:00:00Z',
+        rules: {
+          'tdd-first': { applied: 10, sessions: 5 },
+        },
+        domains: {
+          security: { checks: 3, issues_prevented: 1 },
+        },
+      };
+      vol.mkdirSync('/docs/codingbuddy', { recursive: true });
+      vol.writeFileSync(STATS_PATH, JSON.stringify(existing));
+
+      recordEvents([
+        { type: 'mode_activated', rule: 'tdd-first' },
+        { type: 'checklist_generated', domain: 'security' },
+        { type: 'violation_caught', domain: 'security' },
+      ]);
+
+      await writer.flush();
+
+      const stats = readStatsFile();
+      expect(stats.rules['tdd-first'].applied).toBe(11);
+      expect(stats.rules['tdd-first'].sessions).toBe(6);
+      expect(stats.domains['security'].checks).toBe(4);
+      expect(stats.domains['security'].issues_prevented).toBe(2);
+    });
+
+    it('should add new rules alongside existing ones', async () => {
+      const existing: StatsFile = {
+        lastUpdated: '2026-01-01T00:00:00Z',
+        rules: {
+          'existing-rule': { applied: 5, sessions: 3 },
+        },
+        domains: {},
+      };
+      vol.mkdirSync('/docs/codingbuddy', { recursive: true });
+      vol.writeFileSync(STATS_PATH, JSON.stringify(existing));
+
+      recordEvents([{ type: 'mode_activated', rule: 'new-rule' }]);
+
+      await writer.flush();
+
+      const stats = readStatsFile();
+      expect(stats.rules['existing-rule'].applied).toBe(5);
+      expect(stats.rules['new-rule'].applied).toBe(1);
+    });
+  });
+
+  describe('atomic write', () => {
+    it('should write to temp file then rename', async () => {
+      recordEvents([{ type: 'mode_activated', rule: 'core' }]);
+
+      await writer.flush();
+
+      // Final file should exist
+      expect(vol.existsSync(STATS_PATH)).toBe(true);
+      // Temp file should NOT remain
+      expect(vol.existsSync(STATS_PATH + '.tmp')).toBe(false);
+    });
+  });
+
+  describe('missing file handling', () => {
+    it('should create stats file if it does not exist', async () => {
+      expect(vol.existsSync(STATS_PATH)).toBe(false);
+
+      recordEvents([{ type: 'mode_activated', rule: 'core' }]);
+      await writer.flush();
+
+      expect(vol.existsSync(STATS_PATH)).toBe(true);
+      const stats = readStatsFile();
+      expect(stats.rules['core'].applied).toBe(1);
+    });
+
+    it('should create parent directories if missing', async () => {
+      expect(vol.existsSync('/docs/codingbuddy')).toBe(false);
+
+      recordEvents([{ type: 'mode_activated', rule: 'core' }]);
+      await writer.flush();
+
+      expect(vol.existsSync('/docs/codingbuddy')).toBe(true);
+    });
+
+    it('should handle corrupted stats file gracefully', async () => {
+      vol.mkdirSync('/docs/codingbuddy', { recursive: true });
+      vol.writeFileSync(STATS_PATH, 'NOT VALID JSON{{{');
+
+      recordEvents([{ type: 'mode_activated', rule: 'core' }]);
+      await writer.flush();
+
+      const stats = readStatsFile();
+      expect(stats.rules['core'].applied).toBe(1);
+    });
+  });
+
+  describe('no-op on empty flush', () => {
+    it('should not write file when there are no events', async () => {
+      await writer.flush();
+
+      expect(vol.existsSync(STATS_PATH)).toBe(false);
+    });
+  });
+});

--- a/apps/mcp-server/src/rules/rule-stats-writer.ts
+++ b/apps/mcp-server/src/rules/rule-stats-writer.ts
@@ -1,0 +1,147 @@
+import { Injectable, Inject, Optional } from '@nestjs/common';
+import { readFile, writeFile, rename, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { RuleEventCollector } from './rule-event-collector';
+import { RuleEvent } from './rule-event.types';
+
+export const STATS_FILE_PATH = Symbol('STATS_FILE_PATH');
+const DEFAULT_STATS_RELATIVE_PATH = 'docs/codingbuddy/rule-stats.json';
+
+export interface RuleStatsEntry {
+  applied: number;
+  sessions: number;
+}
+
+export interface DomainStatsEntry {
+  checks: number;
+  issues_prevented: number;
+}
+
+export interface StatsFile {
+  lastUpdated: string;
+  rules: Record<string, RuleStatsEntry>;
+  domains: Record<string, DomainStatsEntry>;
+}
+
+function createEmptyStats(): StatsFile {
+  return {
+    lastUpdated: new Date().toISOString(),
+    rules: {},
+    domains: {},
+  };
+}
+
+function aggregateEvents(events: RuleEvent[]): StatsFile {
+  const stats = createEmptyStats();
+
+  for (const event of events) {
+    switch (event.type) {
+      case 'mode_activated': {
+        if (!event.rule) break;
+        if (!stats.rules[event.rule]) {
+          stats.rules[event.rule] = { applied: 0, sessions: 0 };
+        }
+        stats.rules[event.rule].applied += 1;
+        stats.rules[event.rule].sessions += 1;
+        break;
+      }
+      case 'checklist_generated':
+      case 'specialist_dispatched': {
+        if (!event.domain) break;
+        if (!stats.domains[event.domain]) {
+          stats.domains[event.domain] = { checks: 0, issues_prevented: 0 };
+        }
+        stats.domains[event.domain].checks += 1;
+        break;
+      }
+      case 'violation_caught': {
+        if (!event.domain) break;
+        if (!stats.domains[event.domain]) {
+          stats.domains[event.domain] = { checks: 0, issues_prevented: 0 };
+        }
+        stats.domains[event.domain].issues_prevented += 1;
+        break;
+      }
+    }
+  }
+
+  return stats;
+}
+
+function mergeStats(existing: StatsFile, incoming: StatsFile): StatsFile {
+  const merged: StatsFile = {
+    lastUpdated: new Date().toISOString(),
+    rules: { ...existing.rules },
+    domains: { ...existing.domains },
+  };
+
+  for (const [name, entry] of Object.entries(incoming.rules)) {
+    if (merged.rules[name]) {
+      merged.rules[name] = {
+        applied: merged.rules[name].applied + entry.applied,
+        sessions: merged.rules[name].sessions + entry.sessions,
+      };
+    } else {
+      merged.rules[name] = { ...entry };
+    }
+  }
+
+  for (const [name, entry] of Object.entries(incoming.domains)) {
+    if (merged.domains[name]) {
+      merged.domains[name] = {
+        checks: merged.domains[name].checks + entry.checks,
+        issues_prevented: merged.domains[name].issues_prevented + entry.issues_prevented,
+      };
+    } else {
+      merged.domains[name] = { ...entry };
+    }
+  }
+
+  return merged;
+}
+
+@Injectable()
+export class RuleStatsWriter {
+  private readonly statsPath: string;
+
+  constructor(
+    private readonly collector: RuleEventCollector,
+    @Optional() @Inject(STATS_FILE_PATH) statsPath?: string,
+  ) {
+    this.statsPath = statsPath ?? join(process.cwd(), DEFAULT_STATS_RELATIVE_PATH);
+  }
+
+  async flush(): Promise<void> {
+    const events = this.collector.flush();
+    if (events.length === 0) {
+      return;
+    }
+
+    const incoming = aggregateEvents(events);
+    const existing = await this.readExistingStats();
+    const merged = existing ? mergeStats(existing, incoming) : incoming;
+
+    await this.atomicWrite(merged);
+  }
+
+  private async readExistingStats(): Promise<StatsFile | null> {
+    try {
+      const raw = await readFile(this.statsPath, 'utf-8');
+      return JSON.parse(raw) as StatsFile;
+    } catch {
+      return null;
+    }
+  }
+
+  private async atomicWrite(stats: StatsFile): Promise<void> {
+    const dir = dirname(this.statsPath);
+    if (!existsSync(dir)) {
+      await mkdir(dir, { recursive: true });
+    }
+
+    const tmpPath = this.statsPath + '.tmp';
+    await writeFile(tmpPath, JSON.stringify(stats, null, 2), 'utf-8');
+    await rename(tmpPath, this.statsPath);
+  }
+}

--- a/apps/mcp-server/src/rules/rules.module.ts
+++ b/apps/mcp-server/src/rules/rules.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { RulesService } from './rules.service';
 import { RuleInsightsService } from './rule-insights.service';
 import { RuleEventCollector } from './rule-event-collector';
+import { RuleStatsWriter } from './rule-stats-writer';
 import { CustomModule } from '../custom';
 import { CodingBuddyConfigModule } from '../config/config.module';
 
 @Module({
   imports: [CustomModule, CodingBuddyConfigModule],
-  providers: [RulesService, RuleInsightsService, RuleEventCollector],
-  exports: [RulesService, RuleInsightsService, RuleEventCollector],
+  providers: [RulesService, RuleInsightsService, RuleEventCollector, RuleStatsWriter],
+  exports: [RulesService, RuleInsightsService, RuleEventCollector, RuleStatsWriter],
 })
 export class RulesModule {}


### PR DESCRIPTION
## Summary

- Add `RuleStatsWriter` service that flushes events from `RuleEventCollector`, aggregates them by event type, and persists to `docs/codingbuddy/rule-stats.json`
- Uses atomic file operations (write to `.tmp` then `rename`) to prevent corruption
- Merges incrementally with existing stats — never overwrites historical data
- Registered in `RulesModule` with NestJS DI (injectable via `STATS_FILE_PATH` token for custom paths)

## Aggregation Logic

| Event Type | Stats Update |
|------------|-------------|
| `mode_activated` | `rules[rule].applied++`, `rules[rule].sessions++` |
| `checklist_generated` | `domains[domain].checks++` |
| `specialist_dispatched` | `domains[domain].checks++` |
| `violation_caught` | `domains[domain].issues_prevented++` |

## Test Plan

- [x] 14 tests covering all scenarios (vitest + memfs)
- [x] Aggregation of each event type
- [x] Merge with existing stats file
- [x] Atomic write (temp file + rename)
- [x] Missing file/directory creation
- [x] Corrupted file graceful recovery
- [x] No-op on empty event buffer
- [x] Full test suite passes (222 files, 5537 tests)
- [x] Type check clean
- [x] Lint clean

Closes #1131