### PR TITLE
fix(plugin): remove .ai-rules file path refs from slash commands (#1238)

### DIFF
--- a/packages/claude-code-plugin/commands/act.md
+++ b/packages/claude-code-plugin/commands/act.md
@@ -35,9 +35,9 @@ This command activates ACT mode for the CodingBuddy workflow.
 - Execute implementation steps defined in PLAN
 
 **🔴 Agent Activation (STRICT):**
-- When ACT is triggered, **Frontend Developer Agent** (`.ai-rules/agents/frontend-developer.json`) **MUST** be automatically activated
+- When ACT is triggered, **Frontend Developer Agent** (loaded via parse_mode in MCP mode; defaults in standalone mode) **MUST** be automatically activated
 - The Agent's development philosophy and code quality checklist MUST be followed
-- See `.ai-rules/agents/frontend-developer.json` for complete development framework
+- See agent documentation for complete development framework
 
 **Purpose:**
 Execute implementation following TDD cycle, augmented coding principles, and quality standards
@@ -83,28 +83,28 @@ Execute implementation following TDD cycle, augmented coding principles, and qua
 
 ## 🏗️ Architecture Implementation Verification
 (When architecture implementation verification is needed)
-- Use Architecture Specialist Agent framework (`.ai-rules/agents/architecture-specialist.json`) modes.implementation for comprehensive architecture implementation verification
+- Use Architecture Specialist Agent (dispatched via parse_mode in MCP mode) modes.implementation for comprehensive architecture implementation verification
 - [Layer placement verification]
 - [Dependency direction verification]
 - [Type definitions verification]
 
 ## 🧪 Test Strategy Implementation Verification
 (When test strategy implementation verification is needed)
-- Use Test Strategy Specialist Agent framework (`.ai-rules/agents/test-strategy-specialist.json`) modes.implementation for comprehensive test strategy implementation verification
+- Use Test Strategy Specialist Agent (dispatched via parse_mode in MCP mode) modes.implementation for comprehensive test strategy implementation verification
 - [TDD vs Test-After verification]
 - [Test coverage verification (90%+ for core logic)]
 - [Test file structure verification]
 
 ## ⚡ Performance Implementation Verification
 (When performance implementation verification is needed)
-- Use Performance Specialist Agent framework (`.ai-rules/agents/performance-specialist.json`) modes.implementation for comprehensive performance implementation verification
+- Use Performance Specialist Agent (dispatched via parse_mode in MCP mode) modes.implementation for comprehensive performance implementation verification
 - [Bundle/build size verification]
 - [Code splitting verification]
 - [Framework-specific optimization verification]
 
 ## 🔒 Security Implementation Verification
 (When security implementation verification is needed)
-- Use Security Specialist Agent framework (`.ai-rules/agents/security-specialist.json`) modes.implementation for comprehensive security implementation verification
+- Use Security Specialist Agent (dispatched via parse_mode in MCP mode) modes.implementation for comprehensive security implementation verification
 - [Authentication verification (OAuth 2.0, JWT)]
 - [Authorization verification]
 - [Input validation verification]
@@ -112,7 +112,7 @@ Execute implementation following TDD cycle, augmented coding principles, and qua
 
 ## 📨 Event Architecture Implementation Verification
 (When event-driven architecture implementation verification is needed)
-- Use Event Architecture Specialist Agent framework (`.ai-rules/agents/event-architecture-specialist.json`) modes.implementation for comprehensive event architecture implementation verification
+- Use Event Architecture Specialist Agent (dispatched via parse_mode in MCP mode) modes.implementation for comprehensive event architecture implementation verification
 - [Producer/consumer implementation verification]
 - [Idempotency and retry configuration verification]
 - [DLQ and error handling verification]
@@ -120,7 +120,7 @@ Execute implementation following TDD cycle, augmented coding principles, and qua
 
 ## ♿ Accessibility Implementation Verification
 (When accessibility implementation verification is needed)
-- Use Accessibility Specialist Agent framework (`.ai-rules/agents/accessibility-specialist.json`) modes.implementation for comprehensive accessibility implementation verification
+- Use Accessibility Specialist Agent (dispatched via parse_mode in MCP mode) modes.implementation for comprehensive accessibility implementation verification
 - [WCAG 2.1 AA compliance verification]
 - [ARIA attributes verification]
 - [Keyboard navigation verification]
@@ -128,28 +128,28 @@ Execute implementation following TDD cycle, augmented coding principles, and qua
 
 ## 🔍 SEO Implementation Verification
 (When SEO implementation verification is needed)
-- Use SEO Specialist Agent framework (`.ai-rules/agents/seo-specialist.json`) modes.implementation for comprehensive SEO implementation verification
+- Use SEO Specialist Agent (dispatched via parse_mode in MCP mode) modes.implementation for comprehensive SEO implementation verification
 - [Framework metadata API verification]
 - [Structured data verification]
 - [Social sharing optimization verification]
 
 ## 🎨 UI/UX Design Implementation Verification
 (When UI/UX design implementation verification is needed)
-- Use UI/UX Designer Agent framework (`.ai-rules/agents/ui-ux-designer.json`) modes.implementation for comprehensive UI/UX design implementation verification
+- Use UI/UX Designer Agent (dispatched via parse_mode in MCP mode) modes.implementation for comprehensive UI/UX design implementation verification
 - [Visual hierarchy verification]
 - [Interaction states verification]
 - [Responsive design verification]
 
 ## 📚 Documentation Implementation Verification
 (When documentation implementation verification is needed)
-- Use Documentation Specialist Agent framework (`.ai-rules/agents/documentation-specialist.json`) modes.implementation for comprehensive documentation implementation verification
+- Use Documentation Specialist Agent (dispatched via parse_mode in MCP mode) modes.implementation for comprehensive documentation implementation verification
 - [Code comments verification for complex logic]
 - [TypeScript type definitions verification]
 - [JSDoc verification for public APIs]
 
 ## 📐 Code Quality Implementation Verification
 (When code quality implementation verification is needed)
-- Use Code Quality Specialist Agent framework (`.ai-rules/agents/code-quality-specialist.json`) modes.implementation for comprehensive code quality implementation verification
+- Use Code Quality Specialist Agent (dispatched via parse_mode in MCP mode) modes.implementation for comprehensive code quality implementation verification
 - [SOLID principles verification]
 - [DRY principle verification (code duplication elimination)]
 - [Complexity verification (function size, nesting depth)]

--- a/packages/claude-code-plugin/commands/auto.md
+++ b/packages/claude-code-plugin/commands/auto.md
@@ -79,10 +79,10 @@ Autonomous iterative development - automatically cycling through planning, imple
 | `auto.maxIterations` | 3 | 1-10 | Maximum PLAN→ACT→EVAL cycles before forced exit |
 
 **🔴 Agent Activation (STRICT):**
-- When AUTO mode is triggered, **Primary Developer Agent** (e.g., `.ai-rules/agents/frontend-developer.json`) **MUST** be automatically activated for PLAN and ACT phases
-- During EVAL phase, **Code Reviewer Agent** (`.ai-rules/agents/code-reviewer.json`) **MUST** be automatically activated
+- When AUTO mode is triggered, **Primary Developer Agent** (loaded via parse_mode in MCP mode; defaults in standalone mode) **MUST** be automatically activated for PLAN and ACT phases
+- During EVAL phase, **Code Reviewer Agent** (loaded via parse_mode in MCP mode; defaults in standalone mode) **MUST** be automatically activated
 - The respective Agent's workflow framework and all mandatory requirements MUST be followed
-- See `.ai-rules/agents/` for complete agent frameworks
+- See agent definitions for complete agent frameworks
 
 **Output Format:**
 ```

--- a/packages/claude-code-plugin/commands/eval.md
+++ b/packages/claude-code-plugin/commands/eval.md
@@ -37,9 +37,9 @@ This command activates EVAL mode for the CodingBuddy workflow.
 - Korean: `평가해` or `개선안 제시해`
 
 **🔴 Agent Activation (STRICT):**
-- When EVAL is triggered, **Code Reviewer Agent** (`.ai-rules/agents/code-reviewer.json`) **MUST** be automatically activated
+- When EVAL is triggered, **Code Reviewer Agent** (loaded via parse_mode in MCP mode; defaults in standalone mode) **MUST** be automatically activated
 - The Agent's evaluation framework and all mandatory requirements MUST be followed
-- See `.ai-rules/agents/code-reviewer.json` for complete evaluation framework
+- See agent documentation for complete evaluation framework
 
 **Purpose:**
 Self-improvement through iterative refinement
@@ -54,23 +54,23 @@ Self-improvement through iterative refinement
 
 2. **Assess Quality** (via Code Reviewer Agent mandatory perspectives)
    - 🔴 Code quality (SOLID, DRY, complexity)
-     - **Required**: When evaluating code quality, reference Code Quality Specialist Agent (`.ai-rules/agents/code-quality-specialist.json`) modes.evaluation framework for SOLID principles, DRY, complexity analysis, and design patterns assessment
+     - **Required**: When evaluating code quality, reference Code Quality Specialist Agent (dispatched via parse_mode in MCP mode) modes.evaluation framework for SOLID principles, DRY, complexity analysis, and design patterns assessment
    - 🔴 Architecture (layer boundaries, dependency direction, type safety)
-     - **Required**: When evaluating architecture, reference Architecture Specialist Agent (`.ai-rules/agents/architecture-specialist.json`) framework for layer boundaries, dependency direction, and type safety assessment
+     - **Required**: When evaluating architecture, reference Architecture Specialist Agent (dispatched via parse_mode in MCP mode) framework for layer boundaries, dependency direction, and type safety assessment
    - 🔴 Test coverage (90%+ goal)
-     - **Required**: When evaluating tests, reference Test Strategy Specialist Agent (`.ai-rules/agents/test-strategy-specialist.json`) modes.evaluation framework for test coverage, TDD workflow, and test quality assessment
+     - **Required**: When evaluating tests, reference Test Strategy Specialist Agent (dispatched via parse_mode in MCP mode) modes.evaluation framework for test coverage, TDD workflow, and test quality assessment
    - 🔴 Performance (build size, execution optimization)
-     - **Required**: When evaluating performance, reference Performance Specialist Agent (`.ai-rules/agents/performance-specialist.json`) framework for build size, execution optimization, and performance metrics assessment
+     - **Required**: When evaluating performance, reference Performance Specialist Agent (dispatched via parse_mode in MCP mode) framework for build size, execution optimization, and performance metrics assessment
    - 🔴 Security (XSS/CSRF, authentication/authorization)
-     - **Required**: When evaluating security, reference Security Specialist Agent (`.ai-rules/agents/security-specialist.json`) framework for OAuth 2.0, JWT, CSRF/XSS protection assessment
+     - **Required**: When evaluating security, reference Security Specialist Agent (dispatched via parse_mode in MCP mode) framework for OAuth 2.0, JWT, CSRF/XSS protection assessment
    - 🔴 Accessibility (WCAG 2.1 AA compliance)
-     - **Required**: When evaluating accessibility, reference Accessibility Specialist Agent (`.ai-rules/agents/accessibility-specialist.json`) framework for WCAG 2.1 AA compliance verification
+     - **Required**: When evaluating accessibility, reference Accessibility Specialist Agent (dispatched via parse_mode in MCP mode) framework for WCAG 2.1 AA compliance verification
    - 🔴 SEO (metadata, structured data)
-     - **Required**: When evaluating SEO, reference SEO Specialist Agent (`.ai-rules/agents/seo-specialist.json`) framework for metadata, structured data, and search engine optimization assessment
+     - **Required**: When evaluating SEO, reference SEO Specialist Agent (dispatched via parse_mode in MCP mode) framework for metadata, structured data, and search engine optimization assessment
    - 🔴 UI/UX Design (visual hierarchy, UX patterns)
-     - **Required**: When evaluating UI/UX design, reference UI/UX Designer Agent (`.ai-rules/agents/ui-ux-designer.json`) framework for visual hierarchy, UX laws, and interaction patterns assessment
+     - **Required**: When evaluating UI/UX design, reference UI/UX Designer Agent (dispatched via parse_mode in MCP mode) framework for visual hierarchy, UX laws, and interaction patterns assessment
    - 🔴 Documentation Quality (documentation, cursor rules, AI prompts)
-     - **Required**: When evaluating documentation, cursor rules, or AI prompts, reference Documentation Specialist Agent (`.ai-rules/agents/documentation-specialist.json`) modes.evaluation framework for clarity, completeness, consistency, actionability, structure, and references assessment
+     - **Required**: When evaluating documentation, cursor rules, or AI prompts, reference Documentation Specialist Agent (dispatched via parse_mode in MCP mode) modes.evaluation framework for clarity, completeness, consistency, actionability, structure, and references assessment
 
 3. **Identify Improvements** (via Code Reviewer Agent)
    - Evaluate from multiple perspectives
@@ -91,7 +91,7 @@ Self-improvement through iterative refinement
 - Evaluate OUTPUT only, not implementer's INTENT
 - No subjective assessments - use objective evidence only
 - Must identify at least 3 improvement areas OR all identified issues
-- Prohibited phrases: See `anti_sycophancy.prohibited_phrases` in `.ai-rules/agents/code-reviewer.json` (English + Korean)
+- Prohibited phrases: See Code Reviewer Agent's `anti_sycophancy.prohibited_phrases` (English + Korean)
 - Start with problems, not praise
 - Challenge every design decision
 
@@ -178,14 +178,14 @@ Self-improvement through iterative refinement
 
 ## 🔒 Security Assessment
 (When authentication/authorization code or security-related features are present)
-- Use Security Specialist Agent framework (`.ai-rules/agents/security-specialist.json`) for comprehensive security review
+- Use Security Specialist Agent (dispatched via parse_mode in MCP mode) for comprehensive security review
 - [OAuth 2.0 / JWT security review]
 - [CSRF/XSS protection verification]
 - [Security vulnerabilities with risk assessment (Critical/High/Medium/Low)]
 
 ## 📨 Event Architecture Assessment
 (When event-driven architecture or message queue code is present)
-- Use Event Architecture Specialist Agent framework (`.ai-rules/agents/event-architecture-specialist.json`) modes.evaluation for comprehensive event architecture review
+- Use Event Architecture Specialist Agent (dispatched via parse_mode in MCP mode) modes.evaluation for comprehensive event architecture review
 - [Reliability and delivery guarantees audit]
 - [Consistency and saga pattern verification]
 - [Scalability and partitioning assessment]
@@ -193,14 +193,14 @@ Self-improvement through iterative refinement
 
 ## ♿ Accessibility Assessment
 (When UI components are present)
-- Use Accessibility Specialist Agent framework (`.ai-rules/agents/accessibility-specialist.json`) for comprehensive accessibility review
+- Use Accessibility Specialist Agent (dispatched via parse_mode in MCP mode) for comprehensive accessibility review
 - [WCAG 2.1 AA compliance review]
 - [ARIA attributes and keyboard navigation verification]
 - [Accessibility issues with impact assessment (Critical/High/Medium/Low)]
 
 ## 📐 Code Quality Assessment
 (When code quality evaluation is needed)
-- Use Code Quality Specialist Agent framework (`.ai-rules/agents/code-quality-specialist.json`) modes.evaluation for comprehensive code quality review
+- Use Code Quality Specialist Agent (dispatched via parse_mode in MCP mode) modes.evaluation for comprehensive code quality review
 - [SOLID principles compliance review]
 - [DRY principle verification]
 - [Complexity analysis]
@@ -208,7 +208,7 @@ Self-improvement through iterative refinement
 
 ## 🏗️ Architecture Assessment
 (When architecture evaluation is needed)
-- Use Architecture Specialist Agent framework (`.ai-rules/agents/architecture-specialist.json`) for comprehensive architecture review
+- Use Architecture Specialist Agent (dispatched via parse_mode in MCP mode) for comprehensive architecture review
 - [Layer boundaries compliance review]
 - [Dependency direction verification]
 - [Type safety assessment]
@@ -216,7 +216,7 @@ Self-improvement through iterative refinement
 
 ## 🧪 Test Quality Assessment
 (When test evaluation is needed)
-- Use Test Strategy Specialist Agent framework (`.ai-rules/agents/test-strategy-specialist.json`) modes.evaluation for comprehensive test quality review
+- Use Test Strategy Specialist Agent (dispatched via parse_mode in MCP mode) modes.evaluation for comprehensive test quality review
 - [Test coverage (90%+ goal) review]
 - [TDD workflow verification]
 - [Test-After strategy validation]
@@ -224,7 +224,7 @@ Self-improvement through iterative refinement
 
 ## ⚡ Performance Assessment
 (When performance evaluation is needed)
-- Use Performance Specialist Agent framework (`.ai-rules/agents/performance-specialist.json`) for comprehensive performance review
+- Use Performance Specialist Agent (dispatched via parse_mode in MCP mode) for comprehensive performance review
 - [Build/bundle size optimization review]
 - [Framework-specific optimization assessment]
 - [Performance metrics verification]
@@ -232,7 +232,7 @@ Self-improvement through iterative refinement
 
 ## 🔍 SEO Assessment
 (When SEO evaluation is needed)
-- Use SEO Specialist Agent framework (`.ai-rules/agents/seo-specialist.json`) for comprehensive SEO review
+- Use SEO Specialist Agent (dispatched via parse_mode in MCP mode) for comprehensive SEO review
 - [Framework metadata API usage review]
 - [Structured data verification]
 - [Social sharing optimization assessment]
@@ -240,7 +240,7 @@ Self-improvement through iterative refinement
 
 ## 🎨 UI/UX Design Assessment
 (When UI/UX design evaluation is needed)
-- Use UI/UX Designer Agent framework (`.ai-rules/agents/ui-ux-designer.json`) for comprehensive UI/UX design review
+- Use UI/UX Designer Agent (dispatched via parse_mode in MCP mode) for comprehensive UI/UX design review
 - [Visual hierarchy assessment]
 - [User flow evaluation]
 - [Interaction patterns review]
@@ -248,7 +248,7 @@ Self-improvement through iterative refinement
 
 ## 📚 Documentation Quality Assessment
 (When documentation, cursor rules, or AI prompts are evaluated)
-- Use Documentation Specialist Agent framework (`.ai-rules/agents/documentation-specialist.json`) modes.evaluation for comprehensive documentation quality review
+- Use Documentation Specialist Agent (dispatched via parse_mode in MCP mode) modes.evaluation for comprehensive documentation quality review
 - [Clarity assessment (goals, instructions, terminology)]
 - [Completeness review (required sections, edge cases)]
 - [Consistency verification (naming, format, structure)]
@@ -299,7 +299,7 @@ To preserve this evaluation session for future reference:
 **Special Cases:**
 
 *Documentation-only changes (no code):*
-- Use `documentation_metrics` from `code-reviewer.json` instead of code metrics
+- Use Code Reviewer Agent's `documentation_metrics` instead of code metrics
 - Evaluate: clarity, completeness, consistency, actionability
 - Critical Findings table should reference section names instead of file:line
 

--- a/packages/claude-code-plugin/commands/plan.md
+++ b/packages/claude-code-plugin/commands/plan.md
@@ -31,9 +31,9 @@ This command activates PLAN mode for the CodingBuddy workflow.
 - After creating plan, user can type `ACT` to execute
 
 **🔴 Agent Activation (STRICT):**
-- When in PLAN mode, **Frontend Developer Agent** (`.ai-rules/agents/frontend-developer.json`) **MUST** be automatically activated
+- When in PLAN mode, **Frontend Developer Agent** (loaded via parse_mode in MCP mode; defaults in standalone mode) **MUST** be automatically activated
 - The Agent's workflow framework and all mandatory requirements MUST be followed
-- See `.ai-rules/agents/frontend-developer.json` for complete development framework
+- See agent documentation for complete development framework
 
 **Purpose:**
 Create actionable implementation plans following TDD and augmented coding principles
@@ -72,7 +72,7 @@ Resolve ambiguous requirements through sequential Q&A before creating a plan.
 - User provides comprehensive specification document
 
 **Reference:**
-See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
+See project rules for detailed question guidelines.
 
 ---
 
@@ -128,7 +128,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ## 🏗️ Architecture Planning
 (When architecture planning is needed)
-- Use Architecture Specialist Agent framework (`.ai-rules/agents/architecture-specialist.json`) modes.planning for comprehensive architecture planning
+- Use Architecture Specialist Agent (dispatched via parse_mode in MCP mode) modes.planning for comprehensive architecture planning
 - [Layer placement plan (per project architecture)]
 - [Dependency direction design]
 - [Type definitions planning]
@@ -137,7 +137,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ## 🧪 Test Strategy Planning
 (When test strategy planning is needed)
-- Use Test Strategy Specialist Agent framework (`.ai-rules/agents/test-strategy-specialist.json`) modes.planning for comprehensive test strategy planning
+- Use Test Strategy Specialist Agent (dispatched via parse_mode in MCP mode) modes.planning for comprehensive test strategy planning
 - [TDD vs Test-After decision]
 - [Test coverage goals (90%+ for core logic)]
 - [Test file structure planning]
@@ -145,7 +145,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ## ⚡ Performance Planning
 (When performance planning is needed)
-- Use Performance Specialist Agent framework (`.ai-rules/agents/performance-specialist.json`) modes.planning for comprehensive performance planning
+- Use Performance Specialist Agent (dispatched via parse_mode in MCP mode) modes.planning for comprehensive performance planning
 - [Bundle/build size optimization plan]
 - [Code splitting strategy]
 - [Framework-specific optimization techniques]
@@ -153,7 +153,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ## 🔒 Security Planning
 (When security planning is needed)
-- Use Security Specialist Agent framework (`.ai-rules/agents/security-specialist.json`) modes.planning for comprehensive security planning
+- Use Security Specialist Agent (dispatched via parse_mode in MCP mode) modes.planning for comprehensive security planning
 - [Authentication planning (OAuth 2.0, JWT)]
 - [Authorization planning]
 - [Input validation planning]
@@ -161,7 +161,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ## 📨 Event Architecture Planning
 (When event-driven architecture, message queues, or distributed transactions planning is needed)
-- Use Event Architecture Specialist Agent framework (`.ai-rules/agents/event-architecture-specialist.json`) modes.planning for comprehensive event architecture planning
+- Use Event Architecture Specialist Agent (dispatched via parse_mode in MCP mode) modes.planning for comprehensive event architecture planning
 - [Message broker selection (Kafka, RabbitMQ, SQS)]
 - [Event schema and versioning planning]
 - [Delivery guarantees and idempotency planning]
@@ -170,7 +170,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ## ♿ Accessibility Planning
 (When accessibility planning is needed)
-- Use Accessibility Specialist Agent framework (`.ai-rules/agents/accessibility-specialist.json`) modes.planning for comprehensive accessibility planning
+- Use Accessibility Specialist Agent (dispatched via parse_mode in MCP mode) modes.planning for comprehensive accessibility planning
 - [WCAG 2.1 AA compliance plan]
 - [ARIA attributes planning]
 - [Keyboard navigation planning]
@@ -178,7 +178,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ## 🔍 SEO Planning
 (When SEO planning is needed)
-- Use SEO Specialist Agent framework (`.ai-rules/agents/seo-specialist.json`) modes.planning for comprehensive SEO planning
+- Use SEO Specialist Agent (dispatched via parse_mode in MCP mode) modes.planning for comprehensive SEO planning
 - [Framework metadata API planning]
 - [Structured data planning]
 - [Social sharing optimization planning]
@@ -186,7 +186,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ## 🎨 UI/UX Design Planning
 (When UI/UX design planning is needed)
-- Use UI/UX Designer Agent framework (`.ai-rules/agents/ui-ux-designer.json`) modes.planning for comprehensive UI/UX design planning
+- Use UI/UX Designer Agent (dispatched via parse_mode in MCP mode) modes.planning for comprehensive UI/UX design planning
 - [Visual hierarchy planning]
 - [User flow optimization]
 - [Interaction patterns planning]
@@ -194,7 +194,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ## 📚 Documentation Planning
 (When documentation planning is needed)
-- Use Documentation Specialist Agent framework (`.ai-rules/agents/documentation-specialist.json`) modes.planning for comprehensive documentation planning
+- Use Documentation Specialist Agent (dispatched via parse_mode in MCP mode) modes.planning for comprehensive documentation planning
 - [Code comments planning for complex logic]
 - [TypeScript type definitions as documentation]
 - [JSDoc comments for public APIs]
@@ -202,7 +202,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ## 📐 Code Quality Planning
 (When code quality planning is needed)
-- Use Code Quality Specialist Agent framework (`.ai-rules/agents/code-quality-specialist.json`) modes.planning for comprehensive code quality planning
+- Use Code Quality Specialist Agent (dispatched via parse_mode in MCP mode) modes.planning for comprehensive code quality planning
 - [SOLID principles application planning]
 - [DRY strategy planning (code duplication elimination)]
 - [Complexity management planning (function size, nesting depth)]


### PR DESCRIPTION
## Summary
- Remove all `.ai-rules/agents/*.json` and `.ai-rules/rules/*.md` file path references from `commands/plan.md`, `eval.md`, `auto.md`, and `act.md`
- Replace with agent names + `(loaded via parse_mode in MCP mode; defaults in standalone mode)` or `(dispatched via parse_mode in MCP mode)` patterns
- The npm tarball (53 files) does NOT include `.ai-rules/` assets, so these paths were broken in standalone mode

## Changed Files
- `packages/claude-code-plugin/commands/plan.md` — 13 references replaced
- `packages/claude-code-plugin/commands/eval.md` — 23 references replaced
- `packages/claude-code-plugin/commands/auto.md` — 4 references replaced
- `packages/claude-code-plugin/commands/act.md` — 12 references replaced

## Test plan
- [x] `grep -r ".ai-rules/" commands/` returns empty
- [x] `yarn workspace codingbuddy build` passes
- [x] `yarn workspace codingbuddy test` passes (5822 tests)

Closes #1238