### PR TITLE
docs(plugin): migrate command docs to codingbuddy:* namespace (#1285)

### DIFF
--- a/packages/claude-code-plugin/commands/act.md
+++ b/packages/claude-code-plugin/commands/act.md
@@ -21,6 +21,11 @@ With the CodingBuddy MCP server connected, you additionally get:
 - Cross-session context persistence
 
 ## Activation
+
+Invoke via `/codingbuddy:act` (namespaced) or the `ACT` keyword.
+
+> Legacy bare `/act` is deprecated. See [Migration Guide](../docs/migration-guide.md).
+
 This command activates ACT mode for the CodingBuddy workflow.
 
 ## Instructions

--- a/packages/claude-code-plugin/commands/auto.md
+++ b/packages/claude-code-plugin/commands/auto.md
@@ -21,6 +21,11 @@ With the CodingBuddy MCP server connected, you additionally get:
 - Cross-session context persistence
 
 ## Activation
+
+Invoke via `/codingbuddy:auto` (namespaced) or the `AUTO` keyword.
+
+> Legacy bare `/auto` is deprecated. See [Migration Guide](../docs/migration-guide.md).
+
 This command activates AUTO mode for the CodingBuddy workflow.
 
 ## Instructions

--- a/packages/claude-code-plugin/commands/checklist.md
+++ b/packages/claude-code-plugin/commands/checklist.md
@@ -17,13 +17,15 @@ Generate contextual checklists based on file patterns and domains for comprehens
 ## Usage
 
 ```
-/checklist [files] [domains]
+/codingbuddy:checklist [files] [domains]
 ```
 
 Examples:
-- `/checklist src/auth/*.ts security`
-- `/checklist src/components/*.tsx accessibility performance`
-- `/checklist` (auto-detect from recent changes)
+- `/codingbuddy:checklist src/auth/*.ts security`
+- `/codingbuddy:checklist src/components/*.tsx accessibility performance`
+- `/codingbuddy:checklist` (auto-detect from recent changes)
+
+> Legacy bare `/checklist` is deprecated. See [Migration Guide](../docs/migration-guide.md).
 
 ## MCP Integration
 

--- a/packages/claude-code-plugin/commands/eval.md
+++ b/packages/claude-code-plugin/commands/eval.md
@@ -21,6 +21,11 @@ With the CodingBuddy MCP server connected, you additionally get:
 - Cross-session context persistence
 
 ## Activation
+
+Invoke via `/codingbuddy:eval` (namespaced) or the `EVAL` keyword.
+
+> Legacy bare `/eval` is deprecated. See [Migration Guide](../docs/migration-guide.md).
+
 This command activates EVAL mode for the CodingBuddy workflow.
 
 ## Instructions

--- a/packages/claude-code-plugin/commands/plan.md
+++ b/packages/claude-code-plugin/commands/plan.md
@@ -21,6 +21,11 @@ With the CodingBuddy MCP server connected, you additionally get:
 - Cross-session context persistence
 
 ## Activation
+
+Invoke via `/codingbuddy:plan` (namespaced) or the `PLAN` keyword.
+
+> Legacy bare `/plan` is deprecated. See [Migration Guide](../docs/migration-guide.md).
+
 This command activates PLAN mode for the CodingBuddy workflow.
 
 ## Instructions


### PR DESCRIPTION
## Summary
- Migrate `plan.md`, `act.md`, `eval.md`, `auto.md`, `checklist.md` to reference `codingbuddy:*` namespaced commands
- Add deprecation notes for legacy bare commands with links to migration guide
- Replace bare `/checklist` usage examples with `/codingbuddy:checklist`

Closes #1285

## Test plan
- [x] `yarn prettier --write .` — no formatting changes
- [x] `yarn lint --fix` — no errors in changed files
- [x] `yarn workspace codingbuddy exec tsc --noEmit` — passes
- [x] `yarn workspace codingbuddy exec vitest run` — 5887 tests pass