### PR TITLE
fix(plugin): graceful chmod failure in SessionStats init (#1206)

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/stats.py
+++ b/packages/claude-code-plugin/hooks/lib/stats.py
@@ -40,7 +40,13 @@ class SessionStats:
         self.data_dir = data_dir
         os.makedirs(self.data_dir, mode=0o700, exist_ok=True)
         # Fix permissions if dir already existed
-        os.chmod(self.data_dir, 0o700)
+        try:
+            os.chmod(self.data_dir, 0o700)
+        except OSError:
+            import sys
+            sys.stderr.write(
+                f"[codingbuddy] Warning: could not set permissions on {self.data_dir}\n"
+            )
 
         self.stats_file = os.path.join(self.data_dir, f"{session_id}.json")
 

--- a/packages/claude-code-plugin/tests/test_stats.py
+++ b/packages/claude-code-plugin/tests/test_stats.py
@@ -51,6 +51,18 @@ class TestInit:
         expected_dir = os.path.join(os.path.expanduser("~"), ".codingbuddy")
         assert os.path.isdir(expected_dir)
 
+    def test_chmod_failure_graceful(self, tmp_path, monkeypatch):
+        """chmod failure should not crash initialization."""
+        d = str(tmp_path / "restricted_dir")
+        os.makedirs(d, mode=0o700)
+
+        def failing_chmod(*args, **kwargs):
+            raise PermissionError("Operation not permitted")
+
+        monkeypatch.setattr(os, "chmod", failing_chmod)
+        s = SessionStats(session_id="perm-test", data_dir=d)
+        assert os.path.isdir(d)
+
 
 class TestRecordToolCall:
     def test_increments_count(self, stats):


### PR DESCRIPTION
## Summary

- `os.chmod()` in `SessionStats.__init__()` (stats.py:43) is now wrapped in `try/except OSError`
- On failure, a warning is printed to stderr instead of crashing the plugin
- Added `test_chmod_failure_graceful` test to verify graceful handling

## Test plan

- [x] `python3 -m pytest tests/test_stats.py -v` — 27/27 passed
- [x] `yarn workspace codingbuddy test` — 5821 passed
- [x] `yarn workspace codingbuddy build` — success

Closes #1206