### PR TITLE
fix(mcp-server): update stale delegates_to frontend-developer in test mocks

### DIFF
--- a/apps/mcp-server/src/keyword/keyword.service.spec.ts
+++ b/apps/mcp-server/src/keyword/keyword.service.spec.ts
@@ -21,7 +21,7 @@ const mockConfig: KeywordModesConfig = {
       instructions: 'Design first approach.',
       rules: ['rules/core.md'],
       agent: 'plan-mode',
-      delegates_to: 'frontend-developer',
+      delegates_to: 'solution-architect',
       defaultSpecialists: ['architecture-specialist', 'test-strategy-specialist'],
     },
     ACT: {
@@ -29,7 +29,7 @@ const mockConfig: KeywordModesConfig = {
       instructions: 'Red-Green-Refactor cycle.',
       rules: ['rules/core.md', 'rules/project.md'],
       agent: 'act-mode',
-      delegates_to: 'frontend-developer',
+      delegates_to: 'software-engineer',
       defaultSpecialists: ['code-quality-specialist', 'test-strategy-specialist'],
     },
     EVAL: {
@@ -65,6 +65,20 @@ const mockRulesContent: Record<string, string> = {
 };
 
 const mockAgentData: Record<string, unknown> = {
+  'solution-architect': {
+    name: 'Solution Architect',
+    description: 'High-level system design and architecture planning specialist',
+    role: {
+      expertise: ['Architecture', 'System Design', 'Patterns', 'Scalability'],
+    },
+  },
+  'software-engineer': {
+    name: 'Software Engineer',
+    description: 'General-purpose implementation engineer with TDD focus',
+    role: {
+      expertise: ['TypeScript', 'TDD', 'Clean Architecture', 'Implementation'],
+    },
+  },
   'frontend-developer': {
     name: 'Frontend Developer',
     description: 'React/Next.js specialist with TDD and design system experience',
@@ -115,11 +129,11 @@ describe('KeywordService', () => {
         expect(result.rules[0].name).toBe('rules/core.md');
         expect(result.warnings).toBeUndefined();
         expect(result.agent).toBe('plan-mode');
-        expect(result.delegates_to).toBe('frontend-developer');
+        expect(result.delegates_to).toBe('solution-architect');
         expect(result.delegate_agent_info).toEqual({
-          name: 'Frontend Developer',
-          description: 'React/Next.js specialist with TDD and design system experience',
-          expertise: ['React', 'Next.js', 'TDD', 'TypeScript'],
+          name: 'Solution Architect',
+          description: 'High-level system design and architecture planning specialist',
+          expertise: ['Architecture', 'System Design', 'Patterns', 'Scalability'],
         });
       });
 
@@ -131,11 +145,11 @@ describe('KeywordService', () => {
         expect(result.instructions).toContain('Red-Green-Refactor cycle.');
         expect(result.rules).toHaveLength(2);
         expect(result.agent).toBe('act-mode');
-        expect(result.delegates_to).toBe('frontend-developer');
+        expect(result.delegates_to).toBe('software-engineer');
         expect(result.delegate_agent_info).toEqual({
-          name: 'Frontend Developer',
-          description: 'React/Next.js specialist with TDD and design system experience',
-          expertise: ['React', 'Next.js', 'TDD', 'TypeScript'],
+          name: 'Software Engineer',
+          description: 'General-purpose implementation engineer with TDD focus',
+          expertise: ['TypeScript', 'TDD', 'Clean Architecture', 'Implementation'],
         });
       });
 
@@ -716,13 +730,13 @@ describe('KeywordService', () => {
       it('includes delegate information when delegates_to is configured', async () => {
         const result = await service.parseMode('ACT implement feature');
 
-        expect(result.delegates_to).toBe('frontend-developer');
+        expect(result.delegates_to).toBe('software-engineer');
         expect(result.delegate_agent_info).toEqual({
-          name: 'Frontend Developer',
-          description: 'React/Next.js specialist with TDD and design system experience',
-          expertise: ['React', 'Next.js', 'TDD', 'TypeScript'],
+          name: 'Software Engineer',
+          description: 'General-purpose implementation engineer with TDD focus',
+          expertise: ['TypeScript', 'TDD', 'Clean Architecture', 'Implementation'],
         });
-        expect(mockLoadAgentInfo).toHaveBeenCalledWith('frontend-developer');
+        expect(mockLoadAgentInfo).toHaveBeenCalledWith('software-engineer');
       });
 
       it('includes different delegate for EVAL mode', async () => {
@@ -743,7 +757,7 @@ describe('KeywordService', () => {
 
         const result = await service.parseMode('PLAN design feature');
 
-        expect(result.delegates_to).toBe('frontend-developer');
+        expect(result.delegates_to).toBe('solution-architect');
         expect(result.delegate_agent_info).toBeUndefined();
       });
 
@@ -752,7 +766,7 @@ describe('KeywordService', () => {
 
         const result = await service.parseMode('PLAN design feature');
 
-        expect(result.delegates_to).toBe('frontend-developer');
+        expect(result.delegates_to).toBe('solution-architect');
         expect(result.delegate_agent_info).toBeUndefined();
       });
 
@@ -781,7 +795,7 @@ describe('KeywordService', () => {
         const result = await service.parseMode('PLAN design feature');
 
         expect(result.delegate_agent_info).toEqual({
-          name: 'frontend-developer',
+          name: 'solution-architect',
           description: 'Test description',
           expertise: ['test'],
         });
@@ -806,8 +820,8 @@ describe('KeywordService', () => {
         expect(result.mode).toBe('PLAN');
         expect(result.originalPrompt).toBe('인증 기능 설계');
         expect(result.agent).toBe('plan-mode');
-        expect(result.delegates_to).toBe('frontend-developer');
-        expect(result.delegate_agent_info?.name).toBe('Frontend Developer');
+        expect(result.delegates_to).toBe('solution-architect');
+        expect(result.delegate_agent_info?.name).toBe('Solution Architect');
       });
 
       it('works with default mode and includes agent information', async () => {
@@ -817,7 +831,7 @@ describe('KeywordService', () => {
         expect(result.originalPrompt).toBe('design auth feature');
         expect(result.warnings).toContain('No keyword found, defaulting to PLAN');
         expect(result.agent).toBe('plan-mode');
-        expect(result.delegates_to).toBe('frontend-developer');
+        expect(result.delegates_to).toBe('solution-architect');
       });
     });
   });
@@ -1128,7 +1142,7 @@ describe('KeywordService', () => {
       expect(result.activation_message?.activations).toHaveLength(1);
       expect(result.activation_message?.activations[0]).toMatchObject({
         type: 'agent',
-        name: 'frontend-developer',
+        name: 'solution-architect',
         tier: 'primary',
       });
     });
@@ -1139,7 +1153,7 @@ describe('KeywordService', () => {
       expect(result.activation_message).toBeDefined();
       expect(result.activation_message?.activations[0]).toMatchObject({
         type: 'agent',
-        name: 'frontend-developer',
+        name: 'software-engineer',
         tier: 'primary',
       });
     });
@@ -1173,7 +1187,7 @@ describe('KeywordService', () => {
       const result = await service.parseMode('계획 인증 기능 설계');
 
       expect(result.activation_message).toBeDefined();
-      expect(result.activation_message?.activations[0].name).toBe('frontend-developer');
+      expect(result.activation_message?.activations[0].name).toBe('solution-architect');
     });
 
     it('includes activation_message even without keyword (default mode)', async () => {
@@ -1323,10 +1337,10 @@ describe('KeywordService', () => {
     it('falls back to default resolution if no recommendedActAgent provided', async () => {
       const mockResolver = {
         resolve: vi.fn().mockResolvedValue({
-          agentName: 'frontend-developer',
+          agentName: 'backend-developer',
           source: 'default',
           confidence: 1.0,
-          reason: 'ACT mode default: frontend-developer',
+          reason: 'ACT mode default: backend-developer',
         }),
       };
       const serviceWithResolver = new KeywordService(
@@ -1340,7 +1354,7 @@ describe('KeywordService', () => {
 
       const result = await serviceWithResolver.parseMode('ACT implement feature');
 
-      expect(result.delegates_to).toBe('frontend-developer');
+      expect(result.delegates_to).toBe('backend-developer');
       const call = mockResolver.resolve.mock.calls[0];
       expect(call[0]).toBe('ACT');
       expect(call[1]).toBe('implement feature');
@@ -1351,10 +1365,10 @@ describe('KeywordService', () => {
     it('treats empty string recommendedActAgent as undefined', async () => {
       const mockResolver = {
         resolve: vi.fn().mockResolvedValue({
-          agentName: 'frontend-developer',
+          agentName: 'backend-developer',
           source: 'default',
           confidence: 1.0,
-          reason: 'ACT mode default: frontend-developer',
+          reason: 'ACT mode default: backend-developer',
         }),
       };
       const serviceWithResolver = new KeywordService(
@@ -1371,7 +1385,7 @@ describe('KeywordService', () => {
         recommendedActAgent: '',
       });
 
-      expect(result.delegates_to).toBe('frontend-developer');
+      expect(result.delegates_to).toBe('backend-developer');
       // Should be called with undefined, not empty string
       const call = mockResolver.resolve.mock.calls[0];
       expect(call[0]).toBe('ACT');
@@ -1383,10 +1397,10 @@ describe('KeywordService', () => {
     it('treats whitespace-only recommendedActAgent as undefined', async () => {
       const mockResolver = {
         resolve: vi.fn().mockResolvedValue({
-          agentName: 'frontend-developer',
+          agentName: 'backend-developer',
           source: 'default',
           confidence: 1.0,
-          reason: 'ACT mode default: frontend-developer',
+          reason: 'ACT mode default: backend-developer',
         }),
       };
       const serviceWithResolver = new KeywordService(
@@ -1404,7 +1418,7 @@ describe('KeywordService', () => {
         recommendedActAgent: '   ',
       });
 
-      expect(result.delegates_to).toBe('frontend-developer');
+      expect(result.delegates_to).toBe('backend-developer');
     });
   });
 
@@ -2327,9 +2341,9 @@ describe('KeywordService', () => {
         const mockLoadAgentSystemPrompt = vi.fn(
           async (agentName: string, mode: Mode): Promise<AgentSystemPromptInfo | null> => ({
             agentName,
-            displayName: 'Frontend Developer',
+            displayName: 'Solution Architect',
             systemPrompt: `You are a ${agentName} in ${mode} mode. Follow TDD.`,
-            description: 'Frontend development specialist',
+            description: 'Architecture planning specialist',
           }),
         );
 
@@ -2344,9 +2358,9 @@ describe('KeywordService', () => {
 
         expect(result.included_agent).toBeDefined();
         expect(result.included_agent).toMatchObject({
-          name: 'Frontend Developer',
-          systemPrompt: expect.stringContaining('frontend-developer'),
-          expertise: ['React', 'Next.js', 'TDD', 'TypeScript'],
+          name: 'Solution Architect',
+          systemPrompt: expect.stringContaining('solution-architect'),
+          expertise: ['Architecture', 'System Design', 'Patterns', 'Scalability'],
         });
       });
 
@@ -2411,7 +2425,7 @@ describe('KeywordService', () => {
 
         // Should not throw, just skip agent inclusion
         expect(result.mode).toBe('PLAN');
-        expect(result.delegates_to).toBe('frontend-developer');
+        expect(result.delegates_to).toBe('solution-architect');
         expect(result.included_agent).toBeUndefined();
       });
 
@@ -2509,7 +2523,7 @@ describe('KeywordService', () => {
         const result = await serviceWithNullAgent.parseMode('PLAN test');
 
         // delegates_to should still be set from config, but delegate_agent_info should be undefined
-        expect(result.delegates_to).toBe('frontend-developer');
+        expect(result.delegates_to).toBe('solution-architect');
         expect(result.delegate_agent_info).toBeUndefined();
       });
 
@@ -2523,7 +2537,7 @@ describe('KeywordService', () => {
 
         const result = await serviceWithStringAgent.parseMode('PLAN test');
 
-        expect(result.delegates_to).toBe('frontend-developer');
+        expect(result.delegates_to).toBe('solution-architect');
         expect(result.delegate_agent_info).toBeUndefined();
       });
     });

--- a/apps/mcp-server/src/mcp/mcp.service.spec.ts
+++ b/apps/mcp-server/src/mcp/mcp.service.spec.ts
@@ -129,11 +129,11 @@ const createMockKeywordService = (): Partial<KeywordService> => ({
         instructions: 'Red-Green-Refactor cycle',
         rules: [{ name: 'rules/core.md', content: 'Some rules' }],
         agent: 'act-mode',
-        delegates_to: 'frontend-developer',
+        delegates_to: 'software-engineer',
         delegate_agent_info: {
-          name: 'Frontend Developer',
-          description: 'React/Next.js frontend specialist',
-          expertise: ['React', 'TypeScript'],
+          name: 'Software Engineer',
+          description: 'General-purpose implementation engineer',
+          expertise: ['TypeScript', 'TDD'],
         },
       };
     } else if (firstWord === 'EVAL') {
@@ -157,11 +157,11 @@ const createMockKeywordService = (): Partial<KeywordService> => ({
         instructions: 'Plan the implementation',
         rules: [{ name: 'rules/core.md', content: 'Some rules' }],
         agent: 'plan-mode',
-        delegates_to: 'frontend-developer',
+        delegates_to: 'solution-architect',
         delegate_agent_info: {
-          name: 'Frontend Developer',
-          description: 'React/Next.js frontend specialist',
-          expertise: ['React', 'TypeScript'],
+          name: 'Solution Architect',
+          description: 'Architecture planning specialist',
+          expertise: ['Architecture', 'System Design'],
         },
       };
     }
@@ -914,11 +914,11 @@ describe('McpService', () => {
       const parsedContent = JSON.parse(result.content[0].text);
       expect(parsedContent.mode).toBe('ACT');
       expect(parsedContent.agent).toBe('act-mode');
-      expect(parsedContent.delegates_to).toBe('frontend-developer');
+      expect(parsedContent.delegates_to).toBe('software-engineer');
       expect(parsedContent.delegate_agent_info).toEqual({
-        name: 'Frontend Developer',
-        description: 'React/Next.js frontend specialist',
-        expertise: ['React', 'TypeScript'],
+        name: 'Software Engineer',
+        description: 'General-purpose implementation engineer',
+        expertise: ['TypeScript', 'TDD'],
       });
     });
 

--- a/apps/mcp-server/src/tui/events/tui-interceptor.spec.ts
+++ b/apps/mcp-server/src/tui/events/tui-interceptor.spec.ts
@@ -265,14 +265,14 @@ describe('TuiInterceptor', () => {
       }));
       await new Promise(resolve => setImmediate(resolve));
 
-      // Second call: ACT with frontend-developer
+      // Second call: ACT with software-engineer
       await interceptor.intercept('parse_mode', { prompt: 'ACT implement feature' }, async () => ({
         content: [
           {
             type: 'text',
             text: JSON.stringify({
               mode: 'ACT',
-              delegates_to: 'frontend-developer',
+              delegates_to: 'software-engineer',
             }),
           },
         ],
@@ -286,11 +286,11 @@ describe('TuiInterceptor', () => {
           reason: 'replaced',
         }),
       );
-      // frontend-developer should be activated
+      // software-engineer should be activated
       expect(activatedHandler).toHaveBeenCalledWith(
         expect.objectContaining({
-          agentId: 'primary:frontend-developer',
-          name: 'frontend-developer',
+          agentId: 'primary:software-engineer',
+          name: 'software-engineer',
           isPrimary: true,
         }),
       );
@@ -618,7 +618,7 @@ describe('TuiInterceptor', () => {
         content: [
           {
             type: 'text',
-            text: JSON.stringify({ mode: 'ACT', delegates_to: 'frontend-developer' }),
+            text: JSON.stringify({ mode: 'ACT', delegates_to: 'software-engineer' }),
           },
         ],
       }));


### PR DESCRIPTION
Closes #1397

## Summary

- Updated all 20 stale `delegates_to: 'frontend-developer'` references in test mock data across 3 spec files to match the current runtime contract established by PR #1396
- PLAN mode: `'frontend-developer'` → `'solution-architect'` (default PLAN primary agent)
- ACT mode: `'frontend-developer'` → `'software-engineer'` (DEFAULT_ACT_AGENT)
- Added `solution-architect` and `software-engineer` entries to `mockAgentData` for `delegate_agent_info` assertions

## Files changed (3)

| File | Occurrences fixed |
|------|------------------|
| `apps/mcp-server/src/keyword/keyword.service.spec.ts` | 15 |
| `apps/mcp-server/src/mcp/mcp.service.spec.ts` | 3 |
| `apps/mcp-server/src/tui/events/tui-interceptor.spec.ts` | 2 |

## Test plan

- [x] `grep -rn "delegates_to.*frontend-developer" --include="*.spec.ts"` → zero results
- [x] `yarn workspace codingbuddy lint` — 0 errors
- [x] `yarn workspace codingbuddy typecheck` — clean
- [x] `yarn workspace codingbuddy test` — 6035 passing, 2 skipped (pre-existing)
- [x] `yarn workspace codingbuddy build` — success