### PR TITLE
fix(plugin): clear stale workflow state when entering a new mode

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/hud_helpers.py
+++ b/packages/claude-code-plugin/hooks/lib/hud_helpers.py
@@ -48,6 +48,10 @@ def on_mode_entry(
             "phase": phase,
             "focus": None,
             "blockerCount": 0,
+            "activeAgent": None,
+            "executionStrategy": None,
+            "councilStatus": None,
+            "lastHandoff": None,
         }
         if state_file:
             update_hud_state(state_file=state_file, **kwargs)

--- a/packages/claude-code-plugin/hooks/tests/test_hud_helpers.py
+++ b/packages/claude-code-plugin/hooks/tests/test_hud_helpers.py
@@ -113,6 +113,39 @@ class TestOnModeEntry:
         assert state["focus"] is None
         assert state["blockerCount"] == 0
 
+    @pytest.mark.parametrize("mode,expected_phase", [
+        ("PLAN", "planning"),
+        ("ACT", "executing"),
+        ("EVAL", "evaluating"),
+        ("AUTO", "cycling"),
+    ])
+    def test_resets_all_stale_workflow_fields(self, state_file, mode, expected_phase):
+        """Seed ALL workflow fields with non-default values then verify full reset."""
+        from hud_state import update_hud_state
+        update_hud_state(
+            state_file=state_file,
+            currentMode="EVAL",
+            phase="evaluating",
+            focus="old-file.py",
+            blockerCount=5,
+            activeAgent="Security Specialist",
+            executionStrategy="subagent",
+            councilStatus="voting",
+            lastHandoff="Frontend Developer",
+        )
+
+        on_mode_entry(mode, state_file=state_file)
+        state = _read(state_file)
+
+        assert state["currentMode"] == mode
+        assert state["phase"] == expected_phase
+        assert state["focus"] is None
+        assert state["blockerCount"] == 0
+        assert state["activeAgent"] is None
+        assert state["executionStrategy"] is None
+        assert state["councilStatus"] is None
+        assert state["lastHandoff"] is None
+
     def test_unknown_mode_defaults_to_ready(self, state_file):
         on_mode_entry("UNKNOWN", state_file=state_file)
         state = _read(state_file)


### PR DESCRIPTION
## Summary
- `on_mode_entry()` now resets `activeAgent`, `executionStrategy`, `councilStatus`, `lastHandoff` to `None` on mode entry
- Prevents stale workflow state from leaking across PLAN/ACT/EVAL/AUTO transitions
- Added parametrized tests covering all 4 modes with full field seeding and reset verification

Closes #1334

## Test plan
- [x] `python3 -m pytest hooks/tests/test_hud_helpers.py -v` — 49 tests passed
- [x] Parametrized test seeds all workflow fields with non-default values, calls `on_mode_entry()` for each mode, verifies complete reset