### PR TITLE
refactor(mcp): switch list_skills to filesystem-based discovery (#1162)

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/skill.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/skill.handler.spec.ts
@@ -14,7 +14,7 @@ describe('SkillHandler', () => {
         originalPrompt: 'test prompt',
         recommendations: [{ skillName: 'test-skill', matchedPatterns: [] }],
       }),
-      listSkills: vi.fn().mockReturnValue({
+      listSkills: vi.fn().mockResolvedValue({
         skills: [{ name: 'test-skill', priority: 1 }],
         total: 1,
       }),

--- a/apps/mcp-server/src/mcp/handlers/skill.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/skill.handler.ts
@@ -120,7 +120,7 @@ export class SkillHandler extends AbstractHandler {
     }
   }
 
-  private handleListSkills(args: Record<string, unknown> | undefined): ToolResponse {
+  private async handleListSkills(args: Record<string, unknown> | undefined): Promise<ToolResponse> {
     try {
       const options: ListSkillsOptions = {};
 
@@ -131,7 +131,7 @@ export class SkillHandler extends AbstractHandler {
         options.maxPriority = args.maxPriority;
       }
 
-      const result = this.skillRecommendationService.listSkills(options);
+      const result = await this.skillRecommendationService.listSkills(options);
       return createJsonResponse(result);
     } catch (error) {
       return createErrorResponse(

--- a/apps/mcp-server/src/mcp/mcp.service.spec.ts
+++ b/apps/mcp-server/src/mcp/mcp.service.spec.ts
@@ -228,7 +228,7 @@ const createMockSkillRecommendationService = (): Partial<SkillRecommendationServ
     ],
     originalPrompt: 'I have a bug in my code',
   } as RecommendSkillsResult),
-  listSkills: vi.fn().mockReturnValue({
+  listSkills: vi.fn().mockResolvedValue({
     skills: [
       {
         name: 'systematic-debugging',
@@ -2122,7 +2122,7 @@ describe('McpService', () => {
       });
 
       it('should filter by minPriority', async () => {
-        vi.mocked(mockSkillRecommendationService.listSkills!).mockReturnValue({
+        vi.mocked(mockSkillRecommendationService.listSkills!).mockResolvedValue({
           skills: [
             {
               name: 'systematic-debugging',
@@ -2159,7 +2159,7 @@ describe('McpService', () => {
       });
 
       it('should filter by maxPriority', async () => {
-        vi.mocked(mockSkillRecommendationService.listSkills!).mockReturnValue({
+        vi.mocked(mockSkillRecommendationService.listSkills!).mockResolvedValue({
           skills: [
             {
               name: 'brainstorming',
@@ -2190,7 +2190,7 @@ describe('McpService', () => {
       });
 
       it('should filter by both minPriority and maxPriority', async () => {
-        vi.mocked(mockSkillRecommendationService.listSkills!).mockReturnValue({
+        vi.mocked(mockSkillRecommendationService.listSkills!).mockResolvedValue({
           skills: [
             {
               name: 'test-driven-development',
@@ -2223,9 +2223,9 @@ describe('McpService', () => {
 
     describe('Error Handling', () => {
       it('should return error when service throws', async () => {
-        vi.mocked(mockSkillRecommendationService.listSkills!).mockImplementation(() => {
-          throw new Error('Service error');
-        });
+        vi.mocked(mockSkillRecommendationService.listSkills!).mockRejectedValue(
+          new Error('Service error'),
+        );
 
         const handler = handlers.get('tools/call');
         expect(handler).toBeDefined();

--- a/apps/mcp-server/src/skill/skill-recommendation.service.spec.ts
+++ b/apps/mcp-server/src/skill/skill-recommendation.service.spec.ts
@@ -1,14 +1,42 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { SkillRecommendationService } from './skill-recommendation.service';
 import type { RecommendSkillsResult } from './skill-recommendation.types';
 import { clearTriggerCache } from './skill-triggers';
+import type { RulesService } from '../rules/rules.service';
+
+/** Create a mock RulesService that returns the given skill list */
+function createMockRulesService(
+  skills: Array<{ name: string; description: string }> = [],
+): RulesService {
+  return {
+    listSkillsFromDir: vi.fn().mockResolvedValue(skills),
+  } as unknown as RulesService;
+}
+
+/** Default filesystem-like skills for testing (includes both keyword-registered and extra skills) */
+const FILESYSTEM_SKILLS: Array<{ name: string; description: string }> = [
+  { name: 'systematic-debugging', description: 'Systematic approach to debugging' },
+  { name: 'brainstorming', description: 'Brainstorming and ideation' },
+  { name: 'executing-plans', description: 'Execute implementation plans' },
+  { name: 'writing-plans', description: 'Write implementation plans' },
+  { name: 'frontend-design', description: 'Frontend design patterns' },
+  { name: 'test-driven-development', description: 'TDD workflow' },
+  { name: 'refactoring', description: 'Code refactoring' },
+  { name: 'documentation-generation', description: 'Generate documentation' },
+  // Extra skills NOT in SKILL_KEYWORDS
+  { name: 'api-design', description: 'API design patterns' },
+  { name: 'git-workflow', description: 'Git workflow management' },
+  { name: 'docker-setup', description: 'Docker configuration' },
+];
 
 describe('SkillRecommendationService', () => {
   let service: SkillRecommendationService;
+  let mockRulesService: RulesService;
 
   beforeEach(() => {
     clearTriggerCache();
-    service = new SkillRecommendationService();
+    mockRulesService = createMockRulesService(FILESYSTEM_SKILLS);
+    service = new SkillRecommendationService(mockRulesService);
   });
 
   describe('recommendSkills basic functionality', () => {
@@ -360,11 +388,11 @@ describe('SkillRecommendationService', () => {
   });
 
   describe('listSkills', () => {
-    it('should return all skills sorted by priority descending', () => {
-      const result = service.listSkills();
+    it('should return all filesystem skills sorted by priority descending', async () => {
+      const result = await service.listSkills();
 
       expect(result.skills).toBeDefined();
-      expect(result.total).toBeGreaterThan(0);
+      expect(result.total).toBe(FILESYSTEM_SKILLS.length);
       expect(result.skills.length).toBe(result.total);
 
       // Check sorted by priority descending
@@ -373,8 +401,49 @@ describe('SkillRecommendationService', () => {
       }
     });
 
-    it('should include name, priority, description, concepts for each skill', () => {
-      const result = service.listSkills();
+    it('should call rulesService.listSkillsFromDir as primary source', async () => {
+      await service.listSkills();
+
+      expect(mockRulesService.listSkillsFromDir).toHaveBeenCalled();
+    });
+
+    it('should enrich skills with SKILL_KEYWORDS priority when available', async () => {
+      const result = await service.listSkills();
+
+      // systematic-debugging has priority 25 in SKILL_KEYWORDS
+      const debugging = result.skills.find(s => s.name === 'systematic-debugging');
+      expect(debugging?.priority).toBe(25);
+    });
+
+    it('should assign default priority to skills without SKILL_KEYWORDS entry', async () => {
+      const result = await service.listSkills();
+
+      // api-design is NOT in SKILL_KEYWORDS — should get default priority
+      const apiDesign = result.skills.find(s => s.name === 'api-design');
+      expect(apiDesign).toBeDefined();
+      expect(apiDesign!.priority).toBe(0);
+    });
+
+    it('should use filesystem description for skills', async () => {
+      const result = await service.listSkills();
+
+      const apiDesign = result.skills.find(s => s.name === 'api-design');
+      expect(apiDesign?.description).toBe('API design patterns');
+    });
+
+    it('should include concepts from SKILL_KEYWORDS when available', async () => {
+      const result = await service.listSkills();
+
+      const debugging = result.skills.find(s => s.name === 'systematic-debugging');
+      expect(debugging?.concepts.length).toBeGreaterThan(0);
+
+      // Extra skill should have empty concepts
+      const apiDesign = result.skills.find(s => s.name === 'api-design');
+      expect(apiDesign?.concepts).toEqual([]);
+    });
+
+    it('should include name, priority, description, concepts for each skill', async () => {
+      const result = await service.listSkills();
 
       for (const skill of result.skills) {
         expect(skill.name).toBeDefined();
@@ -384,41 +453,52 @@ describe('SkillRecommendationService', () => {
       }
     });
 
-    it('should filter by minPriority', () => {
-      const result = service.listSkills({ minPriority: 20 });
+    it('should filter by minPriority', async () => {
+      const result = await service.listSkills({ minPriority: 20 });
 
+      expect(result.skills.length).toBeGreaterThan(0);
       for (const skill of result.skills) {
         expect(skill.priority).toBeGreaterThanOrEqual(20);
       }
     });
 
-    it('should filter by maxPriority', () => {
-      const result = service.listSkills({ maxPriority: 15 });
+    it('should filter by maxPriority', async () => {
+      const result = await service.listSkills({ maxPriority: 15 });
 
       for (const skill of result.skills) {
         expect(skill.priority).toBeLessThanOrEqual(15);
       }
     });
 
-    it('should filter by both minPriority and maxPriority', () => {
-      const result = service.listSkills({ minPriority: 12, maxPriority: 20 });
+    it('should filter by both minPriority and maxPriority', async () => {
+      const result = await service.listSkills({ minPriority: 10, maxPriority: 20 });
 
       expect(result.skills.length).toBeGreaterThan(0);
       for (const skill of result.skills) {
-        expect(skill.priority).toBeGreaterThanOrEqual(12);
+        expect(skill.priority).toBeGreaterThanOrEqual(10);
         expect(skill.priority).toBeLessThanOrEqual(20);
       }
     });
 
-    it('should return empty array when minPriority > maxPriority', () => {
-      const result = service.listSkills({ minPriority: 100, maxPriority: 10 });
+    it('should return empty array when minPriority > maxPriority', async () => {
+      const result = await service.listSkills({ minPriority: 100, maxPriority: 10 });
 
       expect(result.skills).toEqual([]);
       expect(result.total).toBe(0);
     });
 
-    it('should return empty array when no skills match filter criteria', () => {
-      const result = service.listSkills({ minPriority: 1000 });
+    it('should return empty array when no skills match filter criteria', async () => {
+      const result = await service.listSkills({ minPriority: 1000 });
+
+      expect(result.skills).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should return empty array when filesystem returns no skills', async () => {
+      const emptyRulesService = createMockRulesService([]);
+      const emptyService = new SkillRecommendationService(emptyRulesService);
+
+      const result = await emptyService.listSkills();
 
       expect(result.skills).toEqual([]);
       expect(result.total).toBe(0);

--- a/apps/mcp-server/src/skill/skill-recommendation.service.ts
+++ b/apps/mcp-server/src/skill/skill-recommendation.service.ts
@@ -8,6 +8,9 @@ import type {
 } from './skill-recommendation.types';
 import { getSortedTriggers } from './skill-triggers';
 import { SKILL_KEYWORDS } from './i18n/keywords';
+import { RulesService } from '../rules/rules.service';
+
+const DEFAULT_PRIORITY = 0;
 
 /**
  * Get skill description from SKILL_KEYWORDS (single source of truth)
@@ -22,6 +25,7 @@ function getSkillDescription(skillName: string): string {
  */
 @Injectable()
 export class SkillRecommendationService {
+  constructor(private readonly rulesService: RulesService) {}
   /**
    * Recommends skills based on the given prompt
    * @param prompt User's input prompt
@@ -113,13 +117,18 @@ export class SkillRecommendationService {
    * listSkills({ minPriority: 20 })
    * // => { skills: [debugging, executing-plans, writing-plans], total: 3 }
    */
-  listSkills(options?: ListSkillsOptions): ListSkillsResult {
-    let skills: SkillInfo[] = SKILL_KEYWORDS.map(skill => ({
-      name: skill.skillName,
-      priority: skill.priority,
-      description: skill.description,
-      concepts: Object.keys(skill.concepts),
-    }));
+  async listSkills(options?: ListSkillsOptions): Promise<ListSkillsResult> {
+    const fsSkills = await this.rulesService.listSkillsFromDir();
+
+    let skills: SkillInfo[] = fsSkills.map(fsSkill => {
+      const kwEntry = SKILL_KEYWORDS.find(k => k.skillName === fsSkill.name);
+      return {
+        name: fsSkill.name,
+        priority: kwEntry?.priority ?? DEFAULT_PRIORITY,
+        description: fsSkill.description,
+        concepts: kwEntry ? Object.keys(kwEntry.concepts) : [],
+      };
+    });
 
     // Apply filters
     if (options?.minPriority !== undefined) {

--- a/apps/mcp-server/src/skill/skill.module.ts
+++ b/apps/mcp-server/src/skill/skill.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { SkillRecommendationService } from './skill-recommendation.service';
+import { RulesModule } from '../rules/rules.module';
 
 @Module({
+  imports: [RulesModule],
   providers: [SkillRecommendationService],
   exports: [SkillRecommendationService],
 })


### PR DESCRIPTION
## Summary

- Switches `list_skills` MCP tool from hardcoded `SKILL_KEYWORDS` (25 skills) to filesystem-based `listSkillsFromDir()` (all skills on disk)
- Injects `RulesService` into `SkillRecommendationService` and makes `listSkills()` async
- Skills with `SKILL_KEYWORDS` entries retain their priority; others get default priority 0

## Changes

- `skill-recommendation.service.ts` — inject `RulesService`, rewrite `listSkills()` to use filesystem as primary source with keyword enrichment
- `skill.module.ts` — import `RulesModule` for DI
- `skill.handler.ts` — make `handleListSkills` async
- `*.spec.ts` — update mocks from `mockReturnValue` to `mockResolvedValue`, add new tests for filesystem-based behavior

## Test plan

- [x] All 5556 tests passing (223 test files)
- [x] TypeScript type check passes
- [x] Lint passes (0 errors)
- [x] Prettier formatting verified
- [x] New tests verify filesystem source, priority enrichment, default priority, empty concepts

Closes #1162