### PR TITLE
fix(plugin): stop build-generated README from reverting to outdated MCP-required messaging (#1299)

### DIFF
--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -24,7 +24,10 @@ claude plugin add codingbuddy
 - **EVAL**: Evaluate code quality and suggest improvements
 - **AUTO**: Autonomous PLAN → ACT → EVAL cycle
 
-### Commands
+### Commands (codingbuddy:* namespace)
+
+All commands use the `codingbuddy:` namespace to avoid collisions with Claude Code built-ins.
+
 - `/codingbuddy:plan` - Enter PLAN mode
 - `/codingbuddy:act` - Enter ACT mode
 - `/codingbuddy:eval` - Enter EVAL mode
@@ -56,18 +59,32 @@ Reusable workflows for consistent development:
 - Refactoring
 - And more...
 
-## MCP Integration (Required)
+## Feature Availability
 
-This plugin requires the CodingBuddy MCP server for full functionality:
+The plugin works standalone with core features. MCP integration unlocks the full experience:
+
+| Feature | Standalone | With MCP |
+|---------|:----------:|:--------:|
+| PLAN/ACT/EVAL/AUTO keyword triggers | ✅ | ✅ |
+| Specialist agent prompts | ✅ | ✅ |
+| Slash commands (codingbuddy:*) | ✅ | ✅ |
+| Dynamic checklists | — | ✅ |
+| Context persistence across modes | — | ✅ |
+| Rule search & impact reports | — | ✅ |
+| Session briefings & recovery | — | ✅ |
+
+## MCP Integration (Recommended)
+
+Install the CodingBuddy MCP server to unlock the full feature set:
 
 ```bash
 npm install -g codingbuddy
 ```
 
 The MCP server provides:
-- Agents, commands, and skills from `packages/rules/.ai-rules/` (single source of truth)
-- Checklists and specialist agent recommendations
+- Dynamic checklists and specialist agent recommendations
 - Context management for PLAN/ACT/EVAL workflow
+- Rule search, impact reports, and session recovery
 
 ## Architecture
 

--- a/packages/claude-code-plugin/scripts/build.spec.ts
+++ b/packages/claude-code-plugin/scripts/build.spec.ts
@@ -187,6 +187,39 @@ describe('build script orchestration', () => {
 });
 
 // ============================================================================
+// README Messaging — standalone-aware MCP messaging
+// ============================================================================
+describe('README messaging', () => {
+  const pluginRoot = path.resolve(__dirname, '..');
+  const readmePath = path.join(pluginRoot, 'README.md');
+
+  let readmeContent: string;
+
+  beforeAll(() => {
+    readmeContent = fs.readFileSync(readmePath, 'utf8');
+  });
+
+  it('marks MCP Integration as Recommended, not Required', () => {
+    expect(readmeContent).toContain('## MCP Integration (Recommended)');
+    expect(readmeContent).not.toContain('## MCP Integration (Required)');
+  });
+
+  it('does not claim MCP is required for full functionality', () => {
+    expect(readmeContent).not.toContain('requires the CodingBuddy MCP server');
+  });
+
+  it('includes the Feature Availability table', () => {
+    expect(readmeContent).toContain('## Feature Availability');
+    expect(readmeContent).toContain('| Feature | Standalone | With MCP |');
+  });
+
+  it('shows standalone features in the availability table', () => {
+    expect(readmeContent).toContain('PLAN/ACT/EVAL/AUTO keyword triggers');
+    expect(readmeContent).toContain('Slash commands (codingbuddy:*)');
+  });
+});
+
+// ============================================================================
 // Packaging Integration — namespaced command assets
 // ============================================================================
 describe('packaging integration', () => {

--- a/packages/claude-code-plugin/scripts/build.ts
+++ b/packages/claude-code-plugin/scripts/build.ts
@@ -112,18 +112,32 @@ Reusable workflows for consistent development:
 - Refactoring
 - And more...
 
-## MCP Integration (Required)
+## Feature Availability
 
-This plugin requires the CodingBuddy MCP server for full functionality:
+The plugin works standalone with core features. MCP integration unlocks the full experience:
+
+| Feature | Standalone | With MCP |
+|---------|:----------:|:--------:|
+| PLAN/ACT/EVAL/AUTO keyword triggers | ✅ | ✅ |
+| Specialist agent prompts | ✅ | ✅ |
+| Slash commands (codingbuddy:*) | ✅ | ✅ |
+| Dynamic checklists | — | ✅ |
+| Context persistence across modes | — | ✅ |
+| Rule search & impact reports | — | ✅ |
+| Session briefings & recovery | — | ✅ |
+
+## MCP Integration (Recommended)
+
+Install the CodingBuddy MCP server to unlock the full feature set:
 
 \`\`\`bash
 npm install -g codingbuddy
 \`\`\`
 
 The MCP server provides:
-- Agents, commands, and skills from \`packages/rules/.ai-rules/\` (single source of truth)
-- Checklists and specialist agent recommendations
+- Dynamic checklists and specialist agent recommendations
 - Context management for PLAN/ACT/EVAL workflow
+- Rule search, impact reports, and session recovery
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- Updated build.ts README template: MCP Integration from "Required" → "Recommended"
- Added Feature Availability table showing standalone vs MCP feature matrix
- Added 4 build.spec.ts tests asserting correct messaging in generated README

Closes #1299

## Test plan

- [x] `yarn workspace codingbuddy exec tsc --noEmit` passes
- [x] `yarn workspace codingbuddy exec vitest run` passes (5887 tests)
- [x] `npx tsx scripts/build.ts` regenerates README with correct messaging