### PR TITLE
docs(plugin): split command docs and README for standalone/MCP modes (#1210)

### DIFF
--- a/docs/plugin-guide.md
+++ b/docs/plugin-guide.md
@@ -64,9 +64,26 @@ npm install -g codingbuddy-claude-plugin
 yarn global add codingbuddy-claude-plugin
 ```
 
-## MCP Server Setup (Required)
+## Feature Availability
 
-The plugin requires the CodingBuddy MCP server for full functionality. The MCP server provides:
+The plugin works standalone but provides enhanced features with the MCP server:
+
+| Feature | Standalone | With MCP |
+|---------|-----------|----------|
+| Mode detection (PLAN/ACT/EVAL/AUTO) | ✅ | ✅ |
+| Basic agent recommendation | ✅ | ✅ |
+| TDD workflow guidance | ✅ | ✅ |
+| HUD / StatusLine | ✅ | ✅ |
+| Session stats & history | ✅ | ✅ |
+| Specialist agent dispatch | ❌ | ✅ |
+| Context tracking (cross-session) | ❌ | ✅ |
+| Parallel agent execution | ❌ | ✅ |
+| Contextual checklists | ❌ | ✅ |
+| Rule search & impact tracking | ❌ | ✅ |
+
+## MCP Server Setup (Recommended)
+
+The CodingBuddy MCP server unlocks the full feature set. The MCP server provides:
 
 - Specialist agents and skills
 - Workflow modes (PLAN/ACT/EVAL/AUTO)

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -46,9 +46,24 @@ Reusable workflows for consistent development:
 - Refactoring
 - And more...
 
-## MCP Integration (Required)
+## Feature Availability
 
-This plugin requires the CodingBuddy MCP server for full functionality:
+| Feature | Standalone | With MCP |
+|---------|-----------|----------|
+| Mode detection (PLAN/ACT/EVAL/AUTO) | ✅ | ✅ |
+| Basic agent recommendation | ✅ | ✅ |
+| TDD workflow guidance | ✅ | ✅ |
+| HUD / StatusLine | ✅ | ✅ |
+| Session stats & history | ✅ | ✅ |
+| Specialist agent dispatch | ❌ | ✅ |
+| Context tracking (cross-session) | ❌ | ✅ |
+| Parallel agent execution | ❌ | ✅ |
+| Contextual checklists | ❌ | ✅ |
+| Rule search & impact tracking | ❌ | ✅ |
+
+## MCP Integration (Recommended)
+
+This plugin works standalone but benefits from the CodingBuddy MCP server for full functionality:
 
 ```bash
 npm install -g codingbuddy

--- a/packages/claude-code-plugin/commands/act.md
+++ b/packages/claude-code-plugin/commands/act.md
@@ -3,6 +3,23 @@
 ## Purpose
 Execute the implementation plan with TDD
 
+## Mode Availability
+
+### Standalone Mode (no MCP server)
+This command works without the CodingBuddy MCP server.
+In standalone mode, you get:
+- Mode detection and transition
+- TDD cycle execution (Red → Green → Refactor)
+- Basic quality standards enforcement
+- Agent-guided implementation
+
+### MCP Enhanced Mode
+With the CodingBuddy MCP server connected, you additionally get:
+- `parse_mode` with full context tracking
+- Specialist agent dispatch for implementation verification
+- Contextual checklists (security, accessibility, performance)
+- Cross-session context persistence
+
 ## Activation
 This command activates ACT mode for the CodingBuddy workflow.
 
@@ -182,12 +199,13 @@ To preserve this implementation session for future reference:
 
 ## MCP Integration
 
-If CodingBuddy MCP server is available, call:
+If MCP is available, call `parse_mode` for enhanced features:
 ```
 parse_mode({ prompt: "ACT: <user request>" })
 ```
 
 This provides additional context, checklists, and specialist agent recommendations.
+In standalone mode, the command works with built-in workflow guidance.
 
 ## Next Mode
 

--- a/packages/claude-code-plugin/commands/auto.md
+++ b/packages/claude-code-plugin/commands/auto.md
@@ -3,6 +3,23 @@
 ## Purpose
 Autonomous PLAN → ACT → EVAL cycle until quality achieved
 
+## Mode Availability
+
+### Standalone Mode (no MCP server)
+This command works without the CodingBuddy MCP server.
+In standalone mode, you get:
+- Autonomous PLAN → ACT → EVAL iteration
+- Basic agent recommendation per phase
+- TDD workflow guidance
+- Quality-based exit conditions
+
+### MCP Enhanced Mode
+With the CodingBuddy MCP server connected, you additionally get:
+- `parse_mode` with full context tracking per phase
+- Specialist agent dispatch for each iteration
+- Contextual checklists (security, accessibility, performance)
+- Cross-session context persistence
+
 ## Activation
 This command activates AUTO mode for the CodingBuddy workflow.
 
@@ -181,12 +198,13 @@ Remaining Issues:
 
 ## MCP Integration
 
-If CodingBuddy MCP server is available, call:
+If MCP is available, call `parse_mode` for enhanced features:
 ```
 parse_mode({ prompt: "AUTO: <user request>" })
 ```
 
 This provides additional context, checklists, and specialist agent recommendations.
+In standalone mode, the command works with built-in workflow guidance.
 
 ## Next Mode
 

--- a/packages/claude-code-plugin/commands/eval.md
+++ b/packages/claude-code-plugin/commands/eval.md
@@ -3,6 +3,23 @@
 ## Purpose
 Evaluate code quality and suggest improvements
 
+## Mode Availability
+
+### Standalone Mode (no MCP server)
+This command works without the CodingBuddy MCP server.
+In standalone mode, you get:
+- Mode detection and transition
+- Code quality evaluation
+- Anti-sycophancy analysis
+- Devil's Advocate and Impact Radius analysis
+
+### MCP Enhanced Mode
+With the CodingBuddy MCP server connected, you additionally get:
+- `parse_mode` with full context tracking
+- Specialist agent dispatch for comprehensive evaluation
+- Contextual checklists (security, accessibility, performance)
+- Cross-session context persistence
+
 ## Activation
 This command activates EVAL mode for the CodingBuddy workflow.
 
@@ -306,12 +323,13 @@ To preserve this evaluation session for future reference:
 
 ## MCP Integration
 
-If CodingBuddy MCP server is available, call:
+If MCP is available, call `parse_mode` for enhanced features:
 ```
 parse_mode({ prompt: "EVAL: <user request>" })
 ```
 
 This provides additional context, checklists, and specialist agent recommendations.
+In standalone mode, the command works with built-in workflow guidance.
 
 ## Next Mode
 

--- a/packages/claude-code-plugin/commands/plan.md
+++ b/packages/claude-code-plugin/commands/plan.md
@@ -3,6 +3,23 @@
 ## Purpose
 Design implementation approach before writing code
 
+## Mode Availability
+
+### Standalone Mode (no MCP server)
+This command works without the CodingBuddy MCP server.
+In standalone mode, you get:
+- Mode detection and transition
+- Basic agent recommendation
+- TDD workflow guidance
+- Core checklist
+
+### MCP Enhanced Mode
+With the CodingBuddy MCP server connected, you additionally get:
+- `parse_mode` with full context tracking
+- Specialist agent dispatch
+- Contextual checklists (security, accessibility, performance)
+- Cross-session context persistence
+
 ## Activation
 This command activates PLAN mode for the CodingBuddy workflow.
 
@@ -237,12 +254,13 @@ To preserve this planning session for future reference:
 
 ## MCP Integration
 
-If CodingBuddy MCP server is available, call:
+If MCP is available, call `parse_mode` for enhanced features:
 ```
 parse_mode({ prompt: "PLAN: <user request>" })
 ```
 
 This provides additional context, checklists, and specialist agent recommendations.
+In standalone mode, the command works with built-in workflow guidance.
 
 ## Next Mode
 


### PR DESCRIPTION
## Summary

- Added "Mode Availability" section to `commands/plan.md`, `act.md`, `eval.md`, `auto.md` clarifying standalone vs MCP-enhanced capabilities
- Changed `README.md` "MCP Integration (Required)" → "MCP Integration (Recommended)" and added feature capability matrix
- Changed `docs/plugin-guide.md` "MCP Server Setup (Required)" → "MCP Server Setup (Recommended)" and added same capability matrix

## Test plan

- [x] `yarn workspace codingbuddy build` — success
- [x] `yarn workspace codingbuddy lint --fix` — 0 errors
- [x] `yarn workspace codingbuddy test` — 5822 passed
- [x] All 6 modified files reviewed for markdown consistency

Closes #1210