### PR TITLE
refactor(rules): sync review-cycle and dispatch guidance to non-claude-code adapters

### DIFF
--- a/packages/rules/.ai-rules/adapters/antigravity.md
+++ b/packages/rules/.ai-rules/adapters/antigravity.md
@@ -593,6 +593,8 @@ When AUTO keyword is detected, Antigravity calls `parse_mode` MCP tool which ret
    - Success: `Critical = 0 AND High = 0`
    - Failure: Max iterations reached (default: 3)
 
+> **Severity and review-cycle canonical sources:** The `Critical`/`High` levels above are the **Code Review Severity** scale defined in [`../rules/severity-classification.md`](../rules/severity-classification.md#code-review-severity). The PR approval loop (CI gate → review → fix → re-review → approve) is specified in [`../rules/pr-review-cycle.md`](../rules/pr-review-cycle.md). Follow those canonical sources rather than re-deriving severity or approval criteria from this adapter.
+
 ### Configuration
 
 Configure in `codingbuddy.config.json`:

--- a/packages/rules/.ai-rules/adapters/codex.md
+++ b/packages/rules/.ai-rules/adapters/codex.md
@@ -619,6 +619,8 @@ AUTO implement user authentication with JWT
    - Success: `Critical = 0 AND High = 0`
    - Failure: Max iterations reached (default: 3)
 
+> **Severity and review-cycle canonical sources:** The `Critical`/`High` levels above are the **Code Review Severity** scale defined in [`../rules/severity-classification.md`](../rules/severity-classification.md#code-review-severity). The PR approval loop (CI gate → review → fix → re-review → approve) is specified in [`../rules/pr-review-cycle.md`](../rules/pr-review-cycle.md). Follow those canonical sources rather than re-deriving severity or approval criteria from this adapter.
+
 ### Copilot Integration
 
 When using GitHub Copilot Chat with AUTO mode:

--- a/packages/rules/.ai-rules/adapters/cursor.md
+++ b/packages/rules/.ai-rules/adapters/cursor.md
@@ -429,6 +429,8 @@ When AUTO keyword is detected, Cursor calls `parse_mode` MCP tool which returns 
    - Success: `Critical = 0 AND High = 0`
    - Failure: Max iterations reached (default: 3)
 
+> **Severity and review-cycle canonical sources:** The `Critical`/`High` levels above are the **Code Review Severity** scale defined in [`../rules/severity-classification.md`](../rules/severity-classification.md#code-review-severity). The PR approval loop (CI gate → review → fix → re-review → approve) is specified in [`../rules/pr-review-cycle.md`](../rules/pr-review-cycle.md). Follow those canonical sources rather than re-deriving severity or approval criteria from this adapter.
+
 ### Configuration
 
 Configure in `codingbuddy.config.json`:

--- a/packages/rules/.ai-rules/adapters/kiro.md
+++ b/packages/rules/.ai-rules/adapters/kiro.md
@@ -552,6 +552,8 @@ When AUTO keyword is detected, Kiro calls `parse_mode` MCP tool which returns AU
    - Success: `Critical = 0 AND High = 0`
    - Failure: Max iterations reached (default: 3)
 
+> **Severity and review-cycle canonical sources:** The `Critical`/`High` levels above are the **Code Review Severity** scale defined in [`../rules/severity-classification.md`](../rules/severity-classification.md#code-review-severity). The PR approval loop (CI gate → review → fix → re-review → approve) is specified in [`../rules/pr-review-cycle.md`](../rules/pr-review-cycle.md). Follow those canonical sources rather than re-deriving severity or approval criteria from this adapter.
+
 ### Configuration
 
 Configure in `codingbuddy.config.json`:

--- a/packages/rules/.ai-rules/adapters/opencode.md
+++ b/packages/rules/.ai-rules/adapters/opencode.md
@@ -774,6 +774,8 @@ AUTO Build a new user authentication feature
    - Success: `Critical = 0 AND High = 0`
    - Failure: Max iterations reached (default: 3)
 
+> **Severity and review-cycle canonical sources:** The `Critical`/`High` levels above are the **Code Review Severity** scale defined in [`../rules/severity-classification.md`](../rules/severity-classification.md#code-review-severity). The PR approval loop (CI gate → review → fix → re-review → approve) is specified in [`../rules/pr-review-cycle.md`](../rules/pr-review-cycle.md). Follow those canonical sources rather than re-deriving severity or approval criteria from this adapter.
+
 ### OpenCode Agent Integration
 
 AUTO mode describes an autonomous PLAN→ACT→EVAL cycle. However, agent switching behavior differs by platform:

--- a/packages/rules/.ai-rules/adapters/q.md
+++ b/packages/rules/.ai-rules/adapters/q.md
@@ -198,6 +198,8 @@ AUTO create a new Lambda function
    - Success: `Critical = 0 AND High = 0`
    - Failure: Max iterations reached (default: 3)
 
+> **Severity and review-cycle canonical sources:** The `Critical`/`High` levels above are the **Code Review Severity** scale defined in [`../rules/severity-classification.md`](../rules/severity-classification.md#code-review-severity). The PR approval loop (CI gate → review → fix → re-review → approve) is specified in [`../rules/pr-review-cycle.md`](../rules/pr-review-cycle.md). Follow those canonical sources rather than re-deriving severity or approval criteria from this adapter.
+
 ### AWS Integration with AUTO Mode
 
 Amazon Q's AWS expertise complements AUTO mode:

--- a/packages/rules/.ai-rules/adapters/windsurf.md
+++ b/packages/rules/.ai-rules/adapters/windsurf.md
@@ -299,6 +299,8 @@ Use the `AUTO` keyword at the start of your message:
    - Success: `Critical = 0 AND High = 0`
    - Failure: Max iterations reached (default: 3)
 
+> **Severity and review-cycle canonical sources:** The `Critical`/`High` levels above are the **Code Review Severity** scale defined in [`../rules/severity-classification.md`](../rules/severity-classification.md#code-review-severity). The PR approval loop (CI gate → review → fix → re-review → approve) is specified in [`../rules/pr-review-cycle.md`](../rules/pr-review-cycle.md). Follow those canonical sources rather than re-deriving severity or approval criteria from this adapter.
+
 ### Configuration
 
 Configure in `codingbuddy.config.json`:


### PR DESCRIPTION
Closes #1387

## Summary

Follow-up to #1385 (canonical review-cycle + severity) and #1386 (conductor vs worker dispatch) that propagates those canonical sources to non-claude-code adapters **by reference, not duplication**.

Each touched adapter gets a single callout immediately after its AUTO-mode `Critical = 0 AND High = 0` exit criterion, pointing at:

- [`packages/rules/.ai-rules/rules/severity-classification.md`](../blob/master/packages/rules/.ai-rules/rules/severity-classification.md#code-review-severity)
- [`packages/rules/.ai-rules/rules/pr-review-cycle.md`](../blob/master/packages/rules/.ai-rules/rules/pr-review-cycle.md)

Adapter-specific quirks (MCP tool availability, agent switching, sequential execution, AWS/Copilot notes) are intentionally preserved.

## Per-Adapter Decisions

| Adapter | Decision | Reason |
|---------|----------|--------|
| `antigravity.md` | ✅ Updated | Has AUTO "Critical = 0 AND High = 0" exit criteria |
| `codex.md` | ✅ Updated | Has AUTO "Critical = 0 AND High = 0" exit criteria |
| `kiro.md` | ✅ Updated | Has AUTO "Critical = 0 AND High = 0" exit criteria |
| `opencode.md` | ✅ Updated | Has AUTO "Critical = 0 AND High = 0" exit criteria |
| `cursor.md` | ✅ Updated | Has AUTO "Critical = 0 AND High = 0" exit criteria |
| `windsurf.md` | ✅ Updated | Has AUTO "Critical = 0 AND High = 0" exit criteria |
| `q.md` | ✅ Updated | Has AUTO "Critical = 0 AND High = 0" exit criteria |
| `aider.md` | ⏭ Skipped | No review-cycle/severity content (only agent-JSON loading for focused reviews) |
| `opencode-skills.md` | ⏭ Skipped | Skills catalog only; references skill names, not protocol content |

Reference, don't duplicate — `aider.md` and `opencode-skills.md` were deliberately left untouched to avoid force-inserting cross-refs where they don't fit.

## Boundaries Respected

**Not touched** (per issue scope):

- `packages/rules/.ai-rules/rules/*.md` — canonical sources (#1385/#1386 locked these in)
- `packages/rules/.ai-rules/adapters/claude-code.md` — already carries the canonical callout
- `.claude/skills/taskmaestro/SKILL.md`

## Test Plan

- [x] `yarn dlx markdownlint-cli2@0.20.0 "packages/rules/.ai-rules/**/*.md"` → 0 errors
- [x] `yarn workspace codingbuddy build` → passed
- [x] `yarn workspace codingbuddy test` → 237 files, 5947 passed, 2 skipped
- [ ] CI green on this PR
- [ ] Spot-check rendered callout in one adapter (e.g., `antigravity.md`) — links resolve