### PR TITLE
feat(mcp-server): gate expensive specialist execution until clarification confirmed

### DIFF
--- a/apps/mcp-server/src/mcp/handlers/execution-gate.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/execution-gate.spec.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateExecutionGate, type ExecutionGateInput } from './execution-gate';
+import type { ClarificationMetadata } from './clarification-gate';
+import type { PlanningStageMetadata } from './planning-stage';
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+function ambiguousClarification(): ClarificationMetadata {
+  return {
+    clarificationNeeded: true,
+    planReady: false,
+    questionBudget: 2,
+    nextQuestion: 'What should change?',
+    clarificationTopics: ['vague-intent'],
+  };
+}
+
+function clearClarification(): ClarificationMetadata {
+  return {
+    clarificationNeeded: false,
+    planReady: true,
+    questionBudget: 3,
+  };
+}
+
+function budgetExhaustedClarification(): ClarificationMetadata {
+  return {
+    clarificationNeeded: false,
+    planReady: true,
+    questionBudget: 0,
+    assumptionNote: 'Proceeding with assumptions.',
+  };
+}
+
+function discoverStage(): PlanningStageMetadata {
+  return {
+    currentStage: 'discover',
+    stageDescription: 'Discover: Surface questions...',
+    nextStage: 'design',
+    stageTransitionHint: 'Answer clarification to proceed.',
+    recommendedAgent: 'solution-architect',
+    recommendedSkill: 'brainstorming',
+  };
+}
+
+function designStage(): PlanningStageMetadata {
+  return {
+    currentStage: 'design',
+    stageDescription: 'Design: Synthesize approaches...',
+    nextStage: 'plan',
+    stageTransitionHint: 'Confirm approach to proceed.',
+    recommendedAgent: 'solution-architect',
+  };
+}
+
+function planStage(): PlanningStageMetadata {
+  return {
+    currentStage: 'plan',
+    stageDescription: 'Plan: Produce implementation plan.',
+    recommendedAgent: 'technical-planner',
+    recommendedSkill: 'writing-plans',
+  };
+}
+
+const SAMPLE_SPECIALISTS = [
+  'security-specialist',
+  'performance-specialist',
+  'code-quality-specialist',
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('execution-gate', () => {
+  describe('evaluateExecutionGate', () => {
+    // ------------------------------------------------------------------
+    // Gated scenarios
+    // ------------------------------------------------------------------
+
+    describe('gated (ambiguous / early stage)', () => {
+      it('gates when clarificationNeeded=true', () => {
+        const input: ExecutionGateInput = {
+          clarification: ambiguousClarification(),
+          specialists: SAMPLE_SPECIALISTS,
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.gated).toBe(true);
+        expect(result.reason).toContain('ambiguous');
+        expect(result.unblockCondition).toBeTruthy();
+        expect(result.deferredSpecialists).toEqual(SAMPLE_SPECIALISTS);
+      });
+
+      it('gates when currentStage=discover', () => {
+        const input: ExecutionGateInput = {
+          clarification: { clarificationNeeded: false, planReady: false },
+          planningStage: discoverStage(),
+          specialists: SAMPLE_SPECIALISTS,
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.gated).toBe(true);
+        expect(result.reason).toContain('discover');
+        expect(result.unblockCondition).toContain('Design');
+      });
+
+      it('gates when currentStage=design', () => {
+        const input: ExecutionGateInput = {
+          clarification: { clarificationNeeded: false, planReady: false },
+          planningStage: designStage(),
+          specialists: SAMPLE_SPECIALISTS,
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.gated).toBe(true);
+        expect(result.reason).toContain('design');
+        expect(result.unblockCondition).toContain('Plan');
+      });
+
+      it('defers specialists list when gated', () => {
+        const input: ExecutionGateInput = {
+          clarification: ambiguousClarification(),
+          specialists: ['security-specialist', 'accessibility-specialist'],
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.deferredSpecialists).toEqual([
+          'security-specialist',
+          'accessibility-specialist',
+        ]);
+      });
+
+      it('omits deferredSpecialists when no specialists provided', () => {
+        const input: ExecutionGateInput = {
+          clarification: ambiguousClarification(),
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.gated).toBe(true);
+        expect(result.deferredSpecialists).toBeUndefined();
+      });
+
+      it('omits deferredSpecialists when specialists list is empty', () => {
+        const input: ExecutionGateInput = {
+          clarification: ambiguousClarification(),
+          specialists: [],
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.gated).toBe(true);
+        expect(result.deferredSpecialists).toBeUndefined();
+      });
+    });
+
+    // ------------------------------------------------------------------
+    // Ungated scenarios
+    // ------------------------------------------------------------------
+
+    describe('ungated (clear / plan stage)', () => {
+      it('does not gate when planReady=true', () => {
+        const input: ExecutionGateInput = {
+          clarification: clearClarification(),
+          specialists: SAMPLE_SPECIALISTS,
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.gated).toBe(false);
+        expect(result.reason).toContain('clear');
+        expect(result.unblockCondition).toBeUndefined();
+        expect(result.deferredSpecialists).toBeUndefined();
+      });
+
+      it('does not gate when currentStage=plan', () => {
+        const input: ExecutionGateInput = {
+          clarification: clearClarification(),
+          planningStage: planStage(),
+          specialists: SAMPLE_SPECIALISTS,
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.gated).toBe(false);
+      });
+
+      it('does not gate when budget is exhausted (planReady forced)', () => {
+        const input: ExecutionGateInput = {
+          clarification: budgetExhaustedClarification(),
+          specialists: SAMPLE_SPECIALISTS,
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.gated).toBe(false);
+      });
+
+      it('planReady=true overrides discover stage', () => {
+        const input: ExecutionGateInput = {
+          clarification: clearClarification(),
+          planningStage: discoverStage(),
+          specialists: SAMPLE_SPECIALISTS,
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        // planReady takes precedence over stage
+        expect(result.gated).toBe(false);
+      });
+
+      it('planReady=true overrides design stage', () => {
+        const input: ExecutionGateInput = {
+          clarification: clearClarification(),
+          planningStage: designStage(),
+          specialists: SAMPLE_SPECIALISTS,
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.gated).toBe(false);
+      });
+    });
+
+    // ------------------------------------------------------------------
+    // Priority / edge cases
+    // ------------------------------------------------------------------
+
+    describe('priority and edge cases', () => {
+      it('clarificationNeeded takes priority over planningStage', () => {
+        const input: ExecutionGateInput = {
+          clarification: ambiguousClarification(),
+          planningStage: planStage(), // even though stage says plan
+          specialists: SAMPLE_SPECIALISTS,
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        // clarificationNeeded=true is checked before stage
+        expect(result.gated).toBe(true);
+        expect(result.reason).toContain('ambiguous');
+      });
+
+      it('works without planningStage metadata', () => {
+        const input: ExecutionGateInput = {
+          clarification: clearClarification(),
+          // no planningStage
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.gated).toBe(false);
+      });
+
+      it('does not mutate the input specialists array', () => {
+        const specialists = ['a', 'b', 'c'];
+        const input: ExecutionGateInput = {
+          clarification: ambiguousClarification(),
+          specialists,
+        };
+
+        const result = evaluateExecutionGate(input);
+
+        expect(result.deferredSpecialists).toEqual(['a', 'b', 'c']);
+        expect(result.deferredSpecialists).not.toBe(specialists); // different reference
+      });
+    });
+  });
+});

--- a/apps/mcp-server/src/mcp/handlers/execution-gate.ts
+++ b/apps/mcp-server/src/mcp/handlers/execution-gate.ts
@@ -1,0 +1,117 @@
+/**
+ * Execution Gate — delay expensive specialist dispatch until clarification
+ * is confirmed (#1378).
+ *
+ * When a request is still ambiguous (discover/design stage or
+ * clarificationNeeded=true), dispatching specialists and tool-heavy
+ * execution creates unnecessary cost and noise. This gate holds
+ * expensive work until the user has confirmed direction.
+ *
+ * Like the Clarification Gate and Planning Stage, this module is
+ * intentionally pure and free of NestJS dependencies.
+ */
+
+import type { ClarificationMetadata } from './clarification-gate';
+import type { PlanningStageMetadata } from './planning-stage';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Execution gate metadata included in the PLAN/AUTO parse_mode response. */
+export interface ExecutionGate {
+  /** True when expensive execution (specialist dispatch, tool-heavy work) is held. */
+  gated: boolean;
+  /** Human-readable reason for the current gate state. */
+  reason: string;
+  /** What must happen for the gate to open. Undefined when not gated. */
+  unblockCondition?: string;
+  /** Specialists that would have been dispatched but are deferred. Present only when gated. */
+  deferredSpecialists?: string[];
+}
+
+/** Inputs consumed by the execution gate evaluator. */
+export interface ExecutionGateInput {
+  /** Clarification metadata from the Clarification Gate (#1371). */
+  clarification: ClarificationMetadata;
+  /** Planning stage metadata from the Stage Router (#1372). */
+  planningStage?: PlanningStageMetadata;
+  /** Specialists that would normally be dispatched. */
+  specialists?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const GATED_STAGES = new Set(['discover', 'design']);
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate whether expensive execution should be gated based on
+ * clarification status and planning stage.
+ *
+ * Gating rules (evaluated in order):
+ * 1. `planReady=true` → ungated (request is clear enough to execute).
+ * 2. `clarificationNeeded=true` → gated (ambiguous).
+ * 3. `currentStage` in {discover, design} → gated (still exploring).
+ * 4. Otherwise → ungated.
+ */
+export function evaluateExecutionGate(input: ExecutionGateInput): ExecutionGate {
+  const { clarification, planningStage, specialists } = input;
+
+  // 1. planReady → always ungated
+  if (clarification.planReady) {
+    return {
+      gated: false,
+      reason: 'Request is clear — full specialist dispatch permitted.',
+    };
+  }
+
+  // 2. clarificationNeeded → gated
+  if (clarification.clarificationNeeded) {
+    return buildGatedResult(
+      'Request is ambiguous — specialist dispatch deferred until clarification is resolved.',
+      'Resolve clarification questions or provide an explicit override (e.g., "just do it").',
+      specialists,
+    );
+  }
+
+  // 3. Stage-based gating (discover/design)
+  if (planningStage && GATED_STAGES.has(planningStage.currentStage)) {
+    const stageName = planningStage.currentStage;
+    return buildGatedResult(
+      `Currently in ${stageName} stage — specialist dispatch deferred until plan stage.`,
+      stageName === 'discover'
+        ? 'Confirm direction to proceed through Design to Plan.'
+        : 'Confirm approach to proceed to Plan.',
+      specialists,
+    );
+  }
+
+  // 4. Fallback — ungated
+  return {
+    gated: false,
+    reason: 'Execution permitted — no gating conditions active.',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildGatedResult(
+  reason: string,
+  unblockCondition: string,
+  specialists?: string[],
+): ExecutionGate {
+  return {
+    gated: true,
+    reason,
+    unblockCondition,
+    ...(specialists?.length && { deferredSpecialists: [...specialists] }),
+  };
+}

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts
@@ -1798,4 +1798,129 @@ describe('ModeHandler', () => {
       expect(parsed.planningStage.recommendedAgent).toBe('technical-planner');
     });
   });
+
+  // ==========================================================================
+  // Execution Gate (#1378)
+  // ==========================================================================
+  describe('parse_mode Execution Gate (#1378)', () => {
+    it('gates execution for ambiguous PLAN prompt', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: '개선해줘',
+        parallelAgentsRecommendation: {
+          specialists: ['security-specialist', 'performance-specialist'],
+          dispatch: 'recommend',
+        },
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN 개선해줘',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.executionGate).toBeDefined();
+      expect(parsed.executionGate.gated).toBe(true);
+      expect(parsed.executionGate.reason).toBeTruthy();
+      expect(parsed.executionGate.unblockCondition).toBeTruthy();
+      expect(parsed.executionGate.deferredSpecialists).toEqual([
+        'security-specialist',
+        'performance-specialist',
+      ]);
+    });
+
+    it('does not gate execution for clear PLAN prompt', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'add unit tests to apps/mcp-server/src/auth/auth.service.ts',
+        parallelAgentsRecommendation: {
+          specialists: ['test-strategy-specialist'],
+          dispatch: 'recommend',
+        },
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN add unit tests to apps/mcp-server/src/auth/auth.service.ts',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.executionGate).toBeDefined();
+      expect(parsed.executionGate.gated).toBe(false);
+      expect(parsed.executionGate.deferredSpecialists).toBeUndefined();
+    });
+
+    it('ungates when budget is exhausted', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'PLAN',
+        originalPrompt: 'improve it',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'PLAN improve it',
+        question_budget: 0,
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.executionGate.gated).toBe(false);
+    });
+
+    it('gates in AUTO mode for ambiguous prompt', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'AUTO',
+        originalPrompt: '개선',
+        parallelAgentsRecommendation: {
+          specialists: ['architecture-specialist'],
+          dispatch: 'auto',
+        },
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'AUTO 개선',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.executionGate).toBeDefined();
+      expect(parsed.executionGate.gated).toBe(true);
+      expect(parsed.executionGate.deferredSpecialists).toEqual(['architecture-specialist']);
+    });
+
+    it('does NOT include executionGate for ACT mode', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'ACT',
+        originalPrompt: 'implement feature',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'ACT implement feature',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.executionGate).toBeUndefined();
+    });
+
+    it('does NOT include executionGate for EVAL mode', async () => {
+      mockKeywordService.parseMode = vi.fn().mockResolvedValue({
+        ...mockParseModeResult,
+        mode: 'EVAL',
+        originalPrompt: 'review code',
+      });
+
+      const result = await handler.handle('parse_mode', {
+        prompt: 'EVAL review code',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse((result?.content[0] as { text: string }).text);
+      expect(parsed.executionGate).toBeUndefined();
+    });
+  });
 });

--- a/apps/mcp-server/src/mcp/handlers/mode.handler.ts
+++ b/apps/mcp-server/src/mcp/handlers/mode.handler.ts
@@ -44,6 +44,7 @@ import { ImpactEventService } from '../../impact';
 import { RuleEventCollector } from '../../rules/rule-event-collector';
 import { evaluateClarification, type ClarificationMetadata } from './clarification-gate';
 import { resolvePlanningStage, type PlanningStageMetadata } from './planning-stage';
+import { evaluateExecutionGate, type ExecutionGate } from './execution-gate';
 
 /** Maximum length for context title slug generation */
 const CONTEXT_TITLE_MAX_LENGTH = 50;
@@ -352,6 +353,15 @@ export class ModeHandler extends AbstractHandler {
         planningStageHint,
       );
 
+      // Execution Gate (#1378) — delay expensive specialist dispatch
+      // until clarification is confirmed. Only for PLAN/AUTO modes.
+      const executionGate = this.buildExecutionGate(
+        result.mode as Mode,
+        clarification,
+        planningStage,
+        result.parallelAgentsRecommendation?.specialists,
+      );
+
       const response = createJsonResponse({
         ...result,
         language,
@@ -377,6 +387,8 @@ export class ModeHandler extends AbstractHandler {
         ...(clarification && clarification),
         // Include Planning Stage metadata for PLAN/AUTO modes (#1372)
         ...(planningStage && { planningStage }),
+        // Include Execution Gate metadata for PLAN/AUTO modes (#1378)
+        ...(executionGate && { executionGate }),
         // Include context document info (mandatory)
         ...contextResult,
         // Include project root warning when auto-detected and config missing
@@ -636,6 +648,31 @@ export class ModeHandler extends AbstractHandler {
 
     return evaluateClarification(originalPrompt, {
       ...(questionBudget !== undefined && { questionBudget }),
+    });
+  }
+
+  /**
+   * Build Execution Gate metadata for PLAN/AUTO modes (#1378).
+   * Delays specialist dispatch when the request is still ambiguous.
+   * Returns undefined for ACT/EVAL modes.
+   */
+  private buildExecutionGate(
+    mode: Mode,
+    clarification: ClarificationMetadata | undefined,
+    planningStage: PlanningStageMetadata | undefined,
+    specialists?: string[],
+  ): ExecutionGate | undefined {
+    if (mode !== 'PLAN' && mode !== 'AUTO') {
+      return undefined;
+    }
+    if (!clarification) {
+      return undefined;
+    }
+
+    return evaluateExecutionGate({
+      clarification,
+      planningStage,
+      specialists,
     });
   }
 


### PR DESCRIPTION
Closes #1378

## Summary

- Delays specialist dispatch and tool-heavy execution until the request is clarified enough to justify the cost
- Builds on Clarification Gate (#1371) and Staged Planning (#1372)
- When gated, specialists are preserved in `deferredSpecialists` for later dispatch

## Gating rules

| Condition | Result |
|-----------|--------|
| `planReady=true` | **Ungated** — full dispatch |
| `clarificationNeeded=true` | **Gated** — ambiguous request |
| `currentStage` = discover/design | **Gated** — still exploring |
| Budget exhausted (planReady forced) | **Ungated** — proceed with assumptions |
| Otherwise | **Ungated** |

## New response field (PLAN/AUTO only)

```json
{
  "executionGate": {
    "gated": true,
    "reason": "Request is ambiguous — specialist dispatch deferred...",
    "unblockCondition": "Resolve clarification questions or provide override.",
    "deferredSpecialists": ["security-specialist", "performance-specialist"]
  }
}
```

## Files changed

- `apps/mcp-server/src/mcp/handlers/execution-gate.ts` — new, pure gate evaluator
- `apps/mcp-server/src/mcp/handlers/execution-gate.spec.ts` — new, 14 unit tests
- `apps/mcp-server/src/mcp/handlers/mode.handler.ts` — wires gate into PLAN/AUTO response
- `apps/mcp-server/src/mcp/handlers/mode.handler.spec.ts` — +6 integration tests

## Test plan

- [x] `yarn workspace codingbuddy lint` — 0 errors
- [x] `yarn workspace codingbuddy typecheck` — clean
- [x] `yarn workspace codingbuddy test` — 6134 passing, 2 skipped
- [x] `yarn workspace codingbuddy circular` — no circular deps
- [x] `yarn workspace codingbuddy build` — success