### PR TITLE
feat(cli): add codingbuddy update command (#1171)

### DIFF
--- a/apps/mcp-server/src/cli/cli.ts
+++ b/apps/mcp-server/src/cli/cli.ts
@@ -14,6 +14,7 @@ import type {
   InstallOptions,
   UninstallOptions,
   SearchOptions,
+  UpdateOptions,
 } from './cli.types';
 
 /**
@@ -26,6 +27,7 @@ export interface ParsedArgs {
     | 'plugins'
     | 'uninstall'
     | 'search'
+    | 'update'
     | 'mcp'
     | 'tui'
     | 'help'
@@ -34,7 +36,8 @@ export interface ParsedArgs {
     Partial<TuiOptions> &
     Partial<InstallOptions> &
     Partial<UninstallOptions> &
-    Partial<SearchOptions>;
+    Partial<SearchOptions> &
+    Partial<UpdateOptions>;
 }
 
 /**
@@ -98,6 +101,14 @@ export function parseArgs(args: string[]): ParsedArgs {
     };
   }
 
+  if (command === 'update') {
+    const updatePluginName = args[1];
+    return {
+      command: 'update',
+      options: { ...options, updatePluginName },
+    };
+  }
+
   if (command !== 'init') {
     return { command: 'help', options };
   }
@@ -133,6 +144,7 @@ Usage:
   codingbuddy install <git-url>        Install a plugin from git repository
   codingbuddy search <query>           Search plugins in the registry
   codingbuddy plugins                  List installed plugins
+  codingbuddy update [name]            Check and update outdated plugins
   codingbuddy uninstall <name>         Uninstall a plugin
   codingbuddy mcp                      Start MCP server (stdio mode)
   codingbuddy tui                      Monitor agent execution in real-time
@@ -152,6 +164,8 @@ Examples:
   codingbuddy install github:user/repo Install a community plugin
   codingbuddy search nextjs            Search for Next.js plugins
   codingbuddy plugins                  List all installed plugins
+  codingbuddy update                    Check all plugins for updates
+  codingbuddy update my-plugin         Update a specific plugin
   codingbuddy uninstall my-plugin      Remove a plugin
   codingbuddy uninstall my-plugin -y   Remove without confirmation
   codingbuddy mcp                      Start MCP server for AI assistants
@@ -281,6 +295,18 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<void
       }
       if (uninstallResult.confirmationRequired) {
         process.stderr.write('Confirmation required. Use --yes or -y to skip.\n');
+        process.exitCode = 1;
+      }
+      break;
+    }
+
+    case 'update': {
+      const { runUpdate } = await import('./plugin/update.command');
+      const updateResult = await runUpdate({
+        projectRoot: options.projectRoot ?? process.cwd(),
+        pluginName: options.updatePluginName,
+      });
+      if (!updateResult.success) {
         process.exitCode = 1;
       }
       break;

--- a/apps/mcp-server/src/cli/cli.types.ts
+++ b/apps/mcp-server/src/cli/cli.types.ts
@@ -76,6 +76,14 @@ export interface SearchOptions {
 }
 
 /**
+ * Update command options (parsed from CLI args)
+ */
+export interface UpdateOptions {
+  /** Specific plugin name to update (optional, updates all if omitted) */
+  updatePluginName?: string;
+}
+
+/**
  * Console output levels
  */
 export type LogLevel = 'info' | 'success' | 'warn' | 'error';

--- a/apps/mcp-server/src/cli/plugin/update.command.spec.ts
+++ b/apps/mcp-server/src/cli/plugin/update.command.spec.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetchIndex = vi.fn();
+const mockInstall = vi.fn();
+const mockConsoleUtils = {
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    step: vi.fn(),
+  },
+};
+
+vi.mock('../../plugin/registry-client', () => ({
+  RegistryClient: class {
+    fetchIndex = mockFetchIndex;
+  },
+}));
+
+vi.mock('../../plugin/plugin-installer.service', () => ({
+  PluginInstallerService: class {
+    install = mockInstall;
+  },
+}));
+
+vi.mock('../utils/console', () => ({
+  createConsoleUtils: () => mockConsoleUtils,
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+  };
+});
+
+import { existsSync, readFileSync } from 'fs';
+import { runUpdate } from './update.command';
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+
+function makePluginsJson(plugins: Array<{ name: string; version: string; source: string }>) {
+  return JSON.stringify({
+    plugins: plugins.map(p => ({
+      ...p,
+      installedAt: '2026-01-01T00:00:00.000Z',
+      provides: { agents: [], rules: [], skills: [], checklists: [] },
+    })),
+  });
+}
+
+function makeRegistryIndex(plugins: Array<{ name: string; version: string }>) {
+  return {
+    plugins: plugins.map(p => ({
+      ...p,
+      description: `${p.name} plugin`,
+      tags: [],
+      provides: {},
+    })),
+  };
+}
+
+describe('update.command', () => {
+  const projectRoot = '/test/project';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('no installed plugins', () => {
+    it('should report no plugins installed when plugins.json does not exist', async () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const result = await runUpdate({ projectRoot });
+
+      expect(result.success).toBe(true);
+      expect(result.checked).toBe(0);
+      expect(result.updated).toBe(0);
+      expect(mockConsoleUtils.log.info).toHaveBeenCalledWith(
+        expect.stringMatching(/no.*plugin.*installed/i),
+      );
+    });
+  });
+
+  describe('all up-to-date', () => {
+    it('should report all plugins are up-to-date', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([{ name: 'my-plugin', version: '1.0.0', source: 'github:user/repo' }]),
+      );
+      mockFetchIndex.mockResolvedValue(
+        makeRegistryIndex([{ name: 'my-plugin', version: '1.0.0' }]),
+      );
+
+      const result = await runUpdate({ projectRoot });
+
+      expect(result.success).toBe(true);
+      expect(result.checked).toBe(1);
+      expect(result.updated).toBe(0);
+      expect(mockConsoleUtils.log.success).toHaveBeenCalledWith(
+        expect.stringMatching(/up.to.date/i),
+      );
+    });
+  });
+
+  describe('outdated plugins', () => {
+    it('should detect and update outdated plugins', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([
+          { name: 'plugin-a', version: '1.0.0', source: 'github:user/plugin-a' },
+          { name: 'plugin-b', version: '2.1.0', source: 'github:user/plugin-b' },
+        ]),
+      );
+      mockFetchIndex.mockResolvedValue(
+        makeRegistryIndex([
+          { name: 'plugin-a', version: '1.2.0' },
+          { name: 'plugin-b', version: '2.1.0' },
+        ]),
+      );
+      mockInstall.mockResolvedValue({ success: true, pluginName: 'plugin-a' });
+
+      const result = await runUpdate({ projectRoot });
+
+      expect(result.success).toBe(true);
+      expect(result.checked).toBe(2);
+      expect(result.updated).toBe(1);
+      expect(mockInstall).toHaveBeenCalledTimes(1);
+      expect(mockInstall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'github:user/plugin-a',
+          force: true,
+        }),
+      );
+    });
+
+    it('should show version diff for outdated plugins', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([{ name: 'my-plugin', version: '1.0.0', source: 'github:user/repo' }]),
+      );
+      mockFetchIndex.mockResolvedValue(
+        makeRegistryIndex([{ name: 'my-plugin', version: '2.0.0' }]),
+      );
+      mockInstall.mockResolvedValue({ success: true, pluginName: 'my-plugin' });
+
+      await runUpdate({ projectRoot });
+
+      const allStepCalls = mockConsoleUtils.log.step.mock.calls.map((c: string[]) => c[1]);
+      const versionLine = allStepCalls.find(
+        (msg: string) => msg.includes('1.0.0') && msg.includes('2.0.0'),
+      );
+      expect(versionLine).toBeDefined();
+    });
+  });
+
+  describe('update specific plugin', () => {
+    it('should update only the named plugin', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([
+          { name: 'plugin-a', version: '1.0.0', source: 'github:user/plugin-a' },
+          { name: 'plugin-b', version: '1.0.0', source: 'github:user/plugin-b' },
+        ]),
+      );
+      mockFetchIndex.mockResolvedValue(
+        makeRegistryIndex([
+          { name: 'plugin-a', version: '2.0.0' },
+          { name: 'plugin-b', version: '2.0.0' },
+        ]),
+      );
+      mockInstall.mockResolvedValue({ success: true, pluginName: 'plugin-a' });
+
+      const result = await runUpdate({ projectRoot, pluginName: 'plugin-a' });
+
+      expect(result.success).toBe(true);
+      expect(result.checked).toBe(1);
+      expect(result.updated).toBe(1);
+      expect(mockInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it('should error when named plugin is not installed', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(makePluginsJson([]));
+
+      const result = await runUpdate({ projectRoot, pluginName: 'nonexistent' });
+
+      expect(result.success).toBe(false);
+      expect(mockConsoleUtils.log.error).toHaveBeenCalledWith(
+        expect.stringMatching(/not found|not installed/i),
+      );
+    });
+  });
+
+  describe('plugin not in registry', () => {
+    it('should skip plugins not found in registry', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([{ name: 'local-only', version: '1.0.0', source: 'github:user/local' }]),
+      );
+      mockFetchIndex.mockResolvedValue(makeRegistryIndex([]));
+
+      const result = await runUpdate({ projectRoot });
+
+      expect(result.success).toBe(true);
+      expect(result.updated).toBe(0);
+      expect(mockConsoleUtils.log.warn).toHaveBeenCalledWith(
+        expect.stringMatching(/not found in registry/i),
+      );
+    });
+  });
+
+  describe('semver comparison', () => {
+    it('should detect major version updates', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([{ name: 'p', version: '1.9.9', source: 'github:u/p' }]),
+      );
+      mockFetchIndex.mockResolvedValue(makeRegistryIndex([{ name: 'p', version: '2.0.0' }]));
+      mockInstall.mockResolvedValue({ success: true, pluginName: 'p' });
+
+      const result = await runUpdate({ projectRoot });
+
+      expect(result.updated).toBe(1);
+    });
+
+    it('should detect minor version updates', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([{ name: 'p', version: '1.0.0', source: 'github:u/p' }]),
+      );
+      mockFetchIndex.mockResolvedValue(makeRegistryIndex([{ name: 'p', version: '1.1.0' }]));
+      mockInstall.mockResolvedValue({ success: true, pluginName: 'p' });
+
+      const result = await runUpdate({ projectRoot });
+
+      expect(result.updated).toBe(1);
+    });
+
+    it('should detect patch version updates', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([{ name: 'p', version: '1.0.0', source: 'github:u/p' }]),
+      );
+      mockFetchIndex.mockResolvedValue(makeRegistryIndex([{ name: 'p', version: '1.0.1' }]));
+      mockInstall.mockResolvedValue({ success: true, pluginName: 'p' });
+
+      const result = await runUpdate({ projectRoot });
+
+      expect(result.updated).toBe(1);
+    });
+
+    it('should not update when installed version is newer than registry', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([{ name: 'p', version: '2.0.0', source: 'github:u/p' }]),
+      );
+      mockFetchIndex.mockResolvedValue(makeRegistryIndex([{ name: 'p', version: '1.0.0' }]));
+
+      const result = await runUpdate({ projectRoot });
+
+      expect(result.updated).toBe(0);
+      expect(mockInstall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('install failure handling', () => {
+    it('should report failure when re-install fails', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([{ name: 'p', version: '1.0.0', source: 'github:u/p' }]),
+      );
+      mockFetchIndex.mockResolvedValue(makeRegistryIndex([{ name: 'p', version: '2.0.0' }]));
+      mockInstall.mockResolvedValue({ success: false, error: 'Clone failed' });
+
+      const result = await runUpdate({ projectRoot });
+
+      expect(result.success).toBe(false);
+      expect(result.updated).toBe(0);
+      expect(mockConsoleUtils.log.error).toHaveBeenCalledWith(expect.stringMatching(/failed/i));
+    });
+  });
+
+  describe('registry fetch failure', () => {
+    it('should handle registry fetch error gracefully', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(
+        makePluginsJson([{ name: 'p', version: '1.0.0', source: 'github:u/p' }]),
+      );
+      mockFetchIndex.mockRejectedValue(new Error('Network error'));
+
+      const result = await runUpdate({ projectRoot });
+
+      expect(result.success).toBe(false);
+      expect(mockConsoleUtils.log.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/mcp-server/src/cli/plugin/update.command.ts
+++ b/apps/mcp-server/src/cli/plugin/update.command.ts
@@ -1,0 +1,174 @@
+/**
+ * Plugin Update Command
+ *
+ * CLI command handler for `codingbuddy update [name]`.
+ * Checks installed plugins against the registry for newer versions
+ * and re-installs outdated plugins.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { RegistryClient } from '../../plugin/registry-client';
+import { PluginInstallerService } from '../../plugin/plugin-installer.service';
+import { createConsoleUtils } from '../utils/console';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface UpdateCommandOptions {
+  projectRoot: string;
+  pluginName?: string;
+}
+
+export interface UpdateCommandResult {
+  success: boolean;
+  checked: number;
+  updated: number;
+  error?: string;
+}
+
+interface PluginRecord {
+  name: string;
+  version: string;
+  source: string;
+  installedAt: string;
+  provides: {
+    agents: string[];
+    rules: string[];
+    skills: string[];
+    checklists: string[];
+  };
+}
+
+interface PluginsRegistry {
+  plugins: PluginRecord[];
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Compare two semver strings. Returns negative if a < b, 0 if equal, positive if a > b.
+ */
+function compareVersions(a: string, b: string): number {
+  const partsA = a.split('.').map(Number);
+  const partsB = b.split('.').map(Number);
+
+  for (let i = 0; i < 3; i++) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+// ============================================================================
+// Command
+// ============================================================================
+
+export async function runUpdate(options: UpdateCommandOptions): Promise<UpdateCommandResult> {
+  const console = createConsoleUtils();
+  const pluginsJsonPath = join(options.projectRoot, '.codingbuddy', 'plugins.json');
+
+  // 1. Read installed plugins
+  if (!existsSync(pluginsJsonPath)) {
+    console.log.info('No plugins installed.');
+    return { success: true, checked: 0, updated: 0 };
+  }
+
+  let registry: PluginsRegistry;
+  try {
+    const raw = readFileSync(pluginsJsonPath, 'utf-8');
+    registry = JSON.parse(raw) as PluginsRegistry;
+  } catch {
+    console.log.error('Failed to read plugins.json. File may be corrupted.');
+    return { success: false, checked: 0, updated: 0, error: 'Corrupted plugins.json' };
+  }
+
+  // 2. Filter to specific plugin if name provided
+  let pluginsToCheck = registry.plugins;
+
+  if (options.pluginName) {
+    const found = registry.plugins.find(p => p.name === options.pluginName);
+    if (!found) {
+      console.log.error(`Plugin "${options.pluginName}" is not installed.`);
+      return { success: false, checked: 0, updated: 0, error: 'Plugin not installed' };
+    }
+    pluginsToCheck = [found];
+  }
+
+  if (pluginsToCheck.length === 0) {
+    console.log.info('No plugins installed.');
+    return { success: true, checked: 0, updated: 0 };
+  }
+
+  // 3. Fetch registry index
+  const client = new RegistryClient();
+  let registryIndex;
+  try {
+    registryIndex = await client.fetchIndex();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.log.error(`Failed to fetch registry: ${message}`);
+    return { success: false, checked: 0, updated: 0, error: message };
+  }
+
+  // 4. Compare versions
+  console.log.step('🔍', 'Checking for plugin updates...\n');
+
+  const outdated: Array<{ installed: PluginRecord; latestVersion: string }> = [];
+
+  for (const installed of pluginsToCheck) {
+    const registryEntry = registryIndex.plugins.find(p => p.name === installed.name);
+
+    if (!registryEntry) {
+      console.log.warn(`${installed.name}: not found in registry, skipping.`);
+      continue;
+    }
+
+    if (compareVersions(registryEntry.version, installed.version) > 0) {
+      outdated.push({ installed, latestVersion: registryEntry.version });
+      console.log.step('📦', `${installed.name}: ${installed.version} → ${registryEntry.version}`);
+    }
+  }
+
+  if (outdated.length === 0) {
+    console.log.success('All plugins are up-to-date.');
+    return { success: true, checked: pluginsToCheck.length, updated: 0 };
+  }
+
+  // 5. Update outdated plugins
+  const installer = new PluginInstallerService();
+  let updatedCount = 0;
+  let hasFailure = false;
+
+  for (const { installed, latestVersion } of outdated) {
+    console.log.step('⬆️', `Updating ${installed.name} to ${latestVersion}...`);
+
+    const result = await installer.install({
+      source: installed.source,
+      targetRoot: options.projectRoot,
+      force: true,
+    });
+
+    if (result.success) {
+      console.log.success(`Updated ${installed.name} to ${latestVersion}`);
+      updatedCount++;
+    } else {
+      console.log.error(`Failed to update ${installed.name}: ${result.error}`);
+      hasFailure = true;
+    }
+  }
+
+  // 6. Summary
+  if (updatedCount > 0) {
+    console.log.info(`Updated ${updatedCount} plugin${updatedCount !== 1 ? 's' : ''}.`);
+  }
+
+  return {
+    success: !hasFailure,
+    checked: pluginsToCheck.length,
+    updated: updatedCount,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `codingbuddy update [name]` CLI command to check and apply plugin updates
- Reads `.codingbuddy/plugins.json`, fetches registry index, compares semver versions
- Re-installs outdated plugins via existing `PluginInstallerService` (force mode)
- Handles: no plugins installed, all up-to-date, specific plugin update, plugin not in registry, install failures

## New Files
- `apps/mcp-server/src/cli/plugin/update.command.ts` — Update command implementation
- `apps/mcp-server/src/cli/plugin/update.command.spec.ts` — 13 tests covering all acceptance criteria

## Modified Files
- `apps/mcp-server/src/cli/cli.ts` — Added `update` to parseArgs + main switch + usage text
- `apps/mcp-server/src/cli/cli.types.ts` — Added `UpdateOptions` interface

## Test plan
- [x] 13 unit tests passing (TDD approach)
- [x] All 5607 existing tests still pass
- [x] Prettier, lint, typecheck all pass
- [ ] Manual: `codingbuddy update` shows outdated plugins
- [ ] Manual: `codingbuddy update <name>` updates specific plugin

Closes #1171