### PR TITLE
fix(plugin): migrate stale global codingbuddy-mode-detect.py on install

### DIFF
--- a/packages/claude-code-plugin/hooks/test_user_prompt_submit.py
+++ b/packages/claude-code-plugin/hooks/test_user_prompt_submit.py
@@ -306,6 +306,69 @@ class TestMcpVsStandaloneOutput:
             assert "mcp__codingbuddy__parse_mode" in result.stdout
 
 
+class TestBackendDiagnosticMarker:
+    """
+    #1384: standalone fallback visibility.
+
+    The hook must emit a `# Backend: ...` marker line so users can tell at
+    a glance whether mode handling is backed by the MCP server or by the
+    self-contained standalone engine. Without this marker users cannot
+    diagnose why enriched instructions are (or are not) being shown.
+    """
+
+    def _run_hook(self, prompt, home_dir, mcp_enabled, cwd=None):
+        import os as _os
+
+        hook_path = Path(__file__).parent / "user-prompt-submit.py"
+        input_data = json.dumps({"prompt": prompt})
+        env = _os.environ.copy()
+        env["HOME"] = str(home_dir)
+        env.pop("CODINGBUDDY_RULES_DIR", None)
+        # Pin CLAUDE_PROJECT_DIR so MCP detection does not depend on cwd.
+        env["CLAUDE_PROJECT_DIR"] = str(home_dir)
+        return subprocess.run(
+            [sys.executable, str(hook_path)],
+            input=input_data,
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=cwd or str(home_dir),
+        )
+
+    def test_standalone_backend_marker(self):
+        """Standalone fallback must be clearly labelled in the hook output."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = Path(tmpdir) / ".claude"
+            claude_dir.mkdir()
+            # No mcp.json anywhere => standalone path.
+
+            result = self._run_hook("PLAN: ship it", tmpdir, mcp_enabled=False)
+            assert result.returncode == 0
+            assert "# Backend: standalone" in result.stdout
+
+    def test_mcp_backend_marker(self):
+        """When MCP is available the marker must say mcp-enhanced."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = Path(tmpdir) / ".claude"
+            claude_dir.mkdir()
+            mcp_json = claude_dir / "mcp.json"
+            mcp_json.write_text(json.dumps({
+                "mcpServers": {
+                    "codingbuddy": {"command": "codingbuddy", "args": ["mcp"]}
+                }
+            }))
+
+            result = self._run_hook("PLAN: ship it", tmpdir, mcp_enabled=True)
+            assert result.returncode == 0
+            assert "# Backend: mcp-enhanced" in result.stdout
+            # MCP branch must not leak standalone wording.
+            assert "# Backend: standalone" not in result.stdout
+
+
 if __name__ == "__main__":
     import pytest
     pytest.main([__file__, "-v"])

--- a/packages/claude-code-plugin/hooks/user-prompt-submit.py
+++ b/packages/claude-code-plugin/hooks/user-prompt-submit.py
@@ -74,18 +74,26 @@ def main():
                 if is_mcp_available(project_dir=project_dir):
                     # MCP mode: minimal output, parse_mode handles the rest
                     print(f"# Mode: {detected_mode}")
+                    print("# Backend: mcp-enhanced")
                     print(
                         "If mcp__codingbuddy__parse_mode is available, "
                         "call it for enhanced features."
                     )
                 else:
-                    # Standalone mode: full enriched instructions
+                    # Standalone mode: full enriched instructions.
+                    # Diagnostic marker (#1384): make it obvious to users that
+                    # the self-contained fallback is active and no MCP server
+                    # is required for mode handling.
+                    print("# Backend: standalone (self-contained, no MCP required)")
                     engine = ModeEngine(cwd=project_dir)
                     instructions = engine.build_instructions(detected_mode)
                     print(instructions)
             except Exception:
-                # Fallback: minimal instruction if imports fail
+                # Fallback: minimal instruction if imports fail.
+                # Still mark this as the standalone-minimal path so it is
+                # diagnosable post-hoc (#1384).
                 print(f"# Mode: {detected_mode}")
+                print("# Backend: standalone-minimal (import failure)")
                 print(
                     "If mcp__codingbuddy__parse_mode is available, "
                     "call it for enhanced features."

--- a/packages/claude-code-plugin/scripts/migrate-legacy-hooks.js
+++ b/packages/claude-code-plugin/scripts/migrate-legacy-hooks.js
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Legacy Hook Migration (#1381 + #1384)
+ *
+ * Cleans up a stale global hook left behind by plugin versions prior to the
+ * self-contained hook refactor. Specifically:
+ *
+ *   1. Deletes `~/.claude/hooks/codingbuddy-mode-detect.py` when present.
+ *   2. Removes `~/.claude/hooks/lib` only if it is a symlink (never a real dir).
+ *   3. Filters any `UserPromptSubmit` entries in `~/.claude/settings.json`
+ *      whose command string references the legacy script file name,
+ *      preserving every unrelated entry.
+ *   4. Drops the `hooks.UserPromptSubmit` key entirely when it becomes empty.
+ *   5. Writes a timestamped backup (`settings.json.bak-codingbuddy-migration-<ts>`)
+ *      whenever `settings.json` is rewritten.
+ *
+ * Runtime constraints:
+ *   - Pure CommonJS, no external dependencies. It is required from
+ *     `postinstall.js` which runs under the end-user's `node` without any
+ *     build step.
+ *   - Idempotent: a second invocation on a clean system is a no-op.
+ *   - Graceful on malformed JSON / missing files / missing `~/.claude`.
+ *   - Respects `CODINGBUDDY_POSTINSTALL_DRY_RUN=1` and the `dryRun` option.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const LEGACY_SCRIPT_NAME = 'codingbuddy-mode-detect.py';
+const BACKUP_PREFIX = 'settings.json.bak-codingbuddy-migration-';
+
+function defaultLogger(line) {
+  // Prefix so users can recognise the migration output in their install log.
+  // eslint-disable-next-line no-console
+  console.log(`[CodingBuddy Plugin] ${line}`);
+}
+
+function isLegacyCommandString(command) {
+  return typeof command === 'string' && command.includes(LEGACY_SCRIPT_NAME);
+}
+
+/**
+ * Filter a single UserPromptSubmit group. A group has shape:
+ *   { matcher?: string, hooks: [{ type: 'command', command: string, ... }] }
+ * Returns either a new group with legacy sub-hooks stripped, or `null` when
+ * the group becomes empty (and should therefore be dropped).
+ */
+function filterGroup(group) {
+  if (!group || typeof group !== 'object' || !Array.isArray(group.hooks)) {
+    // Unknown shape — leave it alone so we do not corrupt user settings.
+    return { next: group, removed: 0 };
+  }
+  let removed = 0;
+  const kept = [];
+  for (const entry of group.hooks) {
+    if (entry && isLegacyCommandString(entry.command)) {
+      removed += 1;
+      continue;
+    }
+    kept.push(entry);
+  }
+  if (kept.length === 0) {
+    return { next: null, removed };
+  }
+  return { next: { ...group, hooks: kept }, removed };
+}
+
+/**
+ * Strip legacy entries from `settings.hooks.UserPromptSubmit`. Returns
+ * `{ changed, removedUserPromptSubmitKey, strippedEntries }` where
+ * `strippedEntries` counts individual `{ type: 'command' }` hooks removed.
+ */
+function stripLegacyFromSettings(settings) {
+  const result = {
+    changed: false,
+    removedUserPromptSubmitKey: false,
+    strippedEntries: 0,
+  };
+  if (!settings || typeof settings !== 'object') return result;
+  const hooks = settings.hooks;
+  if (!hooks || typeof hooks !== 'object') return result;
+  const ups = hooks.UserPromptSubmit;
+  if (!Array.isArray(ups)) return result;
+
+  const nextGroups = [];
+  for (const group of ups) {
+    const { next, removed } = filterGroup(group);
+    if (removed > 0) {
+      result.changed = true;
+      result.strippedEntries += removed;
+    }
+    if (next !== null) nextGroups.push(next);
+    else result.changed = true;
+  }
+
+  if (result.changed) {
+    if (nextGroups.length === 0) {
+      delete hooks.UserPromptSubmit;
+      result.removedUserPromptSubmitKey = true;
+    } else {
+      hooks.UserPromptSubmit = nextGroups;
+    }
+  }
+
+  return result;
+}
+
+function tryReadJson(filePath, warnings) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return { raw: null, parsed: null };
+    warnings.push(`could not read ${filePath}: ${err.message}`);
+    return { raw: null, parsed: null };
+  }
+  try {
+    return { raw, parsed: JSON.parse(raw) };
+  } catch (err) {
+    warnings.push(`settings.json is malformed, skipping migration: ${err.message}`);
+    return { raw, parsed: null };
+  }
+}
+
+function safeLstat(p) {
+  try {
+    return fs.lstatSync(p);
+  } catch {
+    return null;
+  }
+}
+
+function migrateStaleScript({ hooksDir, dryRun, log, result }) {
+  const scriptPath = path.join(hooksDir, LEGACY_SCRIPT_NAME);
+  const stat = safeLstat(scriptPath);
+  if (!stat) return;
+  result.removedScript = true;
+  log(`Migrated legacy hook: ${scriptPath}`);
+  if (!dryRun) {
+    try {
+      fs.unlinkSync(scriptPath);
+    } catch (err) {
+      result.warnings.push(`failed to delete ${scriptPath}: ${err.message}`);
+    }
+  }
+}
+
+function migrateStaleSymlink({ hooksDir, dryRun, log, result }) {
+  const linkPath = path.join(hooksDir, 'lib');
+  const stat = safeLstat(linkPath);
+  if (!stat || !stat.isSymbolicLink()) return;
+  result.removedSymlink = true;
+  log(`Removed legacy symlink: ${linkPath}`);
+  if (!dryRun) {
+    try {
+      fs.unlinkSync(linkPath);
+    } catch (err) {
+      result.warnings.push(`failed to unlink ${linkPath}: ${err.message}`);
+    }
+  }
+}
+
+function migrateSettings({ claudeDir, dryRun, log, result }) {
+  const settingsPath = path.join(claudeDir, 'settings.json');
+  const { raw, parsed } = tryReadJson(settingsPath, result.warnings);
+  if (raw === null || parsed === null) return;
+
+  const strip = stripLegacyFromSettings(parsed);
+  result.strippedSettingsEntries = strip.strippedEntries;
+  result.removedUserPromptSubmitKey = strip.removedUserPromptSubmitKey;
+  if (!strip.changed) return;
+
+  log(
+    `Migrated legacy UserPromptSubmit entries from settings.json ` +
+      `(removed ${strip.strippedEntries} entry${strip.strippedEntries === 1 ? '' : 'ies'})`,
+  );
+
+  if (dryRun) return;
+
+  const backupPath = `${settingsPath}.bak-codingbuddy-migration-${Date.now()}`;
+  try {
+    fs.writeFileSync(backupPath, raw);
+    result.backupPath = backupPath;
+    log(`Wrote settings.json backup: ${backupPath}`);
+  } catch (err) {
+    result.warnings.push(`failed to write backup ${backupPath}: ${err.message}`);
+    return; // do not rewrite settings.json if we could not back it up
+  }
+
+  try {
+    fs.writeFileSync(settingsPath, JSON.stringify(parsed, null, 2) + '\n');
+  } catch (err) {
+    result.warnings.push(`failed to rewrite ${settingsPath}: ${err.message}`);
+  }
+}
+
+/**
+ * Main entry point.
+ *
+ * @param {{ homeDir?: string, dryRun?: boolean, logger?: (line: string) => void }} [opts]
+ */
+function migrateLegacyHooks(opts = {}) {
+  const homeDir = opts.homeDir || os.homedir();
+  const dryRun =
+    opts.dryRun === true ||
+    process.env.CODINGBUDDY_POSTINSTALL_DRY_RUN === '1' ||
+    process.env.CODINGBUDDY_POSTINSTALL_DRY_RUN === 'true';
+  const logger = typeof opts.logger === 'function' ? opts.logger : defaultLogger;
+
+  const result = {
+    removedScript: false,
+    removedSymlink: false,
+    strippedSettingsEntries: 0,
+    removedUserPromptSubmitKey: false,
+    backupPath: null,
+    dryRun,
+    warnings: [],
+  };
+
+  const claudeDir = path.join(homeDir, '.claude');
+  if (!fs.existsSync(claudeDir)) return result;
+
+  const hooksDir = path.join(claudeDir, 'hooks');
+  const log = (line) => logger(line);
+
+  if (fs.existsSync(hooksDir)) {
+    migrateStaleScript({ hooksDir, dryRun, log, result });
+    migrateStaleSymlink({ hooksDir, dryRun, log, result });
+  }
+
+  migrateSettings({ claudeDir, dryRun, log, result });
+
+  return result;
+}
+
+module.exports = {
+  migrateLegacyHooks,
+  LEGACY_SCRIPT_NAME,
+};

--- a/packages/claude-code-plugin/scripts/migrate-legacy-hooks.spec.ts
+++ b/packages/claude-code-plugin/scripts/migrate-legacy-hooks.spec.ts
@@ -1,0 +1,423 @@
+/**
+ * Unit Tests for Legacy Hook Migration (#1381 + #1384)
+ *
+ * Covers the migration path that cleans up the stale global hook script
+ * `~/.claude/hooks/codingbuddy-mode-detect.py` and its corresponding
+ * `UserPromptSubmit` entry in `~/.claude/settings.json` left behind by
+ * plugin versions prior to the self-contained hook refactor.
+ *
+ * Requirements derived from issues #1381 / #1384:
+ *   - Remove stale global `codingbuddy-mode-detect.py`.
+ *   - Remove `~/.claude/hooks/lib` only when it is a symlink (never a real dir).
+ *   - Strip only the legacy `UserPromptSubmit` entry; preserve unrelated ones.
+ *   - Delete the `UserPromptSubmit` key if it becomes empty.
+ *   - Back up `settings.json` before writing.
+ *   - Respect `CODINGBUDDY_POSTINSTALL_DRY_RUN=1` (or opts.dryRun).
+ *   - Idempotent: a second run must be a no-op.
+ *   - Graceful degrade on malformed/missing files.
+ *   - Emit clear log lines describing what changed (#1384 visibility).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// CJS require via createRequire so the migration module can be authored
+// as plain JS (it is executed from `node scripts/postinstall.js` in user
+// environments where ts-node is not guaranteed to be available).
+import { createRequire } from 'module';
+const requireCjs = createRequire(__filename);
+const migrateLegacyHooks = requireCjs('./migrate-legacy-hooks.js') as {
+  migrateLegacyHooks: (opts?: MigrateOpts) => MigrateResult;
+  LEGACY_SCRIPT_NAME: string;
+};
+
+type MigrateOpts = {
+  homeDir?: string;
+  dryRun?: boolean;
+  logger?: (line: string) => void;
+};
+
+type MigrateResult = {
+  removedScript: boolean;
+  removedSymlink: boolean;
+  strippedSettingsEntries: number;
+  removedUserPromptSubmitKey: boolean;
+  backupPath: string | null;
+  dryRun: boolean;
+  warnings: string[];
+};
+
+// -----------------------------------------------------------------------------
+// Fixture helpers
+// -----------------------------------------------------------------------------
+
+function makeTmpHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-migrate-'));
+  fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.claude', 'hooks'), { recursive: true });
+  return dir;
+}
+
+function writeSettings(homeDir: string, content: unknown): string {
+  const p = path.join(homeDir, '.claude', 'settings.json');
+  fs.writeFileSync(p, typeof content === 'string' ? content : JSON.stringify(content, null, 2));
+  return p;
+}
+
+function writeLegacyScript(homeDir: string): string {
+  const p = path.join(homeDir, '.claude', 'hooks', 'codingbuddy-mode-detect.py');
+  fs.writeFileSync(p, '# stale legacy hook\n');
+  return p;
+}
+
+function legacyEntry() {
+  return {
+    hooks: [
+      {
+        type: 'command',
+        command: 'python3 ~/.claude/hooks/codingbuddy-mode-detect.py',
+      },
+    ],
+  };
+}
+
+function unrelatedEntry() {
+  return {
+    hooks: [
+      {
+        type: 'command',
+        command: 'python3 ~/.claude/hooks/other-user-hook.py',
+      },
+    ],
+  };
+}
+
+// Keep temp dirs bounded across tests.
+const createdDirs: string[] = [];
+function tmpHome(): string {
+  const d = makeTmpHome();
+  createdDirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  while (createdDirs.length > 0) {
+    const d = createdDirs.pop();
+    if (d && fs.existsSync(d)) {
+      fs.rmSync(d, { recursive: true, force: true });
+    }
+  }
+});
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+describe('migrate-legacy-hooks', () => {
+  describe('stale global script removal', () => {
+    it('removes ~/.claude/hooks/codingbuddy-mode-detect.py when present', () => {
+      const home = tmpHome();
+      const scriptPath = writeLegacyScript(home);
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      expect(fs.existsSync(scriptPath)).toBe(false);
+      expect(result.removedScript).toBe(true);
+    });
+
+    it('leaves unrelated files in ~/.claude/hooks/ untouched', () => {
+      const home = tmpHome();
+      writeLegacyScript(home);
+      const otherPath = path.join(home, '.claude', 'hooks', 'my-own-hook.py');
+      fs.writeFileSync(otherPath, '# user hook\n');
+
+      migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      expect(fs.existsSync(otherPath)).toBe(true);
+    });
+
+    it('is a no-op when the legacy script does not exist', () => {
+      const home = tmpHome();
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      expect(result.removedScript).toBe(false);
+    });
+  });
+
+  describe('~/.claude/hooks/lib symlink handling', () => {
+    it('removes ~/.claude/hooks/lib when it is a symlink', () => {
+      const home = tmpHome();
+      const target = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-lib-target-'));
+      createdDirs.push(target);
+      const libLink = path.join(home, '.claude', 'hooks', 'lib');
+      fs.symlinkSync(target, libLink, 'dir');
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      expect(fs.existsSync(libLink)).toBe(false);
+      // Target directory must NOT be deleted.
+      expect(fs.existsSync(target)).toBe(true);
+      expect(result.removedSymlink).toBe(true);
+    });
+
+    it('does NOT touch ~/.claude/hooks/lib when it is a real directory', () => {
+      const home = tmpHome();
+      const libDir = path.join(home, '.claude', 'hooks', 'lib');
+      fs.mkdirSync(libDir, { recursive: true });
+      fs.writeFileSync(path.join(libDir, 'user-owned.txt'), 'keep me');
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      expect(fs.existsSync(libDir)).toBe(true);
+      expect(fs.existsSync(path.join(libDir, 'user-owned.txt'))).toBe(true);
+      expect(result.removedSymlink).toBe(false);
+    });
+  });
+
+  describe('settings.json UserPromptSubmit filtering', () => {
+    it('strips the legacy entry and preserves unrelated entries', () => {
+      const home = tmpHome();
+      const settingsPath = writeSettings(home, {
+        hooks: {
+          UserPromptSubmit: [legacyEntry(), unrelatedEntry()],
+        },
+      });
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      expect(after.hooks.UserPromptSubmit).toHaveLength(1);
+      expect(after.hooks.UserPromptSubmit[0].hooks[0].command).toContain('other-user-hook.py');
+      expect(result.strippedSettingsEntries).toBeGreaterThanOrEqual(1);
+    });
+
+    it('removes UserPromptSubmit key when it becomes empty', () => {
+      const home = tmpHome();
+      const settingsPath = writeSettings(home, {
+        hooks: {
+          UserPromptSubmit: [legacyEntry()],
+          SessionStart: [{ hooks: [{ type: 'command', command: 'echo hi' }] }],
+        },
+      });
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      expect(after.hooks.UserPromptSubmit).toBeUndefined();
+      // SessionStart must remain intact.
+      expect(after.hooks.SessionStart).toBeDefined();
+      expect(result.removedUserPromptSubmitKey).toBe(true);
+    });
+
+    it('filters nested hooks arrays where only some sub-entries are legacy', () => {
+      const home = tmpHome();
+      const settingsPath = writeSettings(home, {
+        hooks: {
+          UserPromptSubmit: [
+            {
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'python3 ~/.claude/hooks/codingbuddy-mode-detect.py',
+                },
+                {
+                  type: 'command',
+                  command: 'python3 ~/.claude/hooks/other-user-hook.py',
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      expect(after.hooks.UserPromptSubmit).toHaveLength(1);
+      const inner = after.hooks.UserPromptSubmit[0].hooks;
+      expect(inner).toHaveLength(1);
+      expect(inner[0].command).toContain('other-user-hook.py');
+    });
+
+    it('does nothing when settings.json has no legacy entries', () => {
+      const home = tmpHome();
+      const original = {
+        hooks: {
+          UserPromptSubmit: [unrelatedEntry()],
+        },
+      };
+      const settingsPath = writeSettings(home, original);
+      const before = fs.readFileSync(settingsPath, 'utf8');
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      expect(fs.readFileSync(settingsPath, 'utf8')).toBe(before);
+      expect(result.strippedSettingsEntries).toBe(0);
+      expect(result.backupPath).toBeNull();
+    });
+  });
+
+  describe('backup behavior', () => {
+    it('creates a timestamped backup before rewriting settings.json', () => {
+      const home = tmpHome();
+      writeSettings(home, {
+        hooks: {
+          UserPromptSubmit: [legacyEntry()],
+        },
+      });
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      expect(result.backupPath).toBeTruthy();
+      expect(result.backupPath).toMatch(/settings\.json\.bak-codingbuddy-migration-\d+/);
+      expect(fs.existsSync(result.backupPath as string)).toBe(true);
+    });
+
+    it('does not create a backup when nothing changes', () => {
+      const home = tmpHome();
+      writeSettings(home, { hooks: { UserPromptSubmit: [unrelatedEntry()] } });
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      expect(result.backupPath).toBeNull();
+    });
+  });
+
+  describe('dry-run mode', () => {
+    it('does not write any files when dryRun is true', () => {
+      const home = tmpHome();
+      const scriptPath = writeLegacyScript(home);
+      const settingsPath = writeSettings(home, {
+        hooks: { UserPromptSubmit: [legacyEntry()] },
+      });
+      const before = fs.readFileSync(settingsPath, 'utf8');
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({
+        homeDir: home,
+        dryRun: true,
+      });
+
+      expect(fs.existsSync(scriptPath)).toBe(true);
+      expect(fs.readFileSync(settingsPath, 'utf8')).toBe(before);
+      expect(result.dryRun).toBe(true);
+      // Result reports what *would* change even in dry-run.
+      expect(result.removedScript).toBe(true);
+      expect(result.strippedSettingsEntries).toBeGreaterThanOrEqual(1);
+      expect(result.backupPath).toBeNull();
+    });
+
+    it('honors CODINGBUDDY_POSTINSTALL_DRY_RUN=1 env var', () => {
+      const home = tmpHome();
+      writeLegacyScript(home);
+      writeSettings(home, { hooks: { UserPromptSubmit: [legacyEntry()] } });
+      const prev = process.env.CODINGBUDDY_POSTINSTALL_DRY_RUN;
+      process.env.CODINGBUDDY_POSTINSTALL_DRY_RUN = '1';
+      try {
+        const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+        expect(result.dryRun).toBe(true);
+        expect(
+          fs.existsSync(path.join(home, '.claude', 'hooks', 'codingbuddy-mode-detect.py')),
+        ).toBe(true);
+      } finally {
+        if (prev === undefined) {
+          delete process.env.CODINGBUDDY_POSTINSTALL_DRY_RUN;
+        } else {
+          process.env.CODINGBUDDY_POSTINSTALL_DRY_RUN = prev;
+        }
+      }
+    });
+  });
+
+  describe('idempotency', () => {
+    it('running twice produces the same state and no extra backups', () => {
+      const home = tmpHome();
+      writeLegacyScript(home);
+      writeSettings(home, { hooks: { UserPromptSubmit: [legacyEntry()] } });
+
+      const first = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+      const second = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      expect(first.removedScript).toBe(true);
+      expect(second.removedScript).toBe(false);
+      expect(second.strippedSettingsEntries).toBe(0);
+      expect(second.backupPath).toBeNull();
+    });
+  });
+
+  describe('graceful degradation', () => {
+    it('does not throw when ~/.claude is missing entirely', () => {
+      const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-migrate-empty-'));
+      createdDirs.push(home);
+      // No .claude directory at all.
+      expect(() => migrateLegacyHooks.migrateLegacyHooks({ homeDir: home })).not.toThrow();
+    });
+
+    it('does not throw when settings.json is malformed', () => {
+      const home = tmpHome();
+      writeSettings(home, 'this is not JSON {');
+
+      const result = migrateLegacyHooks.migrateLegacyHooks({ homeDir: home });
+
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(result.strippedSettingsEntries).toBe(0);
+      // Original content must remain untouched when parse fails.
+      const raw = fs.readFileSync(path.join(home, '.claude', 'settings.json'), 'utf8');
+      expect(raw).toBe('this is not JSON {');
+    });
+
+    it('does not throw when settings.json is missing', () => {
+      const home = tmpHome();
+      // No settings.json written.
+      expect(() => migrateLegacyHooks.migrateLegacyHooks({ homeDir: home })).not.toThrow();
+    });
+  });
+
+  describe('log visibility (#1384)', () => {
+    it('emits a log line when stale script is removed', () => {
+      const home = tmpHome();
+      writeLegacyScript(home);
+      const lines: string[] = [];
+
+      migrateLegacyHooks.migrateLegacyHooks({
+        homeDir: home,
+        logger: line => lines.push(line),
+      });
+
+      expect(lines.some(l => /codingbuddy-mode-detect\.py/.test(l))).toBe(true);
+      expect(lines.some(l => /Migrat/i.test(l))).toBe(true);
+    });
+
+    it('emits a log line when settings.json is updated', () => {
+      const home = tmpHome();
+      writeSettings(home, { hooks: { UserPromptSubmit: [legacyEntry()] } });
+      const lines: string[] = [];
+
+      migrateLegacyHooks.migrateLegacyHooks({
+        homeDir: home,
+        logger: line => lines.push(line),
+      });
+
+      expect(lines.some(l => /settings\.json/.test(l))).toBe(true);
+    });
+
+    it('remains quiet when there is nothing to migrate', () => {
+      const home = tmpHome();
+      const lines: string[] = [];
+      migrateLegacyHooks.migrateLegacyHooks({
+        homeDir: home,
+        logger: line => lines.push(line),
+      });
+      // No legacy script, no settings.json => no "Migrated" lines.
+      expect(lines.some(l => /Migrat/i.test(l))).toBe(false);
+    });
+  });
+
+  describe('legacy script name constant', () => {
+    it('exposes the canonical legacy script file name for callers', () => {
+      expect(migrateLegacyHooks.LEGACY_SCRIPT_NAME).toBe('codingbuddy-mode-detect.py');
+    });
+  });
+});

--- a/packages/claude-code-plugin/scripts/postinstall.js
+++ b/packages/claude-code-plugin/scripts/postinstall.js
@@ -1,13 +1,28 @@
 #!/usr/bin/env node
 'use strict';
 
-// Skip banner in CI environments
+const path = require('path');
+const fs = require('fs');
+
+// Run legacy hook migration on every install (idempotent, safe for CI).
+// See packages/claude-code-plugin/scripts/migrate-legacy-hooks.js and
+// issues #1381 / #1384.
+try {
+  const { migrateLegacyHooks } = require('./migrate-legacy-hooks');
+  migrateLegacyHooks();
+} catch (err) {
+  // Never block `npm install` on a migration failure. Surface the error so
+  // users can report it, then continue.
+  console.warn(
+    '[CodingBuddy Plugin] legacy hook migration skipped:',
+    err && err.message ? err.message : err,
+  );
+}
+
+// Skip banner in CI environments (migration still ran above).
 if (process.env.CI === 'true' || process.env.CI === '1') {
   process.exit(0);
 }
-
-const path = require('path');
-const fs = require('fs');
 
 // Read version from package.json
 let version = 'unknown';


### PR DESCRIPTION
## Summary

Bundle fix for **#1381** (primary) and **#1384** (related hardening). Upgraded installs from plugin versions prior to the self-contained hook refactor kept a stale global `~/.claude/hooks/codingbuddy-mode-detect.py` alive via `~/.claude/settings.json`, causing every `PLAN:`/`ACT:` prompt to emit the old mandatory-MCP template even though the newer self-contained hook was shipped. This PR migrates those installs and makes the standalone fallback visibly diagnosable.

- New `packages/claude-code-plugin/scripts/migrate-legacy-hooks.js` (CommonJS, no deps):
  - Deletes `~/.claude/hooks/codingbuddy-mode-detect.py` when present.
  - Removes `~/.claude/hooks/lib` **only** when it is a symlink (real directories are never touched).
  - Filters only `UserPromptSubmit` entries whose command references the legacy script file name, preserving every unrelated entry, and drops the `UserPromptSubmit` key entirely when it becomes empty.
  - Writes a timestamped `settings.json.bak-codingbuddy-migration-<ts>` backup before rewriting `settings.json`.
  - Idempotent, graceful on malformed/missing `settings.json`, graceful on missing `~/.claude`.
  - Supports `opts.dryRun` and `CODINGBUDDY_POSTINSTALL_DRY_RUN=1`.
  - Emits clear `[CodingBuddy Plugin] Migrated ...` log lines so users can see exactly what changed.
- Wires the migration into `scripts/postinstall.js` so every install runs it (including CI, since it is a no-op on clean systems). Migration failures never block `npm install` — they are surfaced as warnings.
- Adds a `# Backend: ...` diagnostic marker to `hooks/user-prompt-submit.py` (#1384) so users can tell at a glance whether mode handling is backed by the MCP server or the self-contained engine. Covers the exception fallback branch too.

## Test plan

- [x] 21 new vitest cases in `scripts/migrate-legacy-hooks.spec.ts`, covering:
  - Stale script removal + unrelated files preserved + no-op when absent.
  - Symlink `lib` removal vs. real-directory safety (target dir never deleted).
  - Legacy entry filtering in top-level and nested `UserPromptSubmit` arrays.
  - `UserPromptSubmit` key dropped when empty; sibling keys preserved.
  - Backup created on change; no backup when nothing changes.
  - Dry-run via both `opts.dryRun` and `CODINGBUDDY_POSTINSTALL_DRY_RUN=1` env var.
  - Idempotency: second run is a clean no-op, no extra backup.
  - Missing `~/.claude`, missing `settings.json`, malformed JSON all degrade gracefully.
  - Log visibility (`#1384`): stale-script and settings-update log lines; quiet on clean systems.
  - `LEGACY_SCRIPT_NAME` constant exposed for callers.
- [x] 2 new pytest cases in `hooks/test_user_prompt_submit.py::TestBackendDiagnosticMarker` asserting the new `# Backend: standalone` / `# Backend: mcp-enhanced` markers.
- [x] Pre-push checks (codingbuddy-claude-plugin):
  - `yarn workspace codingbuddy-claude-plugin lint`
  - `yarn workspace codingbuddy-claude-plugin format:check`
  - `yarn workspace codingbuddy-claude-plugin typecheck`
  - `yarn workspace codingbuddy-claude-plugin test:coverage` → **144/144 passed**
  - `yarn workspace codingbuddy-claude-plugin circular` → no circular deps
  - `yarn workspace codingbuddy-claude-plugin build`
- [x] `python3 -m pytest packages/claude-code-plugin/hooks/test_user_prompt_submit.py` → **39/39 passed**
- [x] Cross-cutting `npm audit --severity high` for `codingbuddy`, `codingbuddy-claude-plugin`, `landing-page` — all clean.

Closes #1381
Closes #1384