### PR TITLE
feat(cli): add registry resolver to install command (#1170)

### DIFF
--- a/apps/mcp-server/src/cli/plugin/install.command.spec.ts
+++ b/apps/mcp-server/src/cli/plugin/install.command.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockInstall = vi.fn();
+const mockResolveSource = vi.fn();
 const mockConsoleUtils = {
   log: {
     info: vi.fn(),
@@ -14,6 +15,7 @@ const mockConsoleUtils = {
 vi.mock('../../plugin/plugin-installer.service', () => ({
   PluginInstallerService: class {
     install = mockInstall;
+    resolveSource = mockResolveSource;
   },
 }));
 
@@ -34,7 +36,11 @@ describe('install.command', () => {
     force: false,
   };
 
-  it('should call PluginInstallerService.install with correct options', async () => {
+  beforeEach(() => {
+    mockResolveSource.mockResolvedValue({ source: 'github:user/repo' });
+  });
+
+  it('should call resolveSource before install', async () => {
     mockInstall.mockResolvedValue({
       success: true,
       pluginName: 'my-plugin',
@@ -43,11 +49,63 @@ describe('install.command', () => {
 
     await runInstall(defaultOptions);
 
+    expect(mockResolveSource).toHaveBeenCalledWith('github:user/repo');
     expect(mockInstall).toHaveBeenCalledWith({
       source: 'github:user/repo',
       targetRoot: '/project',
       force: false,
     });
+  });
+
+  it('should pass resolved source URL to install', async () => {
+    mockResolveSource.mockResolvedValue({
+      source: 'github:codingbuddy-plugins/nextjs-app-router',
+    });
+    mockInstall.mockResolvedValue({
+      success: true,
+      pluginName: 'nextjs-app-router',
+      summary: 'Installed nextjs-app-router@1.0.0',
+    });
+
+    await runInstall({ ...defaultOptions, source: 'nextjs-app-router' });
+
+    expect(mockInstall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'github:codingbuddy-plugins/nextjs-app-router',
+      }),
+    );
+  });
+
+  it('should pass version to install when resolved', async () => {
+    mockResolveSource.mockResolvedValue({
+      source: 'github:codingbuddy-plugins/nextjs-app-router',
+      version: '1.0.0',
+    });
+    mockInstall.mockResolvedValue({
+      success: true,
+      pluginName: 'nextjs-app-router',
+      summary: 'Installed nextjs-app-router@1.0.0',
+    });
+
+    await runInstall({ ...defaultOptions, source: 'nextjs-app-router@1.0.0' });
+
+    expect(mockInstall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'github:codingbuddy-plugins/nextjs-app-router',
+        version: '1.0.0',
+      }),
+    );
+  });
+
+  it('should print error when resolveSource fails', async () => {
+    mockResolveSource.mockRejectedValue(new Error('Plugin "nonexistent" not found in registry.'));
+
+    const result = await runInstall({ ...defaultOptions, source: 'nonexistent' });
+
+    expect(result.success).toBe(false);
+    expect(mockConsoleUtils.log.error).toHaveBeenCalledWith(
+      expect.stringContaining('not found in registry'),
+    );
   });
 
   it('should print success summary on successful install', async () => {
@@ -65,7 +123,7 @@ describe('install.command', () => {
     );
   });
 
-  it('should print error message on failure', async () => {
+  it('should print error message on install failure', async () => {
     mockInstall.mockResolvedValue({
       success: false,
       error: 'Invalid plugin manifest: name is required',

--- a/apps/mcp-server/src/cli/plugin/install.command.ts
+++ b/apps/mcp-server/src/cli/plugin/install.command.ts
@@ -23,13 +23,16 @@ export async function runInstall(options: InstallCommandOptions): Promise<Instal
   const console = createConsoleUtils();
   const installer = new PluginInstallerService();
 
-  console.log.step('📦', `Installing plugin from ${options.source}...`);
-
   try {
+    const resolved = await installer.resolveSource(options.source);
+
+    console.log.step('📦', `Installing plugin from ${resolved.source}...`);
+
     const result = await installer.install({
-      source: options.source,
+      source: resolved.source,
       targetRoot: options.projectRoot,
       force: options.force,
+      version: resolved.version,
     });
 
     if (result.success) {
@@ -41,7 +44,7 @@ export async function runInstall(options: InstallCommandOptions): Promise<Instal
     return { success: false, error: result.error };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.log.error(`Unexpected error: ${message}`);
+    console.log.error(message);
     return { success: false, error: message };
   }
 }

--- a/apps/mcp-server/src/plugin/plugin-installer.service.spec.ts
+++ b/apps/mcp-server/src/plugin/plugin-installer.service.spec.ts
@@ -41,6 +41,14 @@ vi.mock('os', () => ({
   tmpdir: () => '/tmp',
 }));
 
+const mockFindByName = vi.fn();
+
+vi.mock('./registry-client', () => ({
+  RegistryClient: class {
+    findByName = mockFindByName;
+  },
+}));
+
 import { PluginInstallerService, InstallOptions } from './plugin-installer.service';
 
 const TEMP_DIR = '/tmp/codingbuddy-plugin-abc123';
@@ -122,6 +130,63 @@ describe('PluginInstallerService', () => {
 
     it('should throw on invalid URL format', () => {
       expect(() => service.resolveGitUrl('not-a-url')).toThrow('Invalid git URL');
+    });
+  });
+
+  describe('resolveSource', () => {
+    it('should pass through github: URLs', async () => {
+      const result = await service.resolveSource('github:user/repo');
+      expect(result).toEqual({ source: 'github:user/repo' });
+      expect(mockFindByName).not.toHaveBeenCalled();
+    });
+
+    it('should pass through https:// URLs', async () => {
+      const result = await service.resolveSource('https://github.com/user/repo');
+      expect(result).toEqual({ source: 'https://github.com/user/repo' });
+      expect(mockFindByName).not.toHaveBeenCalled();
+    });
+
+    it('should resolve plugin name via registry', async () => {
+      mockFindByName.mockResolvedValue({
+        name: 'nextjs-app-router',
+        version: '1.0.0',
+        source: 'github:codingbuddy-plugins/nextjs-app-router',
+        description: 'Next.js plugin',
+        tags: [],
+        provides: {},
+      });
+
+      const result = await service.resolveSource('nextjs-app-router');
+
+      expect(mockFindByName).toHaveBeenCalledWith('nextjs-app-router');
+      expect(result).toEqual({ source: 'github:codingbuddy-plugins/nextjs-app-router' });
+    });
+
+    it('should parse name@version and return version', async () => {
+      mockFindByName.mockResolvedValue({
+        name: 'nextjs-app-router',
+        version: '2.0.0',
+        source: 'github:codingbuddy-plugins/nextjs-app-router',
+        description: 'Next.js plugin',
+        tags: [],
+        provides: {},
+      });
+
+      const result = await service.resolveSource('nextjs-app-router@1.0.0');
+
+      expect(mockFindByName).toHaveBeenCalledWith('nextjs-app-router');
+      expect(result).toEqual({
+        source: 'github:codingbuddy-plugins/nextjs-app-router',
+        version: '1.0.0',
+      });
+    });
+
+    it('should throw error when name not found in registry', async () => {
+      mockFindByName.mockResolvedValue(undefined);
+
+      await expect(service.resolveSource('nonexistent-plugin')).rejects.toThrow(
+        /not found in registry/,
+      );
     });
   });
 
@@ -299,6 +364,21 @@ describe('PluginInstallerService', () => {
       expect(mockRmSync).toHaveBeenCalledWith(
         TEMP_DIR,
         expect.objectContaining({ recursive: true }),
+      );
+    });
+
+    it('should clone specific version tag when version is provided', async () => {
+      setupCloneSuccess();
+
+      const result = await service.install({
+        ...defaultOptions,
+        version: '1.0.0',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining('--branch v1.0.0'),
+        expect.any(Object),
       );
     });
 

--- a/apps/mcp-server/src/plugin/plugin-installer.service.ts
+++ b/apps/mcp-server/src/plugin/plugin-installer.service.ts
@@ -20,6 +20,7 @@ import {
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { validatePluginManifest, PluginManifest } from './plugin-manifest.schema';
+import { RegistryClient } from './registry-client';
 import { getPackageVersion } from '../shared/version.utils';
 
 // ============================================================================
@@ -30,6 +31,12 @@ export interface InstallOptions {
   source: string;
   targetRoot: string;
   force: boolean;
+  version?: string;
+}
+
+export interface ResolvedSource {
+  source: string;
+  version?: string;
 }
 
 export interface InstallResult {
@@ -68,6 +75,41 @@ const ASSET_DIRS = ['agents', 'rules', 'skills', 'checklists'] as const;
 
 export class PluginInstallerService {
   /**
+   * Resolve a plugin name or URL to a git source.
+   * If input is a git URL (github: or https://), pass through.
+   * Otherwise, look up the plugin name in the registry.
+   * Supports name@version syntax.
+   */
+  async resolveSource(nameOrUrl: string): Promise<ResolvedSource> {
+    if (nameOrUrl.startsWith('github:') || nameOrUrl.startsWith('https://')) {
+      return { source: nameOrUrl };
+    }
+
+    const { name, version } = this.parseNameVersion(nameOrUrl);
+    const client = new RegistryClient();
+    const plugin = await client.findByName(name);
+
+    if (!plugin) {
+      throw new Error(
+        `Plugin "${name}" not found in registry. Use a git URL (github:user/repo or https://...) for unregistered plugins.`,
+      );
+    }
+
+    return version ? { source: plugin.source, version } : { source: plugin.source };
+  }
+
+  /**
+   * Parse name@version syntax into name and optional version.
+   */
+  private parseNameVersion(input: string): { name: string; version?: string } {
+    const atIndex = input.lastIndexOf('@');
+    if (atIndex > 0) {
+      return { name: input.slice(0, atIndex), version: input.slice(atIndex + 1) };
+    }
+    return { name: input };
+  }
+
+  /**
    * Resolve a git source string to a clone-able URL.
    * Supports: github:user/repo shorthand, full HTTPS URLs.
    */
@@ -97,7 +139,8 @@ export class PluginInstallerService {
       // 2. Clone to temp directory
       tempDir = mkdtempSync(join(tmpdir(), 'codingbuddy-plugin-'));
       try {
-        execSync(`git clone --depth=1 ${gitUrl} ${tempDir}`, {
+        const branchFlag = options.version ? ` --branch v${options.version}` : '';
+        execSync(`git clone --depth=1${branchFlag} ${gitUrl} ${tempDir}`, {
           stdio: 'pipe',
           timeout: 60_000,
         });

--- a/apps/mcp-server/src/plugin/registry-client.ts
+++ b/apps/mcp-server/src/plugin/registry-client.ts
@@ -24,6 +24,7 @@ export interface RegistryPlugin {
   name: string;
   version: string;
   description: string;
+  source: string;
   tags: string[];
   provides: RegistryPluginProvides;
 }
@@ -57,6 +58,11 @@ export class RegistryClient {
     } catch {
       return { plugins: [] };
     }
+  }
+
+  async findByName(name: string): Promise<RegistryPlugin | undefined> {
+    const index = await this.fetchIndex();
+    return index.plugins.find(plugin => plugin.name === name);
   }
 
   async search(query: string): Promise<RegistryPlugin[]> {


### PR DESCRIPTION
## Summary
- Add `resolveSource()` method to `PluginInstallerService` that resolves plugin names to git URLs via the registry
- Support `name@version` syntax to install specific versions (clones git tag `v{version}`)
- Update `install.command.ts` to call `resolveSource()` before install, with proper error handling
- Add `source` field to `RegistryPlugin` type and `findByName()` to `RegistryClient`

Closes #1170

## Test plan
- [x] `resolveSource` passes through `github:` and `https://` URLs without registry lookup
- [x] `resolveSource` resolves plugin names via `RegistryClient.findByName()`
- [x] `resolveSource` parses `name@version` syntax and returns version
- [x] `resolveSource` throws error when name not found in registry
- [x] `install` clones with `--branch v{version}` when version is provided
- [x] `runInstall` calls `resolveSource` before `install`
- [x] `runInstall` passes resolved source URL and version to `install`
- [x] `runInstall` shows error message when `resolveSource` fails