### PR TITLE
feat(mcp-server): enforce required planning skills in parse_mode

### DIFF
--- a/apps/mcp-server/src/keyword/keyword.service.spec.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.spec.ts
@@ -2741,4 +2741,181 @@ ${'Even more content.\n'.repeat(150)}`;
       expect(releaseWarning).toBeUndefined();
     });
   });
+
+  describe('required skill enforcement for planning agents', () => {
+    // Mock agent data with skills.required declarations
+    const agentDataWithSkills: Record<string, unknown> = {
+      'solution-architect': {
+        name: 'Solution Architect',
+        description: 'High-level system design specialist',
+        role: { expertise: ['Architecture', 'System Design'] },
+        skills: {
+          required: [
+            {
+              name: 'brainstorming',
+              purpose: 'Explore design options',
+              when: 'Starting any new feature',
+            },
+          ],
+        },
+      },
+      'technical-planner': {
+        name: 'Technical Planner',
+        description: 'Implementation planning specialist',
+        role: { expertise: ['Planning', 'TDD'] },
+        skills: {
+          required: [
+            { name: 'writing-plans', purpose: 'Create implementation plans', when: 'Always' },
+          ],
+        },
+      },
+      'frontend-developer': {
+        name: 'Frontend Developer',
+        description: 'React/Next.js specialist',
+        role: { expertise: ['React', 'Next.js'] },
+        // No skills.required — not a planning agent
+      },
+    };
+
+    const mockLoadSkillContentForRequired = vi.fn(
+      async (skillName: string): Promise<SkillContentInfo | null> => {
+        const skills: Record<string, SkillContentInfo> = {
+          brainstorming: {
+            name: 'brainstorming',
+            description: 'Explore design options through collaborative dialogue',
+            content:
+              '# Brainstorming Skill\nFull content here with detailed instructions for brainstorming sessions.',
+          },
+          'writing-plans': {
+            name: 'writing-plans',
+            description: 'Create comprehensive implementation plans',
+            content:
+              '# Writing Plans Skill\nFull content here with detailed instructions for writing plans.',
+          },
+        };
+        return skills[skillName] ?? null;
+      },
+    );
+
+    function createPlanningService(
+      overrideAgentResolver?: PrimaryAgentResolver,
+      verbosity?: 'minimal' | 'standard' | 'full',
+    ) {
+      const loadAgentFn = vi.fn((agentName: string) => {
+        const data = agentDataWithSkills[agentName];
+        return data ? Promise.resolve(data) : Promise.reject(new Error(`Not found: ${agentName}`));
+      });
+
+      const svc = new KeywordService(mockLoadConfig, mockLoadRule, loadAgentFn, {
+        loadSkillContentFn: mockLoadSkillContentForRequired,
+        getSkillRecommendationsFn: () => [],
+        primaryAgentResolver: overrideAgentResolver,
+      });
+      return { svc, loadAgentFn, verbosity };
+    }
+
+    function createResolver(agentName: string): PrimaryAgentResolver {
+      return {
+        resolve: vi.fn().mockResolvedValue({ agentName, source: 'prompt-analysis' }),
+      } as unknown as PrimaryAgentResolver;
+    }
+
+    it('enforces brainstorming skill for solution-architect in PLAN mode', async () => {
+      const { svc } = createPlanningService(createResolver('solution-architect'));
+      const result = await svc.parseMode('PLAN design new auth system');
+
+      expect(result.delegates_to).toBe('solution-architect');
+      expect(result.requiredSkillsEnforced).toBe(true);
+      expect(result.requiredSkillNames).toEqual(['brainstorming']);
+      expect(result.included_skills).toBeDefined();
+      const brainstorming = result.included_skills!.find(s => s.name === 'brainstorming');
+      expect(brainstorming).toBeDefined();
+      expect(brainstorming!.content).toContain('# Brainstorming Skill');
+      expect(brainstorming!.content).toContain('Full content');
+    });
+
+    it('enforces writing-plans skill for technical-planner in PLAN mode', async () => {
+      const { svc } = createPlanningService(createResolver('technical-planner'));
+      const result = await svc.parseMode('PLAN implement user dashboard');
+
+      expect(result.delegates_to).toBe('technical-planner');
+      expect(result.requiredSkillsEnforced).toBe(true);
+      expect(result.requiredSkillNames).toEqual(['writing-plans']);
+      const writingPlans = result.included_skills!.find(s => s.name === 'writing-plans');
+      expect(writingPlans).toBeDefined();
+      expect(writingPlans!.content).toContain('# Writing Plans Skill');
+    });
+
+    it('does not set enforcement fields for agents without required skills', async () => {
+      const { svc } = createPlanningService(createResolver('frontend-developer'));
+      const result = await svc.parseMode('PLAN build a component');
+
+      expect(result.delegates_to).toBe('frontend-developer');
+      expect(result.requiredSkillsEnforced).toBeUndefined();
+      expect(result.requiredSkillNames).toBeUndefined();
+    });
+
+    it('provides full content in standard verbosity for required skills', async () => {
+      const { svc } = createPlanningService(createResolver('solution-architect'));
+      const result = await svc.parseMode('PLAN design API gateway', { verbosity: 'standard' });
+
+      const brainstorming = result.included_skills!.find(s => s.name === 'brainstorming');
+      expect(brainstorming).toBeDefined();
+      // Full content — not truncated
+      expect(brainstorming!.content).toContain('Full content');
+      expect(brainstorming!.content).not.toContain('truncated');
+    });
+
+    it('includes only skill names in minimal verbosity for required skills', async () => {
+      const { svc } = createPlanningService(createResolver('solution-architect'));
+      const result = await svc.parseMode('PLAN design microservices', { verbosity: 'minimal' });
+
+      // Required skills enforcement still signals the names
+      expect(result.requiredSkillsEnforced).toBe(true);
+      expect(result.requiredSkillNames).toEqual(['brainstorming']);
+      // In minimal verbosity, content is empty but skill entry exists
+      const brainstorming = result.included_skills!.find(s => s.name === 'brainstorming');
+      expect(brainstorming).toBeDefined();
+      expect(brainstorming!.content).toBe('');
+    });
+
+    it('does not enforce skills in ACT mode even for planning agents', async () => {
+      const { svc } = createPlanningService(createResolver('solution-architect'));
+      const result = await svc.parseMode('ACT implement the plan');
+
+      // ACT mode — no required skill enforcement
+      expect(result.requiredSkillsEnforced).toBeUndefined();
+    });
+
+    it('merges required skills with prompt-recommended skills without duplicates', async () => {
+      const loadAgentFn = vi.fn((agentName: string) => {
+        const data = agentDataWithSkills[agentName];
+        return data ? Promise.resolve(data) : Promise.reject(new Error(`Not found: ${agentName}`));
+      });
+
+      // Prompt recommendations return brainstorming too (overlap case)
+      const getSkillRecs = vi.fn((): SkillRecommendationInfo[] => [
+        {
+          skillName: 'brainstorming',
+          confidence: 'high',
+          matchedPatterns: ['design'],
+          description: 'Brainstorming',
+        },
+      ]);
+
+      const svc = new KeywordService(mockLoadConfig, mockLoadRule, loadAgentFn, {
+        loadSkillContentFn: mockLoadSkillContentForRequired,
+        getSkillRecommendationsFn: getSkillRecs,
+        primaryAgentResolver: createResolver('solution-architect'),
+      });
+
+      const result = await svc.parseMode('PLAN design new feature');
+      const brainstormingSkills = result.included_skills!.filter(s => s.name === 'brainstorming');
+      // No duplicates
+      expect(brainstormingSkills).toHaveLength(1);
+      // Full content (not truncated by standard verbosity since it's required)
+      expect(brainstormingSkills[0].content).toContain('Full content');
+      expect(result.requiredSkillsEnforced).toBe(true);
+    });
+  });
 });

--- a/apps/mcp-server/src/keyword/keyword.service.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.ts
@@ -515,6 +515,11 @@ export class KeywordService {
     // 8. Auto-include relevant skills (for MCP mode to force AI execution)
     await this.addIncludedSkillsToResult(result, originalPrompt, options);
 
+    // 8.5. Enforce required skills for planning agents (PLAN/AUTO only)
+    if (mode === 'PLAN' || mode === 'AUTO') {
+      await this.enforceRequiredAgentSkills(result, options);
+    }
+
     // 9. Auto-include primary agent system prompt (for MCP mode to force AI execution)
     await this.addIncludedAgentToResult(result, mode, options);
 
@@ -797,6 +802,79 @@ export class KeywordService {
         `Failed to auto-include skills: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
     }
+  }
+
+  /**
+   * Enforce required skills declared by the selected planning agent.
+   *
+   * When the agent's JSON declares `skills.required`, those skills MUST appear
+   * in `included_skills` with full (un-truncated) content regardless of
+   * verbosity — except in `minimal` mode where only metadata is kept.
+   *
+   * If a required skill was already included (from prompt-based recommendations)
+   * but was truncated by standard verbosity, it gets replaced with full content.
+   */
+  private async enforceRequiredAgentSkills(
+    result: ParseModeResult,
+    options?: ParseModeOptions,
+  ): Promise<void> {
+    if (!this.loadAgentInfoFn || !this.loadSkillContentFn || !result.delegates_to) return;
+
+    try {
+      const agentData = await this.loadAgentInfoFn(result.delegates_to);
+      const requiredSkillNames = this.extractRequiredSkillNames(agentData);
+      if (requiredSkillNames.length === 0) return;
+
+      const verbosity = options?.verbosity ?? 'standard';
+
+      // Ensure included_skills array exists
+      if (!result.included_skills) {
+        result.included_skills = [];
+      }
+
+      for (const skillName of requiredSkillNames) {
+        const existingIndex = result.included_skills.findIndex(s => s.name === skillName);
+        const content = await this.loadSkillContentFn(skillName);
+        if (!content) continue;
+
+        const enforcedSkill: IncludedSkill = {
+          name: content.name,
+          description: content.description,
+          content: verbosity === 'minimal' ? '' : content.content,
+          reason: 'Required by planning agent',
+        };
+
+        if (existingIndex >= 0) {
+          // Replace existing (possibly truncated) entry with enforced version
+          result.included_skills[existingIndex] = enforcedSkill;
+        } else {
+          result.included_skills.push(enforcedSkill);
+        }
+      }
+
+      result.requiredSkillsEnforced = true;
+      result.requiredSkillNames = requiredSkillNames;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to enforce required agent skills: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+
+  /**
+   * Extract `skills.required[].name` from raw agent JSON data.
+   */
+  private extractRequiredSkillNames(agentData: unknown): string[] {
+    if (!agentData || typeof agentData !== 'object') return [];
+    const agent = agentData as Record<string, unknown>;
+    const skills = agent.skills as Record<string, unknown> | undefined;
+    if (!skills || typeof skills !== 'object') return [];
+    const required = skills.required;
+    if (!Array.isArray(required)) return [];
+    return required
+      .filter((s): s is Record<string, unknown> => typeof s === 'object' && s !== null)
+      .map(s => s.name)
+      .filter((n): n is string => typeof n === 'string');
   }
 
   /** Get max included skills from config or use default. */

--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -519,6 +519,19 @@ export interface ParseModeResult {
   councilPreset?: CouncilPreset;
   /**
    * @apiProperty External API - do not rename.
+   * True when the selected planning agent declared `skills.required` and all
+   * those skills were successfully loaded and included in `included_skills`
+   * with full (un-truncated) content.  Absent when no enforcement was needed.
+   */
+  requiredSkillsEnforced?: boolean;
+  /**
+   * @apiProperty External API - do not rename.
+   * Names of the skills that were enforced as required by the planning agent.
+   * Absent when no enforcement was needed.
+   */
+  requiredSkillNames?: string[];
+  /**
+   * @apiProperty External API - do not rename.
    * Describes the outer execution transport and optional inner coordination layer.
    * Built from the composable execution model (#1309). Present when dispatch is active.
    */


### PR DESCRIPTION
## Summary

- **Required skill enforcement**: When a PLAN/AUTO mode planning agent declares `skills.required` in its JSON definition (e.g. solution-architect → `brainstorming`, technical-planner → `writing-plans`), those skills are now guaranteed to appear in `included_skills` with full, un-truncated content.
- **New `enforceRequiredAgentSkills` step**: Runs after prompt-based skill recommendations in `buildParseModeResult`. Loads agent JSON, extracts `skills.required[].name`, loads each via `loadSkillContentFn`, and adds/replaces entries in `included_skills` with full content.
- **Verbosity-aware**: `standard` and `full` → full content; `minimal` → metadata only (empty content). Required skills in `standard` verbosity are never truncated, fixing the core issue.
- **Deduplication**: If a required skill was already included from prompt analysis, it gets replaced (not duplicated) with the enforced full-content version.
- **New response fields** (additive, backward-compatible):
  - `requiredSkillsEnforced: boolean` — true when all required skills were loaded and included
  - `requiredSkillNames: string[]` — list of enforced skill names
  - Both absent when the selected agent has no required skills.
- **PLAN/AUTO only**: ACT and EVAL modes skip enforcement (planning skills are irrelevant there).

## Wave 2 boundary

- Touched only `apps/mcp-server/src/keyword/keyword.service.ts`, `keyword.types.ts`, and `keyword.service.spec.ts`
- No changes to `discussion*` (Wave 1 #1374), `agent-stack*` (#1379), or `rules/*.md`
- Added new test cases to `keyword.service.spec.ts` without modifying existing `delegates_to` mock values (pane-1 coordination)

## Test plan

- [x] 7 new tests in `keyword.service.spec.ts` → `required skill enforcement for planning agents`
  - solution-architect → brainstorming with full content
  - technical-planner → writing-plans with full content
  - frontend-developer (no required skills) → no enforcement fields
  - standard verbosity → full content preserved
  - minimal verbosity → empty content, metadata present
  - ACT mode → no enforcement
  - Deduplication with prompt-recommended skills → no duplicates, full content
- [x] All 267 existing tests pass (no regressions)
- [x] Full suite: 238 files, 6042 passed, 2 skipped, 0 failed
- [x] lint, format:check, typecheck, circular, build — all pass
- [x] Security audit: 3/3 workspaces clean

Closes #1373