### PR TITLE
feat(mcp-server): integrate agent stacks as first-class collective-intelligence presets in parse_mode

### DIFF
--- a/apps/mcp-server/src/agent/index.ts
+++ b/apps/mcp-server/src/agent/index.ts
@@ -10,3 +10,4 @@ export * from './agent-stack.schema';
 export * from './agent-stack.loader';
 export * from './execution-plan';
 export * from './execution-plan.types';
+export * from './stack-matcher';

--- a/apps/mcp-server/src/agent/stack-matcher.spec.ts
+++ b/apps/mcp-server/src/agent/stack-matcher.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { matchStack, type StackMatchInput } from './stack-matcher';
+
+const STACKS: StackMatchInput[] = [
+  {
+    name: 'api-development',
+    category: 'backend',
+    tags: ['api', 'backend', 'rest', 'graphql'],
+  },
+  {
+    name: 'security-audit',
+    category: 'security',
+    tags: ['security', 'audit', 'vulnerability', 'compliance'],
+  },
+  {
+    name: 'frontend-polish',
+    category: 'frontend',
+    tags: ['ui', 'ux', 'accessibility', 'frontend', 'seo'],
+  },
+  {
+    name: 'data-pipeline',
+    category: 'data',
+    tags: ['data', 'pipeline', 'etl', 'analytics'],
+  },
+  {
+    name: 'ml-infrastructure',
+    category: 'ml',
+    tags: ['ml', 'ai', 'model', 'inference', 'training'],
+  },
+  {
+    name: 'full-stack',
+    category: 'development',
+    tags: ['web', 'fullstack', 'frontend', 'backend'],
+  },
+];
+
+describe('matchStack', () => {
+  describe('API context → api-development stack', () => {
+    it('matches REST API prompt to api-development', () => {
+      const result = matchStack('Build a new REST API for user registration', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('api-development');
+    });
+
+    it('matches GraphQL prompt to api-development', () => {
+      const result = matchStack('Implement GraphQL resolvers for the order service', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('api-development');
+    });
+
+    it('matches backend service prompt to api-development', () => {
+      const result = matchStack('Refactor the backend payment service', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('api-development');
+    });
+  });
+
+  describe('security context → security-audit stack', () => {
+    it('matches security audit prompt', () => {
+      const result = matchStack('Perform a security audit on authentication flow', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('security-audit');
+    });
+
+    it('matches vulnerability assessment prompt', () => {
+      const result = matchStack('Fix vulnerability in JWT token handling', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('security-audit');
+    });
+
+    it('matches compliance prompt', () => {
+      const result = matchStack('Ensure OAuth compliance and fix security issues', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('security-audit');
+    });
+  });
+
+  describe('frontend context → frontend-polish stack', () => {
+    it('matches UI polish prompt', () => {
+      const result = matchStack(
+        'Improve the UI accessibility and SEO for the landing page',
+        STACKS,
+      );
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('frontend-polish');
+    });
+
+    it('matches UX improvement prompt', () => {
+      const result = matchStack(
+        'Redesign the UX for the checkout flow with better accessibility',
+        STACKS,
+      );
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('frontend-polish');
+    });
+  });
+
+  describe('data context → data-pipeline stack', () => {
+    it('matches data pipeline prompt', () => {
+      const result = matchStack('Build an ETL pipeline for analytics data', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('data-pipeline');
+    });
+  });
+
+  describe('ML context → ml-infrastructure stack', () => {
+    it('matches ML model prompt', () => {
+      const result = matchStack('Set up model training infrastructure for inference', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('ml-infrastructure');
+    });
+  });
+
+  describe('generic prompt → no match', () => {
+    it('returns null for generic implementation prompt', () => {
+      const result = matchStack('Fix the bug in the user profile component', STACKS);
+      expect(result).toBeNull();
+    });
+
+    it('returns null for empty prompt', () => {
+      const result = matchStack('', STACKS);
+      expect(result).toBeNull();
+    });
+
+    it('returns null for ambiguous prompt with low confidence', () => {
+      const result = matchStack('Implement the feature', STACKS);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null when stacks list is empty', () => {
+      const result = matchStack('Build a REST API', []);
+      expect(result).toBeNull();
+    });
+
+    it('includes matchedTags in result', () => {
+      const result = matchStack('Build a REST API with GraphQL support', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.matchedTags.length).toBeGreaterThan(0);
+    });
+
+    it('has confidence between 0 and 1', () => {
+      const result = matchStack('Build a REST API for the backend service', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.confidence).toBeGreaterThan(0);
+      expect(result!.confidence).toBeLessThanOrEqual(1);
+    });
+
+    it('stackBased is always true in result', () => {
+      const result = matchStack('Build a REST API', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackBased).toBe(true);
+    });
+  });
+
+  describe('Korean prompt support', () => {
+    it('matches API-related Korean prompt', () => {
+      const result = matchStack('REST API 사용자 등록 엔드포인트 구현', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('api-development');
+    });
+
+    it('matches security-related Korean prompt', () => {
+      const result = matchStack('보안 감사 및 취약점 분석 수행', STACKS);
+      expect(result).not.toBeNull();
+      expect(result!.stackName).toBe('security-audit');
+    });
+  });
+});

--- a/apps/mcp-server/src/agent/stack-matcher.ts
+++ b/apps/mcp-server/src/agent/stack-matcher.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure-function stack matcher: maps user prompts to agent stacks
+ * using tag-based heuristics and domain keyword detection.
+ *
+ * No NestJS dependency — designed for direct use in KeywordService.
+ */
+
+export interface StackMatchInput {
+  name: string;
+  category: string;
+  tags: string[];
+  /** Specialist agent names from the stack definition (used for specialist resolution) */
+  specialist_agents?: string[];
+}
+
+export interface StackMatchResult {
+  stackName: string;
+  confidence: number;
+  matchedTags: string[];
+  stackBased: true;
+}
+
+/**
+ * Domain-keyword → tag mapping.
+ * Each entry maps regex patterns in the user prompt to one or more stack tags.
+ */
+const DOMAIN_KEYWORDS: ReadonlyArray<{ pattern: RegExp; tags: string[] }> = [
+  // Backend / API
+  { pattern: /\bREST\b/i, tags: ['rest', 'api'] },
+  { pattern: /\bGraphQL\b/i, tags: ['graphql', 'api'] },
+  { pattern: /\bAPI\b/i, tags: ['api'] },
+  { pattern: /\bbackend\b/i, tags: ['backend'] },
+  { pattern: /\bendpoint/i, tags: ['api', 'backend'] },
+  { pattern: /\bcontroller/i, tags: ['api', 'backend'] },
+  { pattern: /\bservice\s+layer/i, tags: ['backend'] },
+  { pattern: /\broute/i, tags: ['api', 'backend'] },
+
+  // Security
+  { pattern: /\bsecurity\b/i, tags: ['security'] },
+  { pattern: /\baudit\b/i, tags: ['audit', 'security'] },
+  { pattern: /\b(?:vulnerability|vulnerabilities)\b/i, tags: ['vulnerability', 'security'] },
+  { pattern: /\bcompliance\b/i, tags: ['compliance', 'security'] },
+  { pattern: /\bOAuth\b/i, tags: ['security'] },
+  { pattern: /\bJWT\b/i, tags: ['security'] },
+  { pattern: /\b(?:XSS|CSRF)\b/i, tags: ['security', 'vulnerability'] },
+  { pattern: /\bauthenticat/i, tags: ['security'] },
+
+  // Frontend / UI / UX
+  { pattern: /\bUI\b/i, tags: ['ui', 'frontend'] },
+  { pattern: /\bUX\b/i, tags: ['ux', 'frontend'] },
+  { pattern: /\baccessibility\b/i, tags: ['accessibility', 'frontend'] },
+  { pattern: /\bSEO\b/i, tags: ['seo', 'frontend'] },
+  { pattern: /\bfrontend\b/i, tags: ['frontend'] },
+
+  // Data
+  { pattern: /\bETL\b/i, tags: ['etl', 'data'] },
+  { pattern: /\bpipeline\b/i, tags: ['pipeline', 'data'] },
+  { pattern: /\banalytics\b/i, tags: ['analytics', 'data'] },
+  { pattern: /\bdata\s+(warehouse|lake|pipeline|ingestion)/i, tags: ['data', 'pipeline'] },
+
+  // ML
+  { pattern: /\bmodel\s+(training|inference|deploy)/i, tags: ['model', 'ml'] },
+  { pattern: /\bML\b/i, tags: ['ml'] },
+  { pattern: /\bmachine\s*learning/i, tags: ['ml', 'ai'] },
+  { pattern: /\binference\b/i, tags: ['inference', 'ml'] },
+  { pattern: /\btraining\b/i, tags: ['training', 'ml'] },
+
+  // Full-stack
+  { pattern: /\bfull[- ]?stack\b/i, tags: ['fullstack'] },
+
+  // Korean keywords
+  { pattern: /보안/i, tags: ['security'] },
+  { pattern: /취약점/i, tags: ['vulnerability', 'security'] },
+  { pattern: /감사/i, tags: ['audit', 'security'] },
+  { pattern: /접근성/i, tags: ['accessibility', 'frontend'] },
+  { pattern: /데이터\s*파이프라인/i, tags: ['data', 'pipeline'] },
+  { pattern: /머신\s*러닝|기계\s*학습/i, tags: ['ml', 'ai'] },
+];
+
+/** Minimum confidence threshold to suggest a stack */
+const MIN_CONFIDENCE = 0.3;
+
+/**
+ * Match a user prompt against available agent stacks.
+ *
+ * @param prompt - User prompt text
+ * @param stacks - Available agent stacks (name, category, tags)
+ * @returns Best matching stack with confidence, or null if no confident match
+ */
+export function matchStack(
+  prompt: string,
+  stacks: readonly StackMatchInput[],
+): StackMatchResult | null {
+  if (!prompt || stacks.length === 0) return null;
+
+  // Extract tags detected in the prompt
+  const detectedTags = new Set<string>();
+  for (const { pattern, tags } of DOMAIN_KEYWORDS) {
+    if (pattern.test(prompt)) {
+      for (const tag of tags) detectedTags.add(tag);
+    }
+  }
+
+  if (detectedTags.size === 0) return null;
+
+  // Score each stack by tag overlap
+  let bestResult: StackMatchResult | null = null;
+
+  for (const stack of stacks) {
+    const matched: string[] = [];
+    for (const tag of stack.tags) {
+      if (detectedTags.has(tag)) matched.push(tag);
+    }
+
+    if (matched.length === 0) continue;
+
+    // Confidence = matched / total tags, capped at 1.0
+    // Weighted by how many detected tags are covered
+    const tagCoverage = matched.length / stack.tags.length;
+    const detectedCoverage = matched.length / detectedTags.size;
+    const confidence = Math.min((tagCoverage + detectedCoverage) / 2, 1.0);
+
+    if (confidence < MIN_CONFIDENCE) continue;
+
+    if (!bestResult || confidence > bestResult.confidence) {
+      bestResult = {
+        stackName: stack.name,
+        confidence,
+        matchedTags: matched,
+        stackBased: true,
+      };
+    }
+  }
+
+  return bestResult;
+}

--- a/apps/mcp-server/src/keyword/keyword.module.ts
+++ b/apps/mcp-server/src/keyword/keyword.module.ts
@@ -7,6 +7,8 @@ import { SkillModule } from '../skill/skill.module';
 import { SkillRecommendationService } from '../skill/skill-recommendation.service';
 import { AgentModule } from '../agent/agent.module';
 import { AgentService } from '../agent/agent.service';
+import { AgentStackService } from '../agent/agent-stack.service';
+import type { StackMatchInput } from '../agent/stack-matcher';
 import { normalizeAgentName } from '../shared/agent.utils';
 import { resolveClientType } from '../shared/client-type';
 import type { ExplicitPatternsMap } from './explicit-pattern-matcher';
@@ -32,6 +34,7 @@ export const KEYWORD_SERVICE = 'KEYWORD_SERVICE';
         configService: ConfigService,
         skillRecommendationService: SkillRecommendationService,
         agentService: AgentService,
+        agentStackService: AgentStackService,
       ) => {
         const logger = new Logger('KeywordModule');
 
@@ -194,6 +197,40 @@ export const KEYWORD_SERVICE = 'KEYWORD_SERVICE';
           }
         };
 
+        // Load agent stacks for stack-aware specialist resolution
+        const loadStacks = async (): Promise<StackMatchInput[]> => {
+          try {
+            const summaries = await agentStackService.listStacks();
+            // listStacks returns AgentStackSummary; we need specialist_agents too.
+            // Resolve full stacks to include specialist_agents.
+            const results: StackMatchInput[] = [];
+            for (const summary of summaries) {
+              try {
+                const full = await agentStackService.resolveStack(summary.name);
+                results.push({
+                  name: full.name,
+                  category: full.category,
+                  tags: full.tags,
+                  specialist_agents: full.specialist_agents,
+                });
+              } catch {
+                // Skip stacks that fail to resolve
+                results.push({
+                  name: summary.name,
+                  category: summary.category,
+                  tags: summary.tags ?? [],
+                });
+              }
+            }
+            return results;
+          } catch (error) {
+            logger.debug(
+              `Failed to load agent stacks: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            );
+            return [];
+          }
+        };
+
         // Group optional dependencies in options object
         const options: KeywordServiceOptions = {
           primaryAgentResolver,
@@ -203,11 +240,18 @@ export const KEYWORD_SERVICE = 'KEYWORD_SERVICE';
           loadAgentSystemPromptFn: loadAgentSystemPrompt,
           getMaxIncludedSkillsFn: getMaxIncludedSkills,
           getClientTypeFn: () => resolveClientType(configService.getClientName()),
+          loadStacksFn: loadStacks,
         };
 
         return new KeywordService(loadConfig, loadRule, loadAgent, options);
       },
-      inject: [RulesService, ConfigService, SkillRecommendationService, AgentService],
+      inject: [
+        RulesService,
+        ConfigService,
+        SkillRecommendationService,
+        AgentService,
+        AgentStackService,
+      ],
     },
   ],
   exports: [KEYWORD_SERVICE],

--- a/apps/mcp-server/src/keyword/keyword.service.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.ts
@@ -35,6 +35,7 @@ import { getDefaultModeConfig } from '../shared/keyword-core';
 import { isTaskmaestroAvailable } from './taskmaestro-detector';
 import { type ClientType } from '../shared/client-type';
 import { getDiffFiles, analyzeDiffFiles, type DiffAnalysisResult } from './diff-analyzer';
+import { matchStack, type StackMatchInput, type StackMatchResult } from '../agent/stack-matcher';
 
 /**
  * Options for parseMode method
@@ -80,6 +81,8 @@ export interface KeywordServiceOptions {
   getClientTypeFn?: () => ClientType;
   /** Non-blocking callback to track rule usage for effectiveness analysis */
   trackRuleUsageFn?: (ruleNames: string[]) => void;
+  /** Function to list available agent stacks for stack-aware specialist resolution */
+  loadStacksFn?: () => Promise<StackMatchInput[]>;
 }
 
 /**
@@ -243,6 +246,7 @@ export class KeywordService {
   private readonly getMaxIncludedSkillsFn?: () => Promise<number | null>;
   private readonly getClientTypeFn?: () => ClientType;
   private readonly trackRuleUsageFn?: (ruleNames: string[]) => void;
+  private readonly loadStacksFn?: () => Promise<StackMatchInput[]>;
 
   /**
    * Context-aware specialist patterns for automatic agent recommendation.
@@ -325,6 +329,7 @@ export class KeywordService {
     this.getMaxIncludedSkillsFn = options?.getMaxIncludedSkillsFn;
     this.getClientTypeFn = options?.getClientTypeFn;
     this.trackRuleUsageFn = options?.trackRuleUsageFn;
+    this.loadStacksFn = options?.loadStacksFn;
 
     // Environment-based TTL: 5 minutes for development, 1 hour for production
     this.cacheTTL = process.env.NODE_ENV === 'production' ? 3600000 : 300000;
@@ -494,8 +499,8 @@ export class KeywordService {
     );
     await this.addAgentInfoToResult(result, resolvedAgent);
 
-    // 3. Add parallel agents recommendation
-    this.addParallelAgentsToResult(result, mode, config, originalPrompt);
+    // 3. Add parallel agents recommendation (async for stack resolution)
+    await this.addParallelAgentsToResult(result, mode, config, originalPrompt);
 
     // 4. Add ACT agent recommendation for PLAN mode
     await this.addActRecommendationToResult(result, mode, originalPrompt);
@@ -617,13 +622,13 @@ export class KeywordService {
   /**
    * Add parallel agents recommendation to result.
    */
-  private addParallelAgentsToResult(
+  private async addParallelAgentsToResult(
     result: ParseModeResult,
     mode: Mode,
     config: KeywordModesConfig,
     originalPrompt: string,
-  ): void {
-    const recommendation = this.getParallelAgentsRecommendation(mode, config, originalPrompt);
+  ): Promise<void> {
+    const recommendation = await this.getParallelAgentsRecommendation(mode, config, originalPrompt);
     if (recommendation) {
       result.parallelAgentsRecommendation = recommendation;
     }
@@ -920,15 +925,36 @@ export class KeywordService {
   /**
    * Get recommended parallel agents for a given mode.
    * These specialists can be executed as Claude Code subagents via Task tool.
-   * Now includes context-aware specialist recommendations based on prompt content.
+   * Includes stack-aware resolution: if a matching agent stack is detected,
+   * its specialists replace the hard-coded defaults. Context-aware specialists
+   * are still merged on top.
    */
-  private getParallelAgentsRecommendation(
+  private async getParallelAgentsRecommendation(
     mode: Mode,
     config: KeywordModesConfig,
     prompt?: string,
-  ): ParallelAgentRecommendation | undefined {
+  ): Promise<ParallelAgentRecommendation | undefined> {
     const modeConfig = config.modes[mode];
-    const baseSpecialists = modeConfig?.defaultSpecialists ?? [];
+    const defaultSpecialists = modeConfig?.defaultSpecialists ?? [];
+
+    // Try stack-based resolution first
+    let stackResult: StackMatchResult | null = null;
+    let stackSpecialists: string[] | undefined;
+    if (prompt && this.loadStacksFn) {
+      try {
+        const stacks = await this.loadStacksFn();
+        stackResult = matchStack(prompt, stacks);
+        if (stackResult) {
+          const matched = stacks.find(s => s.name === stackResult!.stackName);
+          stackSpecialists = matched?.specialist_agents;
+        }
+      } catch {
+        // Stack loading failed — fall back to defaults silently
+      }
+    }
+
+    // Determine base specialists: stack overrides defaults when matched and has specialists
+    const baseSpecialists = stackSpecialists?.length ? stackSpecialists : defaultSpecialists;
 
     // Get context-aware specialists based on prompt content
     const contextSpecialists = prompt ? this.getContextAwareSpecialists(prompt) : [];
@@ -950,10 +976,17 @@ export class KeywordService {
       hint = `Use Task tool with subagent_type="general-purpose" and run_in_background=true for each specialist. Call prepare_parallel_agents MCP tool to get ready-to-use prompts.`;
     }
 
-    return {
+    const result: ParallelAgentRecommendation = {
       specialists: allSpecialists,
       hint,
     };
+
+    if (stackResult) {
+      result.suggestedStack = stackResult.stackName;
+      result.stackBased = true;
+    }
+
+    return result;
   }
 
   /**

--- a/apps/mcp-server/src/keyword/keyword.types.ts
+++ b/apps/mcp-server/src/keyword/keyword.types.ts
@@ -313,6 +313,10 @@ export interface ParallelAgentRecommendation {
   hint: string;
   /** Dispatch strength: "auto" (must dispatch), "recommend" (suggested), "skip" (do not dispatch) */
   dispatch?: DispatchStrength;
+  /** Matched agent stack name when specialists were resolved from a stack preset */
+  suggestedStack?: string;
+  /** True when specialists were derived from an agent stack rather than hard-coded defaults */
+  stackBased?: boolean;
 }
 
 /**

--- a/apps/mcp-server/src/mcp/handlers/agent.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/agent.handler.ts
@@ -183,7 +183,7 @@ export class AgentHandler extends AbstractHandler {
             agentStack: {
               type: 'string',
               description:
-                'Agent stack name to resolve primary + specialists from a preset (e.g., "api-development"). Overrides primaryAgent and specialists when provided.',
+                'Agent stack name to resolve primary + specialists from a preset (e.g., "api-development"). Overrides primaryAgent and specialists when provided. Tip: use the suggestedStack value from parse_mode response to auto-select the best stack for the current context.',
             },
             inlineAgents: {
               type: 'object',


### PR DESCRIPTION
Closes #1379

## Summary

- Agent stacks (e.g., `api-development`, `security-audit`) now participate in the main `parse_mode` workflow as first-class specialist presets
- When a user prompt matches a known domain (API, security, frontend, data, ML), the matched stack's `specialist_agents` replace the hard-coded `defaultSpecialists` lists
- Generic or ambiguous prompts fall back to existing hard-coded defaults (backward-compatible)
- New `suggestedStack` / `stackBased` fields in `parallelAgentsRecommendation` response let consumers auto-select stacks when calling `dispatch_agents`

## New: StackMatcher utility

Pure function (`stack-matcher.ts`) that maps prompts to stacks:
- Tag-based heuristic matching against stack tags + domain keyword detection
- English + Korean keyword support
- Conservative matching with `MIN_CONFIDENCE = 0.3` threshold
- 19 test cases covering all 6 stacks + edge cases + Korean prompts

## New response fields (additive)

```typescript
parallelAgentsRecommendation: {
  specialists: string[];
  hint: string;
  suggestedStack?: string;  // NEW: e.g., "api-development"
  stackBased?: boolean;     // NEW: true when specialists came from a stack
}
```

## Integration flow

1. `parse_mode("Build a REST API for users")` → StackMatcher detects `api-development`
2. Response includes `suggestedStack: "api-development"`, `stackBased: true`
3. Specialists are `["security-specialist", "test-engineer", "performance-specialist", "documentation-specialist"]` (from stack) instead of hard-coded defaults
4. Consumer can pass `suggestedStack` to `dispatch_agents(agentStack: "api-development")` for automatic resolution

## Test plan

- [x] `yarn workspace codingbuddy test` → **6054 passed** (19 new stack-matcher tests)
- [x] `yarn workspace codingbuddy typecheck` → clean
- [x] `yarn workspace codingbuddy build` → success
- [x] `yarn workspace codingbuddy lint` → 0 errors
- [x] `yarn workspace codingbuddy circular` → no circular deps
- [x] `prettier --check` on all changed files → clean
- [x] Existing `keyword.service.spec.ts` (260 tests) still passes — backward-compatible

## Wave 2 boundary

- `keyword.service.spec.ts` untouched (reserved for pane-1 #1397)
- `keyword.service.ts` core mode logic untouched (reserved for pane-2 #1373)
- Only specialist-resolution section of `keyword.service.ts` modified (`getParallelAgentsRecommendation`)