### PR TITLE
refactor(rules): establish canonical PR review-cycle and severity sources

### DIFF
--- a/.claude/skills/taskmaestro/SKILL.md
+++ b/.claude/skills/taskmaestro/SKILL.md
@@ -85,313 +85,72 @@ MY_PANE=$(tmux display-message -p '#{pane_index}')
 
 ## Review Cycle Protocol
 
-워커가 PR을 생성하고 RESULT.json에 `status: "success"`를 기록하면, 리뷰 사이클을 시작한다.
-`status: "approved"`가 될 때까지 반복하며, 승인 시점이 "진짜 완료"가 된다.
+워커가 `RESULT.json`에 `status: "success"`를 기록하면 리뷰 사이클이 시작되고, `status: "approved"`가 될 때까지 반복된다. 승인이 "진짜 완료"다.
 
-> **기본 동작:** 지휘자가 직접 리뷰를 수행한다 (Conductor Review — primary method).
-> Conductor has PLAN context; worker reviewers do not.
-> `--review-pane` 옵션으로 리뷰 에이전트 패널이 설정된 경우에만 리뷰를 위임한다 (아래 [Review Agent Protocol](#review-agent-protocol) 참조).
+> **Canonical source:** 리뷰 사이클 프로토콜의 단일 소스는 [`packages/rules/.ai-rules/rules/pr-review-cycle.md`](../../../packages/rules/.ai-rules/rules/pr-review-cycle.md)이다.
+> 아래 섹션은 taskmaestro 전용 구현 세부사항(tmux 트리거, `taskmaestro-state.json` 구조)만 남기고, 프로토콜 전체는 canonical 문서를 참조한다.
 
-### Trigger
+### Trigger (taskmaestro 관점)
 
-Watch 모드가 RESULT.json을 감지했을 때:
-- `status: "success"` → **리뷰 사이클 시작** (기존처럼 "done"으로 보고하지 않음)
-- `status: "failure"` / `"error"` → 사용자에게 보고 (기존 동작 유지)
-- `status: "review_pending"` → 워커 응답 대기 중 (지휘자 대기)
-- `status: "review_addressed"` → 재리뷰 시작
-- `status: "approved"` → 진짜 완료 ✅
+지휘자의 watch 모드는 `.taskmaestro/wt-N/RESULT.json`의 `status` 필드를 감지한다:
+
+| `status` | 지휘자 동작 |
+|----------|-------------|
+| `success` | 리뷰 사이클 시작 (done으로 보고하지 않음) |
+| `failure` / `error` | 사용자에게 보고, 리뷰 미진행 |
+| `review_pending` | 워커 응답 대기 |
+| `review_addressed` | 재리뷰 시작 |
+| `approved` | 진짜 완료 ✅ |
 
 ### Review Routing
 
-`status: "success"` 또는 `status: "review_addressed"` 감지 시:
+- `review_pane`이 설정되지 않았으면 (기본) → **Conductor Review** 실행
+- `review_pane`이 설정되었으면 → 해당 패널의 **Review Agent**로 위임
 
-1. **상태 파일에서 `review_pane` 확인**
-2. `review_pane`이 없으면 (기본) → **Conductor Review** 실행 (지휘자 직접 리뷰 — primary method)
-3. `review_pane`이 존재하면 → **Review Agent Protocol** 실행 (리뷰 에이전트에 위임)
+두 경우 모두 실행하는 프로토콜(CI gate → local verify → diff → code quality → spec → tests → write review → approve)은 canonical 문서를 따른다. Severity 등급(critical/high/medium/low), approval 조건, commit hygiene(amend + force-with-lease), 최대 3회 사이클 상한도 canonical 문서가 정의한다.
 
-### Conductor Review (Primary — default method)
+> **Conductor Review가 기본 동작인 이유:** 지휘자는 PLAN 컨텍스트를 보유하지만, 워커 리뷰어는 그렇지 않다.
 
-지휘자가 직접 리뷰를 수행한다 (리뷰 에이전트 패널이 설정되지 않은 경우, 기본 동작):
+### taskmaestro 고유: 파일 기반 리뷰 트리거
 
-0. **CI Gate (MUST — BLOCKING)**
-   ```bash
-   gh pr checks <PR_NUMBER>
-   ```
-   ALL checks must pass before proceeding to review.
-   If any check fails → report to user, do NOT approve. Stop review here.
+프로토콜의 "워커에게 리뷰 반영 지시" 단계를 taskmaestro는 **file-based trigger**로 구현한다. 긴 프롬프트를 `send-keys`로 직접 전송하면 잘릴 수 있으므로:
 
-1. **PR diff 읽기**
-   ```bash
-   gh pr diff <PR_NUMBER>
-   ```
+1. `Review Fix TASK.md`를 워커 worktree 루트(`$REPO/.taskmaestro/wt-$PANE_IDX/TASK.md`)에 작성한다. 내용은 아래 Review Fix TASK.md 템플릿을 따른다.
+2. 짧은 트리거만 `send-keys`로 전송한다:
 
-2. **체크리스트 생성**
-   codingbuddy `generate_checklist` MCP 도구로 변경 파일 기반 도메인별 체크리스트를 생성한다.
+    ```bash
+    tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$PANE_IDX" \
+      "Read TASK.md and execute all steps." Enter
+    ```
 
-3. **리뷰 코멘트 작성**
-   변경 내용 + 체크리스트를 기반으로 리뷰를 수행하고 PR에 코멘트를 작성한다:
-   ```bash
-   gh pr review <PR_NUMBER> --comment --body "<리뷰 내용>"
-   ```
+리뷰 에이전트 패널(`$REVIEW_PANE`)에 리뷰 프롬프트를 전송할 때도 동일한 파일 기반 패턴을 사용한다.
 
-4. **RESULT.json 업데이트**
-   지휘자가 RESULT.json을 업데이트한다:
-   ```json
-   {
-     "status": "review_pending",
-     "review_cycle": 1,
-     "review_comments": ["unused import 'FileChangeStats'", "missing error handling", "..."]
-   }
-   ```
+#### Review Fix TASK.md 템플릿
 
-5. **워커에게 리뷰 반영 지시 (file-based)**
-
-   Review Fix TASK.md를 워커 worktree에 작성한 후 짧은 트리거를 전송한다:
-   ```bash
-   # Review Fix TASK.md를 워커 worktree에 작성 (아래 템플릿 참조)
-   cat > "$REPO/.taskmaestro/wt-$PANE_IDX/TASK.md" << TASKEOF
-   # Review Fix Task
-   ... (Review Fix TASK.md Template 섹션 참조)
-   TASKEOF
-
-   # 짧은 트리거만 send-keys로 전송
-   tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$PANE_IDX" \
-     "Read TASK.md and execute all steps." Enter
-   ```
-
-6. **워커 응답**
-   워커가 리뷰에 대응한다:
-   - 수용: 코드 수정 → push
-   - 거부: PR에 반박 코멘트 작성 (사유 포함)
-   - 각 코멘트에 "Resolved: [수행한 작업]" 형태로 회신
-   - 완료 후 RESULT.json 업데이트: `status: "review_addressed"`
-
-7. **재리뷰**
-   지휘자가 `status: "review_addressed"`를 감지하면:
-   - `gh pr diff <PR_NUMBER>` 재확인
-   - 미해결 코멘트 확인
-   - 충분히 개선됐으면 → **승인** (Step 8)
-   - 아직 부족하면 → Step 3부터 반복
-
-8. **최종 승인**
-   ```bash
-   # 자신의 PR이 아닌 경우
-   gh pr review <PR_NUMBER> --approve --body "LGTM - all review comments addressed"
-   # 자신의 PR인 경우 (approve 불가) — 코멘트로 대체
-   gh pr review <PR_NUMBER> --comment --body "✅ Review complete - all comments addressed"
-   ```
-   RESULT.json 업데이트: `status: "approved"`
-
-### Review Fix TASK.md Template
-
-리뷰 코멘트에 대한 수정 지시를 워커에게 전달할 때 사용하는 TASK.md 템플릿이다.
-지휘자 또는 리뷰 에이전트가 워커의 worktree 루트에 이 파일을 작성한다.
+워커 worktree에 작성하는 `TASK.md`의 내용:
 
 ```markdown
 # Review Fix Task
 
-PR #<PR_NUMBER> (issue #<ISSUE_NUMBER>)에 리뷰 코멘트가 달렸습니다.
+See rules/pr-review-cycle.md for the canonical worker response protocol.
 
 ## Steps
 
-1. `gh pr view <PR_NUMBER> --comments` 로 리뷰 코멘트를 확인하세요.
-2. 수용할 부분은 코드를 수정하세요.
-3. 거부할 부분은 PR에 반박 코멘트를 남기세요 (사유 포함).
-4. 각 코멘트에 "Resolved: [수행한 작업]" 형태로 회신하세요.
-5. 수정 완료 후:
-   a. `yarn prettier --write . && yarn lint --fix && yarn type-check && yarn test` — 모두 통과해야 합니다.
-   b. `git add` → `git commit` → `git push`
-6. RESULT.json을 업데이트하세요:
-   ```json
-   {
-     "status": "review_addressed",
-     "review_cycle": <현재_사이클_번호>
-   }
-   ```
+1. `gh pr view <PR_NUMBER> --comments` 로 리뷰 코멘트를 확인한다.
+2. 각 코멘트에 대응: 수용 시 코드 수정, 거부 시 반박 코멘트, `Resolved: ...` 회신.
+3. MANDATORY 사전 체크: `yarn prettier --write . && yarn lint --fix && yarn type-check && yarn test` — 모두 통과해야 push 한다.
+4. 커밋 위생: `git commit --amend --no-edit && git push --force-with-lease` (fix 커밋을 쌓지 말 것).
+5. `RESULT.json`을 업데이트한다: `{ "status": "review_addressed", "review_cycle": <current_cycle> }`
 
-[MANDATORY PRE-PUSH] yarn prettier --write . && yarn lint --fix && yarn type-check && yarn test — ALL must pass before push.
-[CONTINUOUS] DO NOT stop. Complete ALL steps. Only stop AFTER updating RESULT.json to "review_addressed".
+[CONTINUOUS] DO NOT stop. Only stop AFTER updating RESULT.json to "review_addressed".
 ```
 
-> **핵심:** 워커가 리뷰 반영 후 반드시 RESULT.json의 `status`를 `"review_addressed"`로 업데이트해야 watch cron이 재리뷰를 트리거할 수 있다.
+> **핵심:** 워커는 리뷰 반영 후 반드시 `RESULT.json`의 `status`를 `review_addressed`로 업데이트해야 watch cron이 재리뷰를 트리거한다.
 
-### Max Review Cycles
+### taskmaestro 고유: 상태 스키마
 
-- **최대 3회** 리뷰 사이클 (무한 루프 방지)
-- 3회 초과 시 사용자에게 보고:
-  ```
-  ⚠️ 패널 N: 3회 리뷰 후에도 미해결 이슈가 있습니다.
-  PR: #<PR_NUMBER>
-  미해결 코멘트: [목록]
-  사용자 판단이 필요합니다.
-  ```
-- 이후 지휘자는 해당 패널의 리뷰를 중단하고 사용자 지시를 대기한다.
+리뷰 사이클 중 각 패널의 `taskmaestro-state.json` 필드:
 
-### Quality Criteria for Approval
-
-approve할 조건:
-- CI 전체 통과 (`gh pr checks <PR_NUMBER>`)
-- 미사용 변수/import 없음
-- 새 코드에 적절한 테스트 존재
-- 기존 테스트 깨지지 않음
-- 코드 스타일 일관성 유지
-
----
-
-## Review Agent Protocol
-
-리뷰 에이전트 패널이 설정된 경우, 워커 PR 리뷰를 전담한다.
-지휘자는 오케스트레이션만 담당하고, 코드 리뷰는 리뷰 에이전트가 수행한다.
-
-```
-기존: Worker PR → Conductor 리뷰 (품질 낮음)
-변경: Worker PR → Review Agent 리뷰 → Conductor는 결과만 전달
-```
-
-### Trigger
-
-지휘자가 워커의 RESULT.json에서 `status: "success"` 또는 `status: "review_addressed"`를 감지하면,
-리뷰 에이전트 패널에 리뷰 프롬프트를 전송한다.
-
-### Review Agent Checklist (MANDATORY ORDER)
-
-리뷰 에이전트는 반드시 아래 순서대로 수행한다:
-
-1. **CI Gate (MUST)**: `gh pr checks <PR_NUMBER>` — ALL checks must pass. If any fail, STOP and report failure with logs. DO NOT proceed to code review.
-2. **Local Verification**: PR 브랜치에서 `yarn lint` 및 `yarn type-check` 실행하여 CI와 동일한 이슈를 로컬에서 포착
-3. **Code Quality Scan**: `gh pr diff <PR_NUMBER>` — 다음을 검사:
-   - Unused imports/variables
-   - `any` types
-   - Missing error handling
-   - Dead code
-4. **Spec Compliance**: issue 요구사항(`gh issue view <ISSUE_NUMBER>`)과 실제 구현을 대조
-5. **Test Coverage**: 새 코드에 적절한 테스트가 있는지 확인
-6. **Write Review**: `gh pr review --comment`로 구조화된 리뷰 코멘트를 PR에 작성
-
-### Review Agent Prompt Template
-
-지휘자가 리뷰 에이전트 패널에 전송하는 프롬프트:
-
-```
-Review PR #<PR_NUMBER> for issue #<ISSUE_NUMBER>.
-
-MANDATORY REVIEW CHECKLIST (follow in order):
-
-1. CI CHECK (BLOCKING):
-   gh pr checks <PR_NUMBER>
-   If ANY check fails → STOP. Report: "CI FAILED: <job_name> — <log_url>"
-   DO NOT proceed to code review if CI fails.
-
-2. LOCAL VERIFICATION:
-   git fetch origin && git checkout <branch>
-   yarn lint
-   yarn type-check
-   Report any errors.
-
-3. CODE QUALITY (gh pr diff <PR_NUMBER>):
-   - Unused imports/variables?
-   - any types?
-   - Missing error handling?
-   - Dead code?
-
-4. SPEC COMPLIANCE:
-   gh issue view <ISSUE_NUMBER>
-   Compare requirements with implementation. List any gaps.
-
-5. TEST COVERAGE:
-   Are new functions/features tested?
-   Are edge cases covered?
-
-6. WRITE REVIEW:
-   gh pr review <PR_NUMBER> --comment --body "<structured review>"
-
-Format your review as:
-## Review: [APPROVE | CHANGES_REQUESTED]
-### CI Status: [PASS | FAIL]
-### Issues Found:
-- [critical/high/medium/low]: description
-### Recommendation: [APPROVE | REQUEST_CHANGES]
-
-After posting review, write RESULT.json with:
-{
-  "status": "success",
-  "review_result": "approve | changes_requested",
-  "issues_found": <number>,
-  "critical_count": <number>,
-  "high_count": <number>
-}
-```
-
-전송 방식:
-```bash
-tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$REVIEW_PANE" \
-  "$REVIEW_PROMPT" Enter
-```
-
-> **참고:** 프롬프트가 길어 send-keys로 직접 전송 시 잘릴 수 있다. 이 경우 프롬프트를 TASK.md 파일에 저장하고 `send-keys`로 파일 경로를 참조하여 전송한다.
-
-### Review Agent RESULT.json
-
-리뷰 에이전트의 결과 파일은 리뷰 에이전트 패널의 worktree에 기록된다:
-`<repo>/.taskmaestro/wt-<review_pane_idx>/RESULT.json`
-
-```json
-{
-  "status": "success",
-  "review_result": "approve | changes_requested",
-  "issues_found": 3,
-  "critical_count": 0,
-  "high_count": 1
-}
-```
-
-| 필드 | 타입 | 필수 | 설명 |
-|------|------|------|------|
-| `status` | `"success" \| "error"` | ✅ | 리뷰 작업 자체의 성공/실패 |
-| `review_result` | `"approve" \| "changes_requested"` | ✅ | 리뷰 판정 결과 |
-| `issues_found` | `number` | ✅ | 발견된 총 이슈 수 |
-| `critical_count` | `number` | ✅ | Critical severity 이슈 수 |
-| `high_count` | `number` | ✅ | High severity 이슈 수 |
-
-### Conductor Handling of Review Agent Result
-
-지휘자가 리뷰 에이전트의 RESULT.json을 감지하면:
-
-1. **`review_result: "approve"`인 경우:**
-   - 워커의 RESULT.json을 `status: "approved"`로 업데이트
-   - 최종 승인 코멘트를 PR에 작성:
-     ```bash
-     gh pr review <PR_NUMBER> --approve --body "LGTM - review agent approved"
-     # 자신의 PR인 경우:
-     gh pr review <PR_NUMBER> --comment --body "✅ Review complete - review agent approved"
-     ```
-   - 사용자에게 완료 보고
-
-2. **`review_result: "changes_requested"`인 경우:**
-   - 워커의 RESULT.json을 `status: "review_pending"`으로 업데이트 (review_cycle 증가)
-   - 워커에게 리뷰 반영 지시 (file-based):
-     ```bash
-     # Review Fix TASK.md를 워커 worktree에 작성 (아래 템플릿 참조)
-     cat > "$REPO/.taskmaestro/wt-$WORKER_PANE/TASK.md" << TASKEOF
-     # Review Fix Task
-     ... (Review Fix TASK.md Template 섹션 참조)
-     TASKEOF
-
-     # 짧은 트리거만 send-keys로 전송
-     tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$WORKER_PANE" \
-       "Read TASK.md and execute all steps." Enter
-     ```
-
-3. **리뷰 에이전트 초기화:**
-   - 리뷰 에이전트의 RESULT.json 삭제 (다음 리뷰를 위한 준비):
-     ```bash
-     rm -f "$REPO/.taskmaestro/wt-$REVIEW_PANE/RESULT.json"
-     ```
-   - 리뷰 에이전트 패널의 상태를 `"idle"`로 업데이트
-
-### Review Cycle State in taskmaestro-state.json
-
-리뷰 사이클 중 각 패널의 상태 파일 필드:
 ```json
 {
   "index": 1,
@@ -406,26 +165,34 @@ tmux -L "$SOCKET_NAME" send-keys -t "$SESSION:$WIN_IDX.$REVIEW_PANE" \
 }
 ```
 
-리뷰 에이전트 패널의 상태:
+리뷰 에이전트 패널은 `role: "reviewer"`, `status: "reviewing"`을 사용한다. 리뷰 에이전트의 결과 파일(`<repo>/.taskmaestro/wt-<review_pane>/RESULT.json`)은 다음 스키마를 따른다:
+
 ```json
 {
-  "index": 3,
-  "role": "reviewer",
-  "worktree": "...",
-  "branch": "...",
-  "task": "Reviewing PR #42 for issue #767",
-  "status": "reviewing",
-  "result": null
+  "status": "success",
+  "review_result": "approve | changes_requested",
+  "issues_found": 3,
+  "critical_count": 0,
+  "high_count": 1
 }
 ```
 
+Severity 카운트 필드(`critical_count`, `high_count`)는 [`rules/severity-classification.md`](../../../packages/rules/.ai-rules/rules/severity-classification.md)의 Code Review Severity 스케일을 따른다.
+
+지휘자는 리뷰 에이전트 결과를 읽고:
+
+1. `review_result: "approve"` → 워커 `RESULT.json`을 `approved`로 업데이트, 승인 코멘트 게시, 사용자에게 완료 보고
+2. `review_result: "changes_requested"` → 워커 `RESULT.json`을 `review_pending`으로 업데이트하고 `review_cycle` 증가, file-based 리뷰 수정 트리거 전송
+3. 리뷰 에이전트 `RESULT.json`을 삭제해 다음 리뷰를 위해 초기화
+
 `status` 값 매핑:
-- `"working"` → 워커 작업 중
-- `"reviewing"` → 리뷰 에이전트가 PR 리뷰 중 (리뷰어 패널 전용)
-- `"review_pending"` → 리뷰 코멘트 작성 완료, 워커 응답 대기
-- `"review_addressed"` → 워커 리뷰 반영 완료, 재리뷰 대기
-- `"approved"` → 최종 승인 완료 (진짜 done)
-- `"done"` → 리뷰 없이 완료 (failure/error 포함)
+
+- `working` → 워커 작업 중
+- `reviewing` → 리뷰 에이전트가 PR 리뷰 중 (reviewer 패널 전용)
+- `review_pending` → 리뷰 코멘트 작성 완료, 워커 응답 대기
+- `review_addressed` → 워커 리뷰 반영 완료, 재리뷰 대기
+- `approved` → 최종 승인 완료 (진짜 done)
+- `done` → 리뷰 없이 완료 (failure/error)
 
 ---
 
@@ -962,6 +729,7 @@ TaskMaestro 상태 (workspace-1):
 ```
 
 **상태별 아이콘:**
+
 | status | 아이콘 | 설명 |
 |--------|--------|------|
 | `approved` | ✅ | 최종 승인 완료 (진짜 done) |
@@ -1060,6 +828,7 @@ fi
 ```
 
 **RESULT.json status 매핑:**
+
 | status | watch 동작 |
 |--------|-----------|
 | `"success"` | 리뷰 사이클 시작 ("done"이 아님) |

--- a/packages/rules/.ai-rules/adapters/claude-code.md
+++ b/packages/rules/.ai-rules/adapters/claude-code.md
@@ -770,6 +770,8 @@ AUTO implement user authentication with JWT
 - **Success**: `Critical = 0 AND High = 0` severity issues
 - **Failure**: Max iterations reached (default: 3, configurable via `auto.maxIterations`)
 
+> **Severity and review-cycle canonical sources:** The `Critical`/`High` levels above are the **Code Review Severity** scale defined in [`../rules/severity-classification.md`](../rules/severity-classification.md#code-review-severity). The approval loop Claude Code runs over a PR (CI gate → review → fix → re-review → approve) is specified in [`../rules/pr-review-cycle.md`](../rules/pr-review-cycle.md). Follow those canonical sources rather than re-deriving severity or approval criteria from this adapter.
+
 ### Configuration
 
 Configure AUTO mode in `codingbuddy.config.json`:

--- a/packages/rules/.ai-rules/rules/pr-review-cycle.md
+++ b/packages/rules/.ai-rules/rules/pr-review-cycle.md
@@ -1,0 +1,272 @@
+# PR Review Cycle (Canonical)
+
+Canonical protocol for the PR review cycle in conductor/worker parallel workflows and solo workflows. This file is the single source of truth — local skills, adapter docs, and custom instructions MUST reference this document instead of duplicating the protocol.
+
+Scope: the review loop that runs **after** a worker (or solo developer) has created a PR, until the PR is approved or explicitly failed.
+
+## Quick Reference
+
+| Step | Who | Output |
+|------|-----|--------|
+| 1. PR created | Worker (or solo dev) | `status: "success"` + PR URL |
+| 2. CI gate | Reviewer | Pass/fail decision (BLOCKING) |
+| 3. Review | Conductor or review agent | Structured comment on PR |
+| 4. Response | Worker | Fixes pushed OR dispute posted |
+| 5. Re-review | Reviewer | Approve or request more changes |
+| 6. Approve | Reviewer | `status: "approved"` |
+
+Approval criteria and severity definitions: see [`severity-classification.md`](./severity-classification.md). Commit hygiene during review fixes: see [Commit Hygiene](#commit-hygiene) below.
+
+## Trigger
+
+The review cycle begins when a PR is created. In conductor/worker workflows this is detected through `.taskmaestro/wt-N/RESULT.json`:
+
+| RESULT.json `status` | Meaning | Reviewer Action |
+|----------------------|---------|-----------------|
+| `success` | Worker finished, PR created | Start review cycle |
+| `failure` / `error` | Worker could not finish | Report to user, do not enter review |
+| `review_pending` | Reviewer has posted comments, waiting on worker | Wait |
+| `review_addressed` | Worker has pushed fixes | Re-review |
+| `approved` | Final approval | Cycle complete ✅ |
+
+In solo workflows the trigger is the developer opening the PR; the remaining steps are identical but run in a single session.
+
+## Review Routing
+
+Two review strategies exist. Conductor Review is the **default and primary** method.
+
+### Conductor Review (default)
+
+The conductor runs the review directly. Use this whenever a dedicated review pane is not configured.
+
+**Rationale:** the conductor already holds the PLAN context for the task, so its review is grounded in the original requirements. Worker-level reviewers do not carry that context.
+
+### Review Agent (optional, `--review-pane`)
+
+A dedicated review pane takes over the review. Only used when the orchestrator was started with `--review-pane` explicitly and at least three panes are available (conductor + worker + reviewer).
+
+The review agent follows the **same protocol** as the conductor (CI gate, code quality scan, spec compliance, test coverage, structured comment). The only differences are where the result is written and how approval is propagated back to the worker — see [Review Agent Result Handling](#review-agent-result-handling).
+
+## The Review Protocol
+
+Every reviewer — conductor or review agent — MUST perform these steps **in this order**.
+
+### 1. CI Gate (BLOCKING)
+
+```bash
+gh pr checks <PR_NUMBER>
+```
+
+- ALL checks must pass before proceeding to code review.
+- If ANY check fails → STOP. Report the failing job and log URL. **Do NOT approve.** **Do NOT start code review.** Return the PR to the worker as a failure.
+
+### 2. Local Verification
+
+Check out the PR branch and run the same lint / type / test commands CI runs. This catches issues local to the reviewer's environment and flaky CI blind spots.
+
+```bash
+git fetch origin
+git checkout <branch>
+yarn lint
+yarn type-check
+```
+
+Any local error becomes a `critical` or `high` finding — not a CI retry.
+
+### 3. Read the Diff
+
+```bash
+gh pr diff <PR_NUMBER>
+```
+
+Optionally call the `generate_checklist` MCP tool with the list of changed files to produce a domain-specific checklist (security, accessibility, performance, etc.) before reading the diff.
+
+### 4. Code Quality Scan
+
+Against the diff, look for:
+
+- Unused imports / variables
+- `any` types
+- Missing error handling
+- Dead code
+- Layer boundary violations
+- Obvious performance pitfalls
+
+Use the Code Review Severity scale from [`severity-classification.md`](./severity-classification.md) to rate findings (`critical` / `high` / `medium` / `low`).
+
+### 5. Spec Compliance
+
+```bash
+gh issue view <ISSUE_NUMBER>
+```
+
+Compare the issue's acceptance criteria with the implementation. List every gap as a finding.
+
+### 6. Test Coverage
+
+- Does new non-trivial logic have tests?
+- Are edge cases and error paths covered?
+- Do tests actually verify behavior, not implementation?
+
+Missing tests on new logic is at least `high`.
+
+### 7. Write the Review
+
+```bash
+gh pr review <PR_NUMBER> --comment --body "<structured review>"
+```
+
+Review body format:
+
+```markdown
+## Review: [APPROVE | CHANGES_REQUESTED]
+### CI Status: [PASS | FAIL]
+### Issues Found:
+- [critical]: <description> — <file:line>
+- [high]: <description> — <file:line>
+- [medium]: <description> — <file:line>
+### Recommendation: [APPROVE | REQUEST_CHANGES]
+```
+
+Follow the anti-sycophancy rules in `skills/pr-review/SKILL.md`: every finding must include a location (`file:line`) and an impact statement. No empty praise.
+
+## Worker Response (Review Fix)
+
+When the reviewer has posted a review with changes requested, the worker MUST:
+
+1. Read the comments: `gh pr view <PR_NUMBER> --comments`
+2. For each comment:
+   - **Accept** → fix the code.
+   - **Reject** → post a rebuttal comment on the PR with reasoning. Do not silently ignore.
+   - Reply with `Resolved: <what you did>` so the reviewer can verify.
+3. Run the full local check battery **before pushing** (see [Commit Hygiene](#commit-hygiene)).
+4. Push the fixes (see [Commit Hygiene](#commit-hygiene) for the amend + force-with-lease rule).
+5. Update `RESULT.json`:
+
+    ```json
+    {
+      "status": "review_addressed",
+      "review_cycle": <current cycle number>
+    }
+    ```
+
+Only after `RESULT.json` is updated does the conductor's watch cycle re-trigger a review.
+
+## Re-Review
+
+On `status: "review_addressed"`, the reviewer repeats the protocol from step 1 (CI gate) on the new commit. If the comments are resolved and no new `critical`/`high` findings appear, proceed to approval.
+
+## Approval
+
+Approval is gated on the criteria in [`severity-classification.md`](./severity-classification.md#code-review-severity). Summarized here:
+
+- CI fully green.
+- Zero `critical` findings.
+- Zero `high` findings that were not explicitly accepted as deferred.
+- New code has adequate tests.
+- Existing tests still pass.
+- Code style consistent with the codebase.
+
+Issue the approval:
+
+```bash
+# When the reviewer is not the PR author
+gh pr review <PR_NUMBER> --approve --body "LGTM - all review comments addressed"
+
+# When the reviewer IS the PR author (GitHub forbids self-approve)
+gh pr review <PR_NUMBER> --comment --body "✅ Review complete - all comments addressed"
+```
+
+Then update `RESULT.json` to `status: "approved"`. Only `approved` counts as *done*. `success` means "PR exists"; `approved` means "PR is mergeable".
+
+## Max Review Cycles
+
+Hard cap of **three** review cycles per PR to prevent infinite loops.
+
+When the third cycle still does not reach approval:
+
+```
+⚠️ Pane N: unresolved issues after 3 review cycles.
+PR: #<PR_NUMBER>
+Unresolved: [list]
+User decision required.
+```
+
+The conductor stops reviewing that pane and waits for user instruction. Do not silently approve to exit the loop.
+
+## Review Agent Result Handling
+
+When the `--review-pane` strategy is used, the review agent writes its own `RESULT.json` in its worktree:
+
+```json
+{
+  "status": "success",
+  "review_result": "approve | changes_requested",
+  "issues_found": 3,
+  "critical_count": 0,
+  "high_count": 1
+}
+```
+
+The conductor reads the review agent's `RESULT.json` and:
+
+1. **`review_result: "approve"`** → update the worker's `RESULT.json` to `approved`, post the final approval comment on the PR, report to user.
+2. **`review_result: "changes_requested"`** → update the worker's `RESULT.json` to `review_pending`, increment `review_cycle`, dispatch the review-fix task to the worker.
+3. **Always** → delete the review agent's `RESULT.json` so the next review can trigger.
+
+## Commit Hygiene
+
+**Rule:** During the review fix cycle, do not pile up additional fix commits on top of the original worker commit. Amend the existing commit and force-push with lease.
+
+```bash
+git add <changed files>
+git commit --amend --no-edit
+git push --force-with-lease
+```
+
+**Why:** A single clean commit per PR keeps `git log` reviewable, avoids "fix review 1 / fix review 2 / fix typo" noise, and makes the PR easier to rebase. `--force-with-lease` protects against accidental overwrite if the remote has moved.
+
+**Exception:** When the review explicitly requests splitting the change into multiple commits (e.g., "please move this refactor to its own commit"), follow the review's direction. That is a *deliberate* split, not commit noise. Document the exception in the review reply so future reviewers understand why the PR has multiple commits.
+
+**Pre-push check battery (MANDATORY before every push, including amends):**
+
+```bash
+yarn prettier --write .
+yarn lint --fix
+yarn type-check
+yarn test
+```
+
+All four MUST pass. A failed pre-push check is not a reason to push anyway.
+
+## State Representation
+
+In multi-pane orchestration, each pane's state file carries the review cycle as structured fields:
+
+```json
+{
+  "index": 1,
+  "role": "worker",
+  "status": "review_pending",
+  "review_cycle": 1,
+  "pr_number": 42
+}
+```
+
+Valid `status` values during the review cycle:
+
+| Status | Meaning |
+|--------|---------|
+| `working` | Worker is implementing |
+| `reviewing` | Review agent is running (review-pane only) |
+| `review_pending` | Review comments posted, awaiting worker response |
+| `review_addressed` | Worker has pushed fixes, awaiting re-review |
+| `approved` | Final approval — cycle complete |
+| `done` | Completed without a review cycle (e.g., failure or error) |
+
+## Related
+
+- [`severity-classification.md`](./severity-classification.md) — canonical severity taxonomy used for approval gates
+- `skills/pr-review/SKILL.md` — manual PR review dimensions, anti-sycophancy guidance, feedback tone spectrum
+- `.claude/skills/taskmaestro/SKILL.md` — conductor/worker orchestration that consumes this protocol
+- `adapters/claude-code.md` — Claude Code execution model for parallel review

--- a/packages/rules/.ai-rules/rules/severity-classification.md
+++ b/packages/rules/.ai-rules/rules/severity-classification.md
@@ -1,0 +1,214 @@
+# Severity Classification (Canonical)
+
+Canonical severity taxonomy used across the repo. Two distinct scales — **Code Review Severity** (Critical/High/Medium/Low) and **Production Incident Severity** (P1-P4) — serve different purposes and MUST NOT be conflated.
+
+This file is the single source of truth. Other files (skills, adapters, task protocols) MUST reference this document instead of redefining severity levels.
+
+## When to Use Which Scale
+
+| Context | Use This Scale | Decides |
+|---------|----------------|---------|
+| PR review, code review, EVAL mode, AUTO exit criteria | **Code Review Severity** (Critical/High/Medium/Low) | Whether to approve / request changes |
+| Production incident, on-call alert, SLO burn rate | **Production Incident Severity** (P1/P2/P3/P4) | Response time, pager, war room |
+
+Code review and production incidents are **not** the same problem. A `critical` code review finding blocks a PR; a `P1` incident pages the on-call engineer. Do not map `critical` to `P1` on the PR side or vice versa — see [Mapping Table](#mapping-between-scales) below for the narrow cases where they correspond.
+
+## Code Review Severity
+
+Used in PR review cycles, EVAL mode, AUTO exit criteria, and worker review protocols.
+
+### critical
+
+**Meaning:** The change introduces a defect that blocks approval. A `critical` finding requires changes before merge — no exceptions.
+
+**Criteria (ANY of these):**
+
+- Hardcoded secrets / credentials in source
+- SQL injection, XSS, CSRF, or other exploitable vulnerability
+- Missing authentication on a protected route
+- Missing authorization check on a resource access path
+- Data loss, corruption, or irreversible state change risk
+- Build or CI completely broken
+- Runtime exception on happy path
+- Production-breaking regression introduced
+
+**Action:** Request changes. Block merge. Approval requires fix + re-review.
+
+### high
+
+**Meaning:** A defect that should be fixed before merge but does not block approval if the author has a documented reason to defer.
+
+**Criteria (ANY of these):**
+
+- Missing error handling on a code path that can realistically fail
+- Missing test for new non-trivial logic
+- Clear off-by-one, null dereference, or unhandled edge case
+- `any` type used where a concrete type is available
+- Layer boundary violation or dependency direction reversed
+- Obvious performance pitfall (N+1 query, blocking the main thread)
+- Significant code duplication that invites drift
+
+**Action:** Request changes, or approve with an explicit follow-up ticket. Multiple `high` findings together should block merge.
+
+### medium
+
+**Meaning:** Quality concerns that are worth addressing but do not gate the merge.
+
+**Criteria (ANY of these):**
+
+- Complexity above the project's target (e.g., cyclomatic > 10, function > 20 lines)
+- Inconsistent naming or minor API shape awkwardness
+- Missing documentation on a public API
+- Accessibility issue that does not block core interaction
+- Non-critical test gap (e.g., edge case test missing for stable behavior)
+
+**Action:** Approve with comments, or request changes if the author has time.
+
+### low
+
+**Meaning:** Style, polish, or future-facing suggestions with no correctness impact.
+
+**Criteria (ANY of these):**
+
+- Style nit beyond what lint enforces
+- Suggested refactor for readability
+- Minor comment wording
+- Opportunistic cleanup that could be its own PR
+
+**Action:** Leave as a `Noting` or `Suggesting` comment (per `skills/pr-review/SKILL.md` feedback tone spectrum). Do not block merge.
+
+## Production Incident Severity
+
+Used when a production incident is declared. Based on SLO burn rate and user impact, not code quality.
+
+### P1 - Critical
+
+**SLO Burn Rate:** >14.4x (consuming >2% error budget per hour)
+
+**Impact Criteria (ANY of these):**
+
+- Complete service outage
+- `>50%` of users affected
+- Critical business function unavailable
+- Data loss or corruption risk
+- Active security breach
+- Revenue-generating flow completely blocked
+- Compliance/regulatory violation in progress
+
+**Response Expectations:**
+
+| Metric | Target |
+|--------|--------|
+| Acknowledge | Within 5 minutes |
+| First update | Within 15 minutes |
+| War room formed | Within 15 minutes |
+| Executive notification | Within 30 minutes |
+| Customer communication | Within 1 hour |
+| Update cadence | Every 15 minutes |
+
+**Escalation:** Immediate page to on-call, all hands if needed.
+
+### P2 - High
+
+**SLO Burn Rate:** >6x (consuming >5% error budget per 6 hours)
+
+**Impact Criteria (ANY of these):**
+
+- Major feature unavailable
+- 10-50% of users affected
+- Significant performance degradation (>5x latency)
+- Secondary business function blocked
+- Partial data integrity issues
+- Key integration failing
+
+**Response Expectations:**
+
+| Metric | Target |
+|--------|--------|
+| Acknowledge | Within 15 minutes |
+| First update | Within 30 minutes |
+| Status page update | Within 30 minutes |
+| Stakeholder notification | Within 1 hour |
+| Update cadence | Every 30 minutes |
+
+**Escalation:** Page on-call during business hours, notify team lead.
+
+### P3 - Medium
+
+**SLO Burn Rate:** >3x (consuming >10% error budget per 24 hours)
+
+**Impact Criteria (ANY of these):**
+
+- Minor feature impacted
+- `<10%` of users affected
+- Workaround available
+- Non-critical function degraded
+- Cosmetic issues affecting usability
+- Performance slightly degraded
+
+**Response Expectations:**
+
+| Metric | Target |
+|--------|--------|
+| Acknowledge | Within 1 hour |
+| First update | Within 2 hours |
+| Resolution target | Within 8 business hours |
+| Update cadence | At milestones |
+
+**Escalation:** Create ticket, notify team channel.
+
+### P4 - Low
+
+**SLO Burn Rate:** >1x (projected budget exhaustion within SLO window)
+
+**Impact Criteria (ALL of these):**
+
+- Minimal or no user impact
+- Edge case or rare scenario
+- Cosmetic only
+- Performance within acceptable range
+- Workaround trivial
+
+**Response Expectations:**
+
+| Metric | Target |
+|--------|--------|
+| Acknowledge | Within 1 business day |
+| Resolution target | Next sprint/release |
+| Update cadence | On resolution |
+
+**Escalation:** Backlog item, routine prioritization.
+
+### When Uncertain, Classify Higher
+
+Between two levels, pick the more severe one. Over-response is cheaper than under-response; you can always downgrade. Communicate any severity change to stakeholders immediately.
+
+### Incident-Specific Details
+
+For SLO burn rate math, classification decision tree, and incident report templates, see `skills/incident-response/severity-classification.md`, which narrows this canonical scale to production-incident-specific operational guidance.
+
+## Mapping Between Scales
+
+The two scales answer different questions, but a handful of situations connect them. Use this table only when a PR review finding must influence — or be informed by — an incident.
+
+| Code Review Severity | Rough Production Equivalent | When the Mapping Applies |
+|----------------------|------------------------------|---------------------------|
+| `critical` | P1-P2 | A `critical` PR finding that already shipped to production and is causing user impact becomes an incident at P1 or P2 (impact decides, not the code severity) |
+| `high` | P2-P3 | A `high` PR finding that shipped can become an incident once user impact is observed |
+| `medium` | P3-P4 | A `medium` finding rarely becomes an incident on its own; if it does, it is usually P3 or P4 |
+| `low` | (not applicable) | `low` findings are stylistic and do not map to production incidents |
+
+**Direction of the mapping matters:**
+
+- **PR → Production:** A `critical` code review finding does not automatically imply a P1 incident. Incident severity is decided by real user impact and SLO burn rate, not by the code reviewer's judgement.
+- **Production → PR:** After an incident, the PR(s) that introduced the regression should be reviewed using the Code Review Severity scale during the postmortem. The incident severity does not set the PR severity directly.
+
+## Usage in Other Documents
+
+- `rules/pr-review-cycle.md` — uses Code Review Severity for approval gates
+- `skills/pr-review/SKILL.md` — uses Code Review Severity for priority dimensions and decision matrix
+- `skills/incident-response/severity-classification.md` — narrows Production Incident Severity to operational detail (decision tree, burn rate math, report template)
+- `adapters/claude-code.md` — references Code Review Severity for EVAL / AUTO exit criteria
+- `rules/core.md` EVAL section — prioritizes improvements by Code Review Severity
+
+When adding a new document that mentions severity, link to this file instead of redefining the levels.

--- a/packages/rules/.ai-rules/skills/incident-response/severity-classification.md
+++ b/packages/rules/.ai-rules/skills/incident-response/severity-classification.md
@@ -1,145 +1,19 @@
-# Severity Classification
+# Severity Classification (Incident Operations)
 
-Objective severity classification based on SLO burn rates and business impact.
+> **Canonical source:** P1/P2/P3/P4 severity level **definitions**, impact criteria, and response expectations live in [`packages/rules/.ai-rules/rules/severity-classification.md`](../../rules/severity-classification.md) under *Production Incident Severity*.
+>
+> This file narrows that canonical scale to **operational guidance** for incident response: how to classify in practice, the math behind burn rates, the decision tree, and what to include in an incident report.
 
 ## The Classification Rule
 
 **Classify severity BEFORE taking any action.** Severity determines:
+
 - Response time expectations
 - Who gets notified
 - Resource allocation priority
 - Communication cadence
 
-## Severity Matrix
-
-### P1 - Critical
-
-**SLO Burn Rate:** >14.4x (consuming >2% error budget per hour)
-
-**Impact Criteria (ANY of these):**
-- Complete service outage
-- >50% of users affected
-- Critical business function unavailable
-- Data loss or corruption risk
-- Active security breach
-- Revenue-generating flow completely blocked
-- Compliance/regulatory violation in progress
-
-**Response Expectations:**
-
-| Metric | Target |
-|--------|--------|
-| Acknowledge | Within 5 minutes |
-| First update | Within 15 minutes |
-| War room formed | Within 15 minutes |
-| Executive notification | Within 30 minutes |
-| Customer communication | Within 1 hour |
-| Update cadence | Every 15 minutes |
-
-**Escalation:** Immediate page to on-call, all hands if needed
-
-**Example Incidents:**
-- Production database unreachable
-- Authentication service down
-- Payment processing 100% failure
-- Major cloud region outage affecting services
-- Data breach detected
-
----
-
-### P2 - High
-
-**SLO Burn Rate:** >6x (consuming >5% error budget per 6 hours)
-
-**Impact Criteria (ANY of these):**
-- Major feature unavailable
-- 10-50% of users affected
-- Significant performance degradation (>5x latency)
-- Secondary business function blocked
-- Partial data integrity issues
-- Key integration failing
-
-**Response Expectations:**
-
-| Metric | Target |
-|--------|--------|
-| Acknowledge | Within 15 minutes |
-| First update | Within 30 minutes |
-| Status page update | Within 30 minutes |
-| Stakeholder notification | Within 1 hour |
-| Update cadence | Every 30 minutes |
-
-**Escalation:** Page on-call during business hours, notify team lead
-
-**Example Incidents:**
-- Search functionality completely broken
-- 30% of API requests failing
-- Email notifications not sending
-- Third-party payment provider degraded
-- Mobile app login issues for subset of users
-
----
-
-### P3 - Medium
-
-**SLO Burn Rate:** >3x (consuming >10% error budget per 24 hours)
-
-**Impact Criteria (ANY of these):**
-- Minor feature impacted
-- <10% of users affected
-- Workaround available
-- Non-critical function degraded
-- Cosmetic issues affecting usability
-- Performance slightly degraded
-
-**Response Expectations:**
-
-| Metric | Target |
-|--------|--------|
-| Acknowledge | Within 1 hour |
-| First update | Within 2 hours |
-| Resolution target | Within 8 business hours |
-| Update cadence | At milestones |
-
-**Escalation:** Create ticket, notify team channel
-
-**Example Incidents:**
-- Report generation slow but working
-- Specific browser experiencing issues
-- Non-critical API endpoint intermittent
-- Email formatting broken
-- Search results slightly inaccurate
-
----
-
-### P4 - Low
-
-**SLO Burn Rate:** >1x (projected budget exhaustion within SLO window)
-
-**Impact Criteria (ALL of these):**
-- Minimal or no user impact
-- Edge case or rare scenario
-- Cosmetic only
-- Performance within acceptable range
-- Workaround trivial
-
-**Response Expectations:**
-
-| Metric | Target |
-|--------|--------|
-| Acknowledge | Within 1 business day |
-| Resolution target | Next sprint/release |
-| Update cadence | On resolution |
-
-**Escalation:** Backlog item, routine prioritization
-
-**Example Incidents:**
-- Minor UI misalignment
-- Rare edge case error
-- Documentation inconsistency
-- Non-user-facing optimization opportunity
-
----
+See the canonical severity matrix for P1-P4 definitions, impact criteria, and response expectations. This file does **not** redefine those levels — refer to the canonical document whenever you need the authoritative criteria.
 
 ## Error Budget Integration
 
@@ -170,9 +44,9 @@ Burn Rate = 1.44 / 0.1 = 14.4x (P1!)
 | Tier 2 (Important) | 99.9% | 0.1% | 43.8 minutes |
 | Tier 3 (Standard) | 99.5% | 0.5% | 3.65 hours |
 
----
-
 ## Classification Decision Tree
+
+Use this when an incident is detected and you need to assign severity quickly.
 
 ```
 Is the service completely unavailable?
@@ -208,8 +82,6 @@ Is impact minimal/cosmetic only?
 └── No → Default to P3 (when uncertain)
 ```
 
----
-
 ## When Uncertain, Classify Higher
 
 **Rule:** If you're unsure between two severity levels, classify higher.
@@ -218,29 +90,27 @@ Is impact minimal/cosmetic only?
 - Unsure between P2 and P3? → Classify as P2
 - Unsure between P3 and P4? → Classify as P3
 
-**Rationale:** Over-response is better than under-response. You can always downgrade.
-
----
+**Rationale:** Over-response is better than under-response. You can always downgrade. This rule is also stated in the canonical document; it is repeated here because during an incident you must be able to act without following links.
 
 ## Severity Changes During Incident
 
 Severity can change as you learn more:
 
 **Upgrade when:**
+
 - Impact wider than initially assessed
 - More users affected than thought
 - Business impact greater than estimated
 - Mitigation not working
 
 **Downgrade when:**
+
 - Successful mitigation reduced impact
 - Fewer users affected than thought
 - Workaround discovered
 - Root cause isolated to non-critical path
 
 **Always communicate severity changes** to all stakeholders immediately.
-
----
 
 ## Include in Incident Reports
 
@@ -254,3 +124,9 @@ Impact: [Brief description]
 SLO Status: [Which SLO breaching]
 Error Budget Remaining: [Percentage]
 ```
+
+## Relationship to Code Review Severity
+
+Code review uses a **different** severity scale (`critical`/`high`/`medium`/`low`) for PR approval gating. The two scales are not interchangeable — see [`rules/severity-classification.md`](../../rules/severity-classification.md#mapping-between-scales) for the narrow cases where they correspond (e.g., when a `critical` code review finding that shipped becomes an incident).
+
+Do **not** mix the two scales in incident documents. Use P1-P4 here.

--- a/packages/rules/.ai-rules/skills/pr-review/SKILL.md
+++ b/packages/rules/.ai-rules/skills/pr-review/SKILL.md
@@ -74,6 +74,8 @@ Security, Correctness, and Test Coverage must ALWAYS be reviewed. No exceptions.
 
 ## Quick Reference
 
+> **Severity source:** The `Critical`/`High`/`Medium`/`Low` levels used below are the **Code Review Severity** scale defined in [`../../rules/severity-classification.md`](../../rules/severity-classification.md#code-review-severity). This skill decides *which dimensions to review at each level*; the canonical file defines *what counts as each level*. Do not conflate these levels with production incident severity (P1-P4).
+
 ### Priority Levels
 
 | Priority | Action | Dimensions |


### PR DESCRIPTION
## Summary

Establishes two canonical rule sources to eliminate drift between the local taskmaestro skill, shared rules, adapter docs, and custom instructions — implementing **Option D Hybrid** from the Phase 1 audit.

### New canonical sources

- `packages/rules/.ai-rules/rules/severity-classification.md` — canonical severity taxonomy with two distinct scales:
  - **Code Review Severity** (`critical`/`high`/`medium`/`low`) — PR approval gates
  - **Production Incident Severity** (P1-P4) — on-call, SLO burn rate
  - Explicit mapping table so the two are never conflated
- `packages/rules/.ai-rules/rules/pr-review-cycle.md` — canonical PR review cycle protocol (CI gate, Conductor Review vs Review Agent routing, the review protocol, worker response, re-review, approval criteria, max 3 cycles, commit hygiene: amend + force-with-lease)

### Aligned files (canonical references, duplication removed)

- `.claude/skills/taskmaestro/SKILL.md` — L86-430 replaced with concise summary + canonical link. Retains taskmaestro-specific implementation (file-based tmux trigger, `taskmaestro-state.json` schema).
- `packages/rules/.ai-rules/skills/incident-response/severity-classification.md` — P1-P4 definitions removed (now in canonical). Keeps operational content: burn rate math, SLO tier mapping, decision tree, report template.
- `packages/rules/.ai-rules/skills/pr-review/SKILL.md` — adds note linking Priority Levels to canonical Code Review Severity.
- `packages/rules/.ai-rules/adapters/claude-code.md` — adds cross-reference near Exit Criteria. **Does NOT touch Nested Execution Examples** area (reserved for Wave 4 #1386).

### Why Option D Hybrid

Preserves the taskmaestro skill's operational value (file-based trigger, state schema) while giving the repo one authoritative place for review-cycle and severity semantics. Full deletion would have broken skill self-containment; full duplication would have perpetuated the drift risk.

## Test plan

- [x] `markdownlint-cli2` — 0 errors across 103 files
- [x] `yarn workspace codingbuddy lint` — 0 errors (1 pre-existing warning in unrelated file)
- [x] `yarn workspace codingbuddy format:check`
- [x] `yarn workspace codingbuddy typecheck`
- [x] `yarn workspace codingbuddy test:coverage` — 237 files, 5947 tests passed
- [x] `yarn workspace codingbuddy circular` — 0 circular deps
- [x] `yarn workspace codingbuddy build`
- [x] `ajv-cli validate` all agent JSON schemas
- [x] `npm audit --severity high` across all workspaces — clean
- [x] IDE link diagnostics — 0 broken refs

Closes #1385