### PR TITLE
feat(mcp-server): add Discover → Design → Plan staged planning flow

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
@@ -1647,4 +1647,155 @@ describe('ModeHandler', () => {
       expect(parsed.questionBudget).toBe(2);
     });
   });
+
+  // ==========================================================================
+  // Planning Stage Router (#1372)
+  // ==========================================================================
+  describe('parse_mode Planning Stage (#1372)', () => {
+    it('includes planningStage with discover for ambiguous PLAN prompt', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: '개선해줘',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN 개선해줘',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.planningStage).toBeDefined();
+      expect(parsed.planningStage.currentStage).toBe('discover');
+      expect(parsed.planningStage.nextStage).toBe('design');
+      expect(parsed.planningStage.stageTransitionHint).toBeTruthy();
+      expect(parsed.planningStage.recommendedAgent).toBe('solution-architect');
+      expect(parsed.planningStage.recommendedSkill).toBe('brainstorming');
+    });
+
+    it('includes planningStage with plan for clear PLAN prompt', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'add unit tests to apps/mcp-server/src/auth/auth.service.ts',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN add unit tests to apps/mcp-server/src/auth/auth.service.ts',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.planningStage).toBeDefined();
+      expect(parsed.planningStage.currentStage).toBe('plan');
+      expect(parsed.planningStage.nextStage).toBeUndefined();
+      expect(parsed.planningStage.stageTransitionHint).toBeUndefined();
+      expect(parsed.planningStage.recommendedAgent).toBe('technical-planner');
+      expect(parsed.planningStage.recommendedSkill).toBe('writing-plans');
+    });
+
+    it('honors explicit planning_stage=design hint', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'implement auth feature',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN implement auth feature',
+        planning_stage: 'design',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.planningStage.currentStage).toBe('design');
+      expect(parsed.planningStage.nextStage).toBe('plan');
+      expect(parsed.planningStage.recommendedAgent).toBe('solution-architect');
+    });
+
+    it('includes planningStage in AUTO mode', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'AUTO',
+        originalPrompt: '개선',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'AUTO 개선',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.planningStage).toBeDefined();
+      expect(parsed.planningStage.currentStage).toBe('discover');
+    });
+
+    it('does NOT include planningStage for ACT mode', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'ACT',
+        originalPrompt: 'implement feature',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'ACT implement feature',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.planningStage).toBeUndefined();
+    });
+
+    it('does NOT include planningStage for EVAL mode', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'EVAL',
+        originalPrompt: 'review code',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'EVAL review code',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.planningStage).toBeUndefined();
+    });
+
+    it('ignores invalid planning_stage input', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'improve it',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN improve it',
+        planning_stage: 'invalid-stage',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      // Falls back to automatic routing (discover for ambiguous)
+      expect(parsed.planningStage.currentStage).toBe('discover');
+    });
+
+    it('routes budget-exhausted to plan stage', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'improve it',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN improve it',
+        question_budget: 0,
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.planningStage.currentStage).toBe('plan');
+      expect(parsed.planningStage.recommendedAgent).toBe('technical-planner');
+    });
+  });
 });

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.ts
@@ -43,6 +43,7 @@ import type { ExecutionPlan } from '../../agent/execution-plan.types';
 import { ImpactEventService } from '../../impact';
 import { RuleEventCollector } from '../../rules/rule-event-collector';
 import { evaluateClarification, type ClarificationMetadata } from './clarification-gate';
+import { resolvePlanningStage, type PlanningStageMetadata } from './planning-stage';
 
 /** Maximum length for context title slug generation */
 const CONTEXT_TITLE_MAX_LENGTH = 50;
@@ -157,6 +158,12 @@ export class ModeHandler extends AbstractHandler {
               description:
                 'Clarification Gate budget (#1371). Maximum clarification questions remaining in this session. Defaults to 3 on the first call; pass the `questionBudget` returned from the previous PLAN response to decrement across rounds. When 0, the gate proceeds to planning with explicit assumptions.',
             },
+            planning_stage: {
+              type: 'string',
+              enum: ['discover', 'design', 'plan'],
+              description:
+                'Staged planning hint (#1372). Overrides automatic stage routing when the caller knows which stage to enter. Use "design" after the user confirms direction from Discover, or "plan" after the user confirms the approach from Design.',
+            },
           },
           required: ['prompt'],
         },
@@ -187,6 +194,14 @@ export class ModeHandler extends AbstractHandler {
     const questionBudget =
       typeof rawQuestionBudget === 'number' && Number.isFinite(rawQuestionBudget)
         ? rawQuestionBudget
+        : undefined;
+
+    // Extract optional planning stage hint (#1372).
+    const VALID_STAGES = new Set(['discover', 'design', 'plan']);
+    const rawPlanningStage = extractRequiredString(args, 'planning_stage') ?? undefined;
+    const planningStageHint =
+      rawPlanningStage && VALID_STAGES.has(rawPlanningStage)
+        ? (rawPlanningStage as 'discover' | 'design' | 'plan')
         : undefined;
 
     try {
@@ -329,6 +344,14 @@ export class ModeHandler extends AbstractHandler {
         questionBudget,
       );
 
+      // Planning Stage Router (#1372) — maps clarification output to
+      // discover / design / plan stage. Only for PLAN/AUTO modes.
+      const planningStage = this.buildPlanningStageMetadata(
+        result.mode as Mode,
+        clarification,
+        planningStageHint,
+      );
+
       const response = createJsonResponse({
         ...result,
         language,
@@ -352,6 +375,8 @@ export class ModeHandler extends AbstractHandler {
         ...(teamsCapability && { teamsCapability }),
         // Include Clarification Gate metadata for PLAN/AUTO modes (#1371)
         ...(clarification && clarification),
+        // Include Planning Stage metadata for PLAN/AUTO modes (#1372)
+        ...(planningStage && { planningStage }),
         // Include context document info (mandatory)
         ...contextResult,
         // Include project root warning when auto-detected and config missing
@@ -611,6 +636,30 @@ export class ModeHandler extends AbstractHandler {
 
     return evaluateClarification(originalPrompt, {
       ...(questionBudget !== undefined && { questionBudget }),
+    });
+  }
+
+  /**
+   * Build Planning Stage metadata for PLAN/AUTO modes (#1372).
+   * Returns undefined for ACT/EVAL modes.
+   *
+   * Requires the clarification output to determine whether the request
+   * should start at discover, design, or jump straight to plan.
+   */
+  private buildPlanningStageMetadata(
+    mode: Mode,
+    clarification: ClarificationMetadata | undefined,
+    stageHint?: 'discover' | 'design' | 'plan',
+  ): PlanningStageMetadata | undefined {
+    if (mode !== 'PLAN' && mode !== 'AUTO') {
+      return undefined;
+    }
+    if (!clarification) {
+      return undefined;
+    }
+
+    return resolvePlanningStage(clarification, {
+      ...(stageHint && { stageHint }),
     });
   }
 

--- a/apps/mcp-server/src/mcp/handlers/planning-stage.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/planning-stage.spec.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePlanningStage, type PlanningStageMetadata } from './planning-stage';
+import type { ClarificationMetadata } from './clarification-gate';
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function ambiguousClarification(
+  overrides: Partial<ClarificationMetadata> = {},
+): ClarificationMetadata {
+  return {
+    clarificationNeeded: true,
+    planReady: false,
+    questionBudget: 2,
+    nextQuestion: 'What should change?',
+    clarificationTopics: ['vague-intent'],
+    ...overrides,
+  };
+}
+
+function clearClarification(overrides: Partial<ClarificationMetadata> = {}): ClarificationMetadata {
+  return {
+    clarificationNeeded: false,
+    planReady: true,
+    questionBudget: 3,
+    ...overrides,
+  };
+}
+
+function budgetExhaustedClarification(): ClarificationMetadata {
+  return {
+    clarificationNeeded: false,
+    planReady: true,
+    questionBudget: 0,
+    assumptionNote: 'Proceeding with assumptions.',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('planning-stage', () => {
+  describe('resolvePlanningStage', () => {
+    // ------------------------------------------------------------------
+    // Stage routing
+    // ------------------------------------------------------------------
+
+    describe('stage routing', () => {
+      it('routes ambiguous prompt to discover', () => {
+        const result = resolvePlanningStage(ambiguousClarification());
+
+        expect(result.currentStage).toBe('discover');
+      });
+
+      it('routes clear prompt directly to plan (skip discover + design)', () => {
+        const result = resolvePlanningStage(clearClarification());
+
+        expect(result.currentStage).toBe('plan');
+      });
+
+      it('routes budget-exhausted prompt to plan', () => {
+        const result = resolvePlanningStage(budgetExhaustedClarification());
+
+        expect(result.currentStage).toBe('plan');
+      });
+
+      it('routes explicit stageHint=design to design', () => {
+        const result = resolvePlanningStage(clearClarification(), {
+          stageHint: 'design',
+        });
+
+        expect(result.currentStage).toBe('design');
+      });
+
+      it('routes explicit stageHint=plan to plan even if ambiguous', () => {
+        const result = resolvePlanningStage(ambiguousClarification(), {
+          stageHint: 'plan',
+        });
+
+        expect(result.currentStage).toBe('plan');
+      });
+
+      it('routes explicit stageHint=discover to discover even if clear', () => {
+        const result = resolvePlanningStage(clearClarification(), {
+          stageHint: 'discover',
+        });
+
+        expect(result.currentStage).toBe('discover');
+      });
+    });
+
+    // ------------------------------------------------------------------
+    // Stage descriptions
+    // ------------------------------------------------------------------
+
+    describe('stage descriptions', () => {
+      it('has a description for discover stage', () => {
+        const result = resolvePlanningStage(ambiguousClarification());
+
+        expect(result.stageDescription).toContain('Discover');
+        expect(result.stageDescription).toContain('questions');
+      });
+
+      it('has a description for design stage', () => {
+        const result = resolvePlanningStage(clearClarification(), {
+          stageHint: 'design',
+        });
+
+        expect(result.stageDescription).toContain('Design');
+        expect(result.stageDescription).toContain('trade-offs');
+      });
+
+      it('has a description for plan stage', () => {
+        const result = resolvePlanningStage(clearClarification());
+
+        expect(result.stageDescription).toContain('Plan');
+        expect(result.stageDescription).toContain('implementation');
+      });
+    });
+
+    // ------------------------------------------------------------------
+    // Stage transitions
+    // ------------------------------------------------------------------
+
+    describe('stage transitions', () => {
+      it('discover → nextStage is design', () => {
+        const result = resolvePlanningStage(ambiguousClarification());
+
+        expect(result.nextStage).toBe('design');
+      });
+
+      it('design → nextStage is plan', () => {
+        const result = resolvePlanningStage(clearClarification(), {
+          stageHint: 'design',
+        });
+
+        expect(result.nextStage).toBe('plan');
+      });
+
+      it('plan → nextStage is undefined (terminal)', () => {
+        const result = resolvePlanningStage(clearClarification());
+
+        expect(result.nextStage).toBeUndefined();
+      });
+    });
+
+    // ------------------------------------------------------------------
+    // Stage transition hints
+    // ------------------------------------------------------------------
+
+    describe('stage transition hints', () => {
+      it('has a transition hint for discover stage', () => {
+        const result = resolvePlanningStage(ambiguousClarification());
+
+        expect(result.stageTransitionHint).toBeTruthy();
+        expect(result.stageTransitionHint).toContain('Design');
+      });
+
+      it('has a transition hint for design stage', () => {
+        const result = resolvePlanningStage(clearClarification(), {
+          stageHint: 'design',
+        });
+
+        expect(result.stageTransitionHint).toBeTruthy();
+        expect(result.stageTransitionHint).toContain('Plan');
+      });
+
+      it('has no transition hint for plan stage (terminal)', () => {
+        const result = resolvePlanningStage(clearClarification());
+
+        expect(result.stageTransitionHint).toBeUndefined();
+      });
+    });
+
+    // ------------------------------------------------------------------
+    // Agent selection per stage
+    // ------------------------------------------------------------------
+
+    describe('agent selection', () => {
+      it('recommends solution-architect for discover', () => {
+        const result = resolvePlanningStage(ambiguousClarification());
+
+        expect(result.recommendedAgent).toBe('solution-architect');
+      });
+
+      it('recommends solution-architect for design', () => {
+        const result = resolvePlanningStage(clearClarification(), {
+          stageHint: 'design',
+        });
+
+        expect(result.recommendedAgent).toBe('solution-architect');
+      });
+
+      it('recommends technical-planner for plan', () => {
+        const result = resolvePlanningStage(clearClarification());
+
+        expect(result.recommendedAgent).toBe('technical-planner');
+      });
+    });
+
+    // ------------------------------------------------------------------
+    // Skill selection per stage
+    // ------------------------------------------------------------------
+
+    describe('skill selection', () => {
+      it('recommends brainstorming skill for discover', () => {
+        const result = resolvePlanningStage(ambiguousClarification());
+
+        expect(result.recommendedSkill).toBe('brainstorming');
+      });
+
+      it('has no recommended skill for design', () => {
+        const result = resolvePlanningStage(clearClarification(), {
+          stageHint: 'design',
+        });
+
+        expect(result.recommendedSkill).toBeUndefined();
+      });
+
+      it('recommends writing-plans skill for plan', () => {
+        const result = resolvePlanningStage(clearClarification());
+
+        expect(result.recommendedSkill).toBe('writing-plans');
+      });
+    });
+
+    // ------------------------------------------------------------------
+    // Backward compatibility
+    // ------------------------------------------------------------------
+
+    describe('backward compatibility', () => {
+      it('clear prompt produces planReady + plan stage with no intermediate steps', () => {
+        const clarification = clearClarification();
+        const result = resolvePlanningStage(clarification);
+
+        expect(result.currentStage).toBe('plan');
+        expect(result.nextStage).toBeUndefined();
+        expect(result.stageTransitionHint).toBeUndefined();
+      });
+
+      it('all fields are present in the return type', () => {
+        const result: PlanningStageMetadata = resolvePlanningStage(ambiguousClarification());
+
+        expect(result).toHaveProperty('currentStage');
+        expect(result).toHaveProperty('stageDescription');
+        expect(result).toHaveProperty('nextStage');
+        expect(result).toHaveProperty('stageTransitionHint');
+        expect(result).toHaveProperty('recommendedAgent');
+        expect(result).toHaveProperty('recommendedSkill');
+      });
+    });
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/planning-stage.ts
+++ b/apps/mcp-server/src/mcp/handlers/planning-stage.ts
@@ -1,0 +1,144 @@
+/**
+ * Planning Stage Router — Discover → Design → Plan staged flow (#1372).
+ *
+ * Builds on the Clarification Gate (#1371) to introduce three explicit
+ * planning stages instead of jumping from prompt to implementation plan:
+ *
+ *   1. DISCOVER  — surface questions, constraints, option space
+ *   2. DESIGN    — synthesize candidate approaches, trade-offs, risks
+ *   3. PLAN      — produce a concrete implementation plan
+ *
+ * The router maps the Clarification Gate's output plus caller-supplied
+ * stage context into a `PlanningStageMetadata` object that is included
+ * in the parse_mode response for PLAN/AUTO modes.
+ *
+ * Like the Clarification Gate, this module is intentionally pure and
+ * free of NestJS dependencies so it can be unit tested in isolation.
+ */
+
+import type { ClarificationMetadata } from './clarification-gate';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The three stages of the planning flow. */
+export type PlanningStage = 'discover' | 'design' | 'plan';
+
+/** Metadata emitted alongside the clarification fields in the PLAN response. */
+export interface PlanningStageMetadata {
+  /** Current planning stage. */
+  currentStage: PlanningStage;
+  /** Human-readable description of what this stage produces. */
+  stageDescription: string;
+  /** Next stage the flow will transition to (undefined when at terminal 'plan'). */
+  nextStage?: 'design' | 'plan';
+  /** Action the user must take to move to the next stage. */
+  stageTransitionHint?: string;
+  /** Recommended primary agent for this stage. */
+  recommendedAgent?: string;
+  /** Recommended supporting skill for this stage. */
+  recommendedSkill?: string;
+}
+
+/** Options to override automatic stage resolution. */
+export interface PlanningStageOptions {
+  /**
+   * Explicit stage hint from the caller. When `'design'` the router skips
+   * the DISCOVER stage and routes directly to DESIGN (the caller is stating
+   * that clarification is resolved and direction is confirmed).
+   */
+  stageHint?: PlanningStage;
+}
+
+// ---------------------------------------------------------------------------
+// Stage descriptions & transition hints (i18n-ready strings)
+// ---------------------------------------------------------------------------
+
+const STAGE_DESCRIPTIONS: Record<PlanningStage, string> = {
+  discover:
+    'Discover: Surface questions, constraints, and the option space before committing to an approach.',
+  design: 'Design: Synthesize candidate approaches, compare trade-offs, and identify open risks.',
+  plan: 'Plan: Produce a concrete, step-by-step implementation plan.',
+};
+
+const STAGE_TRANSITION_HINTS: Record<'discover' | 'design', string> = {
+  discover: 'Answer the clarification question(s) or confirm the direction to proceed to Design.',
+  design: 'Confirm the preferred approach to proceed to the concrete implementation Plan.',
+};
+
+const STAGE_AGENTS: Record<PlanningStage, string> = {
+  discover: 'solution-architect',
+  design: 'solution-architect',
+  plan: 'technical-planner',
+};
+
+const STAGE_SKILLS: Record<PlanningStage, string | undefined> = {
+  discover: 'brainstorming',
+  design: undefined,
+  plan: 'writing-plans',
+};
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the current planning stage based on the Clarification Gate output
+ * and optional caller-supplied hints.
+ *
+ * Routing rules (evaluated in order):
+ * 1. If `stageHint` is provided → use it directly (caller knows best).
+ * 2. If `clarification.clarificationNeeded === true` → `discover`.
+ * 3. If `clarification.planReady === true` and no stageHint → `plan`
+ *    (clear prompt — skip discover and design).
+ * 4. Otherwise → `design` (clarification resolved, approach not yet confirmed).
+ */
+export function resolvePlanningStage(
+  clarification: ClarificationMetadata,
+  options: PlanningStageOptions = {},
+): PlanningStageMetadata {
+  const stage = resolveStage(clarification, options);
+
+  return {
+    currentStage: stage,
+    stageDescription: STAGE_DESCRIPTIONS[stage],
+    ...(stage !== 'plan' && { nextStage: getNextStage(stage) }),
+    ...(stage !== 'plan' && {
+      stageTransitionHint: STAGE_TRANSITION_HINTS[stage],
+    }),
+    recommendedAgent: STAGE_AGENTS[stage],
+    ...(STAGE_SKILLS[stage] && { recommendedSkill: STAGE_SKILLS[stage] }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function resolveStage(
+  clarification: ClarificationMetadata,
+  options: PlanningStageOptions,
+): PlanningStage {
+  // 1. Explicit caller override
+  if (options.stageHint) {
+    return options.stageHint;
+  }
+
+  // 2. Ambiguous → discover
+  if (clarification.clarificationNeeded) {
+    return 'discover';
+  }
+
+  // 3. Clear / plan-ready → plan (skip discover+design)
+  if (clarification.planReady) {
+    return 'plan';
+  }
+
+  // 4. Fallback: clarification resolved but approach not confirmed → design
+  return 'design';
+}
+
+function getNextStage(stage: 'discover' | 'design'): 'design' | 'plan' {
+  return stage === 'discover' ? 'design' : 'plan';
+}


### PR DESCRIPTION
Closes #1372

## Summary

- Introduces three explicit planning stages instead of jumping from prompt to implementation plan
- Builds on Clarification Gate (#1371) — routes ambiguous prompts through **Discover → Design → Plan**
- Clear/well-specified prompts skip directly to **Plan** stage (backward-compatible)

## Staged flow

| Stage | Agent | Skill | Output |
|-------|-------|-------|--------|
| **Discover** | solution-architect | brainstorming | Questions, constraints, option space |
| **Design** | solution-architect | — | Trade-offs, preferred approach, risks |
| **Plan** | technical-planner | writing-plans | Concrete implementation plan |

## Stage routing (automatic)

| Condition | Stage |
|-----------|-------|
| `clarificationNeeded=true` | discover |
| Clarification resolved, direction not confirmed | design (via `planning_stage` hint) |
| `planReady=true` | plan |
| Budget exhausted | plan (with assumptions) |
| Explicit `planning_stage` hint | whatever the caller says |

## New response fields (PLAN/AUTO only)

```json
{
  "planningStage": {
    "currentStage": "discover",
    "stageDescription": "Discover: Surface questions...",
    "nextStage": "design",
    "stageTransitionHint": "Answer the clarification question(s)...",
    "recommendedAgent": "solution-architect",
    "recommendedSkill": "brainstorming"
  }
}
```

## New input parameter

`planning_stage` (optional enum: `discover` | `design` | `plan`) — overrides automatic routing

## Files changed

- `apps/mcp-server/src/mcp/handlers/planning-stage.ts` — new, pure stage routing module
- `apps/mcp-server/src/mcp/handlers/planning-stage.spec.ts` — new, 23 unit tests
- `apps/mcp-server/src/mcp/handlers/mode.handler.ts` — wires stage into PLAN/AUTO response
- `apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts` — +8 integration tests

## Wave 3 boundary

Did NOT touch:
- `apps/mcp-server/src/agent/stack-matcher*` (#1379)
- `packages/rules/.ai-rules/agents/*.json` (read only)
- `packages/claude-code-plugin/` (#1377)

## Test plan

- [x] `yarn workspace codingbuddy lint` — 0 errors
- [x] `yarn workspace codingbuddy format:check` — clean
- [x] `yarn workspace codingbuddy typecheck` — clean
- [x] `yarn workspace codingbuddy test` — 6092 passing, 2 skipped
- [x] `yarn workspace codingbuddy circular` — no circular deps
- [x] `yarn workspace codingbuddy build` — success