### PR TITLE
chore(release): prepare v5.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "codingbuddy",
       "source": "./packages/claude-code-plugin",
       "description": "PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic TDD development",
-      "version": "5.6.0",
+      "version": "5.6.1",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.6.1] - 2026-04-11
+
+Hotfix closing the remaining gaps in the v5.6.0 HUD Statusbar Wave cycle:
+a stale-timestamp leak in the self-heal path, plus the four Wave modules
+that shipped as dead code in v5.6.0 (imported but never wired into
+`format_status_line`).
+
+### Fixed
+- HUD heal timestamp leak (Wave 1-B, [#1487](https://github.com/JeremyDev87/codingbuddy/pull/1487)) — `heal_stale_state` preserved `sessionStartTimestamp` for "audit / forensics", but `resolve_duration` read the same field as a fallback when stdin lacked `total_duration_ms`. A manual-fix marker + stale timestamp therefore rendered enormous durations like `322h52m` for brand-new sessions. The timestamp is now relocated into `_healedFromSessionStartTimestamp` so forensic/debug value is preserved while the render fallback path no longer sees it. Idempotent — re-healing an already-healed state keeps the forensics field stable.
+
+### Added
+- Wave 3b — Complete Wave 3 integration ([#1488](https://github.com/JeremyDev87/codingbuddy/pull/1488)) — commit `bd78195` ("integrate Wave 2-B/2-C in `format_status_line`") wired velocity and cache-savings into the cost segment but left four sibling Wave modules as dead code: `hud_buddy`, `hud_rainbow`, `hud_context_bar`, and `hud_layout`. Their unit tests passed, but `format_status_line` never called them. This hotfix hoists all four modules as top-level imports and refactors `format_status_line` to build `(name, priority, text)` segments consumed by `fit_segments`:
+  - **Wave 2-A — Breathing Buddy Face** now actually breathes: the buddy face reflects `hud_state.phase` / `blockerCount` (`ready` → ◕‿◕ idle, `planning` → ◔‿◔ thinking, `executing` → ◕◡◕ active, blockers → ◕︵◕ error, `lastEvent=victory` → ◕ᴗ◕).
+  - **Wave 2-D — Mode Rainbow Coloring** now actually colors: opt-in via `CODINGBUDDY_HUD_RAINBOW=1` because Claude Code statusLine ANSI support is environment-dependent. Default OFF keeps existing terminals clean. Transitively honours the `NO_COLOR` standard (https://no-color.org). Only real modes (PLAN/ACT/EVAL/AUTO) are colored — the "Ready" fallback label stays plain. Coloring is applied post-`fit_segments` so ANSI escapes don't break layout width accounting.
+  - **Wave 2-E — Smart Context Bar** now actually renders: `Ctx:NN%` is replaced with `[████░░░░░░] 42%`. Dark shade `▓` marks the trailing full block above the danger threshold (85%) and a `⚠` suffix is appended above the warning threshold (80%).
+  - **Wave 1-D — Adaptive Layout** now actually adapts: the final `" | ".join(segments)` is replaced with `fit_segments(layout_segments, terminal_width())`. Low-priority segments (`worktree`, `rate_limits`, `model`, `cache`, `ctx`) drop first on narrow terminals; `face_version` and `mode_health` are sacred and always render. `shorten_model_label` trims the `"(1M context)"` suffix so Opus display names fit mid-width terminals without being dropped.
+
+### Test Coverage
+- 17 new Wave 3b integration tests across four classes (`TestWave2ABreathingFaceIntegration`, `TestWave2EContextBarIntegration`, `TestWave2DRainbowIntegration`, `TestWave1DAdaptiveLayoutIntegration`)
+- 5 new Wave 1-B regression tests guarding the heal-timestamp contract
+- 3 existing tests updated for the Wave 2-E `[bar] NN%` format; `test_full_telemetry` hardened with `COLUMNS=300` so the "all segments render" assertion no longer flakes against the pytest 80-col default now that adaptive layout actually runs
+- Plugin test suite: 1077+ passed locally
+
 ## [5.6.0] - 2026-04-11
 
 ### Added

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Multi-AI Rules MCP Server - One source of truth for AI coding rules across all AI assistants",
   "author": "JeremyDev87",
   "license": "MIT",

--- a/apps/mcp-server/src/shared/version.ts
+++ b/apps/mcp-server/src/shared/version.ts
@@ -2,4 +2,4 @@
  * Single source of truth for the runtime package version.
  * Updated automatically by scripts/bump-version.sh on each release.
  */
-export const VERSION = '5.6.0';
+export const VERSION = '5.6.1';

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "PLAN/ACT/EVAL workflow with auto-detection, specialist agents, and reusable skills for systematic TDD development",
   "author": {
     "name": "JeremyDev87",

--- a/packages/claude-code-plugin/README.md
+++ b/packages/claude-code-plugin/README.md
@@ -2,7 +2,7 @@
 
 # CodingBuddy Claude Code Plugin
 
-> Version 5.6.0
+> Version 5.6.1
 
 Multi-AI Rules for consistent coding practices - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic development.
 

--- a/packages/claude-code-plugin/namespace-manifest.json
+++ b/packages/claude-code-plugin/namespace-manifest.json
@@ -34,5 +34,5 @@
       "namespaced": "codingbuddy:plan"
     }
   ],
-  "generatedAt": "2026-04-11T14:34:02.760Z"
+  "generatedAt": "2026-04-11T16:03:33.849Z"
 }

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-claude-plugin",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "Claude Code Plugin for CodingBuddy - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills",
   "author": "JeremyDev87",
   "license": "MIT",
@@ -53,7 +53,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "codingbuddy": "^5.6.0"
+    "codingbuddy": "^5.6.1"
   },
   "peerDependenciesMeta": {
     "codingbuddy": {

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-rules",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "AI coding rules for consistent practices across AI assistants",
   "main": "index.js",
   "types": "index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5735,7 +5735,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:4.0.17"
   peerDependencies:
-    codingbuddy: ^5.6.0
+    codingbuddy: ^5.6.1
   peerDependenciesMeta:
     codingbuddy:
       optional: true


### PR DESCRIPTION
## Summary

Bump the workspace version from **5.6.0 → 5.6.1** and publish the CHANGELOG entry for the HUD hotfix cycle.

v5.6.1 is a hotfix closing the remaining gaps in the v5.6.0 HUD Statusbar Wave cycle:

- **Wave 1-B heal timestamp leak** (#1487, merged as `cd2c9d3`) — `heal_stale_state` preserved `sessionStartTimestamp` for "audit / forensics", but `resolve_duration` read the same field as a fallback when stdin lacked `total_duration_ms`. A manual-fix marker + stale timestamp therefore rendered enormous durations like `322h52m` for brand-new sessions. The timestamp is now relocated into `_healedFromSessionStartTimestamp`.

- **Wave 3b — complete Wave 3 integration** (#1488, merged as `64edfac`) — commit `bd78195` wired Wave 2-B velocity and 2-C cache savings into `format_status_line` but left four sibling Wave modules as dead code: `hud_buddy`, `hud_rainbow`, `hud_context_bar`, and `hud_layout`. Their unit tests passed, but `format_status_line` never called them. v5.6.1 hoists all four as top-level imports and refactors `format_status_line` to build `(name, priority, text)` segments consumed by `fit_segments`, finally delivering Wave 2-A breathing face, Wave 2-D rainbow coloring (opt-in via `CODINGBUDDY_HUD_RAINBOW=1`), Wave 2-E smart context bar, and Wave 1-D adaptive layout — all features v5.6.0 advertised but shipped inert.

## Bump surface (10 files)

| File | Change |
|------|--------|
| `apps/mcp-server/package.json` | 5.6.0 → 5.6.1 |
| `apps/mcp-server/src/shared/version.ts` | VERSION const |
| `packages/rules/package.json` | 5.6.0 → 5.6.1 |
| `packages/claude-code-plugin/package.json` | version + peerDependencies.codingbuddy |
| `packages/claude-code-plugin/.claude-plugin/plugin.json` | plugin schema version |
| `packages/claude-code-plugin/README.md` | generated version stamp |
| `packages/claude-code-plugin/namespace-manifest.json` | `yarn build` output |
| `.claude-plugin/marketplace.json` | plugins[0].version |
| `yarn.lock` | peerDep resolution |
| `CHANGELOG.md` | new `[5.6.1] - 2026-04-11` section |

## Test plan

- [x] `./scripts/bump-version.sh 5.6.1` executed, all 7 version files confirmed ✅ (the `yarn.lock clean` false-positive is just the script's post-install diff check — the actual delta is `codingbuddy: ^5.6.0 → ^5.6.1` in peerDependencies, expected)
- [x] `yarn workspace codingbuddy-claude-plugin build` — `namespace-manifest.json` + `README.md` refreshed
- [x] `python3 -m pytest packages/claude-code-plugin/tests/test_hud.py tests/test_hud_session.py` — **153 passed** on post-merge master
- [ ] CI: `e2e-plugin-hooks`, `install-dependencies`, `e2e-plugin-docker`, Vercel preview
- [ ] User review + merge
- [ ] User executes release: `git tag v5.6.1 && git push origin v5.6.1`
- [ ] User runs GitHub Release / publish workflow

## Follow-on (not in this PR)

- Tag + GitHub Release creation — user-driven per CLAUDE.md release policy
- Post-release validation: verify v5.6.1 HUD behavior in a fresh session (buddy face changes with phase, `CODINGBUDDY_HUD_RAINBOW=1` shows gradient, context bar renders)