### PR TITLE
refactor(plugin): clarify UserPromptSubmit bootstrap architecture

### DIFF
--- a/packages/claude-code-plugin/docs/bootstrap-architecture.md
+++ b/packages/claude-code-plugin/docs/bootstrap-architecture.md
@@ -1,0 +1,115 @@
+# Plugin Hook Bootstrap Architecture
+
+> **Status:** current as of `codingbuddy-claude-plugin` v5.3.0
+> **Related issues:** [#1380](https://github.com/JeremyDev87/codingbuddy/issues/1380) (this document), [#1376](https://github.com/JeremyDev87/codingbuddy/issues/1376) (parent), [#1381](https://github.com/JeremyDev87/codingbuddy/issues/1381) (stale legacy hook migration)
+
+This document explains **how** and **where** the CodingBuddy Claude Code plugin registers its hooks — and in particular, why `UserPromptSubmit` is nowhere to be found in `hooks/hooks.json`.
+
+If you are here because you opened `hooks/hooks.json`, noticed `UserPromptSubmit` was missing, and thought "this plugin forgot to register PLAN/ACT/EVAL detection" — you are not the first. This page exists to make that confusion impossible.
+
+---
+
+## TL;DR
+
+| Event | Where it is registered | Who loads it |
+|-------|------------------------|--------------|
+| `SessionStart` | `hooks/hooks.json` (plugin-local) | Claude Code at plugin load time |
+| `PreToolUse` | `hooks/hooks.json` (plugin-local) | Claude Code at plugin load time |
+| `PostToolUse` | `hooks/hooks.json` (plugin-local) | Claude Code at plugin load time |
+| `Stop` | `hooks/hooks.json` (plugin-local) | Claude Code at plugin load time |
+| **`UserPromptSubmit`** | **`~/.claude/settings.json`** (installed by `hooks/session-start.py` at runtime) | Claude Code globally, for every session |
+
+`UserPromptSubmit` is intentionally installed **globally** so that PLAN/ACT/EVAL/AUTO keyword detection is active in every Claude Code session, regardless of the current working directory.
+
+---
+
+## The two hook layers
+
+CodingBuddy's plugin ships with two distinct hook registration layers. They serve different purposes and are loaded by Claude Code at different times.
+
+### Layer 1 — plugin-local (`hooks/hooks.json`)
+
+Claude Code's plugin runtime reads `hooks/hooks.json` when the plugin is loaded. Hooks declared here are scoped to **this plugin** — they fire when Claude Code is operating inside a project where the CodingBuddy plugin is active.
+
+This layer declares the hooks that only make sense in a project context:
+
+- **`SessionStart`** — runs `session-start.py`, which in turn bootstraps the global `UserPromptSubmit` layer (see below) along with the status line, MCP entry, and other per-user integrations.
+- **`PreToolUse`** — gatekeeps `Bash` commands through `pre-tool-use.py`.
+- **`PostToolUse`** — post-processes tool results via `post-tool-use.py`.
+- **`Stop`** — saves session stats via `stop.py`.
+
+The file carries a top-level `$comment` field pointing readers to this document. JSON has no comment syntax, so `$comment` is used by convention (JSON Schema follows the same convention).
+
+### Layer 2 — global (`~/.claude/settings.json`, installed by `session-start.py`)
+
+`UserPromptSubmit` is handled differently. On **every** session start, `hooks/session-start.py`:
+
+1. Copies `hooks/user-prompt-submit.py` (and its `lib/` dependencies) into `~/.claude/hooks/codingbuddy-mode-detect.py`.
+2. Calls `register_hook_in_settings()` to add a `UserPromptSubmit` entry to `~/.claude/settings.json`, using file locking on Unix to prevent concurrent-write races.
+
+The net effect: once a user has started a Claude Code session with the CodingBuddy plugin installed even once, the PLAN/ACT/EVAL/AUTO keyword hook is registered **globally** and fires in every subsequent session, regardless of project.
+
+---
+
+## Why install `UserPromptSubmit` globally instead of plugin-locally?
+
+This is the first question every reviewer asks, and it is a fair question. A plugin-local entry in `hooks/hooks.json` would be simpler to read and audit.
+
+The reason is **scope of detection**:
+
+- PLAN/ACT/EVAL/AUTO keyword detection is meant to work **any time** the user types those keywords to Claude Code, not only when the current working directory is a CodingBuddy-enabled project.
+- Claude Code evaluates plugin-local hooks in the context of the active plugin root, which means a plugin-local `UserPromptSubmit` would only be considered when the plugin is resolved for the current session. That is too narrow for a workflow primitive that should "just work" everywhere.
+- A global install mirrors how IDE extensions typically register global keybinding handlers: once installed, they are ambient.
+
+The trade-off is that contributors auditing the plugin package can't tell at a glance where `UserPromptSubmit` lives — which is exactly the confusion that motivated [#1380](https://github.com/JeremyDev87/codingbuddy/issues/1380) and this document.
+
+---
+
+## Source of truth (cheat sheet)
+
+| Question | Answer |
+|----------|--------|
+| Where is `UserPromptSubmit` registered in the package? | It isn't. It is installed at runtime into `~/.claude/settings.json`. |
+| Which file performs the install? | `packages/claude-code-plugin/hooks/session-start.py` — specifically `register_hook_in_settings()`. |
+| Which script actually runs on `UserPromptSubmit`? | `~/.claude/hooks/codingbuddy-mode-detect.py`, a copy of `packages/claude-code-plugin/hooks/user-prompt-submit.py`. |
+| How is the install idempotent? | `register_hook_in_settings()` calls `_is_hook_in_settings()` first; if a matching entry exists, it is a no-op. |
+| How do I confirm the install happened? | Inspect `~/.claude/settings.json` and look for a `hooks.UserPromptSubmit` array entry whose `command` contains `codingbuddy-mode-detect.py`. |
+
+---
+
+## Regression safeguards
+
+Two kinds of drift have happened historically and must be prevented going forward:
+
+1. **Silent removal.** Refactors in `session-start.py` can accidentally delete or short-circuit the global install, leaving keyword detection broken for users who install the plugin fresh.
+2. **Duplicate registration.** A contributor who doesn't know about the global install path might "fix" the missing entry by adding `UserPromptSubmit` to `hooks/hooks.json`, producing two competing registrations — one plugin-scoped, one global — with no clear precedence.
+
+The `tests/test_bootstrap_architecture.py` suite locks both invariants:
+
+- `hooks.json` is asserted to declare exactly `{SessionStart, PreToolUse, PostToolUse, Stop}` and to **not** declare `UserPromptSubmit`.
+- `hooks.json` must carry a `$comment` field naming `session-start.py`, `UserPromptSubmit`, and `bootstrap-architecture` so readers are redirected here.
+- `session-start.py`'s module docstring must mention `UserPromptSubmit` and `~/.claude` so its bootstrap role is discoverable from `head -50`.
+- This document must exist, mention both layers, name the global settings path, and reference issue `#1380`.
+
+If you legitimately need to change the architecture, update the tests in the same commit so the invariants move together with the behavior.
+
+---
+
+## Future simplification
+
+An alternative single-path model was considered in [#1380](https://github.com/JeremyDev87/codingbuddy/issues/1380) — move `UserPromptSubmit` into plugin-local `hooks/hooks.json` and delete the global install from `session-start.py`. It was deferred for two reasons:
+
+1. It would break the global-scope semantics described above; PLAN/ACT/EVAL detection would only fire inside CodingBuddy-aware projects.
+2. [#1381](https://github.com/JeremyDev87/codingbuddy/issues/1381) already tracks cleaning up **stale** global entries left over by previous plugin versions. Migrating to a single-path model while stale cleanup is still in flight would stack two incompatible migrations on top of each other.
+
+If and when Claude Code grows a first-class mechanism for "global, plugin-originated" hooks, the bootstrap layer here can be retired and this document retracted. Until then, the two-layer model is the deliberate state.
+
+---
+
+## Related files
+
+- `packages/claude-code-plugin/hooks/hooks.json` — plugin-local hook manifest (`$comment` links back here)
+- `packages/claude-code-plugin/hooks/session-start.py` — global `UserPromptSubmit` bootstrap (`register_hook_in_settings`)
+- `packages/claude-code-plugin/hooks/user-prompt-submit.py` — the actual PLAN/ACT/EVAL keyword detection script
+- `packages/claude-code-plugin/tests/test_bootstrap_architecture.py` — invariant tests for this document
+- `packages/claude-code-plugin/scripts/migrate-legacy-hooks.js` — stale-entry cleanup (tracked in #1381)

--- a/packages/claude-code-plugin/hooks/hooks.json
+++ b/packages/claude-code-plugin/hooks/hooks.json
@@ -1,4 +1,5 @@
 {
+  "$comment": "UserPromptSubmit is intentionally absent from this file. The hook is installed globally into ~/.claude/settings.json at session start by hooks/session-start.py (which copies hooks/user-prompt-submit.py into ~/.claude/hooks/). See docs/bootstrap-architecture.md and issue #1380 for the rationale. Do NOT add a UserPromptSubmit entry here without updating bootstrap-architecture.md and the session-start global install logic in the same change.",
   "description": "CodingBuddy plugin hooks — PLAN/ACT/EVAL workflow enforcement, quality gates, and operational tracking",
   "hooks": {
     "SessionStart": [

--- a/packages/claude-code-plugin/hooks/session-start.py
+++ b/packages/claude-code-plugin/hooks/session-start.py
@@ -1,14 +1,46 @@
 #!/usr/bin/env python3
 """
-CodingBuddy Session Start Hook
+CodingBuddy Session Start Hook — Bootstrap for global UserPromptSubmit.
 
-Automatically installs the UserPromptSubmit hook for mode detection
-when a Claude Code session starts.
+This file is the **source of truth** for how the CodingBuddy plugin
+installs its ``UserPromptSubmit`` hook into Claude Code.
 
-This hook:
-1. Checks if the mode detection hook is already installed
-2. If not, copies it to ~/.claude/hooks/
-3. Registers it in ~/.claude/settings.json
+Why this file exists
+--------------------
+CodingBuddy uses two distinct hook layers:
+
+1. **Plugin-local** ``hooks/hooks.json`` — registers ``SessionStart``,
+   ``PreToolUse``, ``PostToolUse``, and ``Stop`` hooks that Claude Code
+   loads directly from the plugin package at runtime.
+2. **Global install** (this script) — at every session start, copies
+   ``hooks/user-prompt-submit.py`` into ``~/.claude/hooks/`` and
+   registers a ``UserPromptSubmit`` hook in the user's global
+   ``~/.claude/settings.json``.
+
+``UserPromptSubmit`` is deliberately **not** in ``hooks/hooks.json``.
+The global install is what actually wires up PLAN/ACT/EVAL/AUTO mode
+detection today, and contributors reading ``hooks.json`` first have
+repeatedly mistaken the missing entry for a bug (see #1380).
+
+For the long-form rationale and migration options, see:
+``packages/claude-code-plugin/docs/bootstrap-architecture.md``.
+
+What this hook does on every session start
+-------------------------------------------
+1. Check whether the mode-detection hook file already exists at
+   ``~/.claude/hooks/codingbuddy-mode-detect.py``.
+2. If not, copy ``user-prompt-submit.py`` there (alongside its ``lib/``
+   dependencies).
+3. Ensure ``~/.claude/settings.json`` has a ``UserPromptSubmit`` hook
+   entry pointing at that file, creating the settings file if needed
+   and using file locking on Unix to avoid concurrent writes.
+4. Additionally installs the status line, ``~/.claude/mcp.json`` entry,
+   system-prompt injection, and briefing-recovery suggestions.
+
+Invariant: any change that moves ``UserPromptSubmit`` registration into
+``hooks/hooks.json`` **must** delete the corresponding install logic
+below and update ``docs/bootstrap-architecture.md`` plus
+``tests/test_bootstrap_architecture.py`` in the same change.
 """
 
 import json
@@ -325,15 +357,30 @@ def _read_settings_file(settings_file: Path) -> dict:
 
 def register_hook_in_settings(settings_file: Path) -> bool:
     """
-    Register the UserPromptSubmit hook in settings.json.
+    Register the UserPromptSubmit hook in the user's global settings.json.
 
-    Uses file locking on Unix systems to prevent concurrent write issues.
+    This is the **bootstrap source of truth** for CodingBuddy's
+    UserPromptSubmit registration. The plugin-local ``hooks/hooks.json``
+    intentionally does NOT declare UserPromptSubmit; instead, this
+    function writes the hook entry into ``~/.claude/settings.json`` so
+    it is active for *all* Claude Code sessions, not just sessions
+    inside the CodingBuddy project.
+
+    Why global, not plugin-local? PLAN/ACT/EVAL keyword detection is
+    meant to work from any working directory once the plugin is
+    installed. A plugin-local hook would only fire when
+    ``CLAUDE_PLUGIN_ROOT`` resolves to this package, which is too
+    narrow. See ``docs/bootstrap-architecture.md`` and #1380.
+
+    Uses file locking on Unix systems to prevent concurrent write
+    issues when multiple Claude Code sessions start at the same time.
 
     Args:
-        settings_file: Path to ~/.claude/settings.json
+        settings_file: Path to ``~/.claude/settings.json``.
 
     Returns:
-        True if registered successfully, False if already exists
+        ``True`` if the hook was newly registered, ``False`` if an
+        entry already existed (idempotent).
     """
     settings_file.parent.mkdir(parents=True, exist_ok=True)
 

--- a/packages/claude-code-plugin/tests/test_bootstrap_architecture.py
+++ b/packages/claude-code-plugin/tests/test_bootstrap_architecture.py
@@ -1,0 +1,261 @@
+"""Bootstrap architecture regression tests (#1380).
+
+These tests lock in the architectural invariants for how CodingBuddy's
+``UserPromptSubmit`` hook is registered with Claude Code.
+
+Background
+----------
+The plugin intentionally uses **two** distinct hook layers:
+
+1. **plugin-local** ``hooks/hooks.json`` — bundled with the plugin and
+   registers the hooks Claude Code loads directly from the plugin package
+   (``SessionStart``, ``PreToolUse``, ``PostToolUse``, ``Stop``).
+2. **SessionStart-driven global install** — at session start,
+   ``hooks/session-start.py`` copies ``user-prompt-submit.py`` into
+   ``~/.claude/hooks/`` and registers a ``UserPromptSubmit`` hook entry
+   in the user's global ``~/.claude/settings.json``.
+
+Because the global install path is what actually wires up
+``UserPromptSubmit`` today, ``hooks/hooks.json`` deliberately does **not**
+declare a ``UserPromptSubmit`` entry. Contributors reading ``hooks.json``
+for the first time have mistaken this for a missing registration.
+
+These tests exist to:
+
+* prevent regressions where ``UserPromptSubmit`` silently drifts between
+  layers (e.g. accidentally removed from ``session-start.py`` OR
+  accidentally added to ``hooks.json`` without updating the bootstrap
+  documentation),
+* keep the in-repo documentation (``$comment`` in ``hooks.json`` plus
+  ``docs/bootstrap-architecture.md``) synchronized with the actual
+  bootstrap path.
+
+If you intentionally migrate to a single-path model (see #1380 and the
+``Approach B`` notes), update these tests **and** ``bootstrap-architecture.md``
+in the same change.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = PLUGIN_ROOT / "hooks"
+DOCS_DIR = PLUGIN_ROOT / "docs"
+
+HOOKS_JSON_PATH = HOOKS_DIR / "hooks.json"
+SESSION_START_PATH = HOOKS_DIR / "session-start.py"
+USER_PROMPT_SUBMIT_PATH = HOOKS_DIR / "user-prompt-submit.py"
+BOOTSTRAP_DOC_PATH = DOCS_DIR / "bootstrap-architecture.md"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def hooks_json() -> dict:
+    """Parsed contents of the plugin-local hooks.json manifest."""
+    with open(HOOKS_JSON_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def session_start_source() -> str:
+    """Raw source of hooks/session-start.py."""
+    with open(SESSION_START_PATH, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+@pytest.fixture(scope="module")
+def bootstrap_doc() -> str:
+    """Raw contents of docs/bootstrap-architecture.md."""
+    with open(BOOTSTRAP_DOC_PATH, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# hooks.json invariants
+# ---------------------------------------------------------------------------
+
+
+class TestHooksJsonStructure:
+    """Invariants for plugin-local ``hooks/hooks.json``."""
+
+    def test_hooks_json_exists(self) -> None:
+        assert HOOKS_JSON_PATH.is_file(), (
+            f"hooks.json must exist at {HOOKS_JSON_PATH}"
+        )
+
+    def test_hooks_json_is_valid_json(self, hooks_json: dict) -> None:
+        assert isinstance(hooks_json, dict)
+
+    def test_hooks_json_declares_expected_events(self, hooks_json: dict) -> None:
+        """Plugin-local layer registers exactly the events Claude Code loads directly.
+
+        ``UserPromptSubmit`` is intentionally absent — it is installed by
+        ``session-start.py`` into the user's global settings at runtime.
+        """
+        events = hooks_json.get("hooks", {})
+        expected_events = {"SessionStart", "PreToolUse", "PostToolUse", "Stop"}
+        assert set(events.keys()) == expected_events, (
+            "hooks.json must declare exactly "
+            f"{sorted(expected_events)}. Got: {sorted(events.keys())}"
+        )
+
+    def test_hooks_json_does_not_declare_user_prompt_submit(
+        self, hooks_json: dict
+    ) -> None:
+        """``UserPromptSubmit`` must not appear in plugin-local hooks.json.
+
+        If you are intentionally migrating to a single-path model, remove
+        the global install from session-start.py **in the same change**
+        and update ``docs/bootstrap-architecture.md``. See #1380.
+        """
+        events = hooks_json.get("hooks", {})
+        assert "UserPromptSubmit" not in events, (
+            "UserPromptSubmit must not live in plugin-local hooks.json — "
+            "session-start.py installs it globally. See "
+            "docs/bootstrap-architecture.md for rationale."
+        )
+
+
+class TestHooksJsonBootstrapComment:
+    """hooks.json must carry an inline pointer to the bootstrap docs.
+
+    JSON has no comment syntax, so we use the ``$comment`` convention
+    (also used by JSON Schema) to leave a contributor-facing note.
+    """
+
+    def test_hooks_json_has_bootstrap_comment(self, hooks_json: dict) -> None:
+        assert "$comment" in hooks_json, (
+            "hooks.json must include a top-level $comment field pointing "
+            "contributors at the bootstrap architecture docs."
+        )
+
+    def test_bootstrap_comment_mentions_session_start(
+        self, hooks_json: dict
+    ) -> None:
+        comment = hooks_json.get("$comment", "")
+        assert isinstance(comment, str)
+        assert "session-start.py" in comment, (
+            "$comment must name session-start.py as the source of truth "
+            "for UserPromptSubmit installation."
+        )
+
+    def test_bootstrap_comment_mentions_user_prompt_submit(
+        self, hooks_json: dict
+    ) -> None:
+        comment = hooks_json.get("$comment", "")
+        assert "UserPromptSubmit" in comment, (
+            "$comment must explicitly mention UserPromptSubmit so "
+            "contributors understand why it's missing from this file."
+        )
+
+    def test_bootstrap_comment_references_doc(self, hooks_json: dict) -> None:
+        comment = hooks_json.get("$comment", "")
+        assert "bootstrap-architecture" in comment, (
+            "$comment must point readers to docs/bootstrap-architecture.md."
+        )
+
+
+# ---------------------------------------------------------------------------
+# session-start.py invariants
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStartBootstrap:
+    """session-start.py is the source of truth for global UserPromptSubmit."""
+
+    def test_session_start_exists(self) -> None:
+        assert SESSION_START_PATH.is_file()
+
+    def test_user_prompt_submit_source_exists(self) -> None:
+        """The hook source copied into ~/.claude/hooks/ must ship with the plugin."""
+        assert USER_PROMPT_SUBMIT_PATH.is_file(), (
+            "user-prompt-submit.py must exist so session-start.py can "
+            "copy it into ~/.claude/hooks/."
+        )
+
+    def test_session_start_references_user_prompt_submit(
+        self, session_start_source: str
+    ) -> None:
+        assert "user-prompt-submit.py" in session_start_source, (
+            "session-start.py must reference user-prompt-submit.py as "
+            "the source file for the global hook install."
+        )
+
+    def test_session_start_registers_user_prompt_submit_event(
+        self, session_start_source: str
+    ) -> None:
+        """The global install logic must target the UserPromptSubmit event."""
+        assert "UserPromptSubmit" in session_start_source, (
+            "session-start.py must contain the global UserPromptSubmit "
+            "registration logic."
+        )
+
+    def test_session_start_documents_bootstrap_role(
+        self, session_start_source: str
+    ) -> None:
+        """Module docstring must explain the bootstrap responsibility."""
+        # Extract the module docstring (first triple-quoted block).
+        start = session_start_source.find('"""')
+        assert start != -1, "session-start.py must have a module docstring"
+        end = session_start_source.find('"""', start + 3)
+        assert end != -1, "session-start.py module docstring is unterminated"
+        docstring = session_start_source[start:end].lower()
+
+        # The docstring should explain why this file installs a global hook.
+        assert "userpromptsubmit" in docstring, (
+            "session-start.py docstring must mention UserPromptSubmit so "
+            "its bootstrap role is discoverable from a casual read."
+        )
+        assert "~/.claude" in docstring or ".claude/settings.json" in docstring, (
+            "session-start.py docstring must mention the global settings "
+            "location it writes to."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap documentation invariants
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapDocumentation:
+    """docs/bootstrap-architecture.md is the long-form source of truth."""
+
+    def test_bootstrap_doc_exists(self) -> None:
+        assert BOOTSTRAP_DOC_PATH.is_file(), (
+            f"Bootstrap architecture doc must exist at {BOOTSTRAP_DOC_PATH}"
+        )
+
+    def test_bootstrap_doc_mentions_both_layers(self, bootstrap_doc: str) -> None:
+        assert "hooks.json" in bootstrap_doc
+        assert "session-start.py" in bootstrap_doc
+
+    def test_bootstrap_doc_mentions_user_prompt_submit(
+        self, bootstrap_doc: str
+    ) -> None:
+        assert "UserPromptSubmit" in bootstrap_doc
+
+    def test_bootstrap_doc_mentions_global_settings_path(
+        self, bootstrap_doc: str
+    ) -> None:
+        assert "~/.claude/settings.json" in bootstrap_doc or (
+            "~/.claude" in bootstrap_doc and "settings.json" in bootstrap_doc
+        ), (
+            "bootstrap-architecture.md must document the global settings "
+            "file path the hook is registered in."
+        )
+
+    def test_bootstrap_doc_links_issue(self, bootstrap_doc: str) -> None:
+        """Doc should reference #1380 so history is discoverable."""
+        assert "1380" in bootstrap_doc, (
+            "bootstrap-architecture.md should reference issue #1380 for "
+            "historical context."
+        )


### PR DESCRIPTION
## Summary

The plugin uses two distinct hook layers and the split is not self-documenting:

1. **plugin-local** `hooks/hooks.json` — `SessionStart`, `PreToolUse`, `PostToolUse`, `Stop`
2. **global install** — `hooks/session-start.py` writes a `UserPromptSubmit` entry into `~/.claude/settings.json` at every session start

Because `UserPromptSubmit` is absent from `hooks.json`, contributors auditing the package repeatedly mistake the missing entry for a bug. This PR clarifies the architecture without changing behavior.

### Approach A (document + regression-test) chosen over Approach B (migrate into hooks.json)

- **Low risk**: no behavior change, comments + docs + tests only
- **Preserves global-scope semantics**: PLAN/ACT/EVAL/AUTO keyword detection must fire in *any* Claude Code session, not only inside CodingBuddy projects — plugin-local hooks would narrow that scope
- **Parallel-safe with #1381**: keeps file footprint separate from the stale legacy hook migration
- **Approach B remains viable** as a follow-up once #1381 lands

### Changes

- `hooks/hooks.json`: top-level `\$comment` field pointing contributors at `session-start.py` and the new architecture doc
- `hooks/session-start.py`: module docstring expanded to name the bootstrap role and two-layer architecture; `register_hook_in_settings` docstring expanded with the *why* behind global install
- `docs/bootstrap-architecture.md` *(new)*: long-form rationale, source-of-truth cheat sheet, drift safeguards, future-simplification notes
- `tests/test_bootstrap_architecture.py` *(new, 18 tests)*: invariant regression suite covering `hooks.json` shape, `\$comment` presence and contents, `session-start.py` docstring, doc existence and required sections

## Test plan

- [x] `yarn workspace codingbuddy-claude-plugin lint`
- [x] `yarn workspace codingbuddy-claude-plugin format:check`
- [x] `yarn workspace codingbuddy-claude-plugin typecheck`
- [x] `yarn workspace codingbuddy-claude-plugin test:coverage` — 123 passed
- [x] `python3 -m pytest tests/` — 766 passed (incl. 18 new bootstrap tests)
- [x] `yarn workspace codingbuddy-claude-plugin circular`
- [x] `yarn workspace codingbuddy-claude-plugin build`
- [x] `yarn workspace codingbuddy npm audit --severity high`
- [x] `yarn workspace codingbuddy-claude-plugin npm audit --severity high`
- [x] `yarn workspace landing-page npm audit --severity high`

## Verification (RED → GREEN evidence)

Before the changes, 5 bootstrap tests failed + 4 errored (18 total, 9 passing) — confirming the invariants the suite is meant to enforce were not yet in place. After the documentation/comment changes, all 18 pass.

Closes #1380