### PR TITLE
fix(mcp-server): exclude test artifacts and build metadata from npm package

### DIFF
--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -34,6 +34,11 @@
   "bin": "./dist/src/cli/cli.js",
   "files": [
     "dist",
+    "!dist/**/*.spec.js",
+    "!dist/**/*.spec.d.ts",
+    "!dist/**/*.tsbuildinfo",
+    "!dist/**/*.js.map",
+    "!dist/**/*.d.ts.map",
     "README.md"
   ],
   "publishConfig": {


### PR DESCRIPTION
## Summary
- `apps/mcp-server/package.json`의 `files` 필드에 negation 패턴 추가
- spec 파일(`*.spec.js`, `*.spec.d.ts`), 빌드 메타데이터(`*.tsbuildinfo`), 소스맵(`*.js.map`, `*.d.ts.map`)을 npm 패키지에서 제외
- 패키지 파일 수 1081 → 691로 감소 (390개 제거)

Closes #1342

## Test plan
- [x] `npm pack --dry-run` — spec/tsbuildinfo/map 파일 0개 확인
- [x] `yarn workspace codingbuddy build` — 빌드 정상
- [x] `yarn workspace codingbuddy test` — 238 파일 5959 테스트 통과