### PR TITLE
fix(plugin): track .mcp.json and namespace-manifest.json in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ coverage/
 
 # AI
 .mcp.json
+!packages/claude-code-plugin/.mcp.json
 codingbuddy.config.js
 codingbuddy.config.json
 custom.mdc

--- a/packages/claude-code-plugin/.gitignore
+++ b/packages/claude-code-plugin/.gitignore
@@ -1,7 +1,6 @@
 # Build artifacts
 /dist/
 *.tsbuildinfo
-namespace-manifest.json
 
 # Dependencies
 node_modules/

--- a/packages/claude-code-plugin/.mcp.json
+++ b/packages/claude-code-plugin/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "codingbuddy": {
+      "command": "codingbuddy",
+      "args": [
+        "mcp"
+      ]
+    }
+  }
+}

--- a/packages/claude-code-plugin/namespace-manifest.json
+++ b/packages/claude-code-plugin/namespace-manifest.json
@@ -1,0 +1,38 @@
+{
+  "pluginName": "codingbuddy",
+  "namespace": "codingbuddy:",
+  "separator": ":",
+  "commands": [
+    {
+      "file": "commands/act.md",
+      "bare": "act",
+      "namespaced": "codingbuddy:act"
+    },
+    {
+      "file": "commands/auto.md",
+      "bare": "auto",
+      "namespaced": "codingbuddy:auto"
+    },
+    {
+      "file": "commands/buddy.md",
+      "bare": "buddy",
+      "namespaced": "codingbuddy:buddy"
+    },
+    {
+      "file": "commands/checklist.md",
+      "bare": "checklist",
+      "namespaced": "codingbuddy:checklist"
+    },
+    {
+      "file": "commands/eval.md",
+      "bare": "eval",
+      "namespaced": "codingbuddy:eval"
+    },
+    {
+      "file": "commands/plan.md",
+      "bare": "plan",
+      "namespaced": "codingbuddy:plan"
+    }
+  ],
+  "generatedAt": "2026-04-06T09:54:05.647Z"
+}


### PR DESCRIPTION
## Summary
- Add `!packages/claude-code-plugin/.mcp.json` negation pattern in root `.gitignore` to override the global `.mcp.json` ignore rule
- Remove `namespace-manifest.json` from `packages/claude-code-plugin/.gitignore`
- Git-track both files so `npm pack` reliably includes them in the tarball

**Root cause**: Both files were listed in `package.json` `files` field but gitignored, causing npm to silently exclude them from the tarball. Fresh plugin installs were missing MCP tool configuration.

## Test plan
- [x] `git check-ignore` confirms neither file is ignored
- [x] All codingbuddy-claude-plugin CI checks pass (lint, format, typecheck, test:coverage, circular, build)
- [x] Security audit clean across all workspaces
- [ ] Verify `npm pack` includes both files in the tarball

Closes #1393