### PR TITLE
fix(plugin): make validate:commands self-contained and reproducible

### DIFF
--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -45,7 +45,7 @@
     "typecheck": "tsc --noEmit",
     "circular": "madge --circular --extensions ts src/",
     "format:check": "prettier --check \"src/**/*.ts\" \"scripts/**/*.ts\"",
-    "validate:commands": "npx tsx scripts/validate-commands.ts",
+    "validate:commands": "ts-node scripts/validate-commands.ts",
     "test": "vitest run",
     "test:hooks": "python3 -m pytest tests/ -v --tb=short",
     "test:all": "vitest run && python3 -m pytest tests/ -v --tb=short",

--- a/packages/claude-code-plugin/scripts/validate-commands.ts
+++ b/packages/claude-code-plugin/scripts/validate-commands.ts
@@ -12,7 +12,7 @@
  * 4. Namespace validation (codingbuddy:* convention)
  *
  * Usage:
- *   npx tsx scripts/validate-commands.ts
+ *   ts-node scripts/validate-commands.ts
  */
 
 import * as path from 'path';


### PR DESCRIPTION
## Summary

- Replace undeclared `npx tsx` with `ts-node` (already a devDependency) in `validate:commands` script
- Align the script's Usage comment with the actual package.json runner
- Shebang (`#!/usr/bin/env ts-node`) was already correct — now all three references are consistent

## Test plan

- [x] `yarn workspace codingbuddy-claude-plugin validate:commands` succeeds
- [x] No undeclared dependencies required
- [x] CI workflow (`dev.yml`) uses the same `validate:commands` entry point — no changes needed

Closes #1341