### PR TITLE
chore(plugin): regenerate namespace-manifest timestamp

### DIFF
--- a/packages/claude-code-plugin/namespace-manifest.json
+++ b/packages/claude-code-plugin/namespace-manifest.json
@@ -34,5 +34,5 @@
       "namespaced": "codingbuddy:plan"
     }
   ],
-  "generatedAt": "2026-04-11T17:16:02.224Z"
+  "generatedAt": "2026-04-12T00:30:09.386Z"
 }


### PR DESCRIPTION
## Summary
- Regenerate `namespace-manifest.json` `generatedAt` timestamp after recent plugin changes
- No functional change — single-line timestamp diff only

## Test plan
- [x] codingbuddy-claude-plugin: lint / format:check / typecheck / test:coverage (144/144) / circular / build all green
- [x] Cross-cutting security audit (codingbuddy + plugin + landing-page) — no high-severity issues