### PR TITLE
feat(mcp): add triggers field to SKILL.md frontmatter (#1163)

### DIFF
--- a/apps/mcp-server/src/rules/rules.service.ts
+++ b/apps/mcp-server/src/rules/rules.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { existsSync } from 'fs';
 import { AgentProfile, SearchResult } from './rules.types';
-import type { Skill } from './skill.schema';
+import type { Skill, SkillFrontmatterTrigger } from './skill.schema';
 import { CustomService } from '../custom';
 import { ConfigService } from '../config/config.service';
 import { MODE_AGENTS } from '../keyword/keyword.types';
@@ -187,9 +187,11 @@ export class RulesService {
 
   /**
    * List all available skills from the skills directory
-   * @returns Array of skill summaries with name and description
+   * @returns Array of skill summaries with name, description, and optional triggers
    */
-  async listSkillsFromDir(): Promise<Array<{ name: string; description: string }>> {
+  async listSkillsFromDir(): Promise<
+    Array<{ name: string; description: string; triggers?: SkillFrontmatterTrigger[] }>
+  > {
     try {
       return await listSkillSummaries(this.rulesDir);
     } catch (error) {

--- a/apps/mcp-server/src/rules/skill.schema.spec.ts
+++ b/apps/mcp-server/src/rules/skill.schema.spec.ts
@@ -19,6 +19,51 @@ This is the skill content.
       expect(result.description).toBe('A test skill description');
       expect(result.content).toContain('# Test Skill');
       expect(result.path).toBe('skills/test-skill/SKILL.md');
+      expect(result.triggers).toBeUndefined();
+    });
+
+    it('should parse valid SKILL.md with triggers', () => {
+      const content = `---
+name: widget-skill
+description: Widget architecture skill
+triggers:
+  - pattern: "widget.*(slot|architecture)"
+    confidence: high
+  - pattern: "(parallel route|layout)"
+    confidence: medium
+---
+
+# Widget Skill
+
+Content here.
+`;
+      const result = parseSkill(content, 'skills/widget-skill/SKILL.md');
+
+      expect(result.name).toBe('widget-skill');
+      expect(result.triggers).toBeDefined();
+      expect(result.triggers).toHaveLength(2);
+      expect(result.triggers![0]).toEqual({
+        pattern: 'widget.*(slot|architecture)',
+        confidence: 'high',
+      });
+      expect(result.triggers![1]).toEqual({
+        pattern: '(parallel route|layout)',
+        confidence: 'medium',
+      });
+    });
+
+    it('should parse skill with empty triggers array', () => {
+      const content = `---
+name: no-triggers
+description: Skill with empty triggers
+triggers: []
+---
+
+Content.
+`;
+      const result = parseSkill(content, 'path');
+
+      expect(result.triggers).toEqual([]);
     });
 
     it('should handle multiline description', () => {
@@ -121,6 +166,47 @@ Just content.
       const content = `---
 name: test
 description: [invalid yaml array as description]
+---
+
+Content.
+`;
+      expect(() => parseSkill(content, 'path')).toThrow(SkillSchemaError);
+    });
+
+    it('should reject trigger with invalid confidence value', () => {
+      const content = `---
+name: bad-trigger
+description: Bad trigger confidence
+triggers:
+  - pattern: "test"
+    confidence: "invalid"
+---
+
+Content.
+`;
+      expect(() => parseSkill(content, 'path')).toThrow(SkillSchemaError);
+    });
+
+    it('should reject trigger missing pattern field', () => {
+      const content = `---
+name: bad-trigger
+description: Missing pattern
+triggers:
+  - confidence: high
+---
+
+Content.
+`;
+      expect(() => parseSkill(content, 'path')).toThrow(SkillSchemaError);
+    });
+
+    it('should reject trigger with empty pattern string', () => {
+      const content = `---
+name: bad-trigger
+description: Empty pattern
+triggers:
+  - pattern: ""
+    confidence: high
 ---
 
 Content.

--- a/apps/mcp-server/src/rules/skill.schema.ts
+++ b/apps/mcp-server/src/rules/skill.schema.ts
@@ -31,9 +31,20 @@ export class SkillSchemaError extends Error {
 // ============================================================================
 
 /**
+ * Trigger entry schema for SKILL.md frontmatter
+ * - pattern: regex pattern string (non-empty)
+ * - confidence: high | medium | low
+ */
+const SkillFrontmatterTriggerSchema = z.object({
+  pattern: z.string().min(1),
+  confidence: z.enum(['high', 'medium', 'low']),
+});
+
+/**
  * Skill frontmatter schema
  * - name: lowercase with hyphens only (a-z0-9-)
  * - description: 1-500 characters
+ * - triggers: optional array of pattern+confidence entries
  */
 const SkillFrontmatterSchema = z.object({
   name: z
@@ -41,17 +52,24 @@ const SkillFrontmatterSchema = z.object({
     .min(1)
     .regex(/^[a-z0-9-]+$/, 'Skill name must be lowercase alphanumeric with hyphens only'),
   description: z.string().min(1).max(500),
+  triggers: z.array(SkillFrontmatterTriggerSchema).optional(),
 });
 
 // ============================================================================
 // Types
 // ============================================================================
 
+export interface SkillFrontmatterTrigger {
+  pattern: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
 export interface Skill {
   name: string;
   description: string;
   content: string;
   path: string;
+  triggers?: SkillFrontmatterTrigger[];
 }
 
 // ============================================================================
@@ -127,5 +145,6 @@ export function parseSkill(content: string, filePath: string): Skill {
     description: result.data.description,
     content: body,
     path: filePath,
+    triggers: result.data.triggers,
   };
 }

--- a/apps/mcp-server/src/shared/rules-core.ts
+++ b/apps/mcp-server/src/shared/rules-core.ts
@@ -10,7 +10,7 @@ import { isPathSafe } from './security.utils';
 import { parseAgentProfile, AgentSchemaError } from '../rules/agent.schema';
 import { parseSkill, SkillSchemaError } from '../rules/skill.schema';
 import type { AgentProfile, SearchResult } from '../rules/rules.types';
-import type { Skill } from '../rules/skill.schema';
+import type { Skill, SkillFrontmatterTrigger } from '../rules/skill.schema';
 
 // ============================================================================
 // Types
@@ -244,11 +244,15 @@ export async function searchInRuleFiles(
 export async function listSkillSummaries(
   rulesDir: string,
   deps?: FileSystemDeps,
-): Promise<Array<{ name: string; description: string }>> {
+): Promise<Array<{ name: string; description: string; triggers?: SkillFrontmatterTrigger[] }>> {
   const skillsDir = path.join(rulesDir, 'skills');
   const readdir = getReaddir(deps);
   const readFile = getReadFile(deps);
-  const summaries: Array<{ name: string; description: string }> = [];
+  const summaries: Array<{
+    name: string;
+    description: string;
+    triggers?: SkillFrontmatterTrigger[];
+  }> = [];
 
   try {
     const entries = (await readdir(skillsDir, {
@@ -264,6 +268,7 @@ export async function listSkillSummaries(
           summaries.push({
             name: skill.name,
             description: skill.description,
+            triggers: skill.triggers,
           });
         } catch {
           // Skip invalid/missing skills

--- a/apps/mcp-server/src/skill/skill-recommendation.service.spec.ts
+++ b/apps/mcp-server/src/skill/skill-recommendation.service.spec.ts
@@ -4,9 +4,15 @@ import type { RecommendSkillsResult } from './skill-recommendation.types';
 import { clearTriggerCache } from './skill-triggers';
 import type { RulesService } from '../rules/rules.service';
 
+import type { SkillFrontmatterTrigger } from '../rules/skill.schema';
+
 /** Create a mock RulesService that returns the given skill list */
 function createMockRulesService(
-  skills: Array<{ name: string; description: string }> = [],
+  skills: Array<{
+    name: string;
+    description: string;
+    triggers?: SkillFrontmatterTrigger[];
+  }> = [],
 ): RulesService {
   return {
     listSkillsFromDir: vi.fn().mockResolvedValue(skills),
@@ -14,7 +20,11 @@ function createMockRulesService(
 }
 
 /** Default filesystem-like skills for testing (includes both keyword-registered and extra skills) */
-const FILESYSTEM_SKILLS: Array<{ name: string; description: string }> = [
+const FILESYSTEM_SKILLS: Array<{
+  name: string;
+  description: string;
+  triggers?: SkillFrontmatterTrigger[];
+}> = [
   { name: 'systematic-debugging', description: 'Systematic approach to debugging' },
   { name: 'brainstorming', description: 'Brainstorming and ideation' },
   { name: 'executing-plans', description: 'Execute implementation plans' },
@@ -27,16 +37,27 @@ const FILESYSTEM_SKILLS: Array<{ name: string; description: string }> = [
   { name: 'api-design', description: 'API design patterns' },
   { name: 'git-workflow', description: 'Git workflow management' },
   { name: 'docker-setup', description: 'Docker configuration' },
+  // Skill with frontmatter triggers (NOT in SKILL_KEYWORDS)
+  {
+    name: 'widget-slot-architecture',
+    description: 'Next.js Parallel Routes Widget Slot pattern',
+    triggers: [
+      { pattern: 'widget.*(slot|architecture|parallel)', confidence: 'high' as const },
+      { pattern: '(parallel route|next.*layout|slot.*pattern)', confidence: 'medium' as const },
+      { pattern: '(dashboard.*layout|multi.*panel)', confidence: 'low' as const },
+    ],
+  },
 ];
 
 describe('SkillRecommendationService', () => {
   let service: SkillRecommendationService;
   let mockRulesService: RulesService;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     clearTriggerCache();
     mockRulesService = createMockRulesService(FILESYSTEM_SKILLS);
     service = new SkillRecommendationService(mockRulesService);
+    await service.loadFrontmatterTriggers();
   });
 
   describe('recommendSkills basic functionality', () => {
@@ -384,6 +405,120 @@ describe('SkillRecommendationService', () => {
 
       expect(result.recommendations.length).toBeGreaterThan(0);
       expect(result.recommendations[0].skillName).toBe('systematic-debugging');
+    });
+  });
+
+  describe('frontmatter triggers', () => {
+    it('should match skill via frontmatter trigger pattern', () => {
+      const result = service.recommendSkills('I need a widget slot architecture');
+
+      const wsa = result.recommendations.find(r => r.skillName === 'widget-slot-architecture');
+      expect(wsa).toBeDefined();
+      expect(wsa!.confidence).toBe('high');
+    });
+
+    it('should use medium confidence for medium-confidence trigger', () => {
+      const result = service.recommendSkills('How to use parallel route in next layout');
+
+      const wsa = result.recommendations.find(r => r.skillName === 'widget-slot-architecture');
+      expect(wsa).toBeDefined();
+      expect(wsa!.confidence).toBe('medium');
+    });
+
+    it('should use low confidence for low-confidence trigger', () => {
+      const result = service.recommendSkills('Need a dashboard layout for the admin');
+
+      const wsa = result.recommendations.find(r => r.skillName === 'widget-slot-architecture');
+      expect(wsa).toBeDefined();
+      expect(wsa!.confidence).toBe('low');
+    });
+
+    it('should use highest confidence when multiple triggers match', () => {
+      // "widget slot" matches high, "parallel route" matches medium → high wins
+      const result = service.recommendSkills('widget slot with parallel route');
+
+      const wsa = result.recommendations.find(r => r.skillName === 'widget-slot-architecture');
+      expect(wsa).toBeDefined();
+      expect(wsa!.confidence).toBe('high');
+    });
+
+    it('should not match frontmatter triggers for unrelated prompt', () => {
+      const result = service.recommendSkills('random text xyz123');
+
+      const wsa = result.recommendations.find(r => r.skillName === 'widget-slot-architecture');
+      expect(wsa).toBeUndefined();
+    });
+
+    it('should include matched patterns from frontmatter triggers', () => {
+      const result = service.recommendSkills('widget slot architecture');
+
+      const wsa = result.recommendations.find(r => r.skillName === 'widget-slot-architecture');
+      expect(wsa).toBeDefined();
+      expect(wsa!.matchedPatterns.length).toBeGreaterThan(0);
+    });
+
+    it('should use skill description from filesystem for frontmatter-only skills', () => {
+      const result = service.recommendSkills('widget slot architecture');
+
+      const wsa = result.recommendations.find(r => r.skillName === 'widget-slot-architecture');
+      expect(wsa).toBeDefined();
+      expect(wsa!.description).toBe('Next.js Parallel Routes Widget Slot pattern');
+    });
+
+    it('should merge keyword and frontmatter triggers for same skill', async () => {
+      // Create a skill that exists in BOTH keywords.ts and has frontmatter triggers
+      const skillsWithOverlap = [
+        ...FILESYSTEM_SKILLS,
+        {
+          name: 'systematic-debugging',
+          description: 'Debugging skill',
+          triggers: [{ pattern: 'custom-debug-pattern', confidence: 'high' as const }],
+        },
+      ];
+      const overlapService = new SkillRecommendationService(
+        createMockRulesService(skillsWithOverlap),
+      );
+      await overlapService.loadFrontmatterTriggers();
+
+      // Match via keyword trigger
+      const result = overlapService.recommendSkills('There is a bug and custom-debug-pattern');
+
+      const debugging = result.recommendations.find(r => r.skillName === 'systematic-debugging');
+      expect(debugging).toBeDefined();
+      // Should have patterns from both sources
+      expect(debugging!.matchedPatterns.length).toBeGreaterThan(1);
+    });
+
+    it('should skip invalid regex patterns gracefully', async () => {
+      const skillsWithBadRegex = [
+        {
+          name: 'bad-regex-skill',
+          description: 'Skill with invalid regex',
+          triggers: [
+            { pattern: '[invalid(regex', confidence: 'high' as const },
+            { pattern: 'valid-pattern', confidence: 'medium' as const },
+          ],
+        },
+      ];
+      const badService = new SkillRecommendationService(createMockRulesService(skillsWithBadRegex));
+      await badService.loadFrontmatterTriggers();
+
+      // Should still work with valid pattern
+      const result = badService.recommendSkills('valid-pattern text');
+
+      const skill = result.recommendations.find(r => r.skillName === 'bad-regex-skill');
+      expect(skill).toBeDefined();
+    });
+
+    it('should work when no frontmatter triggers are loaded', async () => {
+      const noTriggerService = new SkillRecommendationService(
+        createMockRulesService([{ name: 'plain-skill', description: 'No triggers' }]),
+      );
+      await noTriggerService.loadFrontmatterTriggers();
+
+      const result = noTriggerService.recommendSkills('fix the bug');
+      // Should still work with keyword triggers
+      expect(result.recommendations.length).toBeGreaterThan(0);
     });
   });
 

--- a/apps/mcp-server/src/skill/skill-recommendation.service.ts
+++ b/apps/mcp-server/src/skill/skill-recommendation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, type OnModuleInit } from '@nestjs/common';
 import type {
   SkillRecommendation,
   RecommendSkillsResult,
@@ -12,6 +12,22 @@ import { RulesService } from '../rules/rules.service';
 
 const DEFAULT_PRIORITY = 0;
 
+const CONFIDENCE_RANK: Record<string, number> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+interface CachedFrontmatterTrigger {
+  pattern: RegExp;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+interface FrontmatterTriggerEntry {
+  description: string;
+  triggers: CachedFrontmatterTrigger[];
+}
+
 /**
  * Get skill description from SKILL_KEYWORDS (single source of truth)
  */
@@ -24,8 +40,43 @@ function getSkillDescription(skillName: string): string {
  * Service for recommending skills based on user prompts
  */
 @Injectable()
-export class SkillRecommendationService {
+export class SkillRecommendationService implements OnModuleInit {
+  private frontmatterTriggerCache = new Map<string, FrontmatterTriggerEntry>();
+
   constructor(private readonly rulesService: RulesService) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.loadFrontmatterTriggers();
+  }
+
+  /**
+   * Loads and caches frontmatter triggers from SKILL.md files.
+   * Called at module init and can be called manually for testing.
+   */
+  async loadFrontmatterTriggers(): Promise<void> {
+    const skills = await this.rulesService.listSkillsFromDir();
+    this.frontmatterTriggerCache.clear();
+
+    for (const skill of skills) {
+      if (skill.triggers && skill.triggers.length > 0) {
+        const compiled: CachedFrontmatterTrigger[] = [];
+        for (const t of skill.triggers) {
+          try {
+            compiled.push({ pattern: new RegExp(t.pattern, 'i'), confidence: t.confidence });
+          } catch {
+            // Skip invalid regex patterns
+          }
+        }
+        if (compiled.length > 0) {
+          this.frontmatterTriggerCache.set(skill.name, {
+            description: skill.description,
+            triggers: compiled,
+          });
+        }
+      }
+    }
+  }
+
   /**
    * Recommends skills based on the given prompt
    * @param prompt User's input prompt
@@ -43,48 +94,90 @@ export class SkillRecommendationService {
     }
 
     const triggers = getSortedTriggers();
-    const skillMatches = new Map<string, { matchedPatterns: string[]; priority: number }>();
+    const skillMatches = new Map<
+      string,
+      {
+        matchedPatterns: string[];
+        priority: number;
+        confidence: 'high' | 'medium' | 'low';
+        description: string;
+      }
+    >();
 
-    // Test each trigger's patterns against the prompt
+    // Step 1: Test keyword triggers against the prompt
     for (const trigger of triggers) {
       const matchedPatterns: string[] = [];
 
       for (const pattern of trigger.patterns) {
         if (pattern.test(trimmedPrompt)) {
-          // Extract the matched keyword from the pattern source
-          const patternSource = pattern.source;
-          matchedPatterns.push(patternSource);
+          matchedPatterns.push(pattern.source);
         }
       }
 
-      // Only add if there are matches and skill not already added
       if (matchedPatterns.length > 0 && !skillMatches.has(trigger.skillName)) {
         skillMatches.set(trigger.skillName, {
           matchedPatterns,
           priority: trigger.priority,
+          confidence: this.determineConfidence(matchedPatterns.length),
+          description: getSkillDescription(trigger.skillName),
         });
       }
     }
 
-    // Convert to SkillRecommendation array
+    // Step 2: Check frontmatter triggers and merge
+    for (const [skillName, entry] of this.frontmatterTriggerCache) {
+      const fmMatchedPatterns: string[] = [];
+      let bestConfidence: 'high' | 'medium' | 'low' = 'low';
+
+      for (const trigger of entry.triggers) {
+        if (trigger.pattern.test(trimmedPrompt)) {
+          fmMatchedPatterns.push(trigger.pattern.source);
+          if ((CONFIDENCE_RANK[trigger.confidence] ?? 0) > (CONFIDENCE_RANK[bestConfidence] ?? 0)) {
+            bestConfidence = trigger.confidence;
+          }
+        }
+      }
+
+      if (fmMatchedPatterns.length > 0) {
+        const existing = skillMatches.get(skillName);
+        if (existing) {
+          // Merge: add frontmatter patterns, use higher confidence
+          const mergedPatterns = [...new Set([...existing.matchedPatterns, ...fmMatchedPatterns])];
+          const existingRank = CONFIDENCE_RANK[existing.confidence] ?? 0;
+          const newRank = CONFIDENCE_RANK[bestConfidence] ?? 0;
+          existing.matchedPatterns = mergedPatterns;
+          if (newRank > existingRank) {
+            existing.confidence = bestConfidence;
+          }
+        } else {
+          skillMatches.set(skillName, {
+            matchedPatterns: fmMatchedPatterns,
+            priority: 0,
+            confidence: bestConfidence,
+            description: entry.description,
+          });
+        }
+      }
+    }
+
+    // Step 3: Convert to SkillRecommendation array and sort
     const recommendations: SkillRecommendation[] = [];
 
-    for (const [skillName, { matchedPatterns }] of skillMatches) {
-      const confidence = this.determineConfidence(matchedPatterns.length);
-
+    for (const [skillName, match] of skillMatches) {
       recommendations.push({
         skillName,
-        confidence,
-        matchedPatterns,
-        description: getSkillDescription(skillName),
+        confidence: match.confidence,
+        matchedPatterns: match.matchedPatterns,
+        description: match.description,
       });
     }
 
-    // Sort by priority (triggers are already sorted, but we need to maintain order from Map)
+    // Sort by priority descending, then by confidence descending
     recommendations.sort((a, b) => {
       const aPriority = skillMatches.get(a.skillName)?.priority ?? 0;
       const bPriority = skillMatches.get(b.skillName)?.priority ?? 0;
-      return bPriority - aPriority;
+      if (bPriority !== aPriority) return bPriority - aPriority;
+      return (CONFIDENCE_RANK[b.confidence] ?? 0) - (CONFIDENCE_RANK[a.confidence] ?? 0);
     });
 
     return {

--- a/packages/rules/.ai-rules/skills/widget-slot-architecture/SKILL.md
+++ b/packages/rules/.ai-rules/skills/widget-slot-architecture/SKILL.md
@@ -2,6 +2,13 @@
 name: widget-slot-architecture
 description: Architecture guide using Next.js App Router's Parallel Routes for Widget-Slot pattern. Separates static layouts from dynamic widgets to achieve separation of concerns, fault isolation, and plug-and-play development.
 user-invocable: false
+triggers:
+  - pattern: "widget.*(slot|architecture|parallel)"
+    confidence: high
+  - pattern: "(parallel route|next.*layout|slot.*pattern)"
+    confidence: medium
+  - pattern: "(dashboard.*layout|multi.*panel)"
+    confidence: low
 ---
 
 # Widget-Slot Architecture (WSA)


### PR DESCRIPTION
## Summary

- Add optional `triggers` field to SKILL.md YAML frontmatter for self-contained skill discovery
- `recommend_skills` now checks both frontmatter triggers AND keywords.ts triggers
- Frontmatter triggers specify regex patterns with explicit confidence levels (high/medium/low)
- Skills without keywords.ts entries (like widget-slot-architecture) are now discoverable

## Changes

| File | Change |
|------|--------|
| `skill.schema.ts` | Add `SkillFrontmatterTrigger` Zod schema and `Skill.triggers` field |
| `rules-core.ts` | Surface triggers from `listSkillSummaries` |
| `rules.service.ts` | Update `listSkillsFromDir` return type |
| `skill-recommendation.service.ts` | `OnModuleInit` trigger caching + merge logic |
| `skill-recommendation.service.spec.ts` | 10 new tests for frontmatter triggers |
| `skill.schema.spec.ts` | 6 new tests for trigger schema validation |
| `widget-slot-architecture/SKILL.md` | Add triggers example |

## Test plan

- [x] Schema: validates triggers with high/medium/low confidence
- [x] Schema: rejects invalid confidence, missing pattern, empty pattern
- [x] Schema: triggers field is optional (backward compatible)
- [x] Recommendation: matches via frontmatter trigger pattern
- [x] Recommendation: uses correct confidence from trigger
- [x] Recommendation: merges keyword + frontmatter triggers for same skill
- [x] Recommendation: skips invalid regex gracefully
- [x] Recommendation: works when no frontmatter triggers loaded
- [x] All 5571 existing tests still pass

Closes #1163