### PR TITLE
fix(plugin): make status bar actor badge fall back to hud_state.activeAgent

### DIFF
--- a/packages/claude-code-plugin/hooks/codingbuddy-hud.py
+++ b/packages/claude-code-plugin/hooks/codingbuddy-hud.py
@@ -7,7 +7,7 @@ Reads session data from stdin JSON, outputs formatted status to stdout.
 Telemetry fallback order per field:
   cost     → stdin cost.total_cost_usd  > estimate_cost()
   duration → stdin cost.total_duration_ms > hud-state sessionStartTimestamp
-  agent    → stdin agent.name > CODINGBUDDY_ACTIVE_AGENT env
+  agent    → stdin agent.name > hud_state.activeAgent > CODINGBUDDY_ACTIVE_AGENT env
   model    → stdin model.display_name > model.id
 """
 import json
@@ -220,10 +220,13 @@ def resolve_duration(stdin_data: dict, hud_state: dict) -> str:
     return "0m"
 
 
-def resolve_agent(stdin_data: dict, env_agent: str = "") -> str:
-    """Resolve agent: stdin > env var."""
+def resolve_agent(stdin_data: dict, hud_state=None, env_agent: str = "") -> str:
+    """Resolve agent: stdin > hud_state.activeAgent > env var."""
     stdin_agent = (stdin_data.get("agent") or {}).get("name", "")
-    return stdin_agent or env_agent
+    if stdin_agent:
+        return stdin_agent
+    hud_agent = (hud_state or {}).get("activeAgent", "")
+    return hud_agent or env_agent
 
 
 def resolve_model_label(stdin_data: dict) -> tuple:
@@ -336,7 +339,7 @@ def format_status_line(
     Fallback order per field:
       cost     → stdin cost.total_cost_usd  > estimate_cost()
       duration → stdin cost.total_duration_ms > hud-state sessionStartTimestamp
-      agent    → stdin agent.name > active_agent param
+      agent    → stdin agent.name > hud_state.activeAgent > active_agent param
       model    → stdin model.display_name > model.id
     """
     version = hud_state.get("version", "")
@@ -351,7 +354,7 @@ def format_status_line(
     cost, is_exact = resolve_cost(stdin_data, model_id, ctx_window)
     duration = resolve_duration(stdin_data, hud_state)
     cache = compute_cache_hit_rate(ctx_window)
-    agent = resolve_agent(stdin_data, active_agent)
+    agent = resolve_agent(stdin_data, hud_state, active_agent)
 
     cost_prefix = "$" if is_exact else "~$"
 

--- a/packages/claude-code-plugin/tests/test_hud.py
+++ b/packages/claude-code-plugin/tests/test_hud.py
@@ -229,13 +229,34 @@ class TestResolveDuration:
 class TestResolveAgent:
     def test_stdin_agent_preferred(self):
         stdin = {"agent": {"name": "security-reviewer"}}
-        assert hud.resolve_agent(stdin, "old-env-agent") == "security-reviewer"
+        assert hud.resolve_agent(stdin, env_agent="old-env-agent") == "security-reviewer"
+
+    def test_stdin_overrides_hud_state(self):
+        stdin = {"agent": {"name": "security-reviewer"}}
+        state = {"activeAgent": "plan-mode"}
+        assert hud.resolve_agent(stdin, state, "env-agent") == "security-reviewer"
+
+    def test_hud_state_fallback(self):
+        assert hud.resolve_agent({}, {"activeAgent": "security-specialist"}) == "security-specialist"
+
+    def test_hud_state_overrides_env(self):
+        state = {"activeAgent": "security-specialist"}
+        assert hud.resolve_agent({}, state, "env-agent") == "security-specialist"
 
     def test_fallback_to_env(self):
-        assert hud.resolve_agent({}, "env-agent") == "env-agent"
+        assert hud.resolve_agent({}, env_agent="env-agent") == "env-agent"
 
-    def test_both_empty(self):
-        assert hud.resolve_agent({}, "") == ""
+    def test_env_when_hud_state_empty(self):
+        assert hud.resolve_agent({}, {"activeAgent": ""}, "env-agent") == "env-agent"
+
+    def test_env_when_hud_state_none(self):
+        assert hud.resolve_agent({}, None, "env-agent") == "env-agent"
+
+    def test_all_empty(self):
+        assert hud.resolve_agent({}, {}, "") == ""
+
+    def test_both_empty_no_hud(self):
+        assert hud.resolve_agent({}, None, "") == ""
 
 
 class TestResolveModelLabel:
@@ -358,6 +379,32 @@ class TestFormatStatusLine:
         result = hud.format_status_line(stdin, {}, active_agent="backend-developer")
         assert "[\u2605 fron]" in result   # [★ fron]
         assert "\u25d0" not in result      # ◐ (backend glyph) absent
+
+    def test_hud_state_agent_fallback_badge(self):
+        result = hud.format_status_line(
+            {},
+            {"activeAgent": "security-specialist", "focus": "auth", "blockerCount": 1},
+        )
+        lines = result.strip().split("\n")
+        assert len(lines) == 2
+        assert "[\u25ee secu]" in lines[1]  # [◮ secu]
+        assert "[auth]" in lines[1]
+        assert "[\u26a01]" in lines[1]  # [⚠1]
+
+    def test_stdin_agent_overrides_hud_state(self):
+        stdin = {"agent": {"name": "frontend-developer"}}
+        state = {"activeAgent": "security-specialist"}
+        result = hud.format_status_line(stdin, state)
+        assert "[\u2605 fron]" in result   # [★ fron]
+        assert "\u25ee" not in result      # ◮ (security glyph) absent
+
+    def test_hud_state_agent_overrides_env(self):
+        state = {"activeAgent": "security-specialist"}
+        result = hud.format_status_line({}, state, active_agent="backend-developer")
+        lines = result.strip().split("\n")
+        assert len(lines) == 2
+        assert "[\u25ee secu]" in lines[1]  # [◮ secu] from hud_state
+        assert "\u25d0" not in result        # ◐ (backend glyph) absent
 
     def test_no_agent_single_line(self):
         result = hud.format_status_line({}, {"version": "5.1.1"})


### PR DESCRIPTION
## Summary
- `resolve_agent()`에 `hud_state.activeAgent` fallback 추가 (stdin → hud_state → env 순)
- `format_status_line()`이 hud_state를 `resolve_agent()`에 전달하도록 수정
- 9개 테스트 추가 (resolve_agent 6개, format_status_line 3개), 전체 99개 통과

Closes #1333

## Test plan
- [x] `python3 -m pytest tests/test_hud.py -v` — 99 passed
- [x] stdin agent가 hud_state를 override 확인
- [x] hud_state agent가 env를 override 확인
- [x] 모든 소스 absent 시 빈 문자열 반환 확인