### PR TITLE
fix(plugin): add hooks/commands to package.json files and fix docs MCP config (#1197, #1200)

### DIFF
--- a/docs/es/plugin-architecture.md
+++ b/docs/es/plugin-architecture.md
@@ -258,7 +258,7 @@ El contexto se persiste en `docs/codingbuddy/context.md`:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/es/plugin-guide.md
+++ b/docs/es/plugin-guide.md
@@ -92,7 +92,7 @@ Edite `~/.claude/settings.json`:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }
@@ -107,7 +107,7 @@ Cree `.mcp.json` en la raíz de su proyecto:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/es/plugin-troubleshooting.md
+++ b/docs/es/plugin-troubleshooting.md
@@ -171,7 +171,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }
@@ -230,7 +230,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "/usr/local/bin/codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }

--- a/docs/ja/plugin-architecture.md
+++ b/docs/ja/plugin-architecture.md
@@ -258,7 +258,7 @@ sequenceDiagram
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/ja/plugin-guide.md
+++ b/docs/ja/plugin-guide.md
@@ -92,7 +92,7 @@ MCP サーバーを Claude Code の設定に追加します：
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }
@@ -107,7 +107,7 @@ MCP サーバーを Claude Code の設定に追加します：
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/ja/plugin-troubleshooting.md
+++ b/docs/ja/plugin-troubleshooting.md
@@ -171,7 +171,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }
@@ -230,7 +230,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "/usr/local/bin/codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }

--- a/docs/ko/plugin-architecture.md
+++ b/docs/ko/plugin-architecture.md
@@ -258,7 +258,7 @@ sequenceDiagram
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/ko/plugin-guide.md
+++ b/docs/ko/plugin-guide.md
@@ -92,7 +92,7 @@ Claude Code 설정에 MCP 서버를 추가합니다:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }
@@ -107,7 +107,7 @@ Claude Code 설정에 MCP 서버를 추가합니다:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/ko/plugin-troubleshooting.md
+++ b/docs/ko/plugin-troubleshooting.md
@@ -171,7 +171,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }
@@ -230,7 +230,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "/usr/local/bin/codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -258,7 +258,7 @@ Context is persisted to `docs/codingbuddy/context.md`:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -92,7 +92,7 @@ Edit `~/.claude/settings.json`:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }
@@ -107,7 +107,7 @@ Create `.mcp.json` in your project root:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/plugin-troubleshooting.md
+++ b/docs/plugin-troubleshooting.md
@@ -171,7 +171,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }
@@ -230,7 +230,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "/usr/local/bin/codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }

--- a/docs/pt-BR/plugin-architecture.md
+++ b/docs/pt-BR/plugin-architecture.md
@@ -258,7 +258,7 @@ O contexto e persistido em `docs/codingbuddy/context.md`:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/pt-BR/plugin-guide.md
+++ b/docs/pt-BR/plugin-guide.md
@@ -90,7 +90,7 @@ Edite `~/.claude/settings.json`:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }
@@ -105,7 +105,7 @@ Crie `.mcp.json` na raiz do seu projeto:
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/pt-BR/plugin-troubleshooting.md
+++ b/docs/pt-BR/plugin-troubleshooting.md
@@ -171,7 +171,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }
@@ -230,7 +230,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "/usr/local/bin/codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }

--- a/docs/zh-CN/plugin-architecture.md
+++ b/docs/zh-CN/plugin-architecture.md
@@ -258,7 +258,7 @@ sequenceDiagram
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/zh-CN/plugin-guide.md
+++ b/docs/zh-CN/plugin-guide.md
@@ -92,7 +92,7 @@ npm install -g codingbuddy
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }
@@ -107,7 +107,7 @@ npm install -g codingbuddy
   "mcpServers": {
     "codingbuddy": {
       "command": "codingbuddy",
-      "args": []
+      "args": ["mcp"]
     }
   }
 }

--- a/docs/zh-CN/plugin-troubleshooting.md
+++ b/docs/zh-CN/plugin-troubleshooting.md
@@ -171,7 +171,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }
@@ -230,7 +230,7 @@ cat ~/.claude/settings.json | grep -A5 codingbuddy
      "mcpServers": {
        "codingbuddy": {
          "command": "/usr/local/bin/codingbuddy",
-         "args": []
+         "args": ["mcp"]
        }
      }
    }

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -29,7 +29,9 @@
     ".claude-plugin",
     ".mcp.json",
     "README.md",
-    "scripts/postinstall.js"
+    "scripts/postinstall.js",
+    "hooks/",
+    "commands/"
   ],
   "scripts": {
     "build": "ts-node scripts/build.ts --mode=production",


### PR DESCRIPTION
## Summary

- **#1197 (P1)**: Add `hooks/` and `commands/` directories to `packages/claude-code-plugin/package.json` `files` array. Without these entries, `npm install` delivers the plugin without hooks (no mode detection, no HUD).
- **#1200 (P2)**: Fix MCP server `args` in all documentation across 6 languages (en, ko, ja, zh-CN, es, pt-BR) — changed `"args": []` to `"args": ["mcp"]` in plugin-guide, plugin-architecture, and plugin-troubleshooting docs.

Closes #1197
Closes #1200

## Verification

- `npm pack --dry-run` confirms hooks/*.py and commands/*.md are included (64 files total)
- `grep -r '"args": \[\]' docs/` returns 0 matches
- Build passes, 5808 tests pass

## Test plan

- [ ] Run `cd packages/claude-code-plugin && npm pack --dry-run` — verify hooks/ and commands/ are listed
- [ ] Grep docs for `"args": []` — should find zero matches
- [ ] Fresh `npm install codingbuddy-claude-plugin` should include hooks directory