### PR TITLE
feat(mcp-server): add Clarification Gate to PLAN and parse_mode

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/clarification-gate.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/clarification-gate.spec.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateClarification,
+  hasOverridePhrase,
+  hasVagueIntent,
+  hasTechnicalReference,
+  DEFAULT_QUESTION_BUDGET,
+  CLARIFICATION_TOPICS,
+  MIN_PROMPT_LENGTH,
+} from './clarification-gate';
+
+describe('clarification-gate', () => {
+  describe('hasOverridePhrase', () => {
+    it.each([
+      ['just do it'],
+      ['Just Do It and move on'],
+      ['use your judgment here'],
+      ['use your best guess'],
+      ['use your discretion'],
+      ['go ahead with it'],
+      ['make assumptions where needed'],
+      ['assume defaults'],
+      ['assume reasonable behavior'],
+      ['알아서 해'],
+      ['알아서 진행해줘'],
+      ['알아서 처리'],
+      ['그냥 해'],
+      ['임의로 진행'],
+    ])('detects override phrase in %p', input => {
+      expect(hasOverridePhrase(input)).toBe(true);
+    });
+
+    it.each([
+      ['implement OAuth2 login flow'],
+      ['just another feature request'],
+      ['refactor the login module'],
+      [''],
+    ])('returns false for non-override %p', input => {
+      expect(hasOverridePhrase(input)).toBe(false);
+    });
+  });
+
+  describe('hasVagueIntent', () => {
+    it.each([
+      ['improve the UI'],
+      ['make it better'],
+      ['enhance performance'],
+      ['optimize the flow'],
+      ['optimise the flow'],
+      ['refactor this'],
+      ['clean up the code'],
+      ['clean  up'],
+      ['tweak the settings'],
+      ['fix stuff'],
+      ['fix things'],
+      ['fix issues'],
+      ['로그인 개선'],
+      ['성능 향상'],
+      ['최적화 필요'],
+      ['코드 정리'],
+    ])('detects vague intent in %p', input => {
+      expect(hasVagueIntent(input)).toBe(true);
+    });
+
+    it.each([
+      ['implement login'],
+      ['add a new endpoint'],
+      ['write unit tests'],
+      ['create a button component'],
+    ])('returns false for concrete intent %p', input => {
+      expect(hasVagueIntent(input)).toBe(false);
+    });
+  });
+
+  describe('hasTechnicalReference', () => {
+    it.each([
+      ['add tests to src/auth.ts'],
+      ['update apps/mcp-server/src/main.ts'],
+      ['fix bug in login.tsx'],
+      ['modify config.yaml'],
+      ['update the package.json'],
+      ['call parseMode() from the handler'],
+      ['use the ModeHandler class'],
+      ['rename parse_mode function'],
+      ['check the user_profile field'],
+      ['fix `handleRequest` in the router'],
+      ['invoke fetchUser() helper'],
+    ])('detects technical reference in %p', input => {
+      expect(hasTechnicalReference(input)).toBe(true);
+    });
+
+    it.each([['improve the UI'], ['make things faster'], ['개선해줘'], ['fix stuff'], ['']])(
+      'returns false for non-technical %p',
+      input => {
+        expect(hasTechnicalReference(input)).toBe(false);
+      },
+    );
+  });
+
+  describe('evaluateClarification', () => {
+    describe('clear PLAN requests (planReady path)', () => {
+      it('returns planReady=true for a prompt with an explicit file path', () => {
+        const result = evaluateClarification(
+          'add unit tests to apps/mcp-server/src/auth/auth.service.ts',
+        );
+
+        expect(result.planReady).toBe(true);
+        expect(result.clarificationNeeded).toBe(false);
+        expect(result.nextQuestion).toBeUndefined();
+        expect(result.clarificationTopics).toBeUndefined();
+        expect(result.questionBudget).toBe(DEFAULT_QUESTION_BUDGET);
+      });
+
+      it('returns planReady=true for a prompt with a function identifier', () => {
+        const result = evaluateClarification('refactor parseMode() to handle localized keywords');
+
+        expect(result.planReady).toBe(true);
+        expect(result.clarificationNeeded).toBe(false);
+      });
+
+      it('returns planReady=true for a prompt with a PascalCase class reference', () => {
+        const result = evaluateClarification('add logging to ModeHandler for debugging');
+
+        expect(result.planReady).toBe(true);
+        expect(result.clarificationNeeded).toBe(false);
+      });
+
+      it('returns planReady=true for a well-specified implementation request', () => {
+        const result = evaluateClarification(
+          'implement password reset endpoint that sends an email with a reset link',
+        );
+
+        expect(result.planReady).toBe(true);
+        expect(result.clarificationNeeded).toBe(false);
+      });
+
+      it('preserves the caller-provided budget on a clear path', () => {
+        const result = evaluateClarification('add tests to src/auth.ts', {
+          questionBudget: 2,
+        });
+
+        expect(result.questionBudget).toBe(2);
+      });
+    });
+
+    describe('ambiguous PLAN requests (clarification path)', () => {
+      it('returns clarificationNeeded=true for a short vague prompt', () => {
+        const result = evaluateClarification('개선해줘');
+
+        expect(result.clarificationNeeded).toBe(true);
+        expect(result.planReady).toBe(false);
+        expect(result.nextQuestion).toBeTruthy();
+        expect(result.clarificationTopics?.length).toBeGreaterThan(0);
+      });
+
+      it('returns clarificationNeeded=true for vague intent verbs without scope', () => {
+        const result = evaluateClarification('improve the thing and make it better');
+
+        expect(result.clarificationNeeded).toBe(true);
+        expect(result.planReady).toBe(false);
+        expect(result.clarificationTopics).toContain(CLARIFICATION_TOPICS.VAGUE_INTENT);
+      });
+
+      it('returns clarificationNeeded=true for a too-short prompt without tech reference', () => {
+        expect('fix it'.length).toBeLessThan(MIN_PROMPT_LENGTH);
+        const result = evaluateClarification('fix it');
+
+        expect(result.clarificationNeeded).toBe(true);
+        expect(result.planReady).toBe(false);
+      });
+
+      it('emits a single highest-value next question, not a list', () => {
+        const result = evaluateClarification('개선해줘');
+
+        expect(result.nextQuestion).toBeTruthy();
+        expect(typeof result.nextQuestion).toBe('string');
+        // Single question, no bullet lists
+        expect(result.nextQuestion).not.toMatch(/\n\s*[-*]/);
+      });
+
+      it('decrements the budget on each ambiguous round', () => {
+        const r1 = evaluateClarification('improve it', { questionBudget: 3 });
+        expect(r1.clarificationNeeded).toBe(true);
+        expect(r1.questionBudget).toBe(2);
+
+        const r2 = evaluateClarification('improve it', { questionBudget: 2 });
+        expect(r2.clarificationNeeded).toBe(true);
+        expect(r2.questionBudget).toBe(1);
+
+        const r3 = evaluateClarification('improve it', { questionBudget: 1 });
+        expect(r3.clarificationNeeded).toBe(true);
+        expect(r3.questionBudget).toBe(0);
+      });
+
+      it('orders clarificationTopics by priority (vague-intent first when applicable)', () => {
+        const result = evaluateClarification('개선');
+
+        expect(result.clarificationTopics?.[0]).toBe(CLARIFICATION_TOPICS.VAGUE_INTENT);
+      });
+    });
+
+    describe('override phrases', () => {
+      it('returns planReady=true even when prompt is otherwise ambiguous', () => {
+        const result = evaluateClarification('improve it, just do it');
+
+        expect(result.planReady).toBe(true);
+        expect(result.clarificationNeeded).toBe(false);
+        expect(result.questionBudget).toBe(DEFAULT_QUESTION_BUDGET);
+      });
+
+      it('honors Korean override phrase 알아서', () => {
+        const result = evaluateClarification('개선해줘 알아서 해');
+
+        expect(result.planReady).toBe(true);
+        expect(result.clarificationNeeded).toBe(false);
+      });
+
+      it('does not decrement budget on override path', () => {
+        const result = evaluateClarification('improve it, use your judgment', {
+          questionBudget: 2,
+        });
+
+        expect(result.questionBudget).toBe(2);
+      });
+    });
+
+    describe('budget exhausted', () => {
+      it('returns planReady=true with assumptionNote when budget=0', () => {
+        const result = evaluateClarification('improve it', { questionBudget: 0 });
+
+        expect(result.planReady).toBe(true);
+        expect(result.clarificationNeeded).toBe(false);
+        expect(result.questionBudget).toBe(0);
+        expect(result.assumptionNote).toBeTruthy();
+        expect(result.assumptionNote).toMatch(/assum/i);
+      });
+
+      it('returns planReady=true when budget is negative (defensive)', () => {
+        const result = evaluateClarification('개선', { questionBudget: -1 });
+
+        expect(result.planReady).toBe(true);
+        expect(result.clarificationNeeded).toBe(false);
+        expect(result.questionBudget).toBe(0);
+      });
+
+      it('does not trigger budget-exhausted path when request is already clear', () => {
+        // Even with budget=0 the response is planReady; the distinguishing
+        // factor is that a clear request does not need an assumptionNote.
+        const clearResult = evaluateClarification('add tests to src/auth.ts', {
+          questionBudget: 0,
+        });
+
+        expect(clearResult.planReady).toBe(true);
+        // Budget-exhausted path always sets assumptionNote
+        expect(clearResult.assumptionNote).toBeTruthy();
+      });
+    });
+
+    describe('edge cases', () => {
+      it('handles an empty prompt as clear (no fields to ask about)', () => {
+        const result = evaluateClarification('');
+
+        // An empty string isn't "too short" (length 0), and no vague verbs or
+        // tech references trigger — fall through to planReady.
+        expect(result.planReady).toBe(true);
+      });
+
+      it('uses DEFAULT_QUESTION_BUDGET when options are omitted', () => {
+        const result = evaluateClarification('add tests to src/auth.ts');
+
+        expect(result.questionBudget).toBe(DEFAULT_QUESTION_BUDGET);
+      });
+
+      it('does not include nextQuestion on planReady path', () => {
+        const result = evaluateClarification('add tests to src/auth.ts');
+
+        expect(result.nextQuestion).toBeUndefined();
+        expect(result.clarificationTopics).toBeUndefined();
+      });
+    });
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/clarification-gate.ts
+++ b/apps/mcp-server/src/mcp/handlers/clarification-gate.ts
@@ -1,0 +1,268 @@
+/**
+ * Clarification Gate — runtime contract for PLAN ambiguity detection (#1371).
+ *
+ * Makes clarification a first-class step in the PLAN flow. Instead of optional
+ * prompt-style guidance, the gate returns structured metadata that forces the
+ * AI client to ask before solutioning when a request is materially ambiguous.
+ *
+ * Responsibility:
+ * - Detect ambiguous PLAN requests via conservative, tunable heuristics.
+ * - Emit a single highest-value next question + topic list when unclear.
+ * - Honor explicit user overrides ("just do it", "알아서") — never force questions.
+ * - Enforce a decrementing question budget so the loop cannot run forever.
+ *
+ * This module is intentionally pure and free of NestJS dependencies so it can
+ * be unit tested in isolation.
+ */
+
+/**
+ * Default number of clarification rounds allowed before the gate falls back to
+ * planning with explicit assumptions. Callers may override via options.
+ */
+export const DEFAULT_QUESTION_BUDGET = 3;
+
+/**
+ * Minimum character length below which a PLAN prompt is treated as too short
+ * to contain enough context for planning.
+ */
+export const MIN_PROMPT_LENGTH = 20;
+
+/**
+ * Options accepted by `evaluateClarification`. Callers pass the remaining
+ * questionBudget from a prior round; the gate decrements it on each ambiguous
+ * round.
+ */
+export interface ClarificationOptions {
+  /** Remaining questions allowed in this session. Defaults to DEFAULT_QUESTION_BUDGET. */
+  questionBudget?: number;
+}
+
+/**
+ * Clarification metadata emitted by the gate and included in the PLAN
+ * parse_mode response. Backward-compatible — all fields are additive.
+ */
+export interface ClarificationMetadata {
+  /** True when the request is materially ambiguous and the client should ask before planning. */
+  clarificationNeeded: boolean;
+  /** True when the gate permits the client to proceed to planning. Mutually exclusive with clarificationNeeded. */
+  planReady: boolean;
+  /** Questions remaining after this round (may be 0 when the budget is exhausted). */
+  questionBudget?: number;
+  /** Single highest-value question the client should ask next. Present only when clarificationNeeded=true. */
+  nextQuestion?: string;
+  /** Ordered list of ambiguity topics ranked by priority. Present only when clarificationNeeded=true. */
+  clarificationTopics?: string[];
+  /** Human-readable assumption statement emitted when the budget is exhausted. */
+  assumptionNote?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic primitives — exported for unit testing.
+// ---------------------------------------------------------------------------
+
+/**
+ * Explicit user-override phrases. When present the gate returns planReady=true
+ * immediately, regardless of other ambiguity signals.
+ */
+const OVERRIDE_PHRASE_PATTERNS: readonly RegExp[] = [
+  /\bjust\s+do\s+it\b/i,
+  /\buse\s+your\s+(?:judg(?:e)?ment|best\s+guess|discretion)\b/i,
+  /\bgo\s+ahead\b/i,
+  /\bmake\s+assumptions?\b/i,
+  /\bassume\s+(?:whatever|defaults?|reasonable)\b/i,
+  /알아서\s*(?:해|진행|처리)/,
+  /그냥\s*(?:해|진행)/,
+  /임의로\s*(?:해|진행)/,
+];
+
+/**
+ * Vague intent verbs that describe a desired direction without concrete scope.
+ * A prompt containing these without a specific target is likely ambiguous.
+ */
+const VAGUE_INTENT_PATTERNS: readonly RegExp[] = [
+  /\bimprove\b/i,
+  /\b(?:make\s+it\s+)?better\b/i,
+  /\benhance\b/i,
+  /\boptimi[sz]e\b/i,
+  /\brefactor\b/i,
+  /\bclean\s*up\b/i,
+  /\btweak\b/i,
+  /\bfix\s+(?:stuff|things|issues?)\b/i,
+  /개선/,
+  /향상/,
+  /최적화/,
+  /정리/,
+  /개량/,
+];
+
+/**
+ * Patterns that indicate a concrete technical reference (file path, function
+ * call, class name, code identifier). Presence of any of these anchors the
+ * request enough to proceed to planning.
+ */
+const TECHNICAL_REFERENCE_PATTERNS: readonly RegExp[] = [
+  // File extensions covering common languages/configs
+  /\.(?:ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|swift|rb|php|c|cpp|h|hpp|cs|md|mdx|json|ya?ml|toml|sql|sh|bash|zsh|vue|svelte|html|css|scss|sass|less)\b/i,
+  // Relative or absolute path with at least one slash between word parts
+  /(?:^|[\s([`"'])[\w.-]+\/[\w.\-/]+/,
+  // Function or method invocation: identifier followed by parenthesis
+  /\b[a-zA-Z_][\w]*\(/,
+  // PascalCase / CamelCase identifier with at least two capital segments (e.g., ModeHandler, useFooBar)
+  /\b[A-Z][a-zA-Z0-9]*[A-Z][a-zA-Z0-9]+\b/,
+  // camelCase identifier starting lowercase with at least one later capital (e.g., parseMode)
+  /\b[a-z][a-z0-9]+[A-Z][a-zA-Z0-9]+\b/,
+  // snake_case identifier (at least one underscore between letters)
+  /\b[a-z]+_[a-z][a-z0-9_]*\b/,
+  // Backtick-quoted code spans are an explicit "this exact thing" signal
+  /`[^`]+`/,
+];
+
+/**
+ * True when the prompt contains an explicit override phrase such as
+ * "just do it" or "알아서 해".
+ */
+export function hasOverridePhrase(prompt: string): boolean {
+  return OVERRIDE_PHRASE_PATTERNS.some(pattern => pattern.test(prompt));
+}
+
+/**
+ * True when the prompt contains a vague intent verb (improve, enhance,
+ * refactor, 개선, …) that describes direction without concrete scope.
+ */
+export function hasVagueIntent(prompt: string): boolean {
+  return VAGUE_INTENT_PATTERNS.some(pattern => pattern.test(prompt));
+}
+
+/**
+ * True when the prompt references a concrete technical artifact — a file
+ * path, function call, class name, or code identifier. This is the strongest
+ * "not ambiguous" signal in the heuristic set.
+ */
+export function hasTechnicalReference(prompt: string): boolean {
+  return TECHNICAL_REFERENCE_PATTERNS.some(pattern => pattern.test(prompt));
+}
+
+// ---------------------------------------------------------------------------
+// Topic ordering + next-question builder
+// ---------------------------------------------------------------------------
+
+/** Ambiguity topic identifiers in priority order (highest first). */
+export const CLARIFICATION_TOPICS = {
+  VAGUE_INTENT: 'vague-intent',
+  TARGET_ARTIFACT: 'target-artifact',
+  REQUEST_SCOPE: 'request-scope',
+} as const;
+
+const TOPIC_PRIORITY: readonly string[] = [
+  CLARIFICATION_TOPICS.VAGUE_INTENT,
+  CLARIFICATION_TOPICS.TARGET_ARTIFACT,
+  CLARIFICATION_TOPICS.REQUEST_SCOPE,
+];
+
+/**
+ * Map a prioritized topic list into a single highest-value question. The
+ * question is phrased to elicit the most blocking piece of missing context.
+ */
+function buildNextQuestion(topics: readonly string[]): string {
+  if (topics.includes(CLARIFICATION_TOPICS.VAGUE_INTENT)) {
+    return 'What concrete change are you targeting — which behavior, file, or metric should differ after this task?';
+  }
+  if (topics.includes(CLARIFICATION_TOPICS.TARGET_ARTIFACT)) {
+    return 'Which file, function, module, or component should this change apply to?';
+  }
+  if (topics.includes(CLARIFICATION_TOPICS.REQUEST_SCOPE)) {
+    return 'Can you describe the goal, inputs, and expected outcome in a bit more detail?';
+  }
+  return 'Can you clarify the scope and success criteria of this request?';
+}
+
+/**
+ * Order a set of detected topics according to the canonical priority list so
+ * the highest-value concern is always first.
+ */
+function sortTopicsByPriority(topics: Set<string>): string[] {
+  return TOPIC_PRIORITY.filter(topic => topics.has(topic));
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate whether a PLAN request is materially ambiguous and produce the
+ * Clarification Gate metadata used by the parse_mode response.
+ *
+ * Heuristics (conservative — do not over-trigger on well-specified requests):
+ * 1. Budget exhausted → planReady=true with an assumption note
+ * 2. Explicit override phrase → planReady=true immediately
+ * 3. Concrete technical reference (file path, function, identifier) → planReady=true
+ * 4. Vague intent verb without scope → clarificationNeeded=true
+ * 5. Prompt shorter than `MIN_PROMPT_LENGTH` without tech reference → clarificationNeeded=true
+ * 6. Otherwise → planReady=true
+ */
+export function evaluateClarification(
+  prompt: string,
+  options: ClarificationOptions = {},
+): ClarificationMetadata {
+  const budget = options.questionBudget ?? DEFAULT_QUESTION_BUDGET;
+  const trimmed = (prompt ?? '').trim();
+
+  // 1. Budget exhausted — proceed with explicit assumptions.
+  if (budget <= 0) {
+    return {
+      clarificationNeeded: false,
+      planReady: true,
+      questionBudget: 0,
+      assumptionNote:
+        'Clarification budget exhausted. Proceeding with explicit assumptions — state each assumption clearly in the plan using "assuming …" language so the user can correct course.',
+    };
+  }
+
+  // 2. User explicitly overrode the gate.
+  if (hasOverridePhrase(trimmed)) {
+    return {
+      clarificationNeeded: false,
+      planReady: true,
+      questionBudget: budget,
+    };
+  }
+
+  // 3. Concrete technical reference — strong planReady signal.
+  const hasTech = hasTechnicalReference(trimmed);
+  if (hasTech) {
+    return {
+      clarificationNeeded: false,
+      planReady: true,
+      questionBudget: budget,
+    };
+  }
+
+  // 4-5. Collect ambiguity topics when no technical anchor is present.
+  const topics = new Set<string>();
+  if (hasVagueIntent(trimmed)) {
+    topics.add(CLARIFICATION_TOPICS.VAGUE_INTENT);
+    topics.add(CLARIFICATION_TOPICS.TARGET_ARTIFACT);
+  }
+  if (trimmed.length > 0 && trimmed.length < MIN_PROMPT_LENGTH) {
+    topics.add(CLARIFICATION_TOPICS.REQUEST_SCOPE);
+    topics.add(CLARIFICATION_TOPICS.TARGET_ARTIFACT);
+  }
+
+  // 6. Nothing triggered — request is clear enough to plan.
+  if (topics.size === 0) {
+    return {
+      clarificationNeeded: false,
+      planReady: true,
+      questionBudget: budget,
+    };
+  }
+
+  const orderedTopics = sortTopicsByPriority(topics);
+  return {
+    clarificationNeeded: true,
+    planReady: false,
+    questionBudget: budget - 1,
+    nextQuestion: buildNextQuestion(orderedTopics),
+    clarificationTopics: orderedTopics,
+  };
+}

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
@@ -1466,4 +1466,185 @@ describe('ModeHandler', () => {
       expect(parsed.teamsCapability.source).toBe('config');
     });
   });
+
+  // ==========================================================================
+  // Clarification Gate (#1371)
+  // ==========================================================================
+  describe('parse_mode Clarification Gate (#1371)', () => {
+    it('includes clarificationNeeded=true for ambiguous PLAN prompt', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: '개선해줘',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN 개선해줘',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.clarificationNeeded).toBe(true);
+      expect(parsed.planReady).toBe(false);
+      expect(parsed.nextQuestion).toBeTruthy();
+      expect(Array.isArray(parsed.clarificationTopics)).toBe(true);
+      expect(parsed.clarificationTopics.length).toBeGreaterThan(0);
+      expect(parsed.questionBudget).toBe(2);
+    });
+
+    it('includes planReady=true for clear PLAN prompt with concrete reference', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'add unit tests to apps/mcp-server/src/auth/auth.service.ts',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN add unit tests to apps/mcp-server/src/auth/auth.service.ts',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.clarificationNeeded).toBe(false);
+      expect(parsed.planReady).toBe(true);
+      expect(parsed.nextQuestion).toBeUndefined();
+      expect(parsed.clarificationTopics).toBeUndefined();
+      expect(parsed.questionBudget).toBe(3);
+    });
+
+    it('honors override phrases even when prompt is otherwise ambiguous', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'improve it, just do it',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN improve it, just do it',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.clarificationNeeded).toBe(false);
+      expect(parsed.planReady).toBe(true);
+      expect(parsed.questionBudget).toBe(3);
+      expect(parsed.assumptionNote).toBeUndefined();
+    });
+
+    it('decrements the budget across successive ambiguous calls', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'improve it',
+      });
+
+      const round1 = await handler.handle('parse_mode', {
+        prompt: 'PLAN improve it',
+        question_budget: 3,
+      });
+      const parsed1 = JSON.parse((round1?.content[0] as { text: string }).text);
+      expect(parsed1.clarificationNeeded).toBe(true);
+      expect(parsed1.questionBudget).toBe(2);
+
+      const round2 = await handler.handle('parse_mode', {
+        prompt: 'PLAN improve it',
+        question_budget: 2,
+      });
+      const parsed2 = JSON.parse((round2?.content[0] as { text: string }).text);
+      expect(parsed2.clarificationNeeded).toBe(true);
+      expect(parsed2.questionBudget).toBe(1);
+    });
+
+    it('falls back to assumptions when budget is exhausted', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'improve it',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN improve it',
+        question_budget: 0,
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.clarificationNeeded).toBe(false);
+      expect(parsed.planReady).toBe(true);
+      expect(parsed.questionBudget).toBe(0);
+      expect(parsed.assumptionNote).toBeTruthy();
+      expect(parsed.assumptionNote).toMatch(/assum/i);
+    });
+
+    it('applies the gate in AUTO mode as well', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'AUTO',
+        originalPrompt: '개선',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'AUTO 개선',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.clarificationNeeded).toBe(true);
+      expect(parsed.planReady).toBe(false);
+    });
+
+    it('does NOT include clarification fields for ACT mode', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'ACT',
+        originalPrompt: 'improve it',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'ACT improve it',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.clarificationNeeded).toBeUndefined();
+      expect(parsed.planReady).toBeUndefined();
+      expect(parsed.questionBudget).toBeUndefined();
+      expect(parsed.nextQuestion).toBeUndefined();
+    });
+
+    it('does NOT include clarification fields for EVAL mode', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'EVAL',
+        originalPrompt: 'improve it',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'EVAL improve it',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.clarificationNeeded).toBeUndefined();
+      expect(parsed.planReady).toBeUndefined();
+    });
+
+    it('ignores non-numeric question_budget input', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'improve it',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN improve it',
+        question_budget: 'not-a-number',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      // Falls back to DEFAULT_QUESTION_BUDGET (3); decremented once → 2
+      expect(parsed.questionBudget).toBe(2);
+    });
+  });
 });

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.ts
@@ -42,6 +42,7 @@ import {
 import type { ExecutionPlan } from '../../agent/execution-plan.types';
 import { ImpactEventService } from '../../impact';
 import { RuleEventCollector } from '../../rules/rule-event-collector';
+import { evaluateClarification, type ClarificationMetadata } from './clarification-gate';
 
 /** Maximum length for context title slug generation */
 const CONTEXT_TITLE_MAX_LENGTH = 50;
@@ -151,6 +152,11 @@ export class ModeHandler extends AbstractHandler {
               description:
                 'Control response detail level. minimal: metadata only; standard: truncated content (default); full: complete content',
             },
+            question_budget: {
+              type: 'number',
+              description:
+                'Clarification Gate budget (#1371). Maximum clarification questions remaining in this session. Defaults to 3 on the first call; pass the `questionBudget` returned from the previous PLAN response to decrement across rounds. When 0, the gate proceeds to planning with explicit assumptions.',
+            },
           },
           required: ['prompt'],
         },
@@ -173,6 +179,15 @@ export class ModeHandler extends AbstractHandler {
     // Extract and validate optional verbosity (defaults to 'standard')
     const rawVerbosity = extractRequiredString(args, 'verbosity') ?? 'standard';
     const verbosity = isValidVerbosity(rawVerbosity) ? rawVerbosity : 'standard';
+
+    // Extract optional clarification question budget (#1371).
+    // Accept only finite numbers; ignore malformed input and let the gate
+    // fall back to its DEFAULT_QUESTION_BUDGET.
+    const rawQuestionBudget = args?.['question_budget'];
+    const questionBudget =
+      typeof rawQuestionBudget === 'number' && Number.isFinite(rawQuestionBudget)
+        ? rawQuestionBudget
+        : undefined;
 
     try {
       // Always reload config to ensure fresh language settings
@@ -305,6 +320,15 @@ export class ModeHandler extends AbstractHandler {
         settings?.eco,
       );
 
+      // Clarification Gate (#1371) — only applies to PLAN/AUTO modes where the
+      // response might otherwise produce a plan. ACT and EVAL skip the gate
+      // because they assume PLAN has already set context.
+      const clarification = this.buildClarificationMetadata(
+        result.mode as Mode,
+        result.originalPrompt,
+        questionBudget,
+      );
+
       const response = createJsonResponse({
         ...result,
         language,
@@ -326,6 +350,8 @@ export class ModeHandler extends AbstractHandler {
         ...(executionPlan && { executionPlan: serializeExecutionPlan(executionPlan) }),
         // Include Teams capability status
         ...(teamsCapability && { teamsCapability }),
+        // Include Clarification Gate metadata for PLAN/AUTO modes (#1371)
+        ...(clarification && clarification),
         // Include context document info (mandatory)
         ...contextResult,
         // Include project root warning when auto-detected and config missing
@@ -563,6 +589,29 @@ export class ModeHandler extends AbstractHandler {
       agent: 'plan-reviewer',
       dispatch: 'recommend',
     };
+  }
+
+  /**
+   * Build Clarification Gate metadata for PLAN/AUTO modes (#1371).
+   * Returns undefined for ACT/EVAL modes so the fields are omitted entirely
+   * from the response (additive, backward-compatible).
+   *
+   * The gate runs a conservative ambiguity heuristic on the original prompt
+   * and decrements the caller-provided questionBudget on each ambiguous round
+   * so downstream loops cannot run forever.
+   */
+  private buildClarificationMetadata(
+    mode: Mode,
+    originalPrompt: string,
+    questionBudget?: number,
+  ): ClarificationMetadata | undefined {
+    if (mode !== 'PLAN' && mode !== 'AUTO') {
+      return undefined;
+    }
+
+    return evaluateClarification(originalPrompt, {
+      ...(questionBudget !== undefined && { questionBudget }),
+    });
   }
 
   /**


### PR DESCRIPTION
Closes #1371

## Summary

Makes clarification a **first-class runtime contract** in the `parse_mode` PLAN response. The handler now detects materially ambiguous requests and forces the AI client to ask before solutioning — instead of relying on prompt-style guidance that is easy to skip.

This is the **Critical Path** for Horizon 4 (#1370 Question-First Epic); 5 downstream issues (#1372 #1373 #1377 #1378 + #1375 soft) depend on this gate being in place.

## New fields in PLAN/AUTO parse_mode response

| Field | Type | Purpose |
|-------|------|---------|
| `clarificationNeeded` | boolean | True when the request is materially ambiguous |
| `planReady` | boolean | Mutually exclusive with `clarificationNeeded` |
| `questionBudget` | number | Remaining clarification rounds (defaults 3) |
| `nextQuestion` | string? | Single highest-value question (only when asking) |
| `clarificationTopics` | string[]? | Ordered ambiguity topics (only when asking) |
| `assumptionNote` | string? | Emitted when the budget is exhausted |

All fields are **additive** and omitted entirely for ACT/EVAL modes — backward-compatible.

## Ambiguity heuristics

Extracted as a pure, testable function in `apps/mcp-server/src/mcp/handlers/clarification-gate.ts`:

1. **Override phrases** (`"just do it"`, `"use your judgment"`, `"알아서 해"`) → `planReady=true` immediately
2. **Concrete technical reference** (file path, function call, CamelCase/snake_case identifier, backtick code span) → strong `planReady` signal
3. **Vague intent verbs** (`improve`, `enhance`, `refactor`, `개선`, `향상`, …) without scope → `clarificationNeeded=true`
4. **Request length < 20 chars** without a technical anchor → `clarificationNeeded=true`
5. Otherwise → `planReady=true`

Conservative by design: does NOT over-trigger on well-specified requests.

## Budget mechanism

The caller passes the prior round's `questionBudget` via the new `question_budget` input parameter. The gate decrements on each ambiguous round and falls back to planning with an explicit assumption note when the budget reaches 0. This prevents infinite clarification loops.

## Files changed

- `apps/mcp-server/src/mcp/handlers/clarification-gate.ts` — new, pure heuristic module
- `apps/mcp-server/src/mcp/handlers/clarification-gate.spec.ts` — new, 74 unit tests
- `apps/mcp-server/src/mcp/handlers/mode.handler.ts` — wires the gate into PLAN/AUTO response
- `apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts` — +10 integration tests

## Wave 1 boundary

Did NOT touch (reserved for other workers):
- `discussion.handler.ts` (#1374 pane-2)
- `packages/rules/.ai-rules/agents/*.json` (#1375 pane-4)
- `packages/rules/.ai-rules/rules/*.md` (#1375 pane-4)

## Test plan

- [x] `yarn workspace codingbuddy lint` — 0 errors
- [x] `yarn workspace codingbuddy format:check` — all formatted
- [x] `yarn workspace codingbuddy typecheck` — clean
- [x] `yarn workspace codingbuddy test` — 6030 passing, 2 skipped (pre-existing)
- [x] `yarn workspace codingbuddy circular` — no circular deps
- [x] `yarn workspace codingbuddy build` — success
- [x] 74 unit tests for `clarification-gate` (heuristics, override, budget, edge cases)
- [x] 10 integration tests in `mode.handler.spec.ts` (ambiguous, clear, override, budget-exhausted, AUTO, ACT/EVAL skip)