### PR TITLE
chore: prepare v5.5.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "codingbuddy",
       "source": "./packages/claude-code-plugin",
       "description": "PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic TDD development",
-      "version": "5.4.1",
+      "version": "5.5.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.5.0] - 2026-04-10
+
+### Added
+
+#### Wow Experience Wave 1 — Memory & Rewards
+- Agent Council Memory (#1435) — specialists now recall prior council decisions and inject them into new sessions for continuity across conversations
+- Micro-Achievements (#1436) — badge-style reward system surfaces small wins (first council, first rule suggestion, first team bootstrap) to reinforce good habits
+
+#### Wow Experience Wave 2 — Intelligence Layer
+- Self-Evolving Rules + `suggest_rules` MCP tool (#1437) — PatternDetector → RuleSuggester pipeline analyzes repeated failure patterns and proposes draft rules for human review (never auto-applied)
+- Smart First Prompt / Context-Aware Onboarding (#1438) — project-specific suggestions driven by tech stack detection replace generic first-run hints
+- Live AI Guardrails (#1439) — real-time rule violation interception during tool use prevents drift before it hits disk
+
+#### Wow Experience Wave 3 — Team Bootstrap
+- `codingbuddy init --team` CLI (#1440) — multi-AI tool adapter auto-detection and generation (Cursor, Claude Code, Codex, Antigravity, Q, Kiro) with sub-issues #1449, #1450, #1451
+
+#### Dramatic Polish
+- Council Assembly Animation (#1441) — staggered specialist arrival effect during council scene rendering for a more cinematic council experience
+
+#### Redesign
+- `activate` MCP tool — one-shot entry point returning rules + primary agent + specialists + discussion format, replacing the multi-step `parse_mode` + `dispatch_agents` ceremony
+- Promoted Claude native Teams as the primary specialist execution strategy; subagent dispatch remains as a fallback for non-Teams environments
+
+### Changed
+- RuleTracker: first-class support for `generatedRule`, `baselineFailureRate`, and `currentFailureRate` fields (#1444)
+- Plugin README template now includes standalone Wave feature rows (scripts/build.ts)
+
+### Fixed
+- Effectiveness scoring write-path wiring for self-evolving rules (#1444)
+- Plugin README build drift — `yarn build` now preserves manual surface additions
+
+### Closed Sub-issues
+- #1442, #1443, #1445, #1446, #1447, #1448 — already implemented, closed with SHA references
+
 ## [5.4.1] - 2026-04-08
 
 ### Added

--- a/README.es.md
+++ b/README.es.md
@@ -24,6 +24,18 @@ Una sola IA no puede ser experta en todo. Codingbuddy crea un equipo de desarrol
 
 ---
 
+## Novedades en v5.5.0 — Wow Experience
+
+- **Agent Council Memory** — los especialistas ahora recuerdan hallazgos previos y se basan en el contexto de los demás entre sesiones.
+- **Live AI Guardrails** — interceptación en tiempo real de violaciones de reglas en Edit/Write con detección de patrones (SQL injection, XSS, secretos hardcodeados, eval/exec).
+- **Self-Evolving Rules** — la herramienta MCP `suggest_rules` analiza patrones de fallos y propone borradores de reglas para revisión humana.
+- **Smart First Prompt** — onboarding contextual que lee tu proyecto y sugiere el mejor modo a seguir.
+- **Team Bootstrap** — `codingbuddy init --team` detecta automáticamente las herramientas de IA instaladas (Cursor, Claude Code, Codex, Antigravity, Q, Kiro) y genera los adaptadores correspondientes con un solo comando.
+- **Micro-Achievements** — hitos desbloqueables para entradas de modo, convocatorias del consejo y ciclos TDD.
+- **Council Assembly Animation** — efecto dramático de llegada escalonada de especialistas al entrar en un modo.
+
+---
+
 ## La Visión
 
 ### El Problema

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,6 +24,18 @@
 
 ---
 
+## v5.5.0 の新機能 — Wow Experience
+
+- **Agent Council Memory** — スペシャリストが以前の分析結果を記憶し、セッションをまたいで互いのコンテキストを積み重ねます。
+- **Live AI Guardrails** — Edit/Write 時のリアルタイムルール違反インターセプトとパターン検出（SQL injection、XSS、ハードコードされたシークレット、eval/exec）。
+- **Self-Evolving Rules** — `suggest_rules` MCP ツールが失敗パターンを分析し、人間によるレビュー用のルール草案を提案します。
+- **Smart First Prompt** — プロジェクトを読み取り、次の最適なモードを提案するコンテキスト対応のオンボーディング。
+- **Team Bootstrap** — `codingbuddy init --team` がインストール済みの AI ツール（Cursor、Claude Code、Codex、Antigravity、Q、Kiro）を自動検出し、1 つのコマンドで対応するアダプターを生成します。
+- **Micro-Achievements** — モード開始、協議会召喚、TDD サイクルのためのアンロック可能なマイルストーン。
+- **Council Assembly Animation** — モード開始時にスペシャリストが段階的に到着する劇的な演出。
+
+---
+
 ## ビジョン
 
 ### 問題

--- a/README.ko.md
+++ b/README.ko.md
@@ -24,6 +24,18 @@
 
 ---
 
+## v5.5.0의 새로운 기능 — Wow Experience
+
+- **Agent Council Memory** — 전문가들이 이전 분석 결과를 기억하고 세션 간에 서로의 컨텍스트를 기반으로 발전합니다.
+- **Live AI Guardrails** — Edit/Write 시 실시간 규칙 위반 감지 및 패턴 탐지 (SQL injection, XSS, 하드코딩된 시크릿, eval/exec).
+- **Self-Evolving Rules** — `suggest_rules` MCP 도구가 실패 패턴을 분석하고 사람이 검토할 규칙 초안을 제안합니다.
+- **Smart First Prompt** — 프로젝트를 읽고 다음에 가장 적합한 모드를 제안하는 컨텍스트 인식 온보딩.
+- **Team Bootstrap** — `codingbuddy init --team`이 설치된 AI 도구(Cursor, Claude Code, Codex, Antigravity, Q, Kiro)를 자동으로 감지하고 한 번에 매칭되는 어댑터를 생성합니다.
+- **Micro-Achievements** — 모드 진입, 협의회 소환, TDD 사이클에 대한 잠금 해제 가능한 마일스톤.
+- **Council Assembly Animation** — 모드 진입 시 전문가가 순차적으로 도착하는 극적인 연출.
+
+---
+
 ## 비전
 
 ### 문제점

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Codingbuddy is a multi-AI MCP server that orchestrates 37 specialist agents acro
 
 ---
 
+## What's New in v5.5.0 — Wow Experience
+
+- **Agent Council Memory** — specialists now remember prior findings and build on each other's context across sessions.
+- **Live AI Guardrails** — real-time rule violation interception on Edit/Write with pattern detection (SQL injection, XSS, hardcoded secrets, eval/exec).
+- **Self-Evolving Rules** — `suggest_rules` MCP tool analyzes failure patterns and proposes draft rules for human review.
+- **Smart First Prompt** — context-aware onboarding that reads your project and suggests the next best mode.
+- **Team Bootstrap** — `codingbuddy init --team` auto-detects installed AI tools (Cursor, Claude Code, Codex, Antigravity, Q, Kiro) and generates matching adapters in one command.
+- **Micro-Achievements** — unlockable milestones for mode entries, council summons, and TDD cycles.
+- **Council Assembly Animation** — dramatic staggered specialist arrival effect on mode entry.
+
+---
+
 ## Session Impact Report
 
 At the end of every session, codingbuddy shows you what actually happened:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,6 +24,18 @@
 
 ---
 
+## v5.5.0 新功能 — Wow Experience
+
+- **Agent Council Memory** — 专家们现在能够记住之前的分析结果，并在跨会话中基于彼此的上下文进行构建。
+- **Live AI Guardrails** — 在 Edit/Write 时实时拦截规则违规，支持模式检测（SQL injection、XSS、硬编码密钥、eval/exec）。
+- **Self-Evolving Rules** — `suggest_rules` MCP 工具分析失败模式并为人工审查提出规则草案。
+- **Smart First Prompt** — 上下文感知的引导流程，读取您的项目并建议下一个最佳模式。
+- **Team Bootstrap** — `codingbuddy init --team` 自动检测已安装的 AI 工具（Cursor、Claude Code、Codex、Antigravity、Q、Kiro），并通过一个命令生成匹配的适配器。
+- **Micro-Achievements** — 针对模式进入、协作会议召集和 TDD 周期的可解锁里程碑。
+- **Council Assembly Animation** — 模式进入时专家错落登场的戏剧化效果。
+
+---
+
 ## 愿景
 
 ### 问题

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -20,6 +20,7 @@ npx codingbuddy init
 | Command | Description |
 |---------|-------------|
 | `codingbuddy init` | Analyze project and generate configuration |
+| `codingbuddy init --team` | Auto-detect installed AI tools and generate adapter configs |
 | `codingbuddy mcp` | Start MCP server (stdio mode by default) |
 | `codingbuddy install <source>` | Install plugin from git URL or registry |
 | `codingbuddy search <query>` | Search plugins in registry |
@@ -42,6 +43,8 @@ npx codingbuddy init
 
 | Tool | Description |
 |------|-------------|
+| `activate` | One-shot entry point returning rules, primary agent, specialists, and discussion format for a prompt. Preferred over `parse_mode` in Claude Code |
+| `suggest_rules` | Analyze execution history for repeated failure patterns and generate draft rule suggestions. Proposed for human review — never auto-applied |
 | `get_project_config` | Get project configuration settings |
 | `search_rules` | Search through rules and guidelines |
 | `get_agent_details` | Get detailed profile of a specialist agent |

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "description": "Multi-AI Rules MCP Server - One source of truth for AI coding rules across all AI assistants",
   "author": "JeremyDev87",
   "license": "MIT",

--- a/apps/mcp-server/src/shared/version.ts
+++ b/apps/mcp-server/src/shared/version.ts
@@ -2,4 +2,4 @@
  * Single source of truth for the runtime package version.
  * Updated automatically by scripts/bump-version.sh on each release.
  */
-export const VERSION = '5.4.1';
+export const VERSION = '5.5.0';

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "description": "PLAN/ACT/EVAL workflow with auto-detection, specialist agents, and reusable skills for systematic TDD development",
   "author": {
     "name": "JeremyDev87",

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -2,7 +2,7 @@
 
 # CodingBuddy Claude Code Plugin
 
-> Version 5.4.1
+> Version 5.5.0
 
 Multi-AI Rules for consistent coding practices - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic development.
 

--- a/packages/claude-code-plugin/namespace-manifest.json
+++ b/packages/claude-code-plugin/namespace-manifest.json
@@ -34,5 +34,5 @@
       "namespaced": "codingbuddy:plan"
     }
   ],
-  "generatedAt": "2026-04-10T09:03:53.981Z"
+  "generatedAt": "2026-04-10T09:36:15.095Z"
 }

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-claude-plugin",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "description": "Claude Code Plugin for CodingBuddy - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills",
   "author": "JeremyDev87",
   "license": "MIT",
@@ -53,7 +53,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "codingbuddy": "^5.4.1"
+    "codingbuddy": "^5.5.0"
   },
   "peerDependenciesMeta": {
     "codingbuddy": {

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-rules",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "description": "AI coding rules for consistent practices across AI assistants",
   "main": "index.js",
   "types": "index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5654,7 +5654,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:4.0.17"
   peerDependencies:
-    codingbuddy: ^5.4.1
+    codingbuddy: ^5.5.0
   peerDependenciesMeta:
     codingbuddy:
       optional: true


### PR DESCRIPTION
## Summary

Bundle Wow Experience Wave 1-3, dramatic polish, and the codingbuddy redesign into a minor release. This PR prepares v5.5.0 but **does not publish it** — the final tag/npm publish/GitHub Release steps are reserved for manual execution by the maintainer.

### Included work

**Wow Experience Wave 1 — Memory & Rewards**
- Agent Council Memory (#1435) — specialists recall prior findings across sessions
- Micro-Achievements (#1436) — unlockable milestones for mode entries, council summons, TDD cycles

**Wow Experience Wave 2 — Intelligence Layer**
- Self-Evolving Rules + `suggest_rules` MCP tool (#1437) — PatternDetector → RuleSuggester pipeline; rules proposed for human review only
- Smart First Prompt (#1438) — context-aware onboarding driven by tech-stack detection
- Live AI Guardrails (#1439) — PreToolUse interception for SQL injection, XSS, secrets, eval/exec

**Wow Experience Wave 3 — Team Bootstrap**
- \`codingbuddy init --team\` CLI (#1440) — multi-AI tool adapter auto-detection for Cursor, Claude Code, Codex, Antigravity, Q, Kiro (sub-issues #1449, #1450, #1451)

**Dramatic Polish**
- Council Assembly Animation (#1441) — staggered specialist arrival effect

**Redesign (carried forward)**
- \`activate\` MCP tool — one-shot entry point
- Promoted Claude native Teams as primary specialist execution strategy

**Fixes**
- #1444 RuleTracker effectiveness write-path (\`generatedRule\`, \`baselineFailureRate\`, \`currentFailureRate\`)
- Plugin README build drift (\`scripts/build.ts\` template sync)

### Version bumps (5.4.1 → 5.5.0)

- \`apps/mcp-server/package.json\` + \`src/shared/version.ts\`
- \`packages/rules/package.json\`
- \`packages/claude-code-plugin/package.json\` + \`.claude-plugin/plugin.json\`
- \`.claude-plugin/marketplace.json\`
- \`yarn.lock\`

### Documentation

- \`CHANGELOG.md\`: new \`## [5.5.0]\` section with complete release notes
- Root README (en + ko + zh-CN + ja + es): new "What's New in v5.5.0" section with 7 bullet highlights
- \`apps/mcp-server/README.md\`: CLI Commands table adds \`init --team\`; new MCP Tools section documents \`activate\` and \`suggest_rules\`
- \`packages/claude-code-plugin/README.md\`: regenerated by \`yarn build\` (5.4.0 → 5.5.0, now picks up latest template)

### Execution strategy

Release prep was executed via **Claude native Teams** with 3 parallel specialists:
- \`changelog-writer\` — CHANGELOG v5.5.0 section
- \`readme-writer\` — 5 root README language variants
- \`mcp-docs\` — apps/mcp-server/README.md

Zero file overlap between workers; main session handled version bump + build + CI + commit.

## Test plan

All checks PASS locally:

- [x] \`yarn workspace codingbuddy\` lint / format:check / typecheck / test:coverage / circular / build
  - **6270 passed / 2 skipped** (247 test files)
- [x] \`yarn workspace codingbuddy-claude-plugin\` lint / format:check / typecheck / test:coverage / circular / build
  - **144 passed** (5 test files)
- [x] Security audit (\`npm audit --severity high\`) for all 3 workspaces (codingbuddy, plugin, landing-page)
- [x] \`yarn workspace codingbuddy-claude-plugin build\` regenerates plugin README cleanly at v5.5.0
- [x] Version files verified (mcp-server, rules, plugin, plugin.json, marketplace.json, version.ts all at 5.5.0)

## Post-merge release steps (NOT included in this PR)

After this PR is reviewed and merged by the maintainer:

\`\`\`bash
git tag v5.5.0
git push origin v5.5.0

# npm publish (each package)
yarn workspace codingbuddy npm publish --access public
yarn workspace codingbuddy-claude-plugin npm publish --access public
yarn workspace codingbuddy-rules npm publish --access public

# GitHub Release
gh release create v5.5.0 --title "v5.5.0 — Wow Experience" --notes-from-tag
\`\`\`