### PR TITLE
fix(plugin): align /plan and /act docs with actual standalone defaults (#1248)

### DIFF
--- a/packages/claude-code-plugin/commands/act.md
+++ b/packages/claude-code-plugin/commands/act.md
@@ -35,9 +35,9 @@ This command activates ACT mode for the CodingBuddy workflow.
 - Execute implementation steps defined in PLAN
 
 **🔴 Agent Activation (STRICT):**
-- When ACT is triggered, **Frontend Developer Agent** (loaded via parse_mode in MCP mode; defaults in standalone mode) **MUST** be automatically activated
+- When ACT is triggered, the **default ACT agent** (loaded via parse_mode in MCP mode; Software Engineer in standalone mode) **MUST** be automatically activated
 - The Agent's development philosophy and code quality checklist MUST be followed
-- See agent documentation for complete development framework
+- In MCP mode, the agent framework is loaded via parse_mode. In standalone mode, basic workflow guidance is provided by the mode detection hook.
 
 **Purpose:**
 Execute implementation following TDD cycle, augmented coding principles, and quality standards

--- a/packages/claude-code-plugin/commands/plan.md
+++ b/packages/claude-code-plugin/commands/plan.md
@@ -31,9 +31,9 @@ This command activates PLAN mode for the CodingBuddy workflow.
 - After creating plan, user can type `ACT` to execute
 
 **🔴 Agent Activation (STRICT):**
-- When in PLAN mode, **Frontend Developer Agent** (loaded via parse_mode in MCP mode; defaults in standalone mode) **MUST** be automatically activated
+- When in PLAN mode, the **default PLAN agent** (loaded via parse_mode in MCP mode; Technical Planner in standalone mode) **MUST** be automatically activated
 - The Agent's workflow framework and all mandatory requirements MUST be followed
-- See agent documentation for complete development framework
+- In MCP mode, the agent framework is loaded via parse_mode. In standalone mode, basic workflow guidance is provided by the mode detection hook.
 
 **Purpose:**
 Create actionable implementation plans following TDD and augmented coding principles


### PR DESCRIPTION
## Summary
- `plan.md` referenced "Frontend Developer Agent" as standalone default, but `mode_engine.py` uses `technical-planner` (Technical Planner)
- `act.md` had the same mismatch — said "Frontend Developer Agent" but actual default is `software-engineer` (Software Engineer)
- Updated both docs to reference the correct agent names and clarify MCP vs standalone behavior

Closes #1248

## Test plan
- [x] `grep "Frontend Developer" plan.md act.md` returns no matches
- [x] `yarn workspace codingbuddy test` — 5840 passed
- [x] Verified `mode_engine.py` DEFAULT_AGENTS matches updated docs