### PR TITLE
fix(plugin): finish namespaced slash-command migration in distributable package

### DIFF
--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -29,6 +29,7 @@
     ".claude-plugin",
     ".mcp.json",
     "README.md",
+    "namespace-manifest.json",
     "scripts/postinstall.js",
     "hooks/",
     "commands/"

--- a/packages/claude-code-plugin/scripts/build.spec.ts
+++ b/packages/claude-code-plugin/scripts/build.spec.ts
@@ -254,4 +254,18 @@ describe('packaging integration', () => {
     expect(content).toContain('/codingbuddy:act');
     expect(content).toContain('/codingbuddy:buddy');
   });
+
+  it('package.json files array includes namespace-manifest.json', () => {
+    const pkgPath = path.join(pluginRoot, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    expect(pkg.files).toContain('namespace-manifest.json');
+  });
+
+  it('namespace-manifest.json is present after build', () => {
+    const manifestPath = path.join(pluginRoot, 'namespace-manifest.json');
+    expect(fs.existsSync(manifestPath)).toBe(true);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    expect(manifest.pluginName).toBe(PLUGIN_NAMESPACE);
+    expect(manifest.commands.length).toBeGreaterThanOrEqual(6);
+  });
 });


### PR DESCRIPTION
## Summary
- Add `namespace-manifest.json` to `package.json` `files` array so the codingbuddy:* command mapping ships in the npm tarball
- Add packaging verification tests to `build.spec.ts` (files array check + post-build manifest presence)

Closes #1335

## Test plan
- [x] `yarn build` succeeds, generates `namespace-manifest.json`
- [x] `npm pack --dry-run` includes `namespace-manifest.json`
- [x] `vitest run scripts/build.spec.ts` — 28 tests pass (2 new)