### PR TITLE
refactor(mcp-server): retire fake agent_discussion behind experimental flag

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/discussion.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/discussion.handler.spec.ts
@@ -1,15 +1,35 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { DiscussionHandler } from './discussion.handler';
-import type { AgentOpinion, DiscussionResult } from './discussion.types';
+import type {
+  AgentOpinion,
+  DisabledDiscussionResult,
+  ExperimentalDiscussionResult,
+} from './discussion.types';
+import {
+  DISABLED_DISCUSSION_REASON,
+  EXPERIMENTAL_DISCUSSION_ENV,
+  EXPERIMENTAL_DISCUSSION_WARNING,
+} from './discussion.types';
 import type { RuleEventCollector } from '../../rules/rule-event-collector';
 
 describe('DiscussionHandler', () => {
   let handler: DiscussionHandler;
   let mockRuleEventCollector: Partial<RuleEventCollector>;
+  let savedEnvValue: string | undefined;
 
   beforeEach(() => {
+    savedEnvValue = process.env[EXPERIMENTAL_DISCUSSION_ENV];
+    delete process.env[EXPERIMENTAL_DISCUSSION_ENV];
     mockRuleEventCollector = { record: vi.fn() };
     handler = new DiscussionHandler(mockRuleEventCollector as RuleEventCollector);
+  });
+
+  afterEach(() => {
+    if (savedEnvValue === undefined) {
+      delete process.env[EXPERIMENTAL_DISCUSSION_ENV];
+    } else {
+      process.env[EXPERIMENTAL_DISCUSSION_ENV] = savedEnvValue;
+    }
   });
 
   describe('handle', () => {
@@ -18,7 +38,55 @@ describe('DiscussionHandler', () => {
       expect(result).toBeNull();
     });
 
-    describe('agent_discussion', () => {
+    describe('agent_discussion (disabled by default)', () => {
+      it('should return disabled result when experimental env is unset', async () => {
+        const result = await handler.handle('agent_discussion', {
+          topic: 'Authentication design review',
+          specialists: ['security-specialist', 'performance-specialist'],
+        });
+
+        expect(result?.isError).toBeFalsy();
+        const data = JSON.parse(result!.content[0].text) as DisabledDiscussionResult;
+        expect(data.disabled).toBe(true);
+        expect(data.reason).toBe(DISABLED_DISCUSSION_REASON);
+        expect(data.experimentalFlag).toBe(EXPERIMENTAL_DISCUSSION_ENV);
+      });
+
+      it('should return disabled result even when args would otherwise be invalid', async () => {
+        // Disabled path is the default short-circuit and should not leak
+        // validation errors; callers just learn the feature is off.
+        const result = await handler.handle('agent_discussion', undefined);
+
+        expect(result?.isError).toBeFalsy();
+        const data = JSON.parse(result!.content[0].text) as DisabledDiscussionResult;
+        expect(data.disabled).toBe(true);
+      });
+
+      it('should not record specialist_dispatched events when disabled', async () => {
+        await handler.handle('agent_discussion', {
+          topic: 'Auth review',
+          specialists: ['security-specialist', 'performance-specialist'],
+        });
+
+        expect(mockRuleEventCollector.record).not.toHaveBeenCalled();
+      });
+
+      it('should treat env values other than "1" as disabled', async () => {
+        process.env[EXPERIMENTAL_DISCUSSION_ENV] = '0';
+        const result = await handler.handle('agent_discussion', {
+          topic: 'Review',
+          specialists: ['security-specialist'],
+        });
+        const data = JSON.parse(result!.content[0].text) as DisabledDiscussionResult;
+        expect(data.disabled).toBe(true);
+      });
+    });
+
+    describe('agent_discussion (experimental flag enabled)', () => {
+      beforeEach(() => {
+        process.env[EXPERIMENTAL_DISCUSSION_ENV] = '1';
+      });
+
       it('should return structured discussion result with valid args', async () => {
         const result = await handler.handle('agent_discussion', {
           topic: 'Authentication design review',
@@ -26,13 +94,27 @@ describe('DiscussionHandler', () => {
         });
 
         expect(result?.isError).toBeFalsy();
-        const data = JSON.parse(result!.content[0].text) as DiscussionResult;
+        const data = JSON.parse(result!.content[0].text) as ExperimentalDiscussionResult;
         expect(data.topic).toBe('Authentication design review');
         expect(data.specialists).toEqual(['security-specialist', 'performance-specialist']);
         expect(data.opinions).toHaveLength(2);
         expect(data.consensus).toBeDefined();
         expect(data.summary).toBeDefined();
         expect(data.maxSeverity).toBeDefined();
+      });
+
+      it('should include experimental flag and warning banner in enabled output', async () => {
+        const result = await handler.handle('agent_discussion', {
+          topic: 'Authentication design review',
+          specialists: ['security-specialist'],
+        });
+
+        const data = JSON.parse(result!.content[0].text) as ExperimentalDiscussionResult;
+        expect(data.experimental).toBe(true);
+        expect(data.warning).toBe(EXPERIMENTAL_DISCUSSION_WARNING);
+        expect(data.warning).toContain('experimental');
+        expect(data.warning).toContain('templated synthesis');
+        expect(data.warning).toContain('not real specialist execution');
       });
 
       it('should return error for missing topic', async () => {
@@ -84,7 +166,7 @@ describe('DiscussionHandler', () => {
           specialists,
         });
 
-        const data = JSON.parse(result!.content[0].text) as DiscussionResult;
+        const data = JSON.parse(result!.content[0].text) as ExperimentalDiscussionResult;
         expect(data.opinions).toHaveLength(3);
         expect(data.opinions.map((o: AgentOpinion) => o.agent)).toEqual(specialists);
       });
@@ -95,7 +177,7 @@ describe('DiscussionHandler', () => {
           specialists: ['security-specialist'],
         });
 
-        const data = JSON.parse(result!.content[0].text) as DiscussionResult;
+        const data = JSON.parse(result!.content[0].text) as ExperimentalDiscussionResult;
         const opinion = data.opinions[0];
         expect(opinion).toHaveProperty('agent');
         expect(opinion).toHaveProperty('opinion');
@@ -115,7 +197,7 @@ describe('DiscussionHandler', () => {
           specialists: ['security-specialist', 'performance-specialist'],
         });
 
-        const data = JSON.parse(result!.content[0].text) as DiscussionResult;
+        const data = JSON.parse(result!.content[0].text) as ExperimentalDiscussionResult;
         const validSeverities = ['info', 'low', 'medium', 'high', 'critical'];
         for (const opinion of data.opinions) {
           expect(validSeverities).toContain(opinion.severity);
@@ -129,7 +211,7 @@ describe('DiscussionHandler', () => {
           specialists: ['security-specialist'],
         });
 
-        const data = JSON.parse(result!.content[0].text) as DiscussionResult;
+        const data = JSON.parse(result!.content[0].text) as ExperimentalDiscussionResult;
         // Single specialist always has consensus
         expect(data.consensus).toBe('consensus');
       });
@@ -142,15 +224,8 @@ describe('DiscussionHandler', () => {
         });
 
         expect(result?.isError).toBeFalsy();
-        const data = JSON.parse(result!.content[0].text) as DiscussionResult;
+        const data = JSON.parse(result!.content[0].text) as ExperimentalDiscussionResult;
         expect(data.topic).toBe('Auth review');
-      });
-
-      it('should handle undefined args gracefully', async () => {
-        const result = await handler.handle('agent_discussion', undefined);
-
-        expect(result?.isError).toBe(true);
-        expect(result?.content[0].text).toContain('Missing required parameter: topic');
       });
 
       it('should compute maxSeverity as highest across all opinions', async () => {
@@ -159,7 +234,7 @@ describe('DiscussionHandler', () => {
           specialists: ['security-specialist', 'performance-specialist'],
         });
 
-        const data = JSON.parse(result!.content[0].text) as DiscussionResult;
+        const data = JSON.parse(result!.content[0].text) as ExperimentalDiscussionResult;
         const severityOrder = ['info', 'low', 'medium', 'high', 'critical'];
         const opinionSeverities = data.opinions.map((o: AgentOpinion) =>
           severityOrder.indexOf(o.severity),
@@ -170,7 +245,11 @@ describe('DiscussionHandler', () => {
     });
   });
 
-  describe('rule event tracking', () => {
+  describe('rule event tracking (experimental enabled)', () => {
+    beforeEach(() => {
+      process.env[EXPERIMENTAL_DISCUSSION_ENV] = '1';
+    });
+
     it('should record specialist_dispatched event for each specialist', async () => {
       await handler.handle('agent_discussion', {
         topic: 'Auth review',
@@ -219,6 +298,15 @@ describe('DiscussionHandler', () => {
 
       expect(definitions).toHaveLength(1);
       expect(definitions[0].name).toBe('agent_discussion');
+    });
+
+    it('should mark tool description as experimental', () => {
+      const definitions = handler.getToolDefinitions();
+      const description = definitions[0].description.toLowerCase();
+
+      expect(description).toContain('experimental');
+      expect(description).toContain('templated synthesis');
+      expect(description).toContain(EXPERIMENTAL_DISCUSSION_ENV.toLowerCase());
     });
 
     it('should have correct required parameters', () => {

--- a/apps/mcp-server/src/mcp/handlers/discussion.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/discussion.handler.ts
@@ -10,11 +10,18 @@ import {
 } from '../../shared/validation.constants';
 import type {
   AgentOpinion,
+  DisabledDiscussionResult,
   DiscussionResult,
+  ExperimentalDiscussionResult,
   OpinionSeverity,
   ConsensusStatus,
 } from './discussion.types';
-import { VALID_SEVERITIES } from './discussion.types';
+import {
+  DISABLED_DISCUSSION_REASON,
+  EXPERIMENTAL_DISCUSSION_ENV,
+  EXPERIMENTAL_DISCUSSION_WARNING,
+  VALID_SEVERITIES,
+} from './discussion.types';
 import { RuleEventCollector } from '../../rules/rule-event-collector';
 
 /**
@@ -37,8 +44,16 @@ const SEVERITY_ORDER: readonly OpinionSeverity[] = ['info', 'low', 'medium', 'hi
 /**
  * Handler for the agent_discussion tool.
  *
- * Collects opinions from multiple specialist agents on a given topic,
- * detects consensus or disagreement, and returns a structured discussion result.
+ * EXPERIMENTAL — disabled by default. Current output is templated synthesis of
+ * specialist opinions rather than real specialist execution, so it does NOT
+ * represent collective intelligence from live agents. The tool returns a
+ * {@link DisabledDiscussionResult} unless the caller explicitly opts in via
+ * `CODINGBUDDY_EXPERIMENTAL_DISCUSSION=1`, in which case it returns an
+ * {@link ExperimentalDiscussionResult} that carries a warning banner so
+ * consumers cannot mistake the output for a real multi-agent debate.
+ *
+ * A follow-up effort should rebuild this on top of real specialist dispatch;
+ * until then callers should prefer `dispatch_agents` for actual expert input.
  */
 @Injectable()
 export class DiscussionHandler extends AbstractHandler {
@@ -67,9 +82,12 @@ export class DiscussionHandler extends AbstractHandler {
       {
         name: 'agent_discussion',
         description:
-          'Conduct a structured discussion among specialist agents on a given topic. ' +
-          'Collects opinions from each specialist, detects consensus or disagreement, ' +
-          'and returns a structured summary with severity assessments.',
+          '[EXPERIMENTAL — disabled by default] Produces templated synthesis of ' +
+          'specialist opinions, not real specialist execution. The output does ' +
+          'not reflect collective intelligence from live agents; treat it as a ' +
+          'placeholder until the rebuild lands. Enable by setting ' +
+          `${EXPERIMENTAL_DISCUSSION_ENV}=1. When disabled, the tool returns ` +
+          '{disabled: true} without invoking synthesis.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -98,6 +116,15 @@ export class DiscussionHandler extends AbstractHandler {
   private async handleAgentDiscussion(
     args: Record<string, unknown> | undefined,
   ): Promise<ToolResponse> {
+    if (!this.isExperimentalEnabled()) {
+      const disabled: DisabledDiscussionResult = {
+        disabled: true,
+        reason: DISABLED_DISCUSSION_REASON,
+        experimentalFlag: EXPERIMENTAL_DISCUSSION_ENV,
+      };
+      return createJsonResponse(disabled);
+    }
+
     const topic = extractRequiredString(args, 'topic');
     if (topic === null) {
       return createErrorResponse('Missing required parameter: topic');
@@ -117,13 +144,19 @@ export class DiscussionHandler extends AbstractHandler {
     const maxSeverity = this.computeMaxSeverity(opinions);
     const summary = this.generateSummary(topic, opinions, consensus);
 
-    const result: DiscussionResult = {
+    const base: DiscussionResult = {
       topic,
       specialists,
       opinions,
       consensus,
       summary,
       maxSeverity,
+    };
+
+    const result: ExperimentalDiscussionResult = {
+      ...base,
+      experimental: true,
+      warning: EXPERIMENTAL_DISCUSSION_WARNING,
     };
 
     try {
@@ -140,6 +173,16 @@ export class DiscussionHandler extends AbstractHandler {
     }
 
     return createJsonResponse(result);
+  }
+
+  /**
+   * Returns true only when the experimental flag env var is set to the
+   * explicit opt-in value "1". Any other value (including "true", "yes",
+   * or unset) leaves the tool disabled so callers cannot accidentally
+   * consume templated synthesis.
+   */
+  private isExperimentalEnabled(): boolean {
+    return process.env[EXPERIMENTAL_DISCUSSION_ENV] === '1';
   }
 
   /**

--- a/apps/mcp-server/src/mcp/handlers/discussion.types.ts
+++ b/apps/mcp-server/src/mcp/handlers/discussion.types.ts
@@ -60,3 +60,46 @@ export const VALID_SEVERITIES: readonly OpinionSeverity[] = [
   'high',
   'critical',
 ];
+
+/**
+ * Environment variable that enables the experimental agent_discussion tool.
+ *
+ * This tool produces templated synthesis rather than real specialist execution,
+ * so it is disabled by default. Set this env var to '1' to enable it for
+ * experimentation / evaluation, and understand that its output does NOT
+ * reflect real agent collective intelligence.
+ */
+export const EXPERIMENTAL_DISCUSSION_ENV = 'CODINGBUDDY_EXPERIMENTAL_DISCUSSION';
+
+/**
+ * Warning banner attached to any enabled agent_discussion response so callers
+ * cannot mistake templated synthesis for real specialist execution.
+ */
+export const EXPERIMENTAL_DISCUSSION_WARNING =
+  '\u26a0\ufe0f experimental — templated synthesis, not real specialist execution';
+
+/**
+ * Reason surfaced when the tool is disabled (default state).
+ */
+export const DISABLED_DISCUSSION_REASON =
+  'templated synthesis not aligned with collective intelligence promise';
+
+/**
+ * Response returned when the agent_discussion tool is disabled (default).
+ */
+export interface DisabledDiscussionResult {
+  disabled: true;
+  reason: string;
+  experimentalFlag: string;
+}
+
+/**
+ * Response returned when the agent_discussion tool is explicitly enabled
+ * via the experimental env flag. Extends DiscussionResult with a warning
+ * banner that the output is templated synthesis, not real specialist
+ * execution.
+ */
+export interface ExperimentalDiscussionResult extends DiscussionResult {
+  experimental: true;
+  warning: string;
+}


### PR DESCRIPTION
## Summary

- **Direction A (conservative retire)**: `agent_discussion` is now disabled by default; it only runs when `CODINGBUDDY_EXPERIMENTAL_DISCUSSION=1` is explicitly set.
- **Disabled path**: Returns `{disabled: true, reason, experimentalFlag}` without invoking the templated synthesis — callers cannot accidentally consume fake collective intelligence.
- **Enabled path**: The existing `DiscussionResult` is wrapped in an `ExperimentalDiscussionResult` that carries an `experimental: true` flag and a warning banner ("⚠️ experimental — templated synthesis, not real specialist execution"). Consumers cannot mistake the output for a real multi-agent debate.
- **Tool registration**: `getToolDefinitions().description` and the class docstring now mark the tool as `[EXPERIMENTAL — disabled by default]` and point at the opt-in env flag.
- **Spec rewrite**: `discussion.handler.spec.ts` now covers both contracts (disabled default, experimental enable) and the warning banner. 24 tests, all green.
- **Rules check**: Grepped `packages/rules/.ai-rules/` for `agent_discussion` / collective intelligence claims on the MCP tool. The only hits are formatter skills (`skills/agent-discussion/SKILL.md`, `skills/agent-discussion-panel/SKILL.md`) describing terminal rendering format — they do not claim the MCP tool performs real specialist execution. No pane-4 follow-up needed for this specific concern.

## Out of scope (Direction B — follow-up)

Rebuilding `agent_discussion` on top of real specialist dispatch (evidence-based discussion from actual agent outputs) is intentionally deferred to a separate wave. This PR only retires the misleading templated path behind an explicit opt-in flag.

## Wave 1 boundary

- Touched only `apps/mcp-server/src/mcp/handlers/discussion.*` — no changes to `parse-mode*` (#1371), `agents/*.json` (#1375), or `rules/*.md`.

## Test plan

- [x] `yarn workspace codingbuddy lint` (0 errors)
- [x] `yarn workspace codingbuddy format:check` (clean)
- [x] `yarn workspace codingbuddy typecheck` (clean)
- [x] `yarn workspace codingbuddy test:coverage` (237 files, 5952 passed, 2 skipped)
- [x] `yarn workspace codingbuddy circular` (no cycles)
- [x] `yarn workspace codingbuddy build` (TUI ESM bundle built)
- [x] Security audit across all workspaces (no suggestions)
- [x] RED → GREEN → REFACTOR TDD cycle for the new contract

Closes #1374