### PR TITLE
fix(plugin): correct AUTO mode default agent id to auto-mode (#1226)

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/mode_engine.py
+++ b/packages/claude-code-plugin/hooks/lib/mode_engine.py
@@ -20,7 +20,7 @@ DEFAULT_AGENTS = {
     "PLAN": {"name": "technical-planner", "title": "Technical Planner"},
     "ACT": {"name": "software-engineer", "title": "Software Engineer"},
     "EVAL": {"name": "code-reviewer", "title": "Code Reviewer"},
-    "AUTO": {"name": "auto-mode-agent", "title": "Auto Mode Agent"},
+    "AUTO": {"name": "auto-mode", "title": "Auto Mode Agent"},
 }
 
 # Mode instruction templates (compact, within ~2000 char hook limit)

--- a/packages/claude-code-plugin/hooks/lib/test_mode_engine.py
+++ b/packages/claude-code-plugin/hooks/lib/test_mode_engine.py
@@ -64,7 +64,7 @@ class TestModeEngineGetDefaultAgent(unittest.TestCase):
     def test_auto_agent(self):
         engine = ModeEngine(rules_dir=None)
         agent = engine.get_default_agent("AUTO")
-        self.assertEqual(agent["name"], "auto-mode-agent")
+        self.assertEqual(agent["name"], "auto-mode")
 
     def test_case_insensitive(self):
         engine = ModeEngine(rules_dir=None)


### PR DESCRIPTION
## Summary
- `mode_engine.py` DEFAULT_AGENTS의 AUTO 모드 agent id를 `auto-mode-agent`에서 `auto-mode`로 수정
- `test_mode_engine.py`의 assertion도 동일하게 수정

## Problem
`auto-mode-agent`는 canonical id(`auto-mode`)와 불일치하여 `_load_agent_details()`가 None을 반환, AUTO 모드에서 agent enrichment이 누락됨.

Closes #1226

## Test plan
- [x] `python3 -m pytest hooks/lib/test_mode_engine.py -v` — 37 passed
- [x] `yarn workspace codingbuddy typecheck` — pass
- [x] `yarn workspace codingbuddy test` — 5822 passed