### PR TITLE
docs(rules): clarify conductor vs worker dispatch — #1386

### DIFF
--- a/packages/rules/.ai-rules/adapters/claude-code.md
+++ b/packages/rules/.ai-rules/adapters/claude-code.md
@@ -577,6 +577,28 @@ SubAgent dispatch (outer)
 → Collect results via TaskOutput
 ```
 
+**Example 3: TaskMaestro (outer) + SubAgent (inner, within worker)**
+
+```
+TaskMaestro session (outer, conductor)
+├── Pane 1: Worker for Issue #101 (auth feature)
+│   ├── Explore subAgent → researches existing auth patterns
+│   ├── Plan subAgent → drafts TDD test plan
+│   ├── [Worker writes code directly in its own worktree]
+│   └── [Worker commits, pushes, creates PR, writes RESULT.json]
+├── Pane 2: Worker for Issue #102 (dashboard UI)
+│   └── Worker uses sub-agents for component research
+│       (no cross-pane interference because each worker owns its worktree)
+└── Pane 3: Review Agent (from review cycle protocol)
+    └── EVAL mode reviewer for completed PRs
+```
+
+This is the **recommended pattern for complex worker tasks** where parallel research or context protection would benefit the worker. The conductor still uses TaskMaestro for the outer dispatch — only the worker's internal orchestration uses sub-agents.
+
+**Key invariant:** Sub-agents dispatched by a worker operate inside that worker's git worktree. Cross-pane file conflicts are impossible because each pane's worker owns its own isolated worktree.
+
+See [`../rules/parallel-execution.md`](../rules/parallel-execution.md) "Conductor vs Worker Context" section for the authoritative rule.
+
 ### Execution Strategy Selection (MANDATORY)
 
 When `parse_mode` returns `availableStrategies`, select the **outer transport** strategy:

--- a/packages/rules/.ai-rules/rules/parallel-execution.md
+++ b/packages/rules/.ai-rules/rules/parallel-execution.md
@@ -92,6 +92,33 @@ Implementation tasks (code changes, file modifications, commits) MUST use tmux-b
 
 **Why:** Background sub-agents lack proper git worktree isolation, cannot run pre-push checks reliably, and risk file conflicts when multiple agents write to the same workspace. taskMaestro provides each worker with an isolated worktree, proper shell environment, and full CI toolchain access.
 
+### Conductor vs Worker Context (MANDATORY distinction)
+
+The "Implementation → taskMaestro only" rule applies to the **conductor** (top-level orchestration session). Workers running inside a taskMaestro pane operate under different rules because they already own an isolated worktree.
+
+| Layer | Context | Dispatch Tool | Rationale |
+|-------|---------|---------------|-----------|
+| Conductor → implementation | Outer orchestration session | **taskMaestro only** | Workers need worktree isolation + pre-push checks + visual monitoring |
+| Conductor → read-only research | Outer orchestration session | SubAgent allowed | No file mutations, safe to background |
+| **Worker → internal tasks** | Inside a taskMaestro pane | **SubAgent encouraged** | Worker owns its worktree; file-conflict rationale does not apply. Use Explore/Plan subagents for parallel research or context protection. |
+
+**Why workers can use sub-agents freely:**
+
+1. Each worker operates in an isolated git worktree — no file conflict with other workers
+2. Sub-agents within a worker inherit the worker's worktree, so they share the same isolation boundary
+3. Workers often benefit from parallel read-only research (Explore) or context-protected work before committing
+
+**Examples of good worker-internal sub-agent usage:**
+
+- Dispatch `Explore` sub-agent to survey existing patterns before writing code
+- Dispatch `Plan` sub-agent to draft implementation approach, then act on the plan directly
+- Dispatch multiple read-only sub-agents in parallel to gather context from different parts of the codebase
+
+**What workers still must NOT do:**
+
+- Dispatch sub-agents that modify files in **sibling** worktrees (impossible with proper isolation, but worth stating)
+- Dispatch sub-agents to create PRs on their behalf (the worker owns its PR)
+
 ## Monorepo Path Safety
 
 In monorepo environments, always use absolute paths or `git -C <path>` for git commands to prevent path doubling:


### PR DESCRIPTION
## Summary

Resolves ambiguity where workers inside a taskMaestro pane assumed they were forbidden from using sub-agents. Workers already own an isolated git worktree, so the file-conflict rationale does not apply to their internal dispatch.

**Task 1 — `packages/rules/.ai-rules/rules/parallel-execution.md`**
- New `### Conductor vs Worker Context (MANDATORY distinction)` subsection under `## Implementation vs Read-Only Task Dispatch`
- Three-layer table: conductor-implementation / conductor-readonly / worker-internal
- Rationale, good worker sub-agent usage examples, negative examples

**Task 2 — `packages/rules/.ai-rules/adapters/claude-code.md`**
- New **Example 3: TaskMaestro (outer) + SubAgent (inner, within worker)** after Example 2 in `#### Nested Execution Examples`
- ASCII diagram showing worker → sub-agent inheritance within an isolated worktree
- Key invariant callout + cross-reference to `rules/parallel-execution.md`

Wave 3's cross-refs to `severity-classification.md` / `pr-review-cycle.md` (previously L770-771, now L795 after this insertion) are **untouched**.

## Test plan

- [x] `yarn dlx markdownlint-cli2@0.20.0 "packages/rules/.ai-rules/**/*.md"` → 0 errors
- [x] `yarn workspace codingbuddy lint` → 0 errors
- [x] `yarn workspace codingbuddy format:check` → clean
- [x] `yarn workspace codingbuddy typecheck` → pass
- [x] `yarn workspace codingbuddy test:coverage` → 237 files, 5947 passed
- [x] `yarn workspace codingbuddy circular` → no circular deps
- [x] `yarn workspace codingbuddy build` → success
- [x] `yarn dlx ajv-cli@5.0.0 validate` → all agent schemas valid
- [x] Security audits (codingbuddy / codingbuddy-claude-plugin / landing-page) → clean

## Perspective reads

- **Worker perspective:** unambiguous that workers CAN use sub-agents internally for research/context protection
- **Conductor perspective:** "no sub-agents for implementation dispatch" rule still holds for the outer layer

Closes #1386