### PR TITLE
fix(plugin): guard MCP auto-registration with binary check (#1237)

### DIFF
--- a/packages/claude-code-plugin/hooks/session-start.py
+++ b/packages/claude-code-plugin/hooks/session-start.py
@@ -733,7 +733,9 @@ def main():
 
         # Step 2.6: Ensure ~/.claude/mcp.json has codingbuddy entry (#1100)
         try:
-            _ensure_mcp_json(home / ".claude" / "mcp.json")
+            import shutil as _shutil
+            if _shutil.which("codingbuddy"):
+                _ensure_mcp_json(home / ".claude" / "mcp.json")
         except Exception:
             pass  # Never block session start
 

--- a/packages/claude-code-plugin/hooks/test_session_start.py
+++ b/packages/claude-code-plugin/hooks/test_session_start.py
@@ -368,6 +368,34 @@ class TestEnsureMcpJson:
             data = json.loads(mcp_path.read_text())
             assert "codingbuddy" in data["mcpServers"]
 
+    def test_skips_mcp_json_when_binary_not_installed(self):
+        """Test that mcp.json is NOT created when codingbuddy binary is not on PATH (#1237)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mcp_path = Path(tmpdir) / ".claude" / "mcp.json"
+
+            with patch("shutil.which", return_value=None):
+                # Simulate the guarded call from session-start main flow
+                import shutil as _shutil
+                if _shutil.which("codingbuddy"):
+                    session_hook._ensure_mcp_json(mcp_path)
+
+            assert not mcp_path.exists()
+
+    def test_creates_mcp_json_when_binary_installed(self):
+        """Test that mcp.json IS created when codingbuddy binary is on PATH (#1237)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mcp_path = Path(tmpdir) / ".claude" / "mcp.json"
+
+            with patch("shutil.which", return_value="/usr/local/bin/codingbuddy"):
+                import shutil as _shutil
+                if _shutil.which("codingbuddy"):
+                    session_hook._ensure_mcp_json(mcp_path)
+
+            assert mcp_path.exists()
+            data = json.loads(mcp_path.read_text())
+            assert "codingbuddy" in data["mcpServers"]
+            assert data["mcpServers"]["codingbuddy"]["command"] == "codingbuddy"
+
 
 class TestHookLibCopy:
     """Tests for lib/ directory copying alongside hook file (#1102)."""


### PR DESCRIPTION
## Summary
- Guard `_ensure_mcp_json()` with `shutil.which('codingbuddy')` check so plugin-only users without the binary don't get broken MCP config
- Add two tests: binary absent (mcp.json not created) and binary present (mcp.json created normally)

Closes #1237

## Test plan
- [x] `python3 -m pytest hooks/test_session_start.py -v -k "mcp"` — 6 passed
- [x] `python3 -m pytest hooks/test_session_start.py -v` — 34 passed