### PR TITLE
chore(release): prepare v5.6.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "codingbuddy",
       "source": "./packages/claude-code-plugin",
       "description": "PLAN/ACT/EVAL workflow, specialist agents, and reusable skills for systematic TDD development",
-      "version": "5.6.2",
+      "version": "5.6.3",
       "category": "development"
     }
   ]

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "description": "Multi-AI Rules MCP Server - One source of truth for AI coding rules across all AI assistants",
   "author": "JeremyDev87",
   "license": "MIT",

--- a/apps/mcp-server/src/shared/version.ts
+++ b/apps/mcp-server/src/shared/version.ts
@@ -2,4 +2,4 @@
  * Single source of truth for the runtime package version.
  * Updated automatically by scripts/bump-version.sh on each release.
  */
-export const VERSION = '5.6.2';
+export const VERSION = '5.6.3';

--- a/packages/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "description": "PLAN/ACT/EVAL workflow with auto-detection, specialist agents, and reusable skills for systematic TDD development",
   "author": {
     "name": "JeremyDev87",

--- a/packages/claude-code-plugin/package.json
+++ b/packages/claude-code-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-claude-plugin",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "description": "Claude Code Plugin for CodingBuddy - PLAN/ACT/EVAL workflow, specialist agents, and reusable skills",
   "author": "JeremyDev87",
   "license": "MIT",
@@ -53,7 +53,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "codingbuddy": "^5.6.2"
+    "codingbuddy": "^5.6.3"
   },
   "peerDependenciesMeta": {
     "codingbuddy": {

--- a/packages/rules/package.json
+++ b/packages/rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codingbuddy-rules",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "description": "AI coding rules for consistent practices across AI assistants",
   "main": "index.js",
   "types": "index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5735,7 +5735,7 @@ __metadata:
     typescript: "npm:5.9.3"
     vitest: "npm:4.0.17"
   peerDependencies:
-    codingbuddy: ^5.6.2
+    codingbuddy: ^5.6.3
   peerDependenciesMeta:
     codingbuddy:
       optional: true


### PR DESCRIPTION
## Summary
- Bump all workspace versions: `5.6.2` → `5.6.3`
- Files: 3 `package.json`, `version.ts`, `plugin.json`, `marketplace.json`, `yarn.lock`

## Changes since v5.6.2
- **fix(hooks):** persist tool stats from short-lived hook processes (`487faf7`)
- **fix(hooks):** atomic read-modify-write in SessionStats.flush() (#1493) (`e85d111`)
- **fix(hooks):** wire hook timing recording + delete dead HookTimer (#1494) (`be6502d`)
- **fix(tests):** isolate HUD state in integration tests (`d20150d`)
- **refactor(hooks):** atomic staging-based lib swap + drop redundant chmod (`af0d12b`)
- **docs(claude-code):** slim AI instructions to reduce session token cost (`64168b1`)
- **chore(scripts):** isolate HOME + assert exact version in verify-install-simulation (`0ab3378`, `167c2f3`)

## Test plan
- [x] `bump-version.sh 5.6.3` — all 7 files updated, verification passed
- [ ] CI checks pass on PR
- [ ] After merge: user tags `v5.6.3` and publishes

## Post-merge (user action)
```bash
git tag v5.6.3 && git push origin v5.6.3
```