### PR TITLE
feat(cli): add codingbuddy search command for plugin discovery (#1169)

### DIFF
--- a/apps/mcp-server/src/cli/cli.ts
+++ b/apps/mcp-server/src/cli/cli.ts
@@ -8,17 +8,33 @@
 import { runInit } from './init';
 import { bootstrap } from '../main';
 import { getPackageVersion } from '../shared/version.utils';
-import type { InitOptions, TuiOptions, InstallOptions, UninstallOptions } from './cli.types';
+import type {
+  InitOptions,
+  TuiOptions,
+  InstallOptions,
+  UninstallOptions,
+  SearchOptions,
+} from './cli.types';
 
 /**
  * Parsed command line arguments
  */
 export interface ParsedArgs {
-  command: 'init' | 'install' | 'plugins' | 'uninstall' | 'mcp' | 'tui' | 'help' | 'version';
+  command:
+    | 'init'
+    | 'install'
+    | 'plugins'
+    | 'uninstall'
+    | 'search'
+    | 'mcp'
+    | 'tui'
+    | 'help'
+    | 'version';
   options: Partial<InitOptions> &
     Partial<TuiOptions> &
     Partial<InstallOptions> &
-    Partial<UninstallOptions>;
+    Partial<UninstallOptions> &
+    Partial<SearchOptions>;
 }
 
 /**
@@ -65,6 +81,14 @@ export function parseArgs(args: string[]): ParsedArgs {
     return { command: 'plugins', options };
   }
 
+  if (command === 'search') {
+    const searchQuery = args.slice(1).join(' ');
+    return {
+      command: 'search',
+      options: { ...options, searchQuery },
+    };
+  }
+
   if (command === 'uninstall') {
     const uninstallName = args[1];
     const uninstallYes = args.includes('--yes') || args.includes('-y');
@@ -107,6 +131,7 @@ CodingBuddy CLI - AI-powered project configuration generator
 Usage:
   codingbuddy init [path] [options]    Initialize configuration
   codingbuddy install <git-url>        Install a plugin from git repository
+  codingbuddy search <query>           Search plugins in the registry
   codingbuddy plugins                  List installed plugins
   codingbuddy uninstall <name>         Uninstall a plugin
   codingbuddy mcp                      Start MCP server (stdio mode)
@@ -125,6 +150,7 @@ Examples:
   codingbuddy init ./my-project        Initialize in specific directory
   codingbuddy init --force             Overwrite existing config
   codingbuddy install github:user/repo Install a community plugin
+  codingbuddy search nextjs            Search for Next.js plugins
   codingbuddy plugins                  List all installed plugins
   codingbuddy uninstall my-plugin      Remove a plugin
   codingbuddy uninstall my-plugin -y   Remove without confirmation
@@ -192,6 +218,20 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<void
     case 'tui': {
       const { runTui } = await import('./run-tui');
       await runTui({ restart: options.restart ?? false });
+      break;
+    }
+
+    case 'search': {
+      const { runSearch } = await import('./plugin/search.command');
+      if (!options.searchQuery) {
+        process.stderr.write('Error: Missing query. Usage: codingbuddy search <query>\n');
+        process.exitCode = 1;
+        break;
+      }
+      const searchResult = await runSearch({ query: options.searchQuery });
+      if (!searchResult.success) {
+        process.exitCode = 1;
+      }
       break;
     }
 

--- a/apps/mcp-server/src/cli/cli.types.ts
+++ b/apps/mcp-server/src/cli/cli.types.ts
@@ -68,6 +68,14 @@ export interface UninstallOptions {
 }
 
 /**
+ * Search command options (parsed from CLI args)
+ */
+export interface SearchOptions {
+  /** Search query string */
+  searchQuery?: string;
+}
+
+/**
  * Console output levels
  */
 export type LogLevel = 'info' | 'success' | 'warn' | 'error';

--- a/apps/mcp-server/src/cli/plugin/search.command.spec.ts
+++ b/apps/mcp-server/src/cli/plugin/search.command.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSearch = vi.fn();
+const mockConsoleUtils = {
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+  },
+};
+
+vi.mock('../../plugin/registry-client', () => ({
+  RegistryClient: class {
+    search = mockSearch;
+  },
+}));
+
+vi.mock('../utils/console', () => ({
+  createConsoleUtils: () => mockConsoleUtils,
+}));
+
+import { runSearch } from './search.command';
+
+describe('search.command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call RegistryClient.search with the query', async () => {
+    mockSearch.mockResolvedValue([]);
+
+    await runSearch({ query: 'nextjs' });
+
+    expect(mockSearch).toHaveBeenCalledWith('nextjs');
+  });
+
+  it('should display formatted results when plugins found', async () => {
+    mockSearch.mockResolvedValue([
+      {
+        name: 'nextjs-app-router',
+        version: '1.0.0',
+        description: 'Next.js App Router best practices',
+        tags: ['nextjs', 'react', 'frontend'],
+        provides: { agents: ['a1'], rules: ['r1', 'r2'], skills: ['s1'] },
+      },
+    ]);
+
+    const result = await runSearch({ query: 'nextjs' });
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(1);
+    // Check name/version displayed
+    expect(mockConsoleUtils.log.step).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('nextjs-app-router'),
+    );
+  });
+
+  it('should display provides counts', async () => {
+    mockSearch.mockResolvedValue([
+      {
+        name: 'test-plugin',
+        version: '1.0.0',
+        description: 'Test',
+        tags: ['test'],
+        provides: { agents: ['a1'], rules: ['r1', 'r2'], skills: ['s1'] },
+      },
+    ]);
+
+    await runSearch({ query: 'test' });
+
+    const allStepCalls = mockConsoleUtils.log.step.mock.calls.map((call: string[]) => call[1]);
+    const providesLine = allStepCalls.find((msg: string) => msg.includes('Provides'));
+    expect(providesLine).toContain('1 agent');
+    expect(providesLine).toContain('2 rules');
+    expect(providesLine).toContain('1 skill');
+  });
+
+  it('should display install command for each plugin', async () => {
+    mockSearch.mockResolvedValue([
+      {
+        name: 'my-plugin',
+        version: '1.0.0',
+        description: 'Test',
+        tags: [],
+        provides: {},
+      },
+    ]);
+
+    await runSearch({ query: 'my' });
+
+    const allStepCalls = mockConsoleUtils.log.step.mock.calls.map((call: string[]) => call[1]);
+    const installLine = allStepCalls.find((msg: string) => msg.includes('codingbuddy install'));
+    expect(installLine).toContain('codingbuddy install my-plugin');
+  });
+
+  it('should display summary with match count', async () => {
+    mockSearch.mockResolvedValue([
+      {
+        name: 'a',
+        version: '1.0.0',
+        description: 'A',
+        tags: [],
+        provides: {},
+      },
+      {
+        name: 'b',
+        version: '1.0.0',
+        description: 'B',
+        tags: [],
+        provides: {},
+      },
+    ]);
+
+    await runSearch({ query: 'test' });
+
+    expect(mockConsoleUtils.log.info).toHaveBeenCalledWith(
+      expect.stringMatching(/found 2 plugin/i),
+    );
+  });
+
+  it('should handle no results gracefully', async () => {
+    mockSearch.mockResolvedValue([]);
+
+    const result = await runSearch({ query: 'nonexistent' });
+
+    expect(result.success).toBe(true);
+    expect(result.count).toBe(0);
+    expect(mockConsoleUtils.log.info).toHaveBeenCalledWith(expect.stringMatching(/no plugin/i));
+  });
+
+  it('should handle network errors gracefully', async () => {
+    mockSearch.mockRejectedValue(new Error('Network error'));
+
+    const result = await runSearch({ query: 'test' });
+
+    expect(result.success).toBe(false);
+    expect(mockConsoleUtils.log.error).toHaveBeenCalled();
+  });
+});

--- a/apps/mcp-server/src/cli/plugin/search.command.ts
+++ b/apps/mcp-server/src/cli/plugin/search.command.ts
@@ -1,0 +1,91 @@
+/**
+ * Plugin Search Command
+ *
+ * CLI command handler for `codingbuddy search <query>`.
+ * Fetches the registry index and searches for matching plugins.
+ */
+
+import {
+  RegistryClient,
+  RegistryPlugin,
+  RegistryPluginProvides,
+} from '../../plugin/registry-client';
+import { createConsoleUtils } from '../utils/console';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SearchCommandOptions {
+  query: string;
+}
+
+export interface SearchCommandResult {
+  success: boolean;
+  count: number;
+  error?: string;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatProvides(provides: RegistryPluginProvides): string {
+  const parts: string[] = [];
+
+  const agents = provides.agents?.length ?? 0;
+  const rules = provides.rules?.length ?? 0;
+  const skills = provides.skills?.length ?? 0;
+  const checklists = provides.checklists?.length ?? 0;
+
+  if (agents > 0) parts.push(`${agents} agent${agents !== 1 ? 's' : ''}`);
+  if (rules > 0) parts.push(`${rules} rule${rules !== 1 ? 's' : ''}`);
+  if (skills > 0) parts.push(`${skills} skill${skills !== 1 ? 's' : ''}`);
+  if (checklists > 0) parts.push(`${checklists} checklist${checklists !== 1 ? 's' : ''}`);
+
+  return parts.length > 0 ? parts.join(', ') : 'no assets';
+}
+
+function printPlugin(console: ReturnType<typeof createConsoleUtils>, plugin: RegistryPlugin): void {
+  console.log.step('  ', `${plugin.name} (${plugin.version}) — ${plugin.description}`);
+  if (plugin.tags.length > 0) {
+    console.log.step('  ', `  Tags: ${plugin.tags.join(', ')}`);
+  }
+  console.log.step('  ', `  Provides: ${formatProvides(plugin.provides)}`);
+  console.log.step('  ', `  Install: codingbuddy install ${plugin.name}`);
+}
+
+// ============================================================================
+// Command
+// ============================================================================
+
+export async function runSearch(options: SearchCommandOptions): Promise<SearchCommandResult> {
+  const console = createConsoleUtils();
+  const client = new RegistryClient();
+
+  try {
+    const results = await client.search(options.query);
+
+    if (results.length === 0) {
+      console.log.info(`No plugins found matching "${options.query}"`);
+      return { success: true, count: 0 };
+    }
+
+    console.log.step('🔍', `Search results for "${options.query}":\n`);
+
+    for (const plugin of results) {
+      printPlugin(console, plugin);
+      process.stdout.write('\n');
+    }
+
+    console.log.info(
+      `Found ${results.length} plugin${results.length !== 1 ? 's' : ''} matching "${options.query}"`,
+    );
+
+    return { success: true, count: results.length };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log.error(`Search failed: ${message}`);
+    return { success: false, count: 0, error: message };
+  }
+}

--- a/apps/mcp-server/src/plugin/registry-client.spec.ts
+++ b/apps/mcp-server/src/plugin/registry-client.spec.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RegistryClient } from './registry-client';
+
+describe('RegistryClient', () => {
+  let client: RegistryClient;
+  const mockIndex = {
+    plugins: [
+      {
+        name: 'nextjs-app-router',
+        version: '1.0.0',
+        description: 'Next.js App Router best practices',
+        tags: ['nextjs', 'react', 'frontend'],
+        provides: {
+          agents: ['nextjs-agent'],
+          rules: ['routing', 'caching'],
+          skills: ['app-router'],
+        },
+      },
+      {
+        name: 'nextjs-i18n',
+        version: '0.2.0',
+        description: 'Internationalization for Next.js',
+        tags: ['nextjs', 'i18n'],
+        provides: { agents: [], rules: ['i18n-rule'], skills: ['i18n-skill'] },
+      },
+      {
+        name: 'python-fastapi',
+        version: '1.2.0',
+        description: 'FastAPI best practices',
+        tags: ['python', 'fastapi', 'backend'],
+        provides: { agents: ['fastapi-agent'], rules: [], skills: [] },
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    client = new RegistryClient();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe('fetchIndex', () => {
+    it('should fetch and return the registry index', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockIndex),
+      } as Response);
+
+      const result = await client.fetchIndex();
+
+      expect(result).toEqual(mockIndex);
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://raw.githubusercontent.com/JeremyDev87/codingbuddy-registry/main/index.json',
+      );
+    });
+
+    it('should cache the result for 5 minutes', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockIndex),
+      } as Response);
+
+      await client.fetchIndex();
+      await client.fetchIndex();
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refetch after cache expires (5 minutes)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockIndex),
+      } as Response);
+
+      await client.fetchIndex();
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      await client.fetchIndex();
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return empty index on network error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+
+      const result = await client.fetchIndex();
+
+      expect(result).toEqual({ plugins: [] });
+    });
+
+    it('should return empty index on non-ok response', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      } as Response);
+
+      const result = await client.fetchIndex();
+
+      expect(result).toEqual({ plugins: [] });
+    });
+  });
+
+  describe('search', () => {
+    beforeEach(() => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockIndex),
+      } as Response);
+    });
+
+    it('should match plugins by name', async () => {
+      const results = await client.search('nextjs-app-router');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('nextjs-app-router');
+    });
+
+    it('should match plugins by description', async () => {
+      const results = await client.search('FastAPI');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('python-fastapi');
+    });
+
+    it('should match plugins by tags', async () => {
+      const results = await client.search('nextjs');
+
+      expect(results).toHaveLength(2);
+      expect(results.map(r => r.name)).toEqual(['nextjs-app-router', 'nextjs-i18n']);
+    });
+
+    it('should be case-insensitive', async () => {
+      const results = await client.search('NEXTJS');
+
+      expect(results).toHaveLength(2);
+    });
+
+    it('should return empty array for no matches', async () => {
+      const results = await client.search('nonexistent');
+
+      expect(results).toEqual([]);
+    });
+
+    it('should return empty array on network error', async () => {
+      vi.mocked(globalThis.fetch).mockRejectedValue(new Error('Network error'));
+
+      const results = await client.search('nextjs');
+
+      expect(results).toEqual([]);
+    });
+  });
+});

--- a/apps/mcp-server/src/plugin/registry-client.ts
+++ b/apps/mcp-server/src/plugin/registry-client.ts
@@ -1,0 +1,73 @@
+/**
+ * Registry Client
+ *
+ * Fetches and caches the plugin registry index from GitHub.
+ * Provides search functionality against plugin metadata.
+ */
+
+const REGISTRY_URL =
+  'https://raw.githubusercontent.com/JeremyDev87/codingbuddy-registry/main/index.json';
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RegistryPluginProvides {
+  agents?: string[];
+  rules?: string[];
+  skills?: string[];
+  checklists?: string[];
+}
+
+export interface RegistryPlugin {
+  name: string;
+  version: string;
+  description: string;
+  tags: string[];
+  provides: RegistryPluginProvides;
+}
+
+export interface RegistryIndex {
+  plugins: RegistryPlugin[];
+}
+
+// ============================================================================
+// Client
+// ============================================================================
+
+export class RegistryClient {
+  private cache: RegistryIndex | null = null;
+  private cacheTime = 0;
+
+  async fetchIndex(): Promise<RegistryIndex> {
+    if (this.cache && Date.now() - this.cacheTime < CACHE_TTL_MS) {
+      return this.cache;
+    }
+
+    try {
+      const response = await fetch(REGISTRY_URL);
+      if (!response.ok) {
+        return { plugins: [] };
+      }
+      const data = (await response.json()) as RegistryIndex;
+      this.cache = data;
+      this.cacheTime = Date.now();
+      return data;
+    } catch {
+      return { plugins: [] };
+    }
+  }
+
+  async search(query: string): Promise<RegistryPlugin[]> {
+    const index = await this.fetchIndex();
+    const lowerQuery = query.toLowerCase();
+
+    return index.plugins.filter(plugin => {
+      const nameMatch = plugin.name.toLowerCase().includes(lowerQuery);
+      const descMatch = plugin.description.toLowerCase().includes(lowerQuery);
+      const tagMatch = plugin.tags.some(tag => tag.toLowerCase().includes(lowerQuery));
+      return nameMatch || descMatch || tagMatch;
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Add `codingbuddy search <query>` CLI command for plugin discovery from the registry
- `RegistryClient` fetches and caches `index.json` from GitHub (5min TTL), handles network errors gracefully
- Search matches against plugin name, description, and tags (case-insensitive)
- Formatted output includes version, description, tags, provides counts, and install command

## Test plan
- [x] `RegistryClient.fetchIndex()` — fetches, caches, handles errors
- [x] `RegistryClient.search()` — matches by name, description, tags; case-insensitive
- [x] `runSearch()` — formatted output, no-results handling, network error handling
- [x] CLI integration — `parseArgs` recognizes `search` command
- [x] All 5594 existing tests pass

Closes #1169