### PR TITLE
refactor(rules): remove legacy PLAN contract drift around Frontend Developer and Primary Developer

### DIFF
--- a/packages/rules/.ai-rules/adapters/opencode.md
+++ b/packages/rules/.ai-rules/adapters/opencode.md
@@ -145,11 +145,13 @@ Update your configuration file (`.opencode.json` or `crush.json`):
 
 | Codingbuddy Agent | OpenCode Agent | Purpose |
 |------------------|----------------|---------|
-| **plan-mode.json** | `plan-mode` | PLAN mode workflow (delegates to frontend-developer) |
-| **act-mode.json** | `act-mode` | ACT mode workflow (delegates to frontend-developer) |
+| **plan-mode.json** | `plan-mode` | PLAN mode workflow (delegates to solution-architect or technical-planner based on task complexity) |
+| **act-mode.json** | `act-mode` | ACT mode workflow (delegates to software-engineer or domain specialist per ACT resolution rules) |
 | **eval-mode.json** | `eval-mode` | EVAL mode workflow (delegates to code-reviewer) |
 | **auto-mode.json** | N/A (keyword-triggered) | AUTO mode workflow (autonomous PLAN→ACT→EVAL cycle) |
-| **frontend-developer.json** | N/A (delegate) | Primary development implementation |
+| **solution-architect.json** | N/A (delegate) | PLAN mode system-level design and architecture |
+| **technical-planner.json** | N/A (delegate) | PLAN mode implementation-level TDD planning |
+| **frontend-developer.json** | N/A (delegate) | ACT mode implementation for frontend projects |
 | **backend-developer.json** | `backend` | Backend development (Node.js, Python, Go, Java, Rust) |
 | **code-reviewer.json** | N/A (delegate) | Code quality evaluation implementation |
 | **architecture-specialist.json** | `architect` | Architecture and design patterns |
@@ -162,7 +164,7 @@ Update your configuration file (`.opencode.json` or `crush.json`):
 
 - **Mode Agents** (`plan-mode`, `act-mode`, `eval-mode`, `auto-mode`): Workflow orchestrators that delegate to appropriate implementation agents
 - **Specialist Agents** (`architect`, `security`, etc.): Domain-specific expertise for specialized tasks
-- **Delegate Agents** (`frontend-developer`, `code-reviewer`): Implementation agents that Mode Agents delegate to
+- **Delegate Agents**: PLAN mode delegates to `solution-architect` or `technical-planner`; ACT mode delegates to `software-engineer` or a domain specialist (e.g., `frontend-developer`, `backend-developer`); EVAL mode delegates to `code-reviewer`
 
 ### 3. MCP Server Integration
 
@@ -292,14 +294,16 @@ The `parse_mode` tool now returns additional Mode Agent information and dynamic 
   "language": "en",
   "languageInstruction": "Always respond in English.",
   "agent": "plan-mode",
-  "delegates_to": "frontend-developer",
+  "delegates_to": "solution-architect",
   "delegate_agent_info": {
-    "name": "Frontend Developer",
-    "description": "React/Next.js expert, TDD and design system experience",
-    "expertise": ["React", "Next.js", "TDD", "TypeScript"]
+    "name": "Solution Architect",
+    "description": "High-level system design and architecture planning specialist",
+    "expertise": ["System Architecture", "Technology Selection", "Integration Patterns", "Scalability Planning"]
   }
 }
 ```
+
+> **Note:** `delegates_to` is resolved dynamically based on prompt intent. System-level design prompts resolve to `solution-architect`; implementation-level planning prompts resolve to `technical-planner`.
 
 **New Fields:**
 - `language`: Language code from codingbuddy.config.json

--- a/packages/rules/.ai-rules/agents/README.md
+++ b/packages/rules/.ai-rules/agents/README.md
@@ -342,7 +342,7 @@ This ensures Mode Agents appear first in agent selection interfaces.
 Mode Agents handle workflow orchestration and delegate to implementation experts:
 
 - **Plan Mode** (`plan-mode.json`): Analysis and planning (delegates to primary developer)
-- **Act Mode** (`act-mode.json`): Implementation execution (delegates to primary developer)
+- **Act Mode** (`act-mode.json`): Implementation execution (delegates to software-engineer or a domain specialist)
 - **Eval Mode** (`eval-mode.json`): Quality evaluation (delegates to code reviewer)
 - **Auto Mode** (`auto-mode.json`): Autonomous PLAN→ACT→EVAL cycle until quality achieved (Critical=0, High=0)
 
@@ -350,9 +350,11 @@ Mode Agents handle workflow orchestration and delegate to implementation experts
 
 These agents are automatically activated via Mode Agent delegation:
 
-- **Primary Developer Agent**: Activated by plan-mode/act-mode
-  - Example: `frontend-developer.json` (React/Next.js projects)
-  - Customize per project: `backend-developer.json`, `mobile-developer.json`, etc.
+- **Planning Agents**: Activated by plan-mode (resolved by intent)
+  - `solution-architect.json`: System-level design (new features, architecture decisions, technology selection)
+  - `technical-planner.json`: Implementation-level planning (bite-sized TDD tasks with exact file paths)
+- **Implementation Agent**: Activated by act-mode (resolved by intent / project config)
+  - Example: `frontend-developer.json` (React/Next.js projects), `backend-developer.json`, `mobile-developer.json`, or the language-agnostic `software-engineer.json`
 - **Code Reviewer** (`code-reviewer.json`): Activated by eval-mode
 
 ### Domain Specialists

--- a/packages/rules/.ai-rules/agents/act-mode.json
+++ b/packages/rules/.ai-rules/agents/act-mode.json
@@ -6,7 +6,7 @@
     "title": "Act Mode Agent",
     "type": "utility",
     "mode": "ACT",
-    "purpose": "Mode Agent - delegates to Primary Developer Agent",
+    "purpose": "Mode Agent - delegates to the resolved implementation agent (software-engineer by default, domain specialist when selected)",
     "expertise": [
       "TDD cycle execution (Red → Green → Refactor)",
       "Code quality standards compliance",

--- a/packages/rules/.ai-rules/agents/auto-mode.json
+++ b/packages/rules/.ai-rules/agents/auto-mode.json
@@ -6,7 +6,7 @@
     "title": "Auto Mode Agent",
     "type": "utility",
     "mode": "AUTO",
-    "purpose": "Mode Agent - autonomously cycles through PLAN → ACT → EVAL, delegates to Primary Developer Agent",
+    "purpose": "Mode Agent - autonomously cycles through PLAN → ACT → EVAL, delegates to planning agents (Solution Architect or Technical Planner) during PLAN phase and to the resolved implementation agent during ACT phase",
     "expertise": [
       "Autonomous PLAN → ACT → EVAL cycle execution",
       "Quality-driven iteration (Critical/High issue elimination)",
@@ -14,7 +14,7 @@
       "Multi-dimensional code quality evaluation",
       "Self-correcting development workflow"
     ],
-    "delegates_to": "frontend-developer",
+    "delegates_to": "technical-planner",
     "responsibilities": [
       "Execute autonomous PLAN → ACT → EVAL cycles until quality targets met",
       "PLAN phase: Analyze requirements, define TDD test cases, review architecture",
@@ -44,11 +44,11 @@
         "verification_key": "mode_indicator"
       },
       "🔴 agent_indicator": {
-        "rule": "MUST print '## Agent : Frontend Developer' (or appropriate delegate agent)",
+        "rule": "MUST print '## Agent : [Selected Agent Name]' — during PLAN phase a planning agent (Solution Architect or Technical Planner), during ACT phase the resolved implementation agent (Software Engineer or domain specialist)",
         "verification_key": "agent_indicator"
       },
       "🔴 delegate_activation": {
-        "rule": "MUST activate delegate agent (frontend-developer) framework for autonomous execution",
+        "rule": "MUST activate the appropriate delegate agent framework per phase — solution-architect or technical-planner for PLAN; software-engineer or domain specialist for ACT; code-reviewer for EVAL",
         "verification_key": "delegate_activation"
       },
       "🔴 autonomous_cycle": {
@@ -87,9 +87,14 @@
     }
   },
   "delegate_agent": {
-    "primary": "frontend-developer",
-    "description": "This Mode Agent utilizes the Frontend Developer Agent's full workflow across all phases",
-    "integration": "Applies Frontend Developer Agent's planning, TDD implementation, and evaluation capabilities"
+    "primary": "technical-planner",
+    "description": "AUTO mode delegates per phase. PLAN phase: solution-architect (system-level design) or technical-planner (implementation planning) resolved by intent. ACT phase: software-engineer or domain specialist resolved by ACT mode rules. EVAL phase: code-reviewer.",
+    "per_phase": {
+      "plan": "solution-architect or technical-planner (resolved from prompt intent)",
+      "act": "software-engineer or domain specialist (resolved per ACT mode rules)",
+      "eval": "code-reviewer"
+    },
+    "integration": "Applies each phase's designated agent workflow — planning via architect/planner, implementation via implementation agent, evaluation via code reviewer"
   },
   "communication": {
     "style": "Autonomous execution with clear iteration and phase progress reporting",
@@ -98,7 +103,7 @@
   "verification_guide": {
     "mode_compliance": [
       "✅ Verify '# Mode: AUTO [Iteration N]' is displayed",
-      "✅ Verify '## Agent : Frontend Developer' (or appropriate delegate) is displayed",
+      "✅ Verify '## Agent : [Selected Agent Name]' is displayed per phase (planning agent during PLAN, implementation agent during ACT, code-reviewer during EVAL)",
       "✅ Verify response in configured language",
       "✅ Verify autonomous PLAN → ACT → EVAL cycle execution",
       "✅ Verify iteration tracking with quality metrics",

--- a/packages/rules/.ai-rules/agents/plan-mode.json
+++ b/packages/rules/.ai-rules/agents/plan-mode.json
@@ -7,7 +7,7 @@
     "title": "Plan Mode Agent",
     "type": "utility",
     "mode": "PLAN",
-    "purpose": "Mode Agent - delegates to Primary Developer Agent",
+    "purpose": "Mode Agent - delegates to Solution Architect or Technical Planner based on task complexity",
     "expertise": [
       "Work planning",
       "TDD-oriented design",
@@ -15,7 +15,7 @@
       "Todo list creation",
       "Requirements analysis"
     ],
-    "delegates_to": "frontend-developer",
+    "delegates_to": "technical-planner",
     "responsibilities": [
       "Analyze and clarify user requirements",
       "Prioritize test case definition from TDD perspective",
@@ -44,11 +44,11 @@
         "verification_key": "mode_indicator"
       },
       "🔴 agent_indicator": {
-        "rule": "MUST print '## Agent : Frontend Developer' (or appropriate delegate agent)",
+        "rule": "MUST print '## Agent : [Selected Planning Agent Name]' (e.g., '## Agent : Solution Architect' for system-level design, '## Agent : Technical Planner' for implementation-level plans — actual name depends on task complexity resolution)",
         "verification_key": "agent_indicator"
       },
       "🔴 delegate_activation": {
-        "rule": "MUST activate delegate agent (frontend-developer) framework for detailed planning",
+        "rule": "MUST activate delegate agent (solution-architect or technical-planner) framework for detailed planning",
         "verification_key": "delegate_activation"
       }
     }
@@ -72,9 +72,14 @@
     }
   },
   "delegate_agent": {
-    "primary": "frontend-developer",
-    "description": "This Mode Agent utilizes the Frontend Developer Agent's planning workflow",
-    "integration": "Applies Frontend Developer Agent's planning section and mandatory checklist"
+    "primary": "technical-planner",
+    "description": "PLAN mode selects planning agent dynamically. Resolution order: explicit request > intent pattern (architecture/design → solution-architect; implementation plan/TDD → technical-planner) > default: technical-planner",
+    "resolution_order": [
+      "1. Explicit agent request in prompt (e.g., 'as solution-architect')",
+      "2. Intent pattern matching (architecture/system design → solution-architect; implementation plan/TDD/bite-sized tasks → technical-planner)",
+      "3. Default: technical-planner"
+    ],
+    "integration": "Applies Solution Architect's design workflow for system-level tasks or Technical Planner's TDD planning workflow for implementation-level tasks"
   },
   "communication": {
     "style": "Systematic approach focused on planning",
@@ -83,7 +88,7 @@
   "verification_guide": {
     "mode_compliance": [
       "✅ Verify '# Mode: PLAN' is displayed",
-      "✅ Verify '## Agent : Frontend Developer' (or appropriate delegate) is displayed",
+      "✅ Verify '## Agent : [Selected Planning Agent Name]' (e.g., Solution Architect or Technical Planner) is displayed",
       "✅ Verify response in configured language",
       "✅ Verify todo list created with todo_write tool",
       "✅ Verify all todo items created in pending status",

--- a/packages/rules/.ai-rules/rules/core.md
+++ b/packages/rules/.ai-rules/rules/core.md
@@ -87,9 +87,11 @@ feat(auth): add token validation with session management
 - After creating plan, user can type `ACT` to execute
 
 **🔴 Agent Activation (STRICT):**
-- When in PLAN mode, **Frontend Developer Agent** (`.ai-rules/agents/frontend-developer.json`) **MUST** be automatically activated
-- The Agent's workflow framework and all mandatory requirements MUST be followed
-- See `.ai-rules/agents/frontend-developer.json` for complete development framework
+- When in PLAN mode, either **Solution Architect** (`.ai-rules/agents/solution-architect.json`) or **Technical Planner** (`.ai-rules/agents/technical-planner.json`) **MUST** be automatically activated based on task complexity
+  - Use **Solution Architect** for system-level design (new features, architecture decisions, technology selection)
+  - Use **Technical Planner** for implementation-level planning (bite-sized TDD tasks with exact file paths)
+- The selected Planning Agent's workflow framework and all mandatory requirements MUST be followed
+- See `.ai-rules/agents/solution-architect.json` and `.ai-rules/agents/technical-planner.json` for complete planning frameworks
 
 **Purpose:**
 Create actionable implementation plans following TDD and augmented coding principles
@@ -219,15 +221,15 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
 
 ---
 
-**What PLAN does (with Primary Developer Agent):**
+**What PLAN does (via Solution Architect or Technical Planner):**
 
-1. **Analyze Requirements** (via Primary Developer Agent)
+1. **Analyze Requirements** (via selected Planning Agent)
    - Understand user requirements
    - Identify core logic vs presentation components
    - Determine TDD (test-first) vs Test-After approach
-   - 🔴 **Required**: Follow Primary Developer Agent's workflow framework
+   - 🔴 **Required**: Follow the selected Planning Agent's workflow framework (Solution Architect for system-level design, Technical Planner for implementation-level plans)
 
-2. **Plan Implementation** (via Primary Developer Agent workflow)
+2. **Plan Implementation** (via selected Planning Agent workflow)
    - 🔴 TDD for core logic (business logic, utilities, data access layers)
    - 🔴 Test-After for presentation (UI components, views)
    - Define file structure (types, constants, utils)
@@ -235,7 +237,7 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
    - Consider framework-specific component patterns
    - 🔴 **Required**: Reference Planning Specialist Agents for comprehensive planning (Architecture, Test Strategy, Performance, Security, Accessibility, SEO, Design System, Documentation, Code Quality)
 
-3. **Output Structured PLAN** (via Primary Developer Agent)
+3. **Output Structured PLAN** (via selected Planning Agent)
    - Step-by-step implementation plan
    - Clear task breakdown
    - File naming conventions
@@ -243,10 +245,10 @@ See `.ai-rules/rules/clarification-guide.md` for detailed question guidelines.
    - Type safety requirements
    - 🔴 **Required**: Create todo list using `todo_write` tool for all implementation steps
 
-**Output Format (via Primary Developer Agent):**
+**Output Format (via selected Planning Agent):**
 ```
 # Mode: PLAN
-## Agent : [Primary Developer Agent Name]
+## Agent : [Solution Architect | Technical Planner]
 
 ## 📋 Plan Overview
 [High-level summary of what will be implemented]
@@ -405,7 +407,7 @@ To preserve this planning session for future reference:
 ```
 
 **🔴 Required:**
-- All plans must follow the Primary Developer Agent's workflow framework
+- All plans must follow the selected Planning Agent's workflow framework (Solution Architect for system-level design, Technical Planner for implementation-level plans)
 - Respond in the language specified in the agent's communication.language setting
 - Follow framework-specific component patterns as defined in project configuration
 - 🔴 **MUST use `todo_write` tool** to create todo list for all implementation steps
@@ -415,11 +417,11 @@ To preserve this planning session for future reference:
 - Confidence levels: 🟢 High (0.8+), 🟡 Medium (0.5-0.79), 🔴 Low (<0.5)
 
 **Verification:**
-- Agent name should appear as `## Agent : [Primary Developer Agent Name]` in response
+- Agent name should appear as `## Agent : [Solution Architect | Technical Planner]` in response
 - Mode indicator `# Mode: PLAN` should be first line
 - Plan should include structured sections: Plan Overview, Structured Reasoning (COMPLEX only), Todo List (created with todo_write), Implementation Steps, Planning Specialist sections (when applicable), Risk Assessment, File Structure, Quality Checklist
 - Todo list must be created using `todo_write` tool before outputting plan
-- All mandatory checklist items from the Primary Developer Agent should be considered during planning
+- All mandatory checklist items from the selected Planning Agent should be considered during planning
 - Planning Specialist Agents should be referenced when planning respective areas (Architecture, Test Strategy, Performance, Security, Accessibility, SEO, Design System, Documentation, Code Quality)
 - **SRP Verification (COMPLEX tasks):**
   - Structured Reasoning section must be present
@@ -1020,7 +1022,8 @@ Autonomous iterative development - automatically cycling through planning, imple
 | `auto.maxIterations` | 3 | 1-10 | Maximum PLAN→ACT→EVAL cycles before forced exit |
 
 **🔴 Agent Activation (STRICT):**
-- When AUTO mode is triggered, **Primary Developer Agent** (e.g., `.ai-rules/agents/frontend-developer.json`) **MUST** be automatically activated for PLAN and ACT phases
+- When AUTO mode is triggered, the PLAN phase **MUST** activate **Solution Architect** (`.ai-rules/agents/solution-architect.json`) or **Technical Planner** (`.ai-rules/agents/technical-planner.json`) based on task complexity
+- During the ACT phase, the resolved implementation agent (e.g., **Software Engineer** `.ai-rules/agents/software-engineer.json` or a domain specialist) **MUST** be automatically activated per ACT mode resolution rules
 - During EVAL phase, **Code Reviewer Agent** (`.ai-rules/agents/code-reviewer.json`) **MUST** be automatically activated
 - The respective Agent's workflow framework and all mandatory requirements MUST be followed
 - See `.ai-rules/agents/` for complete agent frameworks
@@ -1118,8 +1121,8 @@ Attempted Approaches:
 | Time efficiency | Optimized for quality | Optimized for control |
 
 **🔴 Required:**
-- All PLAN phases must follow the Primary Developer Agent's workflow framework
-- All ACT phases must follow the Primary Developer Agent's code quality checklist
+- All PLAN phases must follow the selected Planning Agent's workflow framework (Solution Architect or Technical Planner)
+- All ACT phases must follow the resolved implementation agent's code quality checklist (Software Engineer or domain specialist)
 - All EVAL phases must follow the Code Reviewer Agent's evaluation framework
 - Respond in the language specified in the agent's communication.language setting
 - Continue iterating automatically until exit conditions are met (Critical = 0 AND High = 0)
@@ -1159,9 +1162,19 @@ Key principles:
 
 Specialized agents available in `.ai-rules/agents/` directory:
 
+**Solution Architect** (`.ai-rules/agents/solution-architect.json`)
+- **Expertise**: System-level architecture, technology selection, integration patterns, scalability planning
+- **Use when**: 🔴 **STRICT**: In PLAN mode for system-level design tasks (new features, architecture decisions, technology selection); activated automatically via intent pattern resolution
+- **Key traits**: Brainstorm-first, multiple options with trade-offs, incremental validation
+
+**Technical Planner** (`.ai-rules/agents/technical-planner.json`)
+- **Expertise**: Implementation planning, TDD strategy, task decomposition, bite-sized tasks with exact file paths
+- **Use when**: 🔴 **STRICT**: In PLAN mode for implementation-level planning (TDD task sequences, concrete code changes); activated automatically via intent pattern resolution
+- **Key traits**: TDD-first, complete-code plans (no placeholders), exact file paths, Red-Green-Refactor-Commit structure
+
 **Frontend Developer** (`.ai-rules/agents/frontend-developer.json`)
 - **Expertise**: Frontend frameworks, component architecture, TDD, design system
-- **Use when**: 🔴 **STRICT**: When in PLAN or ACT mode, this Agent **MUST** be activated automatically (for frontend projects)
+- **Use when**: 🔴 **STRICT**: In ACT mode for frontend projects, this Agent is activated as the resolved implementation agent
 - **Key traits**: Framework best practices, design system priority, accessibility focused
 
 **Code Reviewer** (`.ai-rules/agents/code-reviewer.json`)
@@ -1185,7 +1198,7 @@ Specialized agents available in `.ai-rules/agents/` directory:
 - **Expertise**: SOLID principles, DRY, complexity analysis, design patterns
 - **Use when**: Code quality framework is referenced within PLAN/ACT/EVAL modes for comprehensive code quality planning/implementation/evaluation
 - **Key traits**: SOLID-focused, DRY enforcement, complexity analysis, design pattern expertise
-- **Integration**: Frontend Developer Agent utilizes Code Quality Specialist modes.planning/implementation during PLAN/ACT modes. Code Reviewer Agent utilizes Code Quality Specialist modes.evaluation during EVAL mode code quality assessment
+- **Integration**: Planning Agents (Solution Architect, Technical Planner) utilize Code Quality Specialist modes.planning during PLAN mode; the resolved implementation agent utilizes modes.implementation during ACT mode. Code Reviewer Agent utilizes Code Quality Specialist modes.evaluation during EVAL mode code quality assessment
 
 **Architecture Specialist** (`.ai-rules/agents/architecture-specialist.json`)
 - **Expertise**: Layer boundaries, dependency direction, type safety, pure/impure separation
@@ -1345,8 +1358,8 @@ Specialized agents available in `.ai-rules/agents/` directory:
 **Code Quality Specialist** (`@.ai-rules/agents/code-quality-specialist.json`)
 
 ✅ **Use for (Integrated with PLAN/ACT/EVAL):**
-- Code quality planning is automatically included in PLAN mode via Primary Developer Agent (modes.planning)
-- Code quality implementation verification is automatically included in ACT mode via Primary Developer Agent (modes.implementation)
+- Code quality planning is automatically included in PLAN mode via the selected Planning Agent (Solution Architect or Technical Planner) (modes.planning)
+- Code quality implementation verification is automatically included in ACT mode via the resolved implementation agent (Software Engineer or domain specialist) (modes.implementation)
 - Code quality assessment is automatically included in EVAL mode via Code Reviewer Agent (modes.evaluation)
 - SOLID principles planning/verification/review
 - DRY strategy planning/verification/review
@@ -1357,7 +1370,7 @@ Specialized agents available in `.ai-rules/agents/` directory:
 - Code quality planning is part of PLAN mode mandatory perspectives
 - Code quality implementation verification is part of ACT mode mandatory perspectives
 - Code quality evaluation is part of EVAL mode mandatory perspectives
-- Primary Developer Agent references Code Quality Specialist modes.planning/implementation during PLAN/ACT modes
+- Planning Agents (Solution Architect, Technical Planner) reference Code Quality Specialist modes.planning during PLAN mode; the resolved implementation agent references modes.implementation during ACT mode
 - Code Reviewer Agent references Code Quality Specialist modes.evaluation during EVAL mode
 - Reference SOLID principles, DRY, complexity metrics
 - Provide specific planning/verification/review recommendations


### PR DESCRIPTION
Closes #1375

## Summary

Aligns all rules, mode agents, and adapter docs to the architect/planner PLAN contract. The runtime (`keyword/strategies/plan-agent.strategy.ts` + `primary-agent-resolver`) was already resolving PLAN to `solution-architect` or `technical-planner`, but rules/core.md and the plan-mode / auto-mode JSONs still named "Frontend Developer" or "Primary Developer" as the PLAN primary. This drift is now removed.

PLAN mode consistently states:

- **Solution Architect** — system-level design (new features, architecture decisions, technology selection)
- **Technical Planner** — implementation-level plans (bite-sized TDD tasks with exact file paths)
- Selection is dynamic via intent pattern resolution (architecture/design → `solution-architect`; implementation plan/TDD → `technical-planner`)

## Drift locations cleaned up

- `packages/rules/.ai-rules/rules/core.md` — PLAN Agent Activation, "What PLAN does" narrative, Verification section, AUTO mode Agent Activation, AUTO Required section, Available Agents catalog (added Solution Architect / Technical Planner entries, relabeled Frontend Developer as ACT-mode specialist), Code Quality Specialist integration lines
- `packages/rules/.ai-rules/agents/plan-mode.json` — `purpose`, `delegates_to`, `mandatory_checklist` (agent_indicator, delegate_activation), `delegate_agent` (dynamic resolution with solution-architect/technical-planner fallback), `verification_guide`
- `packages/rules/.ai-rules/agents/auto-mode.json` — `purpose`, `delegates_to`, `mandatory_checklist`, `delegate_agent` (per-phase delegation), `verification_guide`
- `packages/rules/.ai-rules/agents/act-mode.json` — stale "Primary Developer Agent" purpose label (ACT already delegates to `software-engineer` dynamically)
- `packages/rules/.ai-rules/adapters/opencode.md` — Agent System Mapping table, Mode/Delegate Agent descriptions, `parse_mode` PLAN response example
- `packages/rules/.ai-rules/agents/README.md` — Mode Agents / Core Agents (Auto-activated via delegation) section

## Test plan

- [x] `grep -rE "Frontend Developer.*PLAN|Primary Developer.*PLAN|PLAN.*Frontend Developer|PLAN.*Primary Developer" packages/rules/.ai-rules/ .claude/rules/ docs/` → zero matches
- [x] `yarn dlx ajv-cli@5.0.0 validate` on all agent JSONs → all valid
- [x] `yarn dlx markdownlint-cli2@0.20.0 "packages/rules/.ai-rules/**/*.md"` → 0 errors
- [x] `yarn workspace codingbuddy test` → **5947 passed** (including existing `plan-agent.strategy.spec.ts` and `primary-agent-resolver.spec.ts` which assert architect/planner PLAN model)
- [x] `yarn workspace codingbuddy typecheck` → clean
- [x] `yarn workspace codingbuddy build` → success
- [x] `prettier --check` on 6 changed files → clean

## Wave 1 boundary

No touches to:
- `apps/mcp-server/src/mcp/tools/parse-mode*` (reserved for #1371)
- `apps/mcp-server/src/mcp/tools/discussion*` (reserved for #1374)
- `packages/rules/.ai-rules/rules/pr-review-cycle.md` (canonical)
- `packages/rules/.ai-rules/rules/severity-classification.md` (canonical)
- `packages/rules/.ai-rules/rules/parallel-execution.md` (no legacy PLAN drift found — left alone)