### PR TITLE
feat(plugin): live AI guardrails — real-time rule violation interception

### DIFF
--- a/packages/claude-code-plugin/hooks/lib/rule_checker.py
+++ b/packages/claude-code-plugin/hooks/lib/rule_checker.py
@@ -1,0 +1,285 @@
+"""Live AI Guardrails — real-time rule violation detection (#1439).
+
+Intercepts Edit/Write tool calls and checks content against known
+security violation patterns (SQL injection, XSS, hardcoded secrets, etc.).
+Configurable via CODINGBUDDY_GUARDRAIL_LEVEL env var: strict/normal/off.
+"""
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class Violation:
+    """A single rule violation found in code content."""
+
+    rule_id: str
+    severity: str
+    message: str
+    line_content: str
+    suggested_fix: str
+
+
+# --- Comment detection ---
+
+_COMMENT_RE = re.compile(r"^\s*(?:#|//|/\*|\*|<!--)")
+
+_VALID_LEVELS = {"strict", "normal", "off"}
+
+
+def _is_comment(line: str) -> bool:
+    """Check if a line is a comment."""
+    return bool(_COMMENT_RE.match(line))
+
+
+# --- Placeholder / false-positive filters for secrets ---
+
+_PLACEHOLDER_RE = re.compile(
+    r"(?:your[-_]|example|placeholder|changeme|xxx|test|dummy|fake|sample|TODO)",
+    re.IGNORECASE,
+)
+
+_ENV_REF_RE = re.compile(
+    r"(?:os\.environ|process\.env|getenv|ENV\[|config\.|settings\.)",
+    re.IGNORECASE,
+)
+
+
+# --- Pattern definitions ---
+# Each pattern: (compiled_regex, rule_id, severity, message, suggested_fix)
+# Patterns are applied per-line after filtering out comments.
+
+_SQL_KEYWORDS = r"(?:SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|MERGE|REPLACE)\b"
+
+# SQL injection: f-string, %-format, or concatenation with SQL keywords
+_SQL_FSTRING_RE = re.compile(
+    rf'f["\'].*{_SQL_KEYWORDS}.*\{{',
+    re.IGNORECASE,
+)
+_SQL_PERCENT_RE = re.compile(
+    rf'["\'].*{_SQL_KEYWORDS}.*%\s*(?:s|d|r)["\'].*%\s*\w',
+    re.IGNORECASE,
+)
+_SQL_CONCAT_RE = re.compile(
+    rf'["\'].*{_SQL_KEYWORDS}.*["\']\s*\+\s*\w',
+    re.IGNORECASE,
+)
+
+_NORMAL_PATTERNS = [
+    # SEC-001: SQL Injection
+    (
+        _SQL_FSTRING_RE,
+        "SEC-001",
+        "high",
+        "SQL injection detected — dynamic SQL via string interpolation",
+        "Use parameterized queries (e.g., cursor.execute('SELECT ... WHERE id = ?', (id,)))",
+    ),
+    (
+        _SQL_PERCENT_RE,
+        "SEC-001",
+        "high",
+        "SQL injection detected — dynamic SQL via %-formatting",
+        "Use parameterized queries instead of string formatting",
+    ),
+    (
+        _SQL_CONCAT_RE,
+        "SEC-001",
+        "high",
+        "SQL injection detected — dynamic SQL via string concatenation",
+        "Use parameterized queries instead of string concatenation",
+    ),
+    # SEC-002: XSS
+    (
+        re.compile(r"\.\s*innerHTML\s*=", re.IGNORECASE),
+        "SEC-002",
+        "high",
+        "XSS risk — direct innerHTML assignment",
+        "Use textContent for plain text, or sanitize with DOMPurify before assigning innerHTML",
+    ),
+    (
+        re.compile(r"document\.write\s*\("),
+        "SEC-002",
+        "high",
+        "XSS risk — document.write with potentially unsafe content",
+        "Use DOM APIs (createElement/textContent) instead of document.write",
+    ),
+    (
+        re.compile(r"dangerouslySetInnerHTML"),
+        "SEC-002",
+        "high",
+        "XSS risk — dangerouslySetInnerHTML bypasses React's XSS protection",
+        "Sanitize content with DOMPurify before using dangerouslySetInnerHTML",
+    ),
+    # SEC-004: Dangerous eval/exec
+    (
+        re.compile(r"\beval\s*\("),
+        "SEC-004",
+        "high",
+        "Dangerous eval() call — arbitrary code execution risk",
+        "Avoid eval(). Use JSON.parse() for data, or ast.literal_eval() for Python literals",
+    ),
+    (
+        re.compile(r"\bexec\s*\("),
+        "SEC-004",
+        "high",
+        "Dangerous exec() call — arbitrary code execution risk",
+        "Avoid exec(). Use safer alternatives like importlib or specific parsers",
+    ),
+]
+
+# SEC-003: Hardcoded secrets — handled separately with extra false-positive filtering
+_SECRET_KEY_RE = re.compile(
+    r"""(?:api[_-]?key|secret(?:[_-]?key)?|password|passwd|token|auth[_-]?token|private[_-]?key|access[_-]?key)"""
+    r"""\s*=\s*["']([^"']{8,})["']""",
+    re.IGNORECASE,
+)
+
+# AWS access key pattern
+_AWS_KEY_RE = re.compile(
+    r"""(?:aws[_-]?access[_-]?key(?:[_-]?id)?|aws[_-]?secret)\s*=\s*["']([A-Za-z0-9/+=]{16,})["']""",
+    re.IGNORECASE,
+)
+
+# Generic variable names containing "secret" but not caught above
+_GENERIC_SECRET_RE = re.compile(
+    r"""(?:secret|credential|private_key)\s*=\s*["']([^"']{8,})["']""",
+    re.IGNORECASE,
+)
+
+# Strict-only patterns
+_STRICT_PATTERNS = [
+    # SEC-005: Shell injection
+    (
+        re.compile(r"subprocess\.\w+\(.*shell\s*=\s*True", re.DOTALL),
+        "SEC-005",
+        "medium",
+        "Shell injection risk — subprocess with shell=True",
+        "Use subprocess.run(cmd_list) without shell=True, passing args as a list",
+    ),
+    (
+        re.compile(r"os\.system\s*\("),
+        "SEC-005",
+        "medium",
+        "Shell injection risk — os.system allows arbitrary command execution",
+        "Use subprocess.run(cmd_list) instead of os.system()",
+    ),
+]
+
+
+class RuleChecker:
+    """Checks code content against known security violation patterns."""
+
+    def __init__(self) -> None:
+        raw = os.environ.get("CODINGBUDDY_GUARDRAIL_LEVEL", "normal").lower()
+        self.level: str = raw if raw in _VALID_LEVELS else "normal"
+
+    def check(self, content: str) -> List[Violation]:
+        """Check code content for violations.
+
+        Args:
+            content: Code content string (possibly multiline).
+
+        Returns:
+            List of Violation objects found. Empty if level is 'off'.
+        """
+        if self.level == "off":
+            return []
+
+        violations: List[Violation] = []
+        lines = content.split("\n")
+
+        for line in lines:
+            stripped = line.strip()
+            if not stripped or _is_comment(stripped):
+                continue
+
+            # Normal patterns (always active)
+            for regex, rule_id, severity, message, fix in _NORMAL_PATTERNS:
+                if regex.search(stripped):
+                    violations.append(
+                        Violation(rule_id, severity, message, stripped, fix)
+                    )
+
+            # SEC-003: Hardcoded secrets (special handling)
+            self._check_secrets(stripped, violations)
+
+            # Strict-only patterns
+            if self.level == "strict":
+                for regex, rule_id, severity, message, fix in _STRICT_PATTERNS:
+                    if regex.search(stripped):
+                        violations.append(
+                            Violation(rule_id, severity, message, stripped, fix)
+                        )
+
+        return violations
+
+    def _check_secrets(self, line: str, violations: List[Violation]) -> None:
+        """Check a line for hardcoded secrets with false-positive filtering."""
+        # Skip if line references env vars
+        if _ENV_REF_RE.search(line):
+            return
+
+        # AWS access key IDs (AKIA prefix) — always flag, skip placeholder filter
+        aws_match = _AWS_KEY_RE.search(line)
+        if aws_match:
+            value = aws_match.group(1)
+            if len(value) >= 16:
+                violations.append(
+                    Violation(
+                        rule_id="SEC-003",
+                        severity="high",
+                        message="Hardcoded AWS credential detected — must not be in source code",
+                        line_content=line,
+                        suggested_fix="Use environment variables (AWS_ACCESS_KEY_ID) or AWS credentials file",
+                    )
+                )
+                return
+
+        for regex in (_SECRET_KEY_RE, _GENERIC_SECRET_RE):
+            match = regex.search(line)
+            if match:
+                value = match.group(1)
+                # Skip empty, very short, or placeholder values
+                if len(value) < 8:
+                    continue
+                if _PLACEHOLDER_RE.search(value):
+                    continue
+                violations.append(
+                    Violation(
+                        rule_id="SEC-003",
+                        severity="high",
+                        message="Hardcoded secret detected — credentials should not be in source code",
+                        line_content=line,
+                        suggested_fix="Use environment variables (os.environ / process.env) or a secrets manager",
+                    )
+                )
+                return  # One match per line is enough
+
+    def check_tool_input(
+        self, tool_name: str, tool_input: dict
+    ) -> List[Violation]:
+        """Check a PreToolUse tool_input for violations.
+
+        Only checks Edit and Write tool calls.
+
+        Args:
+            tool_name: Name of the tool being called.
+            tool_input: The tool_input dict from the hook.
+
+        Returns:
+            List of violations found in the content.
+        """
+        if tool_name not in ("Edit", "Write"):
+            return []
+
+        content: Optional[str] = None
+        if tool_name == "Edit":
+            content = tool_input.get("new_string", "")
+        elif tool_name == "Write":
+            content = tool_input.get("content", "")
+
+        if not content:
+            return []
+
+        return self.check(content)

--- a/packages/claude-code-plugin/hooks/lib/violation_renderer.py
+++ b/packages/claude-code-plugin/hooks/lib/violation_renderer.py
@@ -1,0 +1,93 @@
+"""Violation message renderer for Live AI Guardrails (#1439).
+
+Renders clear, actionable violation messages with unicode box formatting,
+rule references, and suggested fixes.
+"""
+from typing import List
+
+from rule_checker import Violation
+
+
+# Severity display
+_SEVERITY_ICONS = {
+    "high": "\u2718",     # ✘
+    "medium": "\u26a0",   # ⚠
+    "low": "\u2139",      # ℹ
+}
+
+
+class ViolationRenderer:
+    """Renders violation messages for terminal and hook output."""
+
+    def render(self, violations: List[Violation]) -> str:
+        """Render violations as a formatted unicode box message.
+
+        Args:
+            violations: List of Violation objects.
+
+        Returns:
+            Formatted string with box-drawing characters, or empty string.
+        """
+        if not violations:
+            return ""
+
+        count = len(violations)
+        header = f" CodingBuddy Guardrail \u2502 {count} violation(s) found "
+        width = max(len(header) + 4, 60)
+
+        lines: list[str] = []
+        lines.append("\u250c" + "\u2500" * (width - 2) + "\u2510")
+        lines.append("\u2502" + header.center(width - 2) + "\u2502")
+        lines.append("\u251c" + "\u2500" * (width - 2) + "\u2524")
+
+        for i, v in enumerate(violations):
+            icon = _SEVERITY_ICONS.get(v.severity, "?")
+            lines.append(
+                "\u2502"
+                + f"  {icon} [{v.severity.upper()}] {v.rule_id}: {v.message}".ljust(width - 2)
+                + "\u2502"
+            )
+            # Truncate long line content
+            content = v.line_content
+            if len(content) > width - 12:
+                content = content[: width - 15] + "..."
+            lines.append(
+                "\u2502"
+                + f"    \u2514\u2500 {content}".ljust(width - 2)
+                + "\u2502"
+            )
+            lines.append(
+                "\u2502"
+                + f"    \u21b3 Fix: {v.suggested_fix}".ljust(width - 2)
+                + "\u2502"
+            )
+            if i < count - 1:
+                lines.append(
+                    "\u2502" + " " * (width - 2) + "\u2502"
+                )
+
+        lines.append("\u2514" + "\u2500" * (width - 2) + "\u2518")
+        return "\n".join(lines)
+
+    def render_for_hook(self, violations: List[Violation]) -> str:
+        """Render violations as concise additionalContext for PreToolUse hook.
+
+        Args:
+            violations: List of Violation objects.
+
+        Returns:
+            Compact string for hook additionalContext, or empty string.
+        """
+        if not violations:
+            return ""
+
+        parts: list[str] = []
+        parts.append(
+            f"[CodingBuddy Guardrail] {len(violations)} violation(s) detected:"
+        )
+        for v in violations:
+            parts.append(
+                f"  - {v.rule_id} ({v.severity.upper()}): {v.message}. "
+                f"Fix: {v.suggested_fix}"
+            )
+        return "\n".join(parts)

--- a/packages/claude-code-plugin/hooks/pre-tool-use.py
+++ b/packages/claude-code-plugin/hooks/pre-tool-use.py
@@ -26,6 +26,8 @@ from config import get_config
 from agent_status import build_status_message
 from adaptive_perf import get_monitor
 from tdd_progress import build_tdd_indicator
+from rule_checker import RuleChecker
+from violation_renderer import ViolationRenderer
 
 # Pattern to detect git commit in a command string
 _GIT_COMMIT_RE = re.compile(r"\bgit\s+commit\b")
@@ -215,11 +217,24 @@ def _handle(data: dict) -> Optional[dict]:
         pass
 
     tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
     contexts = []
 
     # Initialize adaptive performance monitor (#1002)
     perf_config = _get_hook_config()
     perf_monitor = get_monitor(perf_config)
+
+    # Live AI Guardrails — intercept Edit/Write for rule violations (#1439)
+    if tool_name in ("Edit", "Write"):
+        try:
+            checker = RuleChecker()
+            if checker.level != "off":
+                violations = checker.check_tool_input(tool_name, tool_input)
+                if violations:
+                    renderer = ViolationRenderer()
+                    contexts.append(renderer.render_for_hook(violations))
+        except Exception:
+            pass
 
     # Bash-specific checks
     if tool_name == "Bash":
@@ -229,7 +244,7 @@ def _handle(data: dict) -> Optional[dict]:
             if file_change_msg:
                 contexts.append(file_change_msg)
 
-        command = data.get("tool_input", {}).get("command", "")
+        command = tool_input.get("command", "")
 
         # Check git commit quality gates and smart test suggestion (#944)
         if _is_git_commit(command):
@@ -254,7 +269,7 @@ def _handle(data: dict) -> Optional[dict]:
     try:
         from hud_helpers import on_tool_start
 
-        on_tool_start(tool_name, data.get("tool_input", {}))
+        on_tool_start(tool_name, tool_input)
     except Exception:
         pass
 

--- a/packages/claude-code-plugin/hooks/tests/test_rule_checker.py
+++ b/packages/claude-code-plugin/hooks/tests/test_rule_checker.py
@@ -1,0 +1,324 @@
+"""Tests for rule_checker — live AI guardrails for PreToolUse (#1439)."""
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "lib")
+)
+
+from rule_checker import RuleChecker, Violation
+
+
+class TestViolationDataclass(unittest.TestCase):
+    """Test Violation structure."""
+
+    def test_violation_has_required_fields(self):
+        v = Violation(
+            rule_id="SEC-001",
+            severity="high",
+            message="SQL injection detected",
+            line_content="query = f\"SELECT * FROM users WHERE id = {user_id}\"",
+            suggested_fix="Use parameterized queries instead of string interpolation",
+        )
+        self.assertEqual(v.rule_id, "SEC-001")
+        self.assertEqual(v.severity, "high")
+        self.assertEqual(v.message, "SQL injection detected")
+        self.assertIn("SELECT", v.line_content)
+        self.assertIn("parameterized", v.suggested_fix)
+
+
+class TestGuardrailLevel(unittest.TestCase):
+    """Test CODINGBUDDY_GUARDRAIL_LEVEL configuration."""
+
+    def test_default_level_is_normal(self):
+        checker = RuleChecker()
+        self.assertEqual(checker.level, "normal")
+
+    def test_level_from_env(self):
+        os.environ["CODINGBUDDY_GUARDRAIL_LEVEL"] = "strict"
+        try:
+            checker = RuleChecker()
+            self.assertEqual(checker.level, "strict")
+        finally:
+            del os.environ["CODINGBUDDY_GUARDRAIL_LEVEL"]
+
+    def test_level_off_disables_checking(self):
+        os.environ["CODINGBUDDY_GUARDRAIL_LEVEL"] = "off"
+        try:
+            checker = RuleChecker()
+            result = checker.check("query = f\"SELECT * FROM users WHERE id = {uid}\"")
+            self.assertEqual(result, [])
+        finally:
+            del os.environ["CODINGBUDDY_GUARDRAIL_LEVEL"]
+
+    def test_invalid_level_defaults_to_normal(self):
+        os.environ["CODINGBUDDY_GUARDRAIL_LEVEL"] = "invalid"
+        try:
+            checker = RuleChecker()
+            self.assertEqual(checker.level, "normal")
+        finally:
+            del os.environ["CODINGBUDDY_GUARDRAIL_LEVEL"]
+
+
+class TestSQLInjectionDetection(unittest.TestCase):
+    """Test SQL injection pattern detection."""
+
+    def setUp(self):
+        self.checker = RuleChecker()
+
+    def test_fstring_sql_injection(self):
+        code = 'query = f"SELECT * FROM users WHERE id = {user_id}"'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-001" for v in violations))
+
+    def test_format_sql_injection(self):
+        code = 'query = "SELECT * FROM users WHERE id = %s" % user_id'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-001" for v in violations))
+
+    def test_concat_sql_injection(self):
+        code = 'query = "SELECT * FROM users WHERE id = " + user_id'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-001" for v in violations))
+
+    def test_parameterized_query_no_violation(self):
+        code = 'cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))'
+        violations = self.checker.check(code)
+        self.assertFalse(any(v.rule_id == "SEC-001" for v in violations))
+
+    def test_sql_keyword_in_comment_no_violation(self):
+        code = '# SELECT * FROM users WHERE id = {user_id}'
+        violations = self.checker.check(code)
+        self.assertFalse(any(v.rule_id == "SEC-001" for v in violations))
+
+    def test_sql_in_string_constant_no_violation(self):
+        """Static SQL without interpolation should not trigger."""
+        code = 'QUERY = "SELECT * FROM users WHERE active = true"'
+        violations = self.checker.check(code)
+        self.assertFalse(any(v.rule_id == "SEC-001" for v in violations))
+
+
+class TestXSSDetection(unittest.TestCase):
+    """Test XSS pattern detection."""
+
+    def setUp(self):
+        self.checker = RuleChecker()
+
+    def test_innerhtml_assignment(self):
+        code = 'element.innerHTML = userInput'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-002" for v in violations))
+
+    def test_document_write(self):
+        code = 'document.write(userContent)'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-002" for v in violations))
+
+    def test_dangerouslysetinnerhtml(self):
+        code = '<div dangerouslySetInnerHTML={{__html: userInput}} />'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-002" for v in violations))
+
+    def test_innerhtml_in_comment_no_violation(self):
+        code = '// element.innerHTML = sanitized'
+        violations = self.checker.check(code)
+        self.assertFalse(any(v.rule_id == "SEC-002" for v in violations))
+
+
+class TestHardcodedSecretsDetection(unittest.TestCase):
+    """Test hardcoded secrets pattern detection."""
+
+    def setUp(self):
+        self.checker = RuleChecker()
+
+    def test_api_key_assignment(self):
+        code = 'API_KEY = "sk-1234567890abcdef1234567890abcdef"'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-003" for v in violations))
+
+    def test_password_assignment(self):
+        code = 'password = "my_super_secret_password"'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-003" for v in violations))
+
+    def test_secret_assignment(self):
+        code = 'SECRET_KEY = "abcdef1234567890"'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-003" for v in violations))
+
+    def test_aws_key_pattern(self):
+        code = 'aws_access_key = "AKIAIOSFODNN7EXAMPLE"'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-003" for v in violations))
+
+    def test_env_var_reference_no_violation(self):
+        code = 'API_KEY = os.environ["API_KEY"]'
+        violations = self.checker.check(code)
+        self.assertFalse(any(v.rule_id == "SEC-003" for v in violations))
+
+    def test_placeholder_no_violation(self):
+        code = 'API_KEY = "your-api-key-here"'
+        violations = self.checker.check(code)
+        self.assertFalse(any(v.rule_id == "SEC-003" for v in violations))
+
+    def test_empty_string_no_violation(self):
+        code = 'password = ""'
+        violations = self.checker.check(code)
+        self.assertFalse(any(v.rule_id == "SEC-003" for v in violations))
+
+    def test_secret_in_comment_no_violation(self):
+        code = '# SECRET_KEY = "abcdef1234567890"'
+        violations = self.checker.check(code)
+        self.assertFalse(any(v.rule_id == "SEC-003" for v in violations))
+
+
+class TestEvalDetection(unittest.TestCase):
+    """Test dangerous eval/exec detection."""
+
+    def setUp(self):
+        self.checker = RuleChecker()
+
+    def test_eval_call(self):
+        code = 'result = eval(user_input)'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-004" for v in violations))
+
+    def test_exec_call(self):
+        code = 'exec(user_code)'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-004" for v in violations))
+
+    def test_eval_in_comment_no_violation(self):
+        code = '# eval(something)'
+        violations = self.checker.check(code)
+        self.assertFalse(any(v.rule_id == "SEC-004" for v in violations))
+
+
+class TestStrictMode(unittest.TestCase):
+    """Test strict mode catches additional patterns."""
+
+    def setUp(self):
+        os.environ["CODINGBUDDY_GUARDRAIL_LEVEL"] = "strict"
+        self.checker = RuleChecker()
+
+    def tearDown(self):
+        del os.environ["CODINGBUDDY_GUARDRAIL_LEVEL"]
+
+    def test_subprocess_shell_true(self):
+        code = 'subprocess.run(cmd, shell=True)'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-005" for v in violations))
+
+    def test_os_system_call(self):
+        code = 'os.system(user_command)'
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-005" for v in violations))
+
+    def test_subprocess_shell_true_not_in_normal(self):
+        """Normal mode should not flag shell=True."""
+        os.environ["CODINGBUDDY_GUARDRAIL_LEVEL"] = "normal"
+        checker = RuleChecker()
+        code = 'subprocess.run(cmd, shell=True)'
+        violations = checker.check(code)
+        self.assertFalse(any(v.rule_id == "SEC-005" for v in violations))
+
+
+class TestToolInputExtraction(unittest.TestCase):
+    """Test extracting content from Edit/Write tool_input."""
+
+    def setUp(self):
+        self.checker = RuleChecker()
+
+    def test_check_tool_input_edit(self):
+        tool_input = {
+            "file_path": "/src/db.py",
+            "new_string": 'query = f"DELETE FROM users WHERE id = {uid}"',
+            "old_string": "pass",
+        }
+        violations = self.checker.check_tool_input("Edit", tool_input)
+        self.assertTrue(any(v.rule_id == "SEC-001" for v in violations))
+
+    def test_check_tool_input_write(self):
+        tool_input = {
+            "file_path": "/src/app.py",
+            "content": 'SECRET = "hardcoded_secret_value_12345678"',
+        }
+        violations = self.checker.check_tool_input("Write", tool_input)
+        self.assertTrue(any(v.rule_id == "SEC-003" for v in violations))
+
+    def test_check_tool_input_ignores_other_tools(self):
+        tool_input = {"command": 'echo "SELECT * FROM users"'}
+        violations = self.checker.check_tool_input("Bash", tool_input)
+        self.assertEqual(violations, [])
+
+    def test_check_tool_input_empty(self):
+        violations = self.checker.check_tool_input("Edit", {})
+        self.assertEqual(violations, [])
+
+
+class TestMultilineContent(unittest.TestCase):
+    """Test detection across multiline content."""
+
+    def setUp(self):
+        self.checker = RuleChecker()
+
+    def test_violation_in_multiline(self):
+        code = '''
+import os
+
+def get_user(uid):
+    query = f"SELECT * FROM users WHERE id = {uid}"
+    return db.execute(query)
+'''
+        violations = self.checker.check(code)
+        self.assertTrue(any(v.rule_id == "SEC-001" for v in violations))
+
+    def test_multiple_violations_in_one_content(self):
+        code = '''
+API_KEY = "sk-proj-real-secret-key-1234567890ab"
+result = eval(user_input)
+'''
+        violations = self.checker.check(code)
+        rule_ids = {v.rule_id for v in violations}
+        self.assertIn("SEC-003", rule_ids)
+        self.assertIn("SEC-004", rule_ids)
+
+    def test_no_duplicate_violations(self):
+        """Same pattern on different lines should create separate violations."""
+        code = '''
+q1 = f"SELECT * FROM a WHERE id = {x}"
+q2 = f"SELECT * FROM b WHERE id = {y}"
+'''
+        violations = self.checker.check(code)
+        sec001 = [v for v in violations if v.rule_id == "SEC-001"]
+        self.assertEqual(len(sec001), 2)
+
+
+class TestSeverityLevels(unittest.TestCase):
+    """Test that violations have correct severity."""
+
+    def setUp(self):
+        self.checker = RuleChecker()
+
+    def test_sql_injection_is_high(self):
+        code = 'query = f"SELECT * FROM users WHERE id = {uid}"'
+        violations = self.checker.check(code)
+        sql_v = [v for v in violations if v.rule_id == "SEC-001"]
+        self.assertTrue(all(v.severity == "high" for v in sql_v))
+
+    def test_hardcoded_secret_is_high(self):
+        code = 'API_KEY = "sk-1234567890abcdef1234567890abcdef"'
+        violations = self.checker.check(code)
+        sec_v = [v for v in violations if v.rule_id == "SEC-003"]
+        self.assertTrue(all(v.severity == "high" for v in sec_v))
+
+    def test_eval_is_high(self):
+        code = 'eval(user_input)'
+        violations = self.checker.check(code)
+        eval_v = [v for v in violations if v.rule_id == "SEC-004"]
+        self.assertTrue(all(v.severity == "high" for v in eval_v))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/claude-code-plugin/hooks/tests/test_violation_renderer.py
+++ b/packages/claude-code-plugin/hooks/tests/test_violation_renderer.py
@@ -1,0 +1,168 @@
+"""Tests for violation_renderer — clear violation message formatting (#1439)."""
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "lib")
+)
+
+from rule_checker import Violation
+from violation_renderer import ViolationRenderer
+
+
+class TestViolationRenderer(unittest.TestCase):
+    """Test violation message rendering."""
+
+    def setUp(self):
+        self.renderer = ViolationRenderer()
+
+    def test_render_single_violation(self):
+        violations = [
+            Violation(
+                rule_id="SEC-001",
+                severity="high",
+                message="SQL injection detected",
+                line_content='query = f"SELECT * FROM users WHERE id = {uid}"',
+                suggested_fix="Use parameterized queries",
+            ),
+        ]
+        result = self.renderer.render(violations)
+        self.assertIn("SEC-001", result)
+        self.assertIn("SQL injection", result)
+        self.assertIn("parameterized", result)
+
+    def test_render_multiple_violations(self):
+        violations = [
+            Violation(
+                rule_id="SEC-001",
+                severity="high",
+                message="SQL injection detected",
+                line_content='query = f"SELECT * FROM users WHERE id = {uid}"',
+                suggested_fix="Use parameterized queries",
+            ),
+            Violation(
+                rule_id="SEC-003",
+                severity="high",
+                message="Hardcoded secret detected",
+                line_content='API_KEY = "sk-1234567890abcdef"',
+                suggested_fix="Use environment variables",
+            ),
+        ]
+        result = self.renderer.render(violations)
+        self.assertIn("SEC-001", result)
+        self.assertIn("SEC-003", result)
+
+    def test_render_empty_returns_empty(self):
+        result = self.renderer.render([])
+        self.assertEqual(result, "")
+
+    def test_render_includes_severity(self):
+        violations = [
+            Violation(
+                rule_id="SEC-001",
+                severity="high",
+                message="SQL injection",
+                line_content="x",
+                suggested_fix="fix",
+            ),
+        ]
+        result = self.renderer.render(violations)
+        self.assertIn("HIGH", result.upper())
+
+    def test_render_includes_header(self):
+        violations = [
+            Violation(
+                rule_id="SEC-001",
+                severity="high",
+                message="SQL injection",
+                line_content="x",
+                suggested_fix="fix",
+            ),
+        ]
+        result = self.renderer.render(violations)
+        self.assertIn("CodingBuddy", result)
+        self.assertIn("Guardrail", result)
+
+    def test_render_includes_line_content(self):
+        violations = [
+            Violation(
+                rule_id="SEC-004",
+                severity="high",
+                message="Dangerous eval",
+                line_content="eval(user_input)",
+                suggested_fix="Avoid eval",
+            ),
+        ]
+        result = self.renderer.render(violations)
+        self.assertIn("eval(user_input)", result)
+
+    def test_render_includes_suggested_fix(self):
+        violations = [
+            Violation(
+                rule_id="SEC-002",
+                severity="high",
+                message="XSS risk",
+                line_content="innerHTML = x",
+                suggested_fix="Use textContent or sanitize input",
+            ),
+        ]
+        result = self.renderer.render(violations)
+        self.assertIn("textContent", result)
+
+    def test_render_uses_unicode_box(self):
+        """Output should use unicode box-drawing characters."""
+        violations = [
+            Violation(
+                rule_id="SEC-001",
+                severity="high",
+                message="SQL injection",
+                line_content="x",
+                suggested_fix="fix",
+            ),
+        ]
+        result = self.renderer.render(violations)
+        # Should contain box-drawing characters
+        self.assertTrue(
+            any(c in result for c in "━┃┏┓┗┛╋├┤┬┴│─╭╮╰╯"),
+            "Expected unicode box-drawing characters in output",
+        )
+
+    def test_render_shows_violation_count(self):
+        violations = [
+            Violation("SEC-001", "high", "A", "x", "fix"),
+            Violation("SEC-002", "high", "B", "y", "fix"),
+            Violation("SEC-003", "high", "C", "z", "fix"),
+        ]
+        result = self.renderer.render(violations)
+        self.assertIn("3", result)
+
+
+class TestRenderForHook(unittest.TestCase):
+    """Test rendering formatted for hook additionalContext."""
+
+    def setUp(self):
+        self.renderer = ViolationRenderer()
+
+    def test_render_for_hook_context(self):
+        violations = [
+            Violation(
+                rule_id="SEC-001",
+                severity="high",
+                message="SQL injection detected",
+                line_content='query = f"SELECT * FROM users WHERE id = {uid}"',
+                suggested_fix="Use parameterized queries",
+            ),
+        ]
+        result = self.renderer.render_for_hook(violations)
+        # Should be a concise single-line or few-line format for additionalContext
+        self.assertIn("SEC-001", result)
+        self.assertIn("SQL injection", result)
+
+    def test_render_for_hook_empty(self):
+        result = self.renderer.render_for_hook([])
+        self.assertEqual(result, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `RuleChecker` module that intercepts Edit/Write tool calls in PreToolUse hook and detects security violations before code lands in the codebase
- Detects SQL injection (f-string, %-format, concatenation), XSS (innerHTML, document.write, dangerouslySetInnerHTML), hardcoded secrets (API keys, passwords, AWS credentials), and dangerous eval/exec calls
- Strict mode adds shell injection detection (subprocess shell=True, os.system)
- Add `ViolationRenderer` with unicode box-drawing output and compact hook format
- Configurable via `CODINGBUDDY_GUARDRAIL_LEVEL` env var: `strict`, `normal` (default), `off`
- False-positive filtering: skips comments, env var references, placeholder values
- 50 comprehensive tests covering all patterns and edge cases

## Test plan

- [x] `python3 -m pytest packages/claude-code-plugin/hooks/tests/test_rule_checker.py -v` — 39 tests pass
- [x] `python3 -m pytest packages/claude-code-plugin/hooks/tests/test_violation_renderer.py -v` — 11 tests pass
- [x] Plugin CI: lint, format:check, typecheck, test:coverage, circular, build — all pass
- [x] Security audit: all 3 workspaces clean
- [ ] Verify guardrail triggers on actual Edit with SQL injection content
- [ ] Verify `CODINGBUDDY_GUARDRAIL_LEVEL=off` disables all checks

Closes #1439