### PR TITLE
chore: prepare v5.3.0 release

### DIFF
--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Multi-AI Rules MCP Server - One source of truth for AI coding rules across all AI assistants",
   "author": "JeremyDev87",
   "license": "MIT",

--- a/apps/mcp-server/src/shared/version.ts
+++ b/apps/mcp-server/src/shared/version.ts
@@ -2,4 +2,4 @@
  * Single source of truth for the runtime package version.
  * Updated automatically by scripts/bump-version.sh on each release.
  */
-export const VERSION = '5.2.0';
+export const VERSION = '5.3.0';

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "PLAN/ACT/EVAL workflow with auto-detection, specialist agents, and reusable skills for systematic TDD development",
   "author": {
     "name": "JeremyDev87",

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-claude-plugin",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Claude Code Plugin for CodingBuddy - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills",
   "author": "JeremyDev87",
   "license": "MIT",
@@ -53,7 +53,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "codingbuddy": "^5.2.0"
+    "codingbuddy": "^5.3.0"
   },
   "peerDependenciesMeta": {
     "codingbuddy": {

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-rules",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "AI coding rules for consistent practices across AI assistants",
   "main": "index.js",
   "types": "index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5521,7 +5521,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:4.0.17"
   peerDependencies:
-    codingbuddy: ^5.2.0
+    codingbuddy: ^5.3.0
   peerDependenciesMeta:
     codingbuddy:
       optional: true


### PR DESCRIPTION
## Summary
- Bump all 5 version files from 5.2.0 → 5.3.0
- Follows `docs/release-checklist.md` Step 1-5

## Version files updated
| # | File | Method |
|---|------|--------|
| 1 | `apps/mcp-server/package.json` | Manual |
| 2 | `apps/mcp-server/src/shared/version.ts` | Manual |
| 3 | `packages/rules/package.json` | Manual |
| 4 | `packages/claude-code-plugin/package.json` | sync-version |
| 5 | `packages/claude-code-plugin/.claude-plugin/plugin.json` | sync-version |

## Verification
- [x] All 5 files show `5.3.0`
- [x] No remaining `5.2.0` in version files
- [x] `tsc --noEmit` passes
- [x] `yarn workspace codingbuddy build` passes
- [x] `yarn workspace codingbuddy test` — 5959 tests pass

## v5.3.0 changes since v5.2.0
- feat(plugin): status bar two-line model with badge-based rendering
- feat(plugin): hook-driven workflow state updates
- feat(plugin): stdin telemetry preference in status bar
- feat(mcp): composable TaskMaestro+Teams execution model
- feat(mcp): TeamsCapabilityService for runtime gating
- feat(mcp): ExecutionPlan types extraction (circular dep fix)
- feat(mcp): CouncilPresetService integration
- feat(plugin): Tiny Actor Grid enhancements (display-width, eye metadata)
- feat(plugin): namespaced slash-command migration (codingbuddy:*)
- fix(plugin): actor badge hud_state fallback
- fix(plugin): clear stale workflow state on mode entry
- fix(plugin): validate:commands self-contained
- fix(mcp-server): exclude test artifacts from npm package
- improve(plugin): end-to-end /codingbuddy:* runtime proof