### PR TITLE
chore(release): prepare v5.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "codingbuddy",
       "source": "./packages/claude-code-plugin",
       "description": "PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic TDD development",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.0] - 2026-04-11
+
+### Added
+
+#### HUD Statusbar Wave — Visual Intelligence Layer
+- Breathing Buddy Face (Wave 2-A, #1464) — buddy face reacts to HUD phase (idle/thinking/active/blocked/victory) so the status bar feels alive
+- Cost Velocity Indicator (Wave 2-B, #1464) — session spend-rate badge with 🔥/↗/→/💤 trend glyphs (e.g. `$1.23↗$0.08/m`)
+- Cache Savings Badge (Wave 2-C, #1464) — quantifies prompt-cache savings as `💰$N.NN saved` appended to the cost segment
+- Mode Rainbow Coloring (Wave 2-D, #1464) — per-mode ANSI truecolor gradients (PLAN ◇ blue, ACT ◆ green, EVAL ◈ purple, AUTO ◊ rainbow), NO_COLOR env honored
+- Smart Context Bar (Wave 2-E, #1464) — visual `[████░░░░░░] 42%` progress bar replaces plain `Ctx:42%` with warning/danger thresholds and ⚠ glyph
+- Adaptive Layout Engine (Wave 1-D, #1464) — `fit_segments` adaptive truncation for narrow terminals
+- Rate-limit Severity Icons (Wave 1-C, #1464) — visual rate-limit warnings in the status line
+
+#### HUD Statusbar Wave — Infrastructure
+- Wave 3 Integrator (#1464) — Wave 2-B velocity and Wave 2-C cache savings wired into `format_status_line` with defensive `try/except` imports
+- 9 Modular Lib Extraction (#1464) — `lib/hud_*` modules enable parallel statusbar feature work
+
+### Changed
+- HUD status line: defensive `try/except` imports ensure graceful degradation when optional modules fail
+- Plugin statusline: hoisted `_format_velocity_segment` / `_format_cache_savings` to module top (~0.47μs saved per render, perf-1485 H1)
+
+### Fixed
+- Session self-heal (Wave 1-B, #1468) — stale HUD state detection and recovery
+- Version resolution fallback (Wave 1-A, #1466) — plugin.json fallback when package.json unavailable
+- Narrow exception handling (qual-1465 HIGH-1) — `ImportError` instead of bare `Exception` in 3 fallback import blocks so real bugs (SyntaxError, NameError, AttributeError) surface immediately
+- Signature drift elimination (qual-1465 HIGH-2) — removed inline stub functions for `format_rate_limits` and `_get_fresh_version`
+
+### Security
+- next 16.2.3 bump — GHSA-q4gf-8mx6-v5v3 landing-page fix, `eslint-config-next` aligned
+
+### Test Coverage
+- 381/381 tests pass across the 9 Wave-level test suites and the Wave 3 integration harness (Wave 1-B +24, Wave 2-B +33, Wave 2-C +26, Wave 2-D +35, Wave 2-E +29)
+
 ## [5.5.0] - 2026-04-10
 
 ### Added

--- a/README.es.md
+++ b/README.es.md
@@ -24,15 +24,15 @@ Una sola IA no puede ser experta en todo. Codingbuddy crea un equipo de desarrol
 
 ---
 
-## Novedades en v5.5.0 — Wow Experience
+## Novedades en v5.6.0 — HUD Statusbar Wave
 
-- **Agent Council Memory** — los especialistas ahora recuerdan hallazgos previos y se basan en el contexto de los demás entre sesiones.
-- **Live AI Guardrails** — interceptación en tiempo real de violaciones de reglas en Edit/Write con detección de patrones (SQL injection, XSS, secretos hardcodeados, eval/exec).
-- **Self-Evolving Rules** — la herramienta MCP `suggest_rules` analiza patrones de fallos y propone borradores de reglas para revisión humana.
-- **Smart First Prompt** — onboarding contextual que lee tu proyecto y sugiere el mejor modo a seguir.
-- **Team Bootstrap** — `codingbuddy init --team` detecta automáticamente las herramientas de IA instaladas (Cursor, Claude Code, Codex, Antigravity, Q, Kiro) y genera los adaptadores correspondientes con un solo comando.
-- **Micro-Achievements** — hitos desbloqueables para entradas de modo, convocatorias del consejo y ciclos TDD.
-- **Council Assembly Animation** — efecto dramático de llegada escalonada de especialistas al entrar en un modo.
+- **Breathing Buddy Face** — el rostro del Buddy reacciona a la fase de tu sesión (inactivo / pensando / activo / bloqueado / victoria) para que la barra de estado se sienta viva.
+- **Cost Velocity Indicator** — un badge de ritmo de gasto de sesión con glifos 🔥 / ↗ / → / 💤 te dice si estás en una pasada de planificación lenta o en una refactorización intensa.
+- **Cache Savings Badge** — cuantifica los descuentos de caché de prompts como `💰$N.NN saved` para que veas el valor del caché en tiempo real.
+- **Mode Rainbow Coloring** — gradientes ANSI truecolor por modo (PLAN ◇ / ACT ◆ / EVAL ◈ / AUTO ◊) con soporte para la variable de entorno `NO_COLOR` en CI y terminales en escala de grises.
+- **Smart Context Bar** — una barra de progreso visual `[████░░░░░░] 42%` reemplaza el texto plano `Ctx:42%` con umbrales de advertencia y peligro.
+- **Adaptive Layout Engine** — el HUD se adapta con elegancia a terminales estrechos mediante el truncado adaptativo `fit_segments`.
+- **Rate-limit Severity Icons** — advertencias visuales cuando te acercas a los límites de velocidad de la API.
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,15 +24,15 @@
 
 ---
 
-## v5.5.0 の新機能 — Wow Experience
+## v5.6.0 の新機能 — HUD Statusbar Wave
 
-- **Agent Council Memory** — スペシャリストが以前の分析結果を記憶し、セッションをまたいで互いのコンテキストを積み重ねます。
-- **Live AI Guardrails** — Edit/Write 時のリアルタイムルール違反インターセプトとパターン検出（SQL injection、XSS、ハードコードされたシークレット、eval/exec）。
-- **Self-Evolving Rules** — `suggest_rules` MCP ツールが失敗パターンを分析し、人間によるレビュー用のルール草案を提案します。
-- **Smart First Prompt** — プロジェクトを読み取り、次の最適なモードを提案するコンテキスト対応のオンボーディング。
-- **Team Bootstrap** — `codingbuddy init --team` がインストール済みの AI ツール（Cursor、Claude Code、Codex、Antigravity、Q、Kiro）を自動検出し、1 つのコマンドで対応するアダプターを生成します。
-- **Micro-Achievements** — モード開始、協議会召喚、TDD サイクルのためのアンロック可能なマイルストーン。
-- **Council Assembly Animation** — モード開始時にスペシャリストが段階的に到着する劇的な演出。
+- **Breathing Buddy Face** — Buddy の表情がセッションのフェーズ（アイドル / 思考中 / 実行中 / ブロック / 完了）に反応し、ステータスバーに生命感を与えます。
+- **Cost Velocity Indicator** — 🔥 / ↗ / → / 💤 のトレンドグリフ付きセッション支出レートバッジが、ゆっくりとした計画パスか熱いリファクタリングかを教えてくれます。
+- **Cache Savings Badge** — プロンプトキャッシュの割引額を `💰$N.NN saved` として数値化し、キャッシュの価値をリアルタイムで可視化します。
+- **Mode Rainbow Coloring** — モード別の ANSI トゥルーカラーグラデーション（PLAN ◇ / ACT ◆ / EVAL ◈ / AUTO ◊）に加え、CI・グレースケール端末向けの `NO_COLOR` 環境変数サポート。
+- **Smart Context Bar** — 視覚的な `[████░░░░░░] 42%` プログレスバーが、警告および危険閾値とともに `Ctx:42%` テキストを置き換えます。
+- **Adaptive Layout Engine** — `fit_segments` 適応的切り詰めにより、狭い端末でも HUD が美しく収まります。
+- **Rate-limit Severity Icons** — API レート制限に近づいたときに視覚的な警告を表示します。
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -24,15 +24,15 @@
 
 ---
 
-## v5.5.0의 새로운 기능 — Wow Experience
+## v5.6.0의 새로운 기능 — HUD Statusbar Wave
 
-- **Agent Council Memory** — 전문가들이 이전 분석 결과를 기억하고 세션 간에 서로의 컨텍스트를 기반으로 발전합니다.
-- **Live AI Guardrails** — Edit/Write 시 실시간 규칙 위반 감지 및 패턴 탐지 (SQL injection, XSS, 하드코딩된 시크릿, eval/exec).
-- **Self-Evolving Rules** — `suggest_rules` MCP 도구가 실패 패턴을 분석하고 사람이 검토할 규칙 초안을 제안합니다.
-- **Smart First Prompt** — 프로젝트를 읽고 다음에 가장 적합한 모드를 제안하는 컨텍스트 인식 온보딩.
-- **Team Bootstrap** — `codingbuddy init --team`이 설치된 AI 도구(Cursor, Claude Code, Codex, Antigravity, Q, Kiro)를 자동으로 감지하고 한 번에 매칭되는 어댑터를 생성합니다.
-- **Micro-Achievements** — 모드 진입, 협의회 소환, TDD 사이클에 대한 잠금 해제 가능한 마일스톤.
-- **Council Assembly Animation** — 모드 진입 시 전문가가 순차적으로 도착하는 극적인 연출.
+- **Breathing Buddy Face** — 버디 페이스가 세션 단계(유휴 / 사고 중 / 실행 중 / 차단됨 / 완료)에 반응하여 상태 바가 살아 있는 느낌을 줍니다.
+- **Cost Velocity Indicator** — 🔥 / ↗ / → / 💤 트렌드 글리프가 포함된 세션 지출 속도 배지가 천천히 기획 중인지 뜨겁게 리팩토링 중인지 알려줍니다.
+- **Cache Savings Badge** — 프롬프트 캐시 할인을 `💰$N.NN saved`로 수치화하여 캐싱의 가치를 실시간으로 보여줍니다.
+- **Mode Rainbow Coloring** — 모드별 ANSI 트루컬러 그라디언트(PLAN ◇ / ACT ◆ / EVAL ◈ / AUTO ◊)와 CI·그레이스케일 터미널을 위한 `NO_COLOR` 환경변수 지원.
+- **Smart Context Bar** — 시각적 `[████░░░░░░] 42%` 진행 바가 단순한 `Ctx:42%` 텍스트를 경고/위험 임계값과 함께 대체합니다.
+- **Adaptive Layout Engine** — `fit_segments` 적응형 잘라내기로 좁은 터미널에서도 HUD가 우아하게 맞춰집니다.
+- **Rate-limit Severity Icons** — API 속도 제한에 근접할 때 시각적 경고를 표시합니다.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Codingbuddy is a multi-AI MCP server that orchestrates 37 specialist agents acro
 
 ---
 
-## What's New in v5.5.0 — Wow Experience
+## What's New in v5.6.0 — HUD Statusbar Wave
 
-- **Agent Council Memory** — specialists now remember prior findings and build on each other's context across sessions.
-- **Live AI Guardrails** — real-time rule violation interception on Edit/Write with pattern detection (SQL injection, XSS, hardcoded secrets, eval/exec).
-- **Self-Evolving Rules** — `suggest_rules` MCP tool analyzes failure patterns and proposes draft rules for human review.
-- **Smart First Prompt** — context-aware onboarding that reads your project and suggests the next best mode.
-- **Team Bootstrap** — `codingbuddy init --team` auto-detects installed AI tools (Cursor, Claude Code, Codex, Antigravity, Q, Kiro) and generates matching adapters in one command.
-- **Micro-Achievements** — unlockable milestones for mode entries, council summons, and TDD cycles.
-- **Council Assembly Animation** — dramatic staggered specialist arrival effect on mode entry.
+- **Breathing Buddy Face** — the buddy face reacts to your session phase (idle / thinking / active / blocked / victory) so the status bar feels alive.
+- **Cost Velocity Indicator** — session spend-rate badge with 🔥 / ↗ / → / 💤 trend glyphs tells you whether you're on a slow planning pass or a hot refactor burn.
+- **Cache Savings Badge** — quantifies prompt-cache discounts as `💰$N.NN saved` so you see the value of caching in real time.
+- **Mode Rainbow Coloring** — per-mode ANSI truecolor gradients (PLAN ◇ / ACT ◆ / EVAL ◈ / AUTO ◊) with `NO_COLOR` env support for CI and greyscale terminals.
+- **Smart Context Bar** — visual `[████░░░░░░] 42%` progress bar replaces plain `Ctx:42%` text with warning and danger thresholds.
+- **Adaptive Layout Engine** — HUD fits narrow terminals gracefully with `fit_segments` adaptive truncation.
+- **Rate-limit Severity Icons** — visual warnings when you approach API rate limits.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,15 +24,15 @@
 
 ---
 
-## v5.5.0 新功能 — Wow Experience
+## v5.6.0 新功能 — HUD Statusbar Wave
 
-- **Agent Council Memory** — 专家们现在能够记住之前的分析结果，并在跨会话中基于彼此的上下文进行构建。
-- **Live AI Guardrails** — 在 Edit/Write 时实时拦截规则违规，支持模式检测（SQL injection、XSS、硬编码密钥、eval/exec）。
-- **Self-Evolving Rules** — `suggest_rules` MCP 工具分析失败模式并为人工审查提出规则草案。
-- **Smart First Prompt** — 上下文感知的引导流程，读取您的项目并建议下一个最佳模式。
-- **Team Bootstrap** — `codingbuddy init --team` 自动检测已安装的 AI 工具（Cursor、Claude Code、Codex、Antigravity、Q、Kiro），并通过一个命令生成匹配的适配器。
-- **Micro-Achievements** — 针对模式进入、协作会议召集和 TDD 周期的可解锁里程碑。
-- **Council Assembly Animation** — 模式进入时专家错落登场的戏剧化效果。
+- **Breathing Buddy Face** — Buddy 表情会对会话阶段（空闲 / 思考 / 执行 / 阻塞 / 完成）做出反应，让状态栏充满生气。
+- **Cost Velocity Indicator** — 带 🔥 / ↗ / → / 💤 趋势字符的会话花费速率徽章，告诉你当前是缓慢的规划过程还是火热的重构冲刺。
+- **Cache Savings Badge** — 将 prompt 缓存折扣量化为 `💰$N.NN saved`，让你实时看到缓存带来的价值。
+- **Mode Rainbow Coloring** — 针对每个模式的 ANSI 真彩色渐变（PLAN ◇ / ACT ◆ / EVAL ◈ / AUTO ◊），支持 `NO_COLOR` 环境变量以适配 CI 和灰度终端。
+- **Smart Context Bar** — 视觉化 `[████░░░░░░] 42%` 进度条替代纯文本 `Ctx:42%`，附带警告与危险阈值。
+- **Adaptive Layout Engine** — 通过 `fit_segments` 自适应截断，让 HUD 在狭窄终端中也能优雅适配。
+- **Rate-limit Severity Icons** — 在接近 API 速率限制时显示可视化警告。
 
 ---
 

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Multi-AI Rules MCP Server - One source of truth for AI coding rules across all AI assistants",
   "author": "JeremyDev87",
   "license": "MIT",

--- a/apps/mcp-server/src/shared/version.ts
+++ b/apps/mcp-server/src/shared/version.ts
@@ -2,4 +2,4 @@
  * Single source of truth for the runtime package version.
  * Updated automatically by scripts/bump-version.sh on each release.
  */
-export const VERSION = '5.5.0';
+export const VERSION = '5.6.0';

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "PLAN/ACT/EVAL workflow with auto-detection, specialist agents, and reusable skills for systematic TDD development",
   "author": {
     "name": "JeremyDev87",

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -2,7 +2,7 @@
 
 # CodingBuddy Claude Code Plugin
 
-> Version 5.5.0
+> Version 5.6.0
 
 Multi-AI Rules for consistent coding practices - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic development.
 

--- a/packages/claude-code-plugin/namespace-manifest.json
+++ b/packages/claude-code-plugin/namespace-manifest.json
@@ -34,5 +34,5 @@
       "namespaced": "codingbuddy:plan"
     }
   ],
-  "generatedAt": "2026-04-10T09:36:15.095Z"
+  "generatedAt": "2026-04-11T14:34:02.760Z"
 }

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-claude-plugin",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "Claude Code Plugin for CodingBuddy - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills",
   "author": "JeremyDev87",
   "license": "MIT",
@@ -53,7 +53,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "codingbuddy": "^5.5.0"
+    "codingbuddy": "^5.6.0"
   },
   "peerDependenciesMeta": {
     "codingbuddy": {

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-rules",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "AI coding rules for consistent practices across AI assistants",
   "main": "index.js",
   "types": "index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5735,7 +5735,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:4.0.17"
   peerDependencies:
-    codingbuddy: ^5.5.0
+    codingbuddy: ^5.6.0
   peerDependenciesMeta:
     codingbuddy:
       optional: true


### PR DESCRIPTION
## Summary

- Bump workspace version from **5.5.0 → 5.6.0** across `apps/mcp-server`, `packages/rules`, `packages/claude-code-plugin` (+ peerDependencies), `plugin.json`, `marketplace.json`, `version.ts`, and `yarn.lock`
- Add `[5.6.0] - 2026-04-11` section to `CHANGELOG.md` covering Wave 1-A through Wave 3 features, Wave 0 polish fixes, the `next 16.2.3` security bump (GHSA-q4gf-8mx6-v5v3), and a new `### Test Coverage` section documenting **381/381 tests passing**
- Replace the "What's New" section in all 5 README translations (`en`/`ko`/`zh-CN`/`ja`/`es`) with the **HUD Statusbar Wave** feature list: Breathing Buddy Face, Cost Velocity Indicator, Cache Savings Badge, Mode Rainbow Coloring, Smart Context Bar, Adaptive Layout Engine, and Rate-limit Severity Icons
- Refresh `packages/claude-code-plugin/README.md` (`Version 5.6.0`) and `namespace-manifest.json` as regenerated by `yarn build`

## Highlights — HUD Statusbar Wave

| Wave | Feature | Closes |
|------|---------|--------|
| 1-A | Version resolution fallback | #1466 |
| 1-B | Session self-heal & stale state detection | #1468 |
| 1-C | Rate-limit severity icons | #1464 |
| 1-D | Adaptive layout engine | #1464 |
| 2-A | Breathing Buddy Face | #1464 |
| 2-B | Cost Velocity Indicator | #1464 |
| 2-C | Cache Savings Badge | #1464 |
| 2-D | Mode Rainbow Coloring | #1464 |
| 2-E | Smart Context Bar | #1464 |
| 3 | Wave 2-B/2-C integration into `format_status_line` | #1464 |
| Polish | `ImportError` narrowing + hoisted imports | qual-1465, perf-1485 |

## Test plan

- [x] Local CI: `yarn workspace codingbuddy lint / format:check / typecheck / test:coverage / circular / build` — **6270/6272 tests passing, 92.53% statement coverage**
- [x] Local CI: `yarn workspace codingbuddy-claude-plugin lint / format:check / typecheck / test:coverage / circular / build`
- [x] Rules validation: `ajv-cli` (35 agent JSONs valid) + `markdownlint-cli2` (102 `.ai-rules` files, 0 errors)
- [x] Security audits: `yarn workspace codingbuddy npm audit --severity high` ✅ / `codingbuddy-claude-plugin` ✅ / `landing-page` ✅
- [x] Version consistency verified across 6 version files (`version.ts`, 3× `package.json`, `plugin.json`, `marketplace.json`)
- [x] `apps/landing-page/**` intentionally untouched in this release prep (pre-existing `next 16.2.3` security bump already landed in commit `b847b75`)
- [ ] CI green on PR
- [ ] Merge → tag `v5.6.0` → npm publish (manual, per release policy)