### PR TITLE
fix(mcp): filter disable-model-invocation skills from auto-recommendations (#1254)

### DIFF
--- a/apps/mcp-server/src/skill/skill-recommendation.service.spec.ts
+++ b/apps/mcp-server/src/skill/skill-recommendation.service.spec.ts
@@ -13,6 +13,7 @@ function createMockRulesService(
     description: string;
     triggers?: SkillFrontmatterTrigger[];
     userInvocable?: boolean;
+    disableModelInvocation?: boolean;
   }> = [],
 ): RulesService {
   return {
@@ -592,6 +593,58 @@ describe('SkillRecommendationService', () => {
 
       const debugging = result.recommendations.find(r => r.skillName === 'systematic-debugging');
       expect(debugging).toBeUndefined();
+    });
+  });
+
+  describe('disableModelInvocation filtering', () => {
+    it('should exclude skills with disableModelInvocation: true from recommendations', async () => {
+      const skillsWithDisabled = [
+        ...FILESYSTEM_SKILLS,
+        {
+          name: 'incident-response',
+          description: 'Incident response skill',
+          disableModelInvocation: true,
+          triggers: [{ pattern: 'incident.*response', confidence: 'high' as const }],
+        },
+      ];
+      const filteredService = new SkillRecommendationService(
+        createMockRulesService(skillsWithDisabled),
+      );
+      await filteredService.loadFrontmatterTriggers();
+
+      const result = filteredService.recommendSkills('handle incident response procedure');
+
+      const incident = result.recommendations.find(r => r.skillName === 'incident-response');
+      expect(incident).toBeUndefined();
+    });
+
+    it('should include skills with disableModelInvocation: false in recommendations', async () => {
+      const skillsWithEnabled = [
+        ...FILESYSTEM_SKILLS,
+        {
+          name: 'enabled-skill',
+          description: 'Model invocation enabled skill',
+          disableModelInvocation: false,
+          triggers: [{ pattern: 'enabled-model-test-xyz', confidence: 'high' as const }],
+        },
+      ];
+      const enabledService = new SkillRecommendationService(
+        createMockRulesService(skillsWithEnabled),
+      );
+      await enabledService.loadFrontmatterTriggers();
+
+      const result = enabledService.recommendSkills('enabled-model-test-xyz');
+
+      const skill = result.recommendations.find(r => r.skillName === 'enabled-skill');
+      expect(skill).toBeDefined();
+    });
+
+    it('should include skills without disableModelInvocation field (default behavior)', async () => {
+      // Skills without disableModelInvocation should be included (backwards compatible)
+      const result = service.recommendSkills('widget slot architecture');
+
+      const wsa = result.recommendations.find(r => r.skillName === 'widget-slot-architecture');
+      expect(wsa).toBeDefined();
     });
   });
 

--- a/apps/mcp-server/src/skill/skill-recommendation.service.ts
+++ b/apps/mcp-server/src/skill/skill-recommendation.service.ts
@@ -43,7 +43,10 @@ function getSkillDescription(skillName: string): string {
 @Injectable()
 export class SkillRecommendationService implements OnModuleInit {
   private frontmatterTriggerCache = new Map<string, FrontmatterTriggerEntry>();
-  private skillMetadataCache = new Map<string, { userInvocable?: boolean }>();
+  private skillMetadataCache = new Map<
+    string,
+    { userInvocable?: boolean; disableModelInvocation?: boolean }
+  >();
 
   constructor(private readonly rulesService: RulesService) {}
 
@@ -61,8 +64,11 @@ export class SkillRecommendationService implements OnModuleInit {
     this.skillMetadataCache.clear();
 
     for (const skill of skills) {
-      if (skill.userInvocable !== undefined) {
-        this.skillMetadataCache.set(skill.name, { userInvocable: skill.userInvocable });
+      if (skill.userInvocable !== undefined || skill.disableModelInvocation !== undefined) {
+        this.skillMetadataCache.set(skill.name, {
+          userInvocable: skill.userInvocable,
+          disableModelInvocation: skill.disableModelInvocation,
+        });
       }
       if (skill.triggers && skill.triggers.length > 0) {
         const compiled: CachedFrontmatterTrigger[] = [];
@@ -170,9 +176,12 @@ export class SkillRecommendationService implements OnModuleInit {
     const recommendations: SkillRecommendation[] = [];
 
     for (const [skillName, match] of skillMatches) {
-      // Filter out skills explicitly marked as user-invocable: false
+      // Filter out skills explicitly marked as non-invocable
       const metadata = this.skillMetadataCache.get(skillName);
       if (metadata?.userInvocable === false) {
+        continue;
+      }
+      if (metadata?.disableModelInvocation === true) {
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Extended `skillMetadataCache` in `skill-recommendation.service.ts` to cache `disableModelInvocation` field alongside `userInvocable`
- Added filtering logic to exclude skills with `disableModelInvocation: true` from auto-recommendations
- Added 3 test cases covering: excluded when `true`, included when `false`, included when undefined (default)

Closes #1254

## Test plan
- [x] Skill with `disableModelInvocation: true` excluded from recommendations
- [x] Skill with `disableModelInvocation: false` still recommended
- [x] Skill without `disableModelInvocation` still recommended (backwards compatible)
- [x] All 5852 existing tests pass
- [x] TypeScript type check passes