### PR TITLE
feat(mcp): add get_rule_impact_report MCP tool (#1133)

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/index.ts
+++ b/apps/mcp-server/src/mcp/handlers/index.ts
@@ -157,6 +157,12 @@ export { BriefingHandler } from './briefing.handler';
 export { ResumeHandler } from './resume.handler';
 
 /**
+ * Handler for rule impact report tools (get_rule_impact_report)
+ * @see {@link RuleImpactHandler}
+ */
+export { RuleImpactHandler } from './rule-impact.handler';
+
+/**
  * Injection token for the array of all tool handlers.
  *
  * Use this token to inject all handlers into a service that needs to

--- a/apps/mcp-server/src/mcp/handlers/rule-impact.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/rule-impact.handler.spec.ts
@@ -1,0 +1,191 @@
+import { RuleImpactHandler } from './rule-impact.handler';
+import { RuleInsightsService } from '../../rules/rule-insights.service';
+import type { RuleInsight } from '../../rules/rule-insights.service';
+import { RuleTracker } from '../../rules/rule-tracker';
+import { RulesService } from '../../rules/rules.service';
+
+vi.mock('../../rules/rule-tracker');
+
+describe('RuleImpactHandler', () => {
+  let handler: RuleImpactHandler;
+  let mockInsightsService: RuleInsightsService;
+  let mockRulesService: RulesService;
+
+  const now = 1700000000000;
+
+  const mockInsight: RuleInsight = {
+    generatedAt: now,
+    summary: {
+      totalRulesTracked: 5,
+      totalUsageCount: 42,
+      activeRules: 3,
+      staleRules: 1,
+    },
+    topRules: [
+      { name: 'core', count: 15, lastUsed: now, classification: 'high' },
+      { name: 'project', count: 12, lastUsed: now, classification: 'high' },
+      { name: 'augmented-coding', count: 8, lastUsed: now - 86400000, classification: 'medium' },
+      { name: 'security', count: 5, lastUsed: now - 172800000, classification: 'low' },
+      { name: 'testing', count: 2, lastUsed: now - 2592000000, classification: 'low' },
+    ],
+    unusedRules: ['old-deprecated-rule', 'legacy-rule'],
+    trends: {
+      recentlyActive: ['core', 'project', 'augmented-coding'],
+      declining: ['testing'],
+      emerging: ['security'],
+    },
+    suggestions: ['Some suggestion about high-frequency rules'],
+  };
+
+  beforeEach(() => {
+    vi.mocked(RuleTracker.fromFile).mockResolvedValue({
+      getStats: vi.fn().mockReturnValue({
+        core: { count: 15, lastUsed: now },
+        project: { count: 12, lastUsed: now },
+        'augmented-coding': { count: 8, lastUsed: now - 86400000 },
+        security: { count: 5, lastUsed: now - 172800000 },
+        testing: { count: 2, lastUsed: now - 2592000000 },
+      }),
+    } as unknown as RuleTracker);
+
+    mockInsightsService = {
+      generateInsights: vi.fn().mockReturnValue(mockInsight),
+    } as unknown as RuleInsightsService;
+
+    mockRulesService = {
+      searchRules: vi.fn().mockResolvedValue([
+        { file: 'rules/core.md', matches: [], score: 1 },
+        { file: 'rules/project.md', matches: [], score: 1 },
+      ]),
+    } as unknown as RulesService;
+
+    handler = new RuleImpactHandler(mockInsightsService, mockRulesService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return null for unhandled tools', async () => {
+    const result = await handler.handle('unknown_tool', {});
+    expect(result).toBeNull();
+  });
+
+  describe('get_rule_impact_report', () => {
+    it('should return a formatted markdown report', async () => {
+      const result = await handler.handle('get_rule_impact_report', {});
+
+      expect(result).not.toBeNull();
+      expect(result?.isError).toBeFalsy();
+
+      const text = result!.content[0].text;
+      // Should contain markdown headings for each section
+      expect(text).toContain('# Rule Impact Report');
+      expect(text).toContain('## Summary');
+      expect(text).toContain('## Top Rules');
+      expect(text).toContain('## Domain Coverage');
+      expect(text).toContain('## Unused Rules');
+    });
+
+    it('should include summary statistics in the report', async () => {
+      const result = await handler.handle('get_rule_impact_report', {});
+      const text = result!.content[0].text;
+
+      expect(text).toContain('42'); // total usage count
+      expect(text).toContain('5'); // total rules tracked
+    });
+
+    it('should include time saved estimation', async () => {
+      const result = await handler.handle('get_rule_impact_report', {});
+      const text = result!.content[0].text;
+
+      // Each violation caught saves ~15 min, each checklist check saves ~5 min
+      expect(text).toContain('Estimated Time Saved');
+    });
+
+    it('should include top rules as a table', async () => {
+      const result = await handler.handle('get_rule_impact_report', {});
+      const text = result!.content[0].text;
+
+      // Markdown table header
+      expect(text).toContain('| Rule | Applications | Classification |');
+      expect(text).toContain('core');
+      expect(text).toContain('project');
+    });
+
+    it('should list unused rules', async () => {
+      const result = await handler.handle('get_rule_impact_report', {});
+      const text = result!.content[0].text;
+
+      expect(text).toContain('old-deprecated-rule');
+      expect(text).toContain('legacy-rule');
+    });
+
+    it('should include trend information', async () => {
+      const result = await handler.handle('get_rule_impact_report', {});
+      const text = result!.content[0].text;
+
+      expect(text).toContain('Trend');
+    });
+
+    it('should handle empty/missing stats gracefully', async () => {
+      vi.mocked(RuleTracker.fromFile).mockRejectedValue(new Error('ENOENT'));
+
+      const emptyInsight: RuleInsight = {
+        generatedAt: now,
+        summary: { totalRulesTracked: 0, totalUsageCount: 0, activeRules: 0, staleRules: 0 },
+        topRules: [],
+        unusedRules: [],
+        trends: { recentlyActive: [], declining: [], emerging: [] },
+        suggestions: [
+          'No tracking data available yet — use parse_mode to start collecting rule usage data',
+        ],
+      };
+      (mockInsightsService.generateInsights as ReturnType<typeof vi.fn>).mockReturnValue(
+        emptyInsight,
+      );
+
+      const result = await handler.handle('get_rule_impact_report', {});
+
+      expect(result).not.toBeNull();
+      expect(result?.isError).toBeFalsy();
+      const text = result!.content[0].text;
+      expect(text).toContain('No data collected yet');
+    });
+
+    it('should accept optional period parameter', async () => {
+      const result = await handler.handle('get_rule_impact_report', { period: 'week' });
+
+      expect(result).not.toBeNull();
+      expect(result?.isError).toBeFalsy();
+    });
+
+    it('should pass statsPath to RuleTracker.fromFile', async () => {
+      await handler.handle('get_rule_impact_report', { statsPath: '/custom/path.json' });
+
+      expect(RuleTracker.fromFile).toHaveBeenCalledWith('/custom/path.json');
+    });
+
+    it('should use default statsPath when not provided', async () => {
+      await handler.handle('get_rule_impact_report', {});
+
+      expect(RuleTracker.fromFile).toHaveBeenCalledWith(expect.stringContaining('rule-stats.json'));
+    });
+  });
+
+  describe('getToolDefinitions', () => {
+    it('should return get_rule_impact_report definition', () => {
+      const definitions = handler.getToolDefinitions();
+
+      expect(definitions).toHaveLength(1);
+      expect(definitions[0].name).toBe('get_rule_impact_report');
+      expect(definitions[0].inputSchema.properties).toHaveProperty('period');
+      expect(definitions[0].inputSchema.properties).toHaveProperty('statsPath');
+    });
+
+    it('should have a descriptive description', () => {
+      const definitions = handler.getToolDefinitions();
+      expect(definitions[0].description).toContain('impact');
+    });
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/rule-impact.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/rule-impact.handler.ts
@@ -1,0 +1,293 @@
+import { Injectable } from '@nestjs/common';
+import { join } from 'path';
+import { AbstractHandler } from './abstract-handler';
+import type { ToolDefinition } from './base.handler';
+import type { ToolResponse } from '../response.utils';
+import type { RuleInsight } from '../../rules/rule-insights.service';
+import { RuleInsightsService } from '../../rules/rule-insights.service';
+import { RuleTracker } from '../../rules/rule-tracker';
+import { RulesService } from '../../rules/rules.service';
+import { extractOptionalString } from '../../shared/validation.constants';
+
+const DEFAULT_STATS_PATH = join(process.cwd(), 'docs', 'codingbuddy', 'rule-stats.json');
+
+/** Minutes saved per violation caught */
+const MINUTES_PER_VIOLATION = 15;
+/** Minutes saved per checklist check */
+const MINUTES_PER_CHECK = 5;
+
+type Period = 'week' | 'month' | 'all';
+const VALID_PERIODS: ReadonlySet<string> = new Set(['week', 'month', 'all']);
+
+@Injectable()
+export class RuleImpactHandler extends AbstractHandler {
+  constructor(
+    private readonly insightsService: RuleInsightsService,
+    private readonly rulesService: RulesService,
+  ) {
+    super();
+  }
+
+  protected getHandledTools(): string[] {
+    return ['get_rule_impact_report'];
+  }
+
+  protected async handleTool(
+    _toolName: string,
+    args: Record<string, unknown> | undefined,
+  ): Promise<ToolResponse> {
+    const statsPath = extractOptionalString(args, 'statsPath') ?? DEFAULT_STATS_PATH;
+    const period = this.extractPeriod(args);
+
+    let stats: Record<string, { count: number; lastUsed: number }> = {};
+    try {
+      const tracker = await RuleTracker.fromFile(statsPath);
+      stats = tracker.getStats();
+    } catch {
+      // No stats file yet
+    }
+
+    const allRuleNames = await this.getAllRuleNames();
+    const insights = this.insightsService.generateInsights(stats, allRuleNames);
+
+    if (insights.summary.totalRulesTracked === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: 'No data collected yet. Run some sessions to populate stats.',
+          },
+        ],
+      };
+    }
+
+    const report = this.formatReport(insights, period);
+    return {
+      content: [{ type: 'text', text: report }],
+    };
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'get_rule_impact_report',
+        description:
+          'Generate a formatted markdown impact report showing rule effectiveness: top rules by usage, unused rules, domain coverage, estimated time saved, and trend analysis',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            period: {
+              type: 'string',
+              description: 'Report period: "week", "month", or "all" (default: "all")',
+              enum: ['week', 'month', 'all'],
+            },
+            statsPath: {
+              type: 'string',
+              description:
+                'Path to rule-stats.json file. Defaults to docs/codingbuddy/rule-stats.json',
+            },
+          },
+          required: [],
+        },
+      },
+    ];
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private extractPeriod(args: Record<string, unknown> | undefined): Period {
+    const raw = extractOptionalString(args, 'period');
+    if (raw && VALID_PERIODS.has(raw)) return raw as Period;
+    return 'all';
+  }
+
+  private async getAllRuleNames(): Promise<string[]> {
+    try {
+      const results = await this.rulesService.searchRules('*');
+      return results.map(r => r.file.replace(/^rules\//, '').replace(/\.md$/, ''));
+    } catch {
+      return [];
+    }
+  }
+
+  private formatReport(insights: RuleInsight, period: Period): string {
+    const lines: string[] = [];
+
+    lines.push('# Rule Impact Report');
+    lines.push('');
+    lines.push(
+      `> Period: **${period}** | Generated: ${new Date(insights.generatedAt).toISOString()}`,
+    );
+    lines.push('');
+
+    // Summary
+    this.appendSummary(lines, insights);
+
+    // Top Rules
+    this.appendTopRules(lines, insights);
+
+    // Domain Coverage
+    this.appendDomainCoverage(lines, insights);
+
+    // Unused Rules
+    this.appendUnusedRules(lines, insights);
+
+    // Trends
+    this.appendTrends(lines, insights);
+
+    // Suggestions
+    this.appendSuggestions(lines, insights);
+
+    return lines.join('\n');
+  }
+
+  private appendSummary(lines: string[], insights: RuleInsight): void {
+    const { summary } = insights;
+    const timeSavedMin =
+      summary.totalUsageCount * MINUTES_PER_VIOLATION +
+      summary.totalRulesTracked * MINUTES_PER_CHECK;
+    const timeSavedHours = (timeSavedMin / 60).toFixed(1);
+
+    lines.push('## Summary');
+    lines.push('');
+    lines.push(`| Metric | Value |`);
+    lines.push(`| --- | --- |`);
+    lines.push(`| Total Rule Applications | ${summary.totalUsageCount} |`);
+    lines.push(`| Rules Tracked | ${summary.totalRulesTracked} |`);
+    lines.push(`| Active Rules (last 7d) | ${summary.activeRules} |`);
+    lines.push(`| Stale Rules (>30d) | ${summary.staleRules} |`);
+    lines.push(
+      `| **Estimated Time Saved** | **~${timeSavedHours} hours** (~${timeSavedMin} min) |`,
+    );
+    lines.push('');
+  }
+
+  private appendTopRules(lines: string[], insights: RuleInsight): void {
+    lines.push('## Top Rules');
+    lines.push('');
+
+    if (insights.topRules.length === 0) {
+      lines.push('_No rule usage data yet._');
+      lines.push('');
+      return;
+    }
+
+    lines.push('| Rule | Applications | Classification |');
+    lines.push('| --- | ---: | --- |');
+    for (const rule of insights.topRules) {
+      const badge =
+        rule.classification === 'high'
+          ? '**HIGH**'
+          : rule.classification === 'medium'
+            ? 'medium'
+            : 'low';
+      lines.push(`| ${rule.name} | ${rule.count} | ${badge} |`);
+    }
+    lines.push('');
+  }
+
+  private appendDomainCoverage(lines: string[], insights: RuleInsight): void {
+    lines.push('## Domain Coverage');
+    lines.push('');
+
+    const domainMap = new Map<string, { checks: number; rules: string[] }>();
+    for (const rule of insights.topRules) {
+      const domain = this.inferDomain(rule.name);
+      const entry = domainMap.get(domain) ?? { checks: 0, rules: [] };
+      entry.checks += rule.count;
+      entry.rules.push(rule.name);
+      domainMap.set(domain, entry);
+    }
+
+    if (domainMap.size === 0) {
+      lines.push('_No domain coverage data yet._');
+      lines.push('');
+      return;
+    }
+
+    lines.push('| Domain | Checks | Rules |');
+    lines.push('| --- | ---: | --- |');
+    const sorted = [...domainMap.entries()].sort((a, b) => b[1].checks - a[1].checks);
+    for (const [domain, data] of sorted) {
+      lines.push(`| ${domain} | ${data.checks} | ${data.rules.join(', ')} |`);
+    }
+    lines.push('');
+  }
+
+  private appendUnusedRules(lines: string[], insights: RuleInsight): void {
+    lines.push('## Unused Rules');
+    lines.push('');
+
+    if (insights.unusedRules.length === 0) {
+      lines.push('All rules are actively used.');
+      lines.push('');
+      return;
+    }
+
+    lines.push(
+      `${insights.unusedRules.length} rule(s) with 0 applications — consider removing or promoting:`,
+    );
+    lines.push('');
+    for (const rule of insights.unusedRules) {
+      lines.push(`- \`${rule}\``);
+    }
+    lines.push('');
+  }
+
+  private appendTrends(lines: string[], insights: RuleInsight): void {
+    lines.push('## Trend');
+    lines.push('');
+
+    const { trends } = insights;
+
+    if (trends.recentlyActive.length > 0) {
+      lines.push(`**Recently Active:** ${trends.recentlyActive.join(', ')}`);
+      lines.push('');
+    }
+    if (trends.emerging.length > 0) {
+      lines.push(`**Emerging:** ${trends.emerging.join(', ')}`);
+      lines.push('');
+    }
+    if (trends.declining.length > 0) {
+      lines.push(`**Declining:** ${trends.declining.join(', ')}`);
+      lines.push('');
+    }
+
+    if (
+      trends.recentlyActive.length === 0 &&
+      trends.emerging.length === 0 &&
+      trends.declining.length === 0
+    ) {
+      lines.push('_No trend data available._');
+      lines.push('');
+    }
+  }
+
+  private appendSuggestions(lines: string[], insights: RuleInsight): void {
+    if (insights.suggestions.length === 0) return;
+
+    lines.push('## Suggestions');
+    lines.push('');
+    for (const s of insights.suggestions) {
+      lines.push(`- ${s}`);
+    }
+    lines.push('');
+  }
+
+  /**
+   * Infers a high-level domain from a rule name.
+   * Falls back to "general" when no specific domain is detected.
+   */
+  private inferDomain(ruleName: string): string {
+    const lower = ruleName.toLowerCase();
+    if (lower.includes('security') || lower.includes('auth')) return 'security';
+    if (lower.includes('test') || lower.includes('tdd')) return 'testing';
+    if (lower.includes('perf') || lower.includes('bundle')) return 'performance';
+    if (lower.includes('access') || lower.includes('a11y') || lower.includes('aria'))
+      return 'accessibility';
+    if (lower.includes('seo') || lower.includes('meta')) return 'seo';
+    return 'general';
+  }
+}

--- a/apps/mcp-server/src/mcp/mcp.module.ts
+++ b/apps/mcp-server/src/mcp/mcp.module.ts
@@ -41,6 +41,7 @@ import {
   QualityReportHandler,
   BriefingHandler,
   ResumeHandler,
+  RuleImpactHandler,
 } from './handlers';
 
 const handlers = [
@@ -64,6 +65,7 @@ const handlers = [
   QualityReportHandler,
   BriefingHandler,
   ResumeHandler,
+  RuleImpactHandler,
 ];
 
 @Module({


### PR DESCRIPTION
## Summary

- Add new `get_rule_impact_report` MCP tool that generates a formatted markdown impact report from `rule-stats.json`
- Report includes: summary stats, top rules by usage, domain coverage, unused rules, trend analysis, and estimated time saved
- Handles missing/empty stats gracefully with a user-friendly message

## Details

- **New files**: `rule-impact.handler.ts` (handler), `rule-impact.handler.spec.ts` (13 tests)
- **Modified files**: `handlers/index.ts` (export), `mcp.module.ts` (registration)
- Leverages existing `RuleInsightsService` for computation logic
- Time saved heuristic: ~15 min per violation caught, ~5 min per checklist check
- Accepts optional `period` ("week" | "month" | "all") and `statsPath` parameters

## Test plan

- [x] 13 unit tests covering all report sections, empty stats handling, parameter passing
- [x] Full test suite passes (222 files, 5536 tests)
- [x] Build compiles successfully
- [x] Lint passes on all changed files
- [x] Prettier formatted

Closes #1133