### PR TITLE
feat(plugin): conditional prompt injection for MCP/standalone (#1213)

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/prompt_injection.py
+++ b/packages/claude-code-plugin/hooks/lib/prompt_injection.py
@@ -6,6 +6,8 @@ Sources only trusted local content (never external URLs).
 """
 from typing import Any, Dict
 
+from runtime_mode import is_mcp_available
+
 CHAR_LIMIT = 2000
 
 # --- Section builders (each returns a string or empty) ---
@@ -13,6 +15,12 @@ CHAR_LIMIT = 2000
 _BASE_RULES = (
     "[CodingBuddy] When user message starts with PLAN/ACT/EVAL/AUTO, "
     "you MUST call parse_mode FIRST before any other action. "
+    "Follow TDD cycle: RED (failing test) -> GREEN (minimal code) -> REFACTOR."
+)
+
+_BASE_RULES_STANDALONE = (
+    "[CodingBuddy] When user message starts with PLAN/ACT/EVAL/AUTO, "
+    "follow the mode instructions provided by the mode detection hook. "
     "Follow TDD cycle: RED (failing test) -> GREEN (minimal code) -> REFACTOR."
 )
 
@@ -102,12 +110,14 @@ class PromptInjector:
         if not isinstance(sections_cfg, dict):
             sections_cfg = {}
 
+        mcp_mode = is_mcp_available()
+
         parts: list[str] = []
 
         if sections_cfg.get("baseRules", True):
-            parts.append(_BASE_RULES)
+            parts.append(_BASE_RULES if mcp_mode else _BASE_RULES_STANDALONE)
 
-        if sections_cfg.get("dispatchEnforcement", True):
+        if mcp_mode and sections_cfg.get("dispatchEnforcement", True):
             parts.append(_DISPATCH_ENFORCEMENT)
 
         if sections_cfg.get("qualityGates", True):

--- a/packages/claude-code-plugin/tests/test_prompt_injection.py
+++ b/packages/claude-code-plugin/tests/test_prompt_injection.py
@@ -1,6 +1,7 @@
 """Tests for PromptInjector — system prompt injection module (#828)."""
 import os
 import sys
+from unittest import mock
 import pytest
 
 # Ensure hooks/lib is on path
@@ -10,6 +11,13 @@ if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
 
 from prompt_injection import PromptInjector
+
+
+@pytest.fixture(autouse=True)
+def _mock_mcp_available():
+    """Default: mock is_mcp_available to return True (MCP mode) for all existing tests."""
+    with mock.patch("prompt_injection.is_mcp_available", return_value=True):
+        yield
 
 
 @pytest.fixture
@@ -225,3 +233,44 @@ class TestDisabledInjection:
     def test_returns_empty_when_none_config(self, injector):
         result = injector.build_system_prompt({"promptInjection": None}, "/tmp")
         assert result == ""
+
+
+class TestStandaloneMode:
+    """Tests for standalone mode (MCP not available)."""
+
+    @pytest.fixture(autouse=True)
+    def _standalone(self):
+        with mock.patch("prompt_injection.is_mcp_available", return_value=False):
+            yield
+
+    def test_standalone_contains_mode_hook_instruction(self, injector, base_config):
+        result = injector.build_system_prompt(base_config, "/tmp")
+        assert "follow the mode instructions provided by the mode detection hook" in result
+
+    def test_standalone_no_parse_mode_must(self, injector, base_config):
+        result = injector.build_system_prompt(base_config, "/tmp")
+        assert "MUST call parse_mode" not in result
+
+    def test_standalone_no_dispatch_enforcement(self, injector, base_config):
+        result = injector.build_system_prompt(base_config, "/tmp")
+        assert "dispatch" not in result.lower() or "dispatch=\"auto\"" not in result
+
+    def test_standalone_still_has_tdd(self, injector, base_config):
+        result = injector.build_system_prompt(base_config, "/tmp")
+        assert "TDD" in result
+
+    def test_standalone_still_has_quality_gates(self, injector, base_config):
+        result = injector.build_system_prompt(base_config, "/tmp")
+        assert "lint" in result.lower() or "test" in result.lower()
+
+
+class TestMcpMode:
+    """Explicit MCP mode tests — verify original behavior is preserved."""
+
+    def test_mcp_contains_parse_mode_must(self, injector, base_config):
+        result = injector.build_system_prompt(base_config, "/tmp")
+        assert "MUST call parse_mode FIRST" in result
+
+    def test_mcp_contains_dispatch_enforcement(self, injector, base_config):
+        result = injector.build_system_prompt(base_config, "/tmp")
+        assert 'dispatch="auto"' in result


### PR DESCRIPTION
## Summary

- Branch `build_system_prompt` by runtime mode: MCP injects `parse_mode` + dispatch enforcement, standalone uses hook-based instructions
- Import `is_mcp_available` from `runtime_mode` (from #1211)
- Add `_BASE_RULES_STANDALONE` — references mode detection hook instead of MCP-only `parse_mode` tool
- `dispatchEnforcement` section only injected in MCP mode
- 7 new tests: 5 standalone mode + 2 explicit MCP mode verification

## Test plan

- [x] 37 prompt_injection + runtime tests pass
- [x] TypeScript type-check passes
- [x] Full workspace: 234 test files, 5822 tests passed

Closes #1213